### PR TITLE
Studio: detect tool support from executable Jinja

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2526,30 +2526,6 @@ def _extract_model_size_b(model_id: str):
     return extract_model_size_b(model_id)
 
 
-# Tool support, matched on the Jinja construct rather than on one spelling of it. The literal
-# list this replaced held `"{%- if tools %}"` and three whitespace variants, so Granite 3.3
-# (`{%- if tools and not available_tools -%}`) and Phi-4-mini (tools on the system message)
-# read as tool-less. A false greys out the Search and Code pills, so the user cannot correct it.
-_TOOL_TEMPLATE_PATTERNS = (
-    # Any if/elif testing `tools`, whatever the trim markers, spacing or predicate.
-    # `\btools\b` keeps Llama 3.1's `builtin_tools` and `tools_in_user_message` out: those are
-    # separate switches and neither renders a schema.
-    re.compile(r"\{%[-+]?\s*(?:el)?if\b[^%]*\btools\b"),
-    # No guard at all, straight into the loop.
-    re.compile(r"\{%[-+]?\s*for\b[^%]*\bin\s+tools\b"),
-    # message.role == "tool" / message['role'] == 'tool', either quoting. Equality only:
-    # `role != "tool"` excludes tool turns, which is not evidence of handling them.
-    re.compile(r"""(?:\.role|\[\s*['"]role['"]\s*\])\s*==\s*['"]tool['"]"""),
-    re.compile(r"""['"]role['"]\s*==\s*['"]tool['"]"""),
-    # DeepSeek gates on tool_calls rather than on `tools`. Access or test only, so the bare
-    # word in a Jinja comment is not a capability.
-    re.compile(
-        r"""(?:\.tool_calls\b|\[\s*['"]tool_calls['"]\s*\]"""
-        r"""|\btool_calls\s+is\s+(?:defined|not\s+none))"""
-    ),
-)
-
-
 # Canonical reasoning_effort levels, weakest -> strongest. Used to read the
 # discrete set a template branches on (e.g. GLM-5.2 uses 'high' | 'max', Inkling
 # uses the full 'none'..'max' ladder) so we only ever offer levels the template
@@ -2720,9 +2696,9 @@ def detect_reasoning_flags(
         flags["preserve_thinking_default"] = bool(_QWEN38_MODEL_RE.search(model_identifier or ""))
         _log(f"{prefix}model supports preserve_thinking")
 
-    # "tool" first: one pass, and it skips the regex arms for most templates. This classifier
-    # is re-derived several times per request.
-    if "tool" in tpl and any(pattern.search(tpl) for pattern in _TOOL_TEMPLATE_PATTERNS):
+    from core.inference.template_capabilities import template_supports_tools
+
+    if isinstance(tpl, str) and template_supports_tools(tpl):
         flags["supports_tools"] = True
         _log(f"{prefix}model supports tool calling")
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2537,11 +2537,16 @@ _TOOL_TEMPLATE_PATTERNS = (
     re.compile(r"\{%[-+]?\s*(?:el)?if\b[^%]*\btools\b"),
     # No guard at all, straight into the loop.
     re.compile(r"\{%[-+]?\s*for\b[^%]*\bin\s+tools\b"),
-    # message.role == "tool" / message['role'] == 'tool', either quoting, == or !=.
-    re.compile(r"""(?:\.role|\[\s*['"]role['"]\s*\])\s*[!=]=\s*['"]tool['"]"""),
-    re.compile(r"""['"]role['"]\s*[!=]=\s*['"]tool['"]"""),
-    # DeepSeek gates on tool_calls rather than on `tools`.
-    re.compile(r"\btool_calls\b"),
+    # message.role == "tool" / message['role'] == 'tool', either quoting. Equality only:
+    # `role != "tool"` excludes tool turns, which is not evidence of handling them.
+    re.compile(r"""(?:\.role|\[\s*['"]role['"]\s*\])\s*==\s*['"]tool['"]"""),
+    re.compile(r"""['"]role['"]\s*==\s*['"]tool['"]"""),
+    # DeepSeek gates on tool_calls rather than on `tools`. Access or test only, so the bare
+    # word in a Jinja comment is not a capability.
+    re.compile(
+        r"""(?:\.tool_calls\b|\[\s*['"]tool_calls['"]\s*\]"""
+        r"""|\btool_calls\s+is\s+(?:defined|not\s+none))"""
+    ),
 )
 
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2526,26 +2526,22 @@ def _extract_model_size_b(model_id: str):
     return extract_model_size_b(model_id)
 
 
-_TOOL_TEMPLATE_MARKERS = (
-    "{%- if tools %}",
-    "{%- if tools -%}",
-    "{% if tools %}",
-    "{% if tools -%}",
-    # Defensive templates guard with `tools is defined` before truth-testing
-    # (e.g. Inkling: `{%- if tools is defined and tools -%}`).
-    "{%- if tools is defined",
-    "{% if tools is defined",
-    '"role" == "tool"',
-    "'role' == 'tool'",
-    'message.role == "tool"',
-    "message.role == 'tool'",
-    # DeepSeek: no top-level ``{% if tools %}`` block; it gates emission on
-    # ``message['role'] == 'tool'`` plus ``message['tool_calls'] is defined``.
-    "message['role'] == 'tool'",
-    'message["role"] == "tool"',
-    "message['tool_calls']",
-    'message["tool_calls"]',
-    "tool_calls is defined",
+# Tool support, matched on the Jinja construct rather than on one spelling of it. The literal
+# list this replaced held `"{%- if tools %}"` and three whitespace variants, so Granite 3.3
+# (`{%- if tools and not available_tools -%}`) and Phi-4-mini (tools on the system message)
+# read as tool-less. A false greys out the Search and Code pills, so the user cannot correct it.
+_TOOL_TEMPLATE_PATTERNS = (
+    # Any if/elif testing `tools`, whatever the trim markers, spacing or predicate.
+    # `\btools\b` keeps Llama 3.1's `builtin_tools` and `tools_in_user_message` out: those are
+    # separate switches and neither renders a schema.
+    re.compile(r"\{%[-+]?\s*(?:el)?if\b[^%]*\btools\b"),
+    # No guard at all, straight into the loop.
+    re.compile(r"\{%[-+]?\s*for\b[^%]*\bin\s+tools\b"),
+    # message.role == "tool" / message['role'] == 'tool', either quoting, == or !=.
+    re.compile(r"""(?:\.role|\[\s*['"]role['"]\s*\])\s*[!=]=\s*['"]tool['"]"""),
+    re.compile(r"""['"]role['"]\s*[!=]=\s*['"]tool['"]"""),
+    # DeepSeek gates on tool_calls rather than on `tools`.
+    re.compile(r"\btool_calls\b"),
 )
 
 
@@ -2719,7 +2715,9 @@ def detect_reasoning_flags(
         flags["preserve_thinking_default"] = bool(_QWEN38_MODEL_RE.search(model_identifier or ""))
         _log(f"{prefix}model supports preserve_thinking")
 
-    if any(marker in tpl for marker in _TOOL_TEMPLATE_MARKERS):
+    # "tool" first: one pass, and it skips the regex arms for most templates. This classifier
+    # is re-derived several times per request.
+    if "tool" in tpl and any(pattern.search(tpl) for pattern in _TOOL_TEMPLATE_PATTERNS):
         flags["supports_tools"] = True
         _log(f"{prefix}model supports tool calling")
 

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -40,9 +40,11 @@ class _State:
     # Names bound to a constant, so a subscript written through one resolves to a
     # single field rather than to every field.
     consts: dict = field(default_factory = dict)
-    # Set when the path hit break or continue, so a literal loop stops simulating
-    # further items for it.
+    # Set when the path hit break, so a literal loop stops simulating further items
+    # for it. `continue` only ends the current iteration, so it is tracked apart:
+    # the path skips the rest of the body but still sees the next item.
     terminated: bool = False
+    continued: bool = False
     budget: list = field(default_factory = lambda: [8192])
 
     def copy(self, scoped = False):
@@ -55,6 +57,7 @@ class _State:
             self.constructed.copy(),
             self.consts.copy(),
             self.terminated,
+            self.continued,
             self.budget,
         )
 
@@ -99,6 +102,19 @@ def _names(node):
     )
 
 
+def _as_const(node, state):
+    """The literal a node is known to be, either written out or bound to a name."""
+    if isinstance(node, nodes.Const):
+        return node
+    if (
+        state is not None
+        and isinstance(node, nodes.Name)
+        and node.name in state.consts
+    ):
+        return nodes.Const(state.consts[node.name])
+    return None
+
+
 def _constant_truth(node, state = None):
     fact = state.facts.get(repr(node)) if state is not None else None
     if fact is not None:
@@ -107,15 +123,25 @@ def _constant_truth(node, state = None):
         return bool(node.value)
     if isinstance(node, (nodes.List, nodes.Tuple, nodes.Dict)):
         return bool(node.items)
-    if (
-        isinstance(node, nodes.Compare)
-        and isinstance(node.expr, nodes.Const)
-        and all(isinstance(operand.expr, nodes.Const) for operand in node.ops)
-    ):
-        try:
-            return bool(node.as_const())
-        except nodes.Impossible:
-            pass
+    if isinstance(node, nodes.Compare):
+        # `{% set flag = true %}{% if flag == false %}` is dead at render time, so
+        # resolve names the template bound to a literal before folding.
+        folded = _as_const(node.expr, state)
+        operands = [_as_const(operand.expr, state) for operand in node.ops]
+        if folded is not None and all(operand is not None for operand in operands):
+            replacement = nodes.Compare(
+                folded,
+                [
+                    nodes.Operand(operand.op, value)
+                    for operand, value in zip(node.ops, operands)
+                ],
+            )
+            try:
+                # The rebuilt node is synthetic, so it carries no environment of its
+                # own and has to be handed an evaluation context explicitly.
+                return bool(replacement.as_const(nodes.EvalContext(_ENVIRONMENT)))
+            except Exception:
+                pass
     if isinstance(node, nodes.Not):
         value = _constant_truth(node.node, state)
         return None if value is None else not value
@@ -157,6 +183,50 @@ def _assume(node, truth, state):
     return [result]
 
 
+def _signature(state):
+    """Everything about a path that can still change the verdict."""
+    return (
+        frozenset(state.aliases),
+        tuple(sorted((name, id(node)) for name, node in state.macros.items())),
+        frozenset((expression, fact[0]) for expression, fact in state.facts.items()),
+        frozenset(state.assigned),
+        frozenset(state.mutated),
+        frozenset(state.constructed),
+        frozenset((name, repr(value)) for name, value in state.consts.items()),
+        state.terminated,
+        state.continued,
+    )
+
+
+def _live_names(body):
+    """Names each suffix of `body` still refers to, so a fact about a name nothing
+    reads again can be dropped and the two paths that carried it collapse into one.
+
+    Without this a template pays for the full Cartesian product of its conditions:
+    twelve unrelated `{% if flagN %}` blocks are 4096 paths, which exhausts the
+    budget and fails closed on a template that does support tools. Qwen3-Coder
+    already spends most of the budget, so the headroom is not theoretical.
+    """
+    suffixes = [frozenset()] * (len(body) + 1)
+    for index in range(len(body) - 1, -1, -1):
+        suffixes[index] = _names(body[index]) | suffixes[index + 1]
+    return suffixes
+
+
+def _collapse(states, live):
+    """Drop facts nothing reads again, then merge paths that became identical."""
+    seen = {}
+    for state in states:
+        if state.facts:
+            state.facts = {
+                expression: fact
+                for expression, fact in state.facts.items()
+                if fact[1] & live
+            }
+        seen.setdefault(_signature(state), state)
+    return list(seen.values()) if len(seen) < len(states) else states
+
+
 def _forget(key, state):
     state.facts = {
         expression: fact for expression, fact in state.facts.items() if key[0] not in fact[1]
@@ -196,6 +266,56 @@ def _negated_guard(node, state):
         return _positive_test(node.node, state)
     if isinstance(node, nodes.Test) and node.name in ("none", "undefined"):
         return _tool_reference(node.node, state)
+    if isinstance(node, nodes.Compare) and len(node.ops) == 1 and node.ops[0].op == "eq":
+        return any(
+            (_tool_reference(a, state) or _counts_tools(a, state)) and _empty_literal(b)
+            for a, b in ((node.expr, node.ops[0].expr), (node.ops[0].expr, node.expr))
+        )
+    return False
+
+
+def _empty_literal(node):
+    """`[]`, `{}`, `()`, `''`, `0`, `none` - the values a catalog is compared against
+    to ask whether it is empty."""
+    if isinstance(node, nodes.Const):
+        return not node.value
+    if isinstance(node, (nodes.List, nodes.Tuple, nodes.Dict)):
+        return not node.items
+    return False
+
+
+def _counts_tools(node, state):
+    """`tools|length` and friends, so `tools|length > 0` reads as a tool guard."""
+    return (
+        isinstance(node, nodes.Filter)
+        and node.name in ("length", "count")
+        and node.node is not None
+        and _tool_reference(node.node, state)
+    )
+
+
+def _non_empty_tools(node, state):
+    """A comparison that holds exactly when the catalog is present and non-empty.
+
+    Templates spell the guard as `{% if tools != [] %}` or `{% if tools|length > 0 %}`
+    as often as `{% if tools %}`, and all three advertise tools the same way.
+    """
+    if not (isinstance(node, nodes.Compare) and len(node.ops) == 1):
+        return False
+    operand = node.ops[0]
+    left, right, op = node.expr, operand.expr, operand.op
+    if op == "ne":
+        return any(
+            (_tool_reference(a, state) or _counts_tools(a, state)) and _empty_literal(b)
+            for a, b in ((left, right), (right, left))
+        )
+    # `tools|length > 0` and the mirrored `0 < tools|length`.
+    mirror = {"gt": "lt", "lt": "gt", "gteq": "lteq", "lteq": "gteq"}
+    for counted, bound, sense in ((left, right, op), (right, left, mirror.get(op, op))):
+        if not _counts_tools(counted, state) or not isinstance(bound, nodes.Const):
+            continue
+        if (sense == "gt" and bound.value == 0) or (sense == "gteq" and bound.value == 1):
+            return True
     return False
 
 
@@ -218,6 +338,8 @@ def _positive_test(node, state):
             and node.node.name in ("none", "undefined")
             and _tool_reference(node.node.node, state)
         )
+    if _non_empty_tools(node, state):
+        return True
     if isinstance(node, nodes.Compare) and len(node.ops) == 1:
         operand = node.ops[0]
         if operand.op == "eq":
@@ -299,8 +421,12 @@ def _value_aliases(value, state, active):
         removed = _removed_key(value.node.attr, value)
         if removed is not None:
             return _select(_value_aliases(value.node.node, state, active), removed)
+        # A shallow copy is the receiver again as far as provenance goes; without this
+        # the fallback reads `copy` as a data field and loses everything under it.
+        if value.node.attr == "copy" and not value.args and not value.kwargs:
+            return _value_aliases(value.node.node, state, active)
     if isinstance(value, nodes.Call) and isinstance(value.node, nodes.Name):
-        if value.node.name == "namespace":
+        if value.node.name in ("namespace", "dict"):
             result = set().union(*(_value_aliases(arg, state, active) for arg in value.args))
             for keyword in value.kwargs:
                 _replace(result, (keyword.key,), _value_aliases(keyword.value, state, active))
@@ -329,7 +455,21 @@ def _value_aliases(value, state, active):
                     active,
                     source = state if parameter.name in arguments else local.copy(),
                 )
-            emits, _ = _scan(macro.body, local, active | {macro.name})
+            # The macro's own names stay live: nothing outside it constrains its body.
+            emits, children = _scan(
+                macro.body, local, active | {macro.name}, tail = _names(macro)
+            )
+            # A namespace write inside a macro escapes it, so the caller sees it:
+            # {% macro load() %}{% set ns.catalog = tools %}{% endmacro %}{{ load() }}
+            # leaves the catalog in ns. _export_scope already knows which of a
+            # scope's mutations outlive it, and the macro's own parameters were
+            # dropped from `assigned` by the scoped copy above.
+            for child in children:
+                exported = _export_scope(state, child)
+                state.aliases.clear()
+                state.aliases.update(exported.aliases)
+                state.mutated.update(exported.mutated)
+                state.facts = exported.facts
             return {()} if emits else set()
     # Other expressions serialize or transform their inputs.
     return (
@@ -346,7 +486,8 @@ def _bind(
     active,
     source = None,
 ):
-    source = state.copy() if source is None else source
+    private = source is None
+    source = state.copy() if private else source
     if isinstance(target, (nodes.Tuple, nodes.List)):
         if isinstance(value, (nodes.Tuple, nodes.List)):
             for item, expression in zip(target.items, value.items):
@@ -356,7 +497,16 @@ def _bind(
             for index, item in enumerate(target.items):
                 _bind_paths(item, _select(paths, index), state)
         return
-    _bind_paths(target, _value_aliases(value, source, active), state)
+    paths = _value_aliases(value, source, active)
+    if private and source.mutated - state.mutated:
+        # Evaluating the value ran a macro whose namespace writes escape it. Those
+        # landed on the private copy, so carry them over before the target is bound.
+        carried = _export_scope(state, source)
+        state.aliases.clear()
+        state.aliases.update(carried.aliases)
+        state.mutated.update(carried.mutated)
+        state.facts = carried.facts
+    _bind_paths(target, paths, state)
     key = _reference_key(target)
     if key is not None:
         source_key = (
@@ -367,7 +517,14 @@ def _bind(
         if _constructs_object(value):
             _mark_constructed(key, value, state)
         elif source_key is not None and source_key in state.constructed:
-            state.constructed.add(key)
+            # The nested members were built by the template too, so the alias has to
+            # carry them: otherwise `current.message.role` reads as external data.
+            inherited = [
+                (*key, *built[len(source_key) :])
+                for built in state.constructed
+                if built[: len(source_key)] == source_key
+            ]
+            state.constructed.update(inherited)
         else:
             state.constructed.discard(key)
     if isinstance(target, nodes.Name):
@@ -436,7 +593,12 @@ def _mutate(call, state, active):
         return
     method = call.node.attr
     positional = {suffix for arg in call.args for suffix in _value_aliases(arg, state, active)}
-    if method != "extend":
+    if method == "update" and all(isinstance(arg, nodes.Dict) for arg in call.args):
+        # A positional mapping keeps its own keys, exactly as the keyword form below
+        # does: d.update({'catalog': tools}) puts the catalog at d.catalog and leaves
+        # every other field of d alone.
+        pass
+    elif method != "extend":
         # append, insert, add, setdefault: the argument lands somewhere under the
         # receiver rather than being spliced into it. Any unrecognised method handed
         # tool data is treated the same way rather than ignored.
@@ -521,7 +683,7 @@ def _export_scope(parent, child):
     return result
 
 
-def _scan_if(node, state, active, guarded):
+def _scan_if(node, state, active, guarded, tail):
     remaining = [state]
     results = []
     for branch in [node, *node.elif_]:
@@ -529,7 +691,11 @@ def _scan_if(node, state, active, guarded):
         for current in remaining:
             for positive in _assume(branch.test, True, current):
                 emits, states = _scan(
-                    branch.body, positive, active, guarded or _positive_test(branch.test, current)
+                    branch.body,
+                    positive,
+                    active,
+                    guarded or _positive_test(branch.test, current),
+                    tail,
                 )
                 if emits:
                     return True, []
@@ -540,21 +706,25 @@ def _scan_if(node, state, active, guarded):
         # With an elif in the chain the else arm is reached for more than one
         # reason, so only a plain if/else carries the negated guard across.
         else_guarded = guarded or (not node.elif_ and _negated_guard(node.test, current))
-        emits, states = _scan(node.else_, current, active, else_guarded)
+        emits, states = _scan(node.else_, current, active, else_guarded, tail)
         if emits:
             return True, []
         results.extend(states)
     return False, results
 
 
-def _scan_loop(node, state, active, guarded):
+def _scan_loop(node, state, active, guarded, tail):
+    # A fact established on one iteration is read on the next, so nothing the loop
+    # itself mentions may be pruned inside it.
+    inner_tail = tail | _names(node)
     literal = isinstance(node.iter, (nodes.List, nodes.Tuple))
     values = node.iter.items if literal else [None]
     states = [state]
     finished = []
     if not values:
-        emits, children = _scan(node.else_, state.copy(scoped = True), active, guarded)
+        emits, children = _scan(node.else_, state.copy(scoped = True), active, guarded, inner_tail)
         return emits, [_export_scope(state, child) for child in children]
+    else_reachable = True
     for value in values:
         results = []
         for parent in states:
@@ -571,29 +741,39 @@ def _scan_loop(node, state, active, guarded):
             candidates = [local] if node.test is None else _assume(node.test, True, local)
             for candidate in candidates:
                 emits, children = _scan(
-                    node.body, candidate, active, guarded or _tool_reference(node.iter, parent)
+                    node.body,
+                    candidate,
+                    active,
+                    guarded or _tool_reference(node.iter, parent),
+                    inner_tail,
                 )
                 if emits:
                     return True, []
                 for child in children:
                     exported = _export_scope(parent, child)
                     if child.terminated:
-                        # break/continue ended this path, so later items of a literal
-                        # iterable never run for it: park it instead of simulating on.
+                        # break left the loop, so later items of a literal iterable
+                        # never run for this path: park it instead of simulating on.
                         exported.terminated = False
+                        exported.continued = False
                         finished.append(exported)
                     else:
+                        # continue only skipped the rest of this iteration.
+                        exported.continued = False
                         results.append(exported)
             if node.test is not None:
-                results.extend(
-                    _export_scope(parent, child) for child in _assume(node.test, False, local)
-                )
+                rejected = _assume(node.test, False, local)
+                if not rejected:
+                    # This item always passes the filter, so the body runs at least
+                    # once and the else arm is unreachable.
+                    else_reachable = False
+                results.extend(_export_scope(parent, child) for child in rejected)
         states = results
     # A filter can reject every item of a literal iterable, in which case the body
     # never runs and Jinja takes the else. Only an unfiltered literal is guaranteed
     # to iterate.
-    if not literal or node.test is not None:
-        emits, children = _scan(node.else_, state.copy(scoped = True), active, guarded)
+    if not literal or (node.test is not None and else_reachable):
+        emits, children = _scan(node.else_, state.copy(scoped = True), active, guarded, inner_tail)
         if emits:
             return True, []
         states.extend(_export_scope(state, child) for child in children)
@@ -605,10 +785,14 @@ def _scan(
     state,
     active,
     guarded = False,
+    tail = frozenset(),
 ):
     states = [state]
     stopped = []
-    for node in body:
+    live = _live_names(body)
+    for index, node in enumerate(body):
+        # Everything still readable once this statement is done, here or further out.
+        rest = live[index + 1] | tail
         results = []
         for current in states:
             current.budget[0] -= 1
@@ -635,13 +819,13 @@ def _scan(
                 # catalog and `{{ tools }}` renders the macro object instead.
                 _replace(current.aliases, (node.name,), set())
             elif isinstance(node, nodes.If):
-                emits, children = _scan_if(node, current, active, guarded)
+                emits, children = _scan_if(node, current, active, guarded, rest)
                 if emits:
                     return True, []
                 results.extend(children)
                 continue
             elif isinstance(node, nodes.For):
-                emits, children = _scan_loop(node, current, active, guarded)
+                emits, children = _scan_loop(node, current, active, guarded, rest)
                 if emits:
                     return True, []
                 results.extend(children)
@@ -649,7 +833,10 @@ def _scan(
             elif isinstance(node, (nodes.Break, nodes.Continue)):
                 # Nothing after this in the body runs, so the path stops being scanned.
                 # It still carries whatever it already mutated, which outlives the loop.
-                current.terminated = True
+                if isinstance(node, nodes.Break):
+                    current.terminated = True
+                else:
+                    current.continued = True
                 stopped.append(current)
                 continue
             elif isinstance(node, nodes.CallBlock):
@@ -660,34 +847,34 @@ def _scan(
                     return True, []
                 # The caller block runs only if the macro invokes caller().
                 if _invokes_caller(node.call, current):
-                    emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded)
+                    emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded, rest)
                     if emits:
                         return True, []
             elif isinstance(node, nodes.FilterBlock):
                 # The block's own filter decides what survives: `{% filter first %}`
                 # emits one character of the catalog, which is no schema at all.
                 if _keeps_content(node.filter):
-                    emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded)
+                    emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded, rest)
                     if emits:
                         return True, []
             elif isinstance(node, nodes.AssignBlock):
-                emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded)
+                emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded, rest)
                 _bind_paths(node.target, {()} if emits else set(), current)
             elif isinstance(node, nodes.With):
                 local = current.copy(scoped = True)
                 for target, value in zip(node.targets, node.values):
                     _bind(target, value, local, active, source = current)
-                emits, children = _scan(node.body, local, active, guarded)
+                emits, children = _scan(node.body, local, active, guarded, rest)
                 if emits:
                     return True, []
                 results.extend(_export_scope(current, child) for child in children)
                 continue
             elif hasattr(node, "body"):
-                emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded)
+                emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded, rest)
                 if emits:
                     return True, []
             results.append(current)
-        states = results
+        states = _collapse(results, rest)
     return False, states + stopped
 
 

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -21,6 +21,12 @@ class _Generation(Extension):
 _ENVIRONMENT = Environment(extensions = [_Generation, "jinja2.ext.loopcontrols", "jinja2.ext.do"])
 _UNKNOWN = object()
 
+# In-place mutators: `{{ catalog.append(tools) }}` renders "None", so the argument
+# reaches the receiver but never the output.
+_MUTATORS_RETURNING_NONE = frozenset(
+    {"append", "extend", "insert", "update", "add", "clear", "sort", "reverse", "discard"}
+)
+
 
 class _AnalysisLimit(Exception):
     pass
@@ -416,6 +422,21 @@ def _value_aliases(value, state, active):
         # the fallback reads `copy` as a data field and loses everything under it.
         if value.node.attr == "copy" and not value.args and not value.kwargs:
             return _value_aliases(value.node.node, state, active)
+        if value.node.attr == "get" and value.args:
+            member = (
+                value.args[0].value
+                if isinstance(value.args[0], nodes.Const)
+                else _UNKNOWN
+            )
+            result = _select(_value_aliases(value.node.node, state, active), member)
+            # The default is what a missing field falls back to, so it counts too.
+            for fallback in value.args[1:]:
+                result |= _value_aliases(fallback, state, active)
+            return result
+        # append/extend/update and the other in-place mutators return None: the data
+        # goes into the receiver, not into the rendered result.
+        if value.node.attr in _MUTATORS_RETURNING_NONE:
+            return set()
     if isinstance(value, nodes.Call) and isinstance(value.node, nodes.Name):
         if value.node.name in ("namespace", "dict"):
             result = set().union(*(_value_aliases(arg, state, active) for arg in value.args))
@@ -453,12 +474,19 @@ def _value_aliases(value, state, active):
             # leaves the catalog in ns. _export_scope already knows which of a
             # scope's mutations outlive it, and the macro's own parameters were
             # dropped from `assigned` by the scoped copy above.
+            # Different paths through the macro can leave different things in the
+            # namespace. The question this analyser answers is whether the catalog
+            # can reach the output on any feasible path, so the outcomes are unioned
+            # rather than overwritten - otherwise the last child scanned wins.
+            merged = set()
             for child in children:
                 exported = _export_scope(state, child)
-                state.aliases.clear()
-                state.aliases.update(exported.aliases)
+                merged |= exported.aliases
                 state.mutated.update(exported.mutated)
                 state.facts = exported.facts
+            if children:
+                state.aliases.clear()
+                state.aliases.update(merged)
             return {()} if emits else set()
     # Other expressions serialize or transform their inputs.
     return (
@@ -515,7 +543,11 @@ def _bind(
             ]
             state.constructed.update(inherited)
         else:
-            state.constructed.discard(key)
+            # Not just the root: `{% set wrapper = payload %}` makes every member of
+            # the old wrapper external again, so a role check on one has to count.
+            state.constructed.difference_update(
+                [built for built in state.constructed if built[: len(key)] == key]
+            )
     if isinstance(target, nodes.Name):
         if isinstance(value, nodes.Const) and isinstance(value.value, (str, int)):
             state.consts[target.name] = value.value
@@ -551,7 +583,7 @@ def _constructs_object(value):
     return (
         isinstance(value, nodes.Call)
         and isinstance(value.node, nodes.Name)
-        and value.node.name == "namespace"
+        and value.node.name in ("namespace", "dict")
     )
 
 
@@ -582,6 +614,17 @@ def _mutate(call, state, active):
         return
     method = call.node.attr
     positional = {suffix for arg in call.args for suffix in _value_aliases(arg, state, active)}
+    if method == "update":
+        # An update REPLACES the fields it names, so whatever they held before is
+        # gone whether or not the new value carries provenance of its own.
+        overwritten = [keyword.key for keyword in call.kwargs]
+        for argument in call.args:
+            if isinstance(argument, nodes.Dict):
+                overwritten.extend(
+                    pair.key.value for pair in argument.items if isinstance(pair.key, nodes.Const)
+                )
+        for member in overwritten:
+            _replace(state.aliases, (*key, member), set())
     if method == "update" and all(isinstance(arg, nodes.Dict) for arg in call.args):
         # A positional mapping keeps its own keys, exactly as the keyword form below
         # does: d.update({'catalog': tools}) puts the catalog at d.catalog and leaves
@@ -719,21 +762,43 @@ def _scan_loop(node, state, active, guarded, tail):
         for parent in states:
             local = parent.copy(scoped = True)
             if value is None:
+                # `{% for key in {'x': tools} %}` walks the keys, not the values, so
+                # nothing under the mapping reaches the target.
+                over_keys = isinstance(node.iter, nodes.Dict)
                 _bind_paths(
-                    node.target, _select(_value_aliases(node.iter, parent, active), _UNKNOWN), local
+                    node.target,
+                    set()
+                    if over_keys
+                    else _select(_value_aliases(node.iter, parent, active), _UNKNOWN),
+                    local,
                 )
             else:
                 _bind(node.target, value, local, active)
             # `loop.first` reprs the same in every loop, so an outer loop's facts would
             # otherwise prune branches of a nested one.
             _forget(("loop",), local)
+            if literal:
+                # A literal iterable is simulated item by item, so which iteration this
+                # is happens to be known: `{% for x in [1] %}{% if not loop.first %}`
+                # never runs its body.
+                position = values.index(value)
+                for member, truth in (
+                    ("first", position == 0),
+                    ("last", position == len(values) - 1),
+                ):
+                    local.facts[repr(nodes.Getattr(nodes.Name("loop", "load"), member, "load"))] = (
+                        truth,
+                        {"loop"},
+                    )
             candidates = [local] if node.test is None else _assume(node.test, True, local)
             for candidate in candidates:
                 emits, children = _scan(
                     node.body,
                     candidate,
                     active,
-                    guarded or _tool_reference(node.iter, parent),
+                    guarded
+                    or _tool_reference(node.iter, parent)
+                    or (node.test is not None and _positive_test(node.test, candidate)),
                     inner_tail,
                 )
                 if emits:

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -60,9 +60,10 @@ class _State:
     # Names bound straight to a field of something else, so `{% set role =
     # message.role %}` still reads as a role check when the comparison uses `role`.
     origins: dict = field(default_factory = dict)
-    # Keys holding a mapping the template built, so `{% for name in by_name %}` is
-    # known to walk its keys rather than its values.
-    mappings: set = field(default_factory = set)
+    # Keys holding a mapping the template built, mapped to the field names that
+    # mapping was written with. Answers both `{% for name in by_name %}` walking keys
+    # and whether a get/pop default can be reached.
+    mappings: dict = field(default_factory = dict)
     # Set when the path hit break, so a literal loop stops simulating further items
     # for it. `continue` only ends the current iteration, so it is tracked apart:
     # the path skips the rest of the body but still sees the next item.
@@ -250,7 +251,7 @@ def _signature(state):
         frozenset(state.constructed),
         frozenset((name, repr(value)) for name, value in state.consts.items()),
         frozenset(state.origins.items()),
-        frozenset(state.mappings),
+        frozenset((name, members) for name, members in state.mappings.items()),
         state.terminated,
         state.continued,
     )
@@ -450,7 +451,7 @@ def _known_empty(node, state):
     return _constant_truth(inner, state) is False
 
 
-def _raises(node):
+def _raises(node, state = None):
     """Whether evaluating this expression always reaches `raise_exception`.
 
     Only the positions certain to be evaluated: the left operand that `and` and `or`
@@ -465,17 +466,34 @@ def _raises(node):
     ):
         return True
     if isinstance(node, (nodes.And, nodes.Or)):
-        return _raises(node.left)
+        return _raises(node.left, state)
     if isinstance(node, (nodes.Filter, nodes.Not)) and node.node is not None:
-        return _raises(node.node)
+        return _raises(node.node, state)
     if isinstance(node, nodes.Concat):
-        return any(_raises(item) for item in node.nodes)
+        return any(_raises(item, state) for item in node.nodes)
     if isinstance(node, nodes.Call):
         # Arguments are evaluated before the call, so one that raises aborts it.
-        return any(_raises(argument) for argument in node.args) or any(
-            _raises(keyword.value) for keyword in node.kwargs
-        )
+        if any(_raises(argument, state) for argument in node.args) or any(
+            _raises(keyword.value, state) for keyword in node.kwargs
+        ):
+            return True
+        # A macro whose body raises unconditionally aborts wherever it is invoked.
+        if state is not None and isinstance(node.node, nodes.Name):
+            return any(
+                _always_raises(macro.body, state)
+                for macro in _macro_group(state.macros.get(node.node.name))
+            )
     return False
+
+
+def _always_raises(body, state):
+    """Whether every render of this body reaches a raise. Only statements that always
+    run count, so a raise inside an `{% if %}` does not."""
+    return any(
+        isinstance(statement, nodes.Output)
+        and any(_raises(value, state) for value in statement.nodes)
+        for statement in body
+    )
 
 
 def _is_payload(node):
@@ -582,7 +600,24 @@ def _value_aliases(value, state, active):
             for keyword in value.kwargs:
                 _replace(result, (keyword.key,), _value_aliases(keyword.value, state, active))
             return result
-        macro = state.macros.get(value.node.name)
+        group = _macro_group(state.macros.get(value.node.name))
+        if len(group) > 1:
+            # `{% set render = plain if flag else show %}` could be either, so the
+            # catalog counts if ANY of them renders it.
+            return set().union(
+                *(
+                    _value_aliases(
+                        nodes.Call(
+                            nodes.Name(candidate.name, "load"), value.args, value.kwargs, None, None
+                        ),
+                        _with_macro(state, value.node.name, candidate),
+                        active,
+                    )
+                    for candidate in group
+                ),
+                set(),
+            )
+        macro = group[0] if group else None
         if macro is not None:
             if active.count(macro.name) >= _RECURSION_LIMIT:
                 # Deep enough. A macro that recurses without bound renders nothing
@@ -654,10 +689,13 @@ def _value_aliases(value, state, active):
                 exported = _export_scope(state, child)
                 merged |= exported.aliases
                 state.mutated.update(exported.mutated)
-                state.facts = exported.facts
             if children:
                 state.aliases.clear()
                 state.aliases.update(merged)
+                # The macro's own facts are deliberately NOT carried out. Keeping one
+                # child's facts alongside every child's aliases pairs a mutation made
+                # under one condition with a different condition, which no render
+                # takes. The caller's facts already describe what holds out here.
             return {()} if emits else set()
     # Other expressions serialize or transform their inputs.
     return (
@@ -702,10 +740,11 @@ def _bind(
             if isinstance(value, (nodes.Name, nodes.Getattr, nodes.Getitem))
             else None
         )
-        if isinstance(value, nodes.Dict):
-            state.mappings.add(key)
+        members = _mapping_keys(value)
+        if members is None:
+            state.mappings.pop(key, None)
         else:
-            state.mappings.discard(key)
+            state.mappings[key] = members
         if isinstance(value, nodes.Const):
             # `{% set ns.role = 'tool' %}` writes a literal, so the field is the
             # template's own and a role check on it means nothing.
@@ -746,14 +785,31 @@ def _bind(
         # `{% set render = show %}` hands the name the macro, so calling it runs the
         # same body. _bind_paths has already dropped any macro under this name.
         # A conditional picks one of its arms, and either may be a macro.
-        for candidate in _macro_sources(value):
-            macro = state.macros.get(candidate)
-            if macro is not None:
-                state.macros[target.name] = macro
-                break
+        selected = tuple(
+            macro
+            for candidate in _macro_sources(value)
+            for macro in _macro_group(state.macros.get(candidate))
+        )
+        if selected:
+            state.macros[target.name] = selected if len(selected) > 1 else selected[0]
     truth = _constant_truth(value, source) if value is not None else None
     if isinstance(target, nodes.Name) and truth is not None:
         state.facts[repr(nodes.Name(target.name, "load"))] = (truth, {target.name})
+
+
+def _with_macro(state, name, macro):
+    """The same state with one macro table entry narrowed to a single candidate."""
+    narrowed = state.copy()
+    narrowed.macros[name] = macro
+    narrowed.macros[macro.name] = macro
+    return narrowed
+
+
+def _macro_group(entry):
+    """A macro table entry as a tuple: an expression may have selected several."""
+    if entry is None:
+        return ()
+    return entry if isinstance(entry, tuple) else (entry,)
 
 
 def _macro_sources(value):
@@ -840,6 +896,9 @@ def _mutate(call, state, active):
     if key is None:
         return
     method = call.node.attr
+    if method in _SCALAR_RETURNING_METHODS:
+        # `catalog.count(x)` reads the receiver and answers a number: nothing moves.
+        return
     positional = {suffix for arg in call.args for suffix in _value_aliases(arg, state, active)}
     if method == "update":
         # An update REPLACES the fields it names, so whatever they held before is
@@ -940,6 +999,25 @@ def _unknown_callee(call, state):
     return not (isinstance(call.node, nodes.Name) and call.node.name in state.macros)
 
 
+def _mapping_keys(value):
+    """The field names a mapping literal was written with, or None if this is not one.
+
+    Every written key counts, including one whose value came from outside: what makes
+    a `get`/`pop` default unreachable is the key being THERE, not what it holds.
+    """
+    if isinstance(value, nodes.Dict):
+        return frozenset(
+            pair.key.value for pair in value.items if isinstance(pair.key, nodes.Const)
+        )
+    if (
+        isinstance(value, nodes.Call)
+        and isinstance(value.node, nodes.Name)
+        and value.node.name == "dict"
+    ):
+        return frozenset(keyword.key for keyword in value.kwargs)
+    return None
+
+
 def _definitely_has(node, member, state):
     """Whether the receiver is a literal this template built that visibly holds
     `member`, so a `get`/`pop` default can never be reached."""
@@ -950,7 +1028,11 @@ def _definitely_has(node, member, state):
             isinstance(pair.key, nodes.Const) and pair.key.value == member for pair in node.items
         )
     key = _reference_key(node)
-    return key is not None and key in state.constructed and (*key, member) in state.constructed
+    if key is None:
+        return False
+    if member in state.mappings.get(key, ()):
+        return True
+    return key in state.constructed and (*key, member) in state.constructed
 
 
 def _removed_key(method, call):
@@ -1137,7 +1219,7 @@ def _scan(
                 # does not, and a mutating call lands before the next statement.
                 aborted = False
                 for value in node.nodes:
-                    if _raises(value):
+                    if _raises(value, current):
                         # Checked first: the raise happens before this expression's
                         # own payload would be rendered, not after it.
                         _mutate(value, current, active)
@@ -1200,7 +1282,15 @@ def _scan(
                 # cannot execute does not drag the block in with it.
                 invoked = current.copy()
                 invoked.macros["caller"] = nodes.Macro("caller", [], [], node.body)
-                if _value_aliases(node.call, invoked, active):
+                emitted = _value_aliases(node.call, invoked, active)
+                # The macro ran, so whatever it wrote to an outer namespace escapes,
+                # exactly as it does for a plain call.
+                if invoked.mutated - current.mutated:
+                    carried = _export_scope(current, invoked)
+                    current.aliases.clear()
+                    current.aliases.update(carried.aliases)
+                    current.mutated.update(carried.mutated)
+                if emitted:
                     return True, []
                 if _unknown_callee(node.call, current):
                     emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded, rest)
@@ -1214,6 +1304,8 @@ def _scan(
                     if emits:
                         return True, []
             elif isinstance(node, nodes.AssignBlock):
+                # `{% set catalog|length %}` binds the filtered result, so a filter
+                # that keeps nothing of the catalog leaves nothing to find.
                 emits, captured = _scan(node.body, current.copy(scoped = True), active, guarded, rest)
                 # Jinja keeps a namespace write made inside the capture, so the
                 # escaping mutations are exported before the target is bound.
@@ -1225,7 +1317,8 @@ def _scan(
                 if captured:
                     current.aliases.clear()
                     current.aliases.update(escaped)
-                _bind_paths(node.target, {()} if emits else set(), current)
+                kept = emits and _keeps_content(node.filter)
+                _bind_paths(node.target, {()} if kept else set(), current)
             elif isinstance(node, nodes.With):
                 local = current.copy(scoped = True)
                 for target, value in zip(node.targets, node.values):

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -423,11 +423,7 @@ def _value_aliases(value, state, active):
         if value.node.attr == "copy" and not value.args and not value.kwargs:
             return _value_aliases(value.node.node, state, active)
         if value.node.attr == "get" and value.args:
-            member = (
-                value.args[0].value
-                if isinstance(value.args[0], nodes.Const)
-                else _UNKNOWN
-            )
+            member = value.args[0].value if isinstance(value.args[0], nodes.Const) else _UNKNOWN
             result = _select(_value_aliases(value.node.node, state, active), member)
             # The default is what a missing field falls back to, so it counts too.
             for fallback in value.args[1:]:

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -99,7 +99,7 @@ def _reading_call(node):
         isinstance(node, nodes.Call)
         and isinstance(node.node, nodes.Getattr)
         and node.node.attr == "get"
-        and len(node.args) == 1
+        and len(node.args) in (1, 2)
         and not node.kwargs
     )
 
@@ -114,11 +114,34 @@ def _origin_field(node, state):
     return _UNKNOWN
 
 
+def _literal_length(node):
+    """How many items a literal sequence has, or None when that is not known here."""
+    if isinstance(node, (nodes.List, nodes.Tuple)):
+        return len(node.items)
+    return None
+
+
+def _index_value(node):
+    """A subscript written as a literal, including the negated form `[-1]`."""
+    if isinstance(node, nodes.Const):
+        return node.value
+    if isinstance(node, nodes.Neg) and isinstance(node.node, nodes.Const):
+        value = node.node.value
+        return -value if isinstance(value, int) and not isinstance(value, bool) else None
+    return None
+
+
 def _field(node):
     if isinstance(node, nodes.Getattr):
         return node.attr
-    if isinstance(node, nodes.Getitem) and isinstance(node.arg, nodes.Const):
-        return node.arg.value
+    if isinstance(node, nodes.Getitem):
+        index = _index_value(node.arg)
+        if index is not None:
+            if isinstance(index, int) and index < 0:
+                # Counts from the end, so it needs the length to become a position.
+                length = _literal_length(node.node)
+                return _UNKNOWN if length is None or -index > length else length + index
+            return index
     if _reading_call(node):
         return node.args[0].value if isinstance(node.args[0], nodes.Const) else _UNKNOWN
     return _UNKNOWN
@@ -628,6 +651,9 @@ def _value_aliases(value, state, active):
             paths = _value_aliases(value.node.node, state, active)
             tail = (1,) if value.node.attr == "items" else ()
             return {(_UNKNOWN, *tail, *suffix[1:]) for suffix in paths if suffix}
+        if _reading_call(value):
+            if _field(value) == "tool_calls" and not _template_built(value, state):
+                return {()}
         if value.node.attr == "get" and value.args:
             member = value.args[0].value if isinstance(value.args[0], nodes.Const) else _UNKNOWN
             result = _select(_value_aliases(value.node.node, state, active), member)
@@ -1176,9 +1202,11 @@ def _scan_if(node, state, active, guarded, tail):
             next_remaining.extend(_assume(branch.test, False, current))
         remaining = next_remaining
     for current in remaining:
-        # With an elif in the chain the else arm is reached for more than one
-        # reason, so only a plain if/else carries the negated guard across.
-        else_guarded = guarded or (not node.elif_ and _negated_guard(node.test, current))
+        # The else arm runs only when EVERY test was false, so if the negation of any
+        # of them means the catalog is present, the arm is guarded by it.
+        else_guarded = guarded or any(
+            _negated_guard(branch.test, current) for branch in [node, *node.elif_]
+        )
         emits, states = _scan(node.else_, current, active, else_guarded, tail)
         if emits:
             return True, []
@@ -1287,7 +1315,10 @@ def _scan_loop(node, state, active, guarded, tail):
         if emits:
             return True, []
         states.extend(_export_scope(entry, child) for child in children)
-    return False, states + finished
+    # `finished` is not added back: each parked path is already represented by what
+    # came out of the else arm it went on to run. Keeping both leaves the pre-else
+    # state alive alongside the state that arm produced.
+    return False, states
 
 
 def _scan(
@@ -1342,6 +1373,9 @@ def _scan(
                 # macro, so it is evaluated for the state it leaves behind.
                 _value_aliases(node.node, current, active)
                 _mutate(node.node, current, active)
+                if _raises(node.node, current):
+                    # Same as the output form: nothing after this runs on this path.
+                    continue
             elif isinstance(node, nodes.Macro):
                 current.macros[node.name] = node
                 # The declaration binds the name, so `{% macro tools() %}` shadows the

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -60,10 +60,11 @@ class _State:
     # Names bound straight to a field of something else, so `{% set role =
     # message.role %}` still reads as a role check when the comparison uses `role`.
     origins: dict = field(default_factory = dict)
-    # Keys holding a mapping the template built, mapped to the field names that
-    # mapping was written with. Answers both `{% for name in by_name %}` walking keys
-    # and whether a get/pop default can be reached.
-    mappings: dict = field(default_factory = dict)
+    # Keys holding a literal the template wrote, mapped to that literal's node. One
+    # record answers three questions: is this a mapping (so a loop walks its keys),
+    # which keys does it have (so a get/pop default may be unreachable), and is it
+    # empty (so a loop over it never runs).
+    literals: dict = field(default_factory = dict)
     # Set when the path hit break, so a literal loop stops simulating further items
     # for it. `continue` only ends the current iteration, so it is tracked apart:
     # the path skips the rest of the body but still sees the next item.
@@ -81,7 +82,7 @@ class _State:
             self.constructed.copy(),
             self.consts.copy(),
             self.origins.copy(),
-            self.mappings.copy(),
+            self.literals.copy(),
             self.terminated,
             self.continued,
             self.budget,
@@ -237,6 +238,11 @@ def _assume(node, truth, state):
         ]
     result = state.copy()
     result.facts[repr(node)] = (truth, _names(node))
+    # `{% if tools == [] %}` and `{% if tools is none %}` prove the catalog itself
+    # falsy on the taken branch, which is what tells an emission of it apart from a
+    # real schema. Recorded against the reference, not only the whole condition.
+    for reference in _proves_empty(node):
+        result.facts[repr(reference)] = (not truth, _names(reference))
     return [result]
 
 
@@ -251,7 +257,7 @@ def _signature(state):
         frozenset(state.constructed),
         frozenset((name, repr(value)) for name, value in state.consts.items()),
         frozenset(state.origins.items()),
-        frozenset((name, members) for name, members in state.mappings.items()),
+        frozenset((name, id(node)) for name, node in state.literals.items()),
         state.terminated,
         state.continued,
     )
@@ -284,6 +290,20 @@ def _collapse(states, live):
     return list(seen.values()) if len(seen) < len(states) else states
 
 
+def _proves_empty(node):
+    """References this condition shows to be empty when it holds."""
+    if isinstance(node, nodes.Test) and node.name in ("none", "undefined"):
+        return [node.node] if isinstance(node.node, (nodes.Name, nodes.Getattr)) else []
+    if isinstance(node, nodes.Compare) and len(node.ops) == 1 and node.ops[0].op == "eq":
+        for left, right in (
+            (node.expr, node.ops[0].expr),
+            (node.ops[0].expr, node.expr),
+        ):
+            if isinstance(left, (nodes.Name, nodes.Getattr)) and _empty_literal(right):
+                return [left]
+    return []
+
+
 def _forget(key, state):
     state.facts = {
         expression: fact for expression, fact in state.facts.items() if key[0] not in fact[1]
@@ -301,6 +321,11 @@ def _select(paths, member):
 def _empty_slice(node):
     """`tools[0:0]` renders an empty list whatever the catalog holds."""
     if not (isinstance(node, nodes.Getitem) and isinstance(node.arg, nodes.Slice)):
+        return False
+    if node.arg.step is not None and not (
+        isinstance(node.arg.step, nodes.Const) and node.arg.step.value > 0
+    ):
+        # A negative or unknown step reverses or unsettles the ordering below.
         return False
     start, stop = node.arg.start, node.arg.stop
     start_value = 0 if start is None else (start.value if isinstance(start, nodes.Const) else None)
@@ -348,11 +373,23 @@ def _negated_guard(node, state):
         return True
     if isinstance(node, nodes.Test) and node.name in ("none", "undefined"):
         return _tool_reference(node.node, state)
-    if isinstance(node, nodes.Compare) and len(node.ops) == 1 and node.ops[0].op == "eq":
-        return any(
-            (_tool_reference(a, state) or _counts_tools(a, state)) and _empty_literal(b)
-            for a, b in ((node.expr, node.ops[0].expr), (node.ops[0].expr, node.expr))
-        )
+    if isinstance(node, nodes.Compare) and len(node.ops) == 1:
+        operand = node.ops[0]
+        if operand.op == "eq":
+            return any(
+                (_tool_reference(a, state) or _counts_tools(a, state)) and _empty_literal(b)
+                for a, b in ((node.expr, operand.expr), (operand.expr, node.expr))
+            )
+        if operand.op == "ne":
+            # `{% if message.role != 'tool' %}plain{% else %}...` is the same role
+            # check with its arms the other way round.
+            return any(
+                (_field(role) == "role" or _origin_field(role, state) == "role")
+                and not _template_built(role, state)
+                and (literal := _as_const(value, state)) is not None
+                and literal.value == "tool"
+                for role, value in ((node.expr, operand.expr), (operand.expr, node.expr))
+            )
     return False
 
 
@@ -471,6 +508,10 @@ def _raises(node, state = None):
         return _raises(node.node, state)
     if isinstance(node, nodes.Concat):
         return any(_raises(item, state) for item in node.nodes)
+    if isinstance(node, (nodes.List, nodes.Tuple)):
+        return any(_raises(item, state) for item in node.items)
+    if isinstance(node, nodes.Dict):
+        return any(_raises(pair.key, state) or _raises(pair.value, state) for pair in node.items)
     if isinstance(node, nodes.Call):
         # Arguments are evaluated before the call, so one that raises aborts it.
         if any(_raises(argument, state) for argument in node.args) or any(
@@ -499,7 +540,7 @@ def _always_raises(body, state):
 def _is_payload(node):
     if isinstance(node, (nodes.Not, nodes.Test, nodes.Compare)):
         return False
-    if isinstance(node, nodes.Filter) and node.name in ("length", "count"):
+    if isinstance(node, nodes.Filter) and not _keeps_content(node):
         return False
     if isinstance(node, nodes.TemplateData):
         return bool(node.data.strip())
@@ -581,6 +622,12 @@ def _value_aliases(value, state, active):
         # the fallback reads `copy` as a data field and loses everything under it.
         if value.node.attr == "copy" and not value.args and not value.kwargs:
             return _value_aliases(value.node.node, state, active)
+        if value.node.attr in ("values", "items") and not value.args:
+            # A view over the mapping's values: the key is gone, the position is
+            # unknown, and items() wraps each value as the second half of a pair.
+            paths = _value_aliases(value.node.node, state, active)
+            tail = (1,) if value.node.attr == "items" else ()
+            return {(_UNKNOWN, *tail, *suffix[1:]) for suffix in paths if suffix}
         if value.node.attr == "get" and value.args:
             member = value.args[0].value if isinstance(value.args[0], nodes.Const) else _UNKNOWN
             result = _select(_value_aliases(value.node.node, state, active), member)
@@ -740,11 +787,14 @@ def _bind(
             if isinstance(value, (nodes.Name, nodes.Getattr, nodes.Getitem))
             else None
         )
-        members = _mapping_keys(value)
-        if members is None:
-            state.mappings.pop(key, None)
+        literal = value if _is_literal(value) else None
+        if literal is None and isinstance(value, nodes.Name):
+            # `{% set b = a %}` is the same object, so it is the same literal.
+            literal = state.literals.get((value.name,))
+        if literal is None:
+            state.literals.pop(key, None)
         else:
-            state.mappings[key] = members
+            state.literals[key] = literal
         if isinstance(value, nodes.Const):
             # `{% set ns.role = 'tool' %}` writes a literal, so the field is the
             # template's own and a role check on it means nothing.
@@ -805,6 +855,22 @@ def _with_macro(state, name, macro):
     return narrowed
 
 
+def _indexed_member(value):
+    """The member a constant subscript of a literal collection selects, or None."""
+    if not isinstance(value.arg, nodes.Const):
+        return None
+    if isinstance(value.node, (nodes.List, nodes.Tuple)):
+        index = value.arg.value
+        if isinstance(index, int) and -len(value.node.items) <= index < len(value.node.items):
+            return value.node.items[index]
+        return None
+    if isinstance(value.node, nodes.Dict):
+        for pair in value.node.items:
+            if isinstance(pair.key, nodes.Const) and pair.key.value == value.arg.value:
+                return pair.value
+    return None
+
+
 def _macro_group(entry):
     """A macro table entry as a tuple: an expression may have selected several."""
     if entry is None:
@@ -827,7 +893,11 @@ def _macro_sources(value):
     if isinstance(value, (nodes.List, nodes.Tuple)):
         return [name for item in value.items for name in _macro_sources(item)]
     if isinstance(value, nodes.Getitem):
-        # `{% set render = [show][0] %}`: a lookup table of formatters.
+        # `{% set render = [show][0] %}`: a lookup table of formatters. A constant
+        # index picks one entry, so the others are not callees at all.
+        chosen = _indexed_member(value)
+        if chosen is not None:
+            return _macro_sources(chosen)
         return _macro_sources(value.node)
     if isinstance(value, nodes.Dict):
         return [name for pair in value.items for name in _macro_sources(pair.value)]
@@ -949,9 +1019,12 @@ def _mutate(call, state, active):
     if method != "clear" and removed is None and not paths:
         return
     if method == "clear" or removed is _UNKNOWN:
+        state.literals.pop(key, None)
         _replace(state.aliases, key, set())
     elif removed is not None:
-        # pop/remove/discard take the value back out, so its provenance goes too.
+        # pop/remove/discard take the value back out, so its provenance goes too, and
+        # the record of which keys this literal has is no longer accurate.
+        state.literals.pop(key, None)
         _replace(state.aliases, (*key, removed), set())
         if isinstance(removed, int) and not isinstance(removed, bool):
             # A list closes the gap, so everything after the hole moves down one.
@@ -999,6 +1072,18 @@ def _unknown_callee(call, state):
     return not (isinstance(call.node, nodes.Name) and call.node.name in state.macros)
 
 
+def _dict_call(value):
+    return (
+        isinstance(value, nodes.Call)
+        and isinstance(value.node, nodes.Name)
+        and value.node.name == "dict"
+    )
+
+
+def _is_literal(value):
+    return isinstance(value, (nodes.Dict, nodes.List, nodes.Tuple)) or _dict_call(value)
+
+
 def _mapping_keys(value):
     """The field names a mapping literal was written with, or None if this is not one.
 
@@ -1009,13 +1094,15 @@ def _mapping_keys(value):
         return frozenset(
             pair.key.value for pair in value.items if isinstance(pair.key, nodes.Const)
         )
-    if (
-        isinstance(value, nodes.Call)
-        and isinstance(value.node, nodes.Name)
-        and value.node.name == "dict"
-    ):
+    if _dict_call(value):
         return frozenset(keyword.key for keyword in value.kwargs)
     return None
+
+
+def _is_empty_literal(value):
+    if _dict_call(value):
+        return not value.kwargs and not value.args
+    return _is_literal(value) and not value.items
 
 
 def _definitely_has(node, member, state):
@@ -1030,9 +1117,9 @@ def _definitely_has(node, member, state):
     key = _reference_key(node)
     if key is None:
         return False
-    if member in state.mappings.get(key, ()):
-        return True
-    return key in state.constructed and (*key, member) in state.constructed
+    # Only the literals record: `constructed` also holds members of literals that a
+    # destructive call has since emptied, which would answer this stale.
+    return member in (_mapping_keys(state.literals.get(key)) or ())
 
 
 def _removed_key(method, call):
@@ -1071,6 +1158,10 @@ def _scan_if(node, state, active, guarded, tail):
     for branch in [node, *node.elif_]:
         next_remaining = []
         for current in remaining:
+            # Evaluating the condition runs whatever is in it - a mutator, or a macro
+            # that writes to an outer namespace - before either arm is chosen.
+            _value_aliases(branch.test, current, active)
+            _mutate(branch.test, current, active)
             for positive in _assume(branch.test, True, current):
                 emits, states = _scan(
                     branch.body,
@@ -1101,13 +1192,18 @@ def _scan_loop(node, state, active, guarded, tail):
     inner_tail = tail | _names(node)
     literal = isinstance(node.iter, (nodes.List, nodes.Tuple))
     values = node.iter.items if literal else [None]
+    if not literal:
+        # `{% set xs = [] %}{% for x in xs %}` never runs its body either.
+        bound = state.literals.get(_reference_key(node.iter))
+        if bound is not None and _is_empty_literal(bound):
+            literal, values = True, []
     states = [state]
     finished = []
     if not values:
         emits, children = _scan(node.else_, state.copy(scoped = True), active, guarded, inner_tail)
         return emits, [_export_scope(state, child) for child in children]
     else_reachable = True
-    for value in values:
+    for position, value in enumerate(values):
         results = []
         for parent in states:
             local = parent.copy(scoped = True)
@@ -1115,8 +1211,8 @@ def _scan_loop(node, state, active, guarded, tail):
                 # `{% for key in {'x': tools} %}` walks the keys, not the values, so
                 # nothing under the mapping reaches the target. The mapping may have
                 # been given a name first, which `state.mappings` records.
-                over_keys = isinstance(node.iter, nodes.Dict) or (
-                    _reference_key(node.iter) in parent.mappings
+                over_keys = _mapping_keys(node.iter) is not None or (
+                    _mapping_keys(parent.literals.get(_reference_key(node.iter))) is not None
                 )
                 _bind_paths(
                     node.target,
@@ -1136,7 +1232,6 @@ def _scan_loop(node, state, active, guarded, tail):
                 # loop.first %}` never runs its body. With a filter the position
                 # describes the accepted sequence, not the source, so it stays
                 # unknown rather than being read off the source index.
-                position = values.index(value)
                 for member, truth in (
                     ("first", position == 0),
                     ("last", position == len(values) - 1),
@@ -1299,10 +1394,18 @@ def _scan(
             elif isinstance(node, nodes.FilterBlock):
                 # The block's own filter decides what survives: `{% filter first %}`
                 # emits one character of the catalog, which is no schema at all.
-                if _keeps_content(node.filter):
-                    emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded, rest)
-                    if emits:
-                        return True, []
+                filtered, produced = _scan(
+                    node.body, current.copy(scoped = True), active, guarded, rest
+                )
+                # The body runs whatever the filter then does with its output, so
+                # namespace writes inside it escape.
+                for child in produced:
+                    exported = _export_scope(current, child)
+                    current.aliases.clear()
+                    current.aliases.update(exported.aliases)
+                    current.mutated.update(exported.mutated)
+                if filtered and _keeps_content(node.filter):
+                    return True, []
             elif isinstance(node, nodes.AssignBlock):
                 # `{% set catalog|length %}` binds the filtered result, so a filter
                 # that keeps nothing of the catalog leaves nothing to find.

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -23,6 +23,17 @@ _UNKNOWN = object()
 
 # In-place mutators: `{{ catalog.append(tools) }}` renders "None", so the argument
 # reaches the receiver but never the output.
+# Methods whose result is a number, so nothing of the receiver or the arguments
+# survives into the rendered value. The `length` and `count` FILTERS are already
+# excluded by `_is_payload`; these are the method spellings.
+_SCALAR_RETURNING_METHODS = frozenset({"count", "index"})
+
+# How many nested activations of one macro to simulate. A schema formatter that
+# recurses over nested parameter objects reaches its catalog a level or two down, and
+# refusing at the first repeat reported those templates as tool-less. The step budget
+# is what stops this from being expensive.
+_RECURSION_LIMIT = 3
+
 _MUTATORS_RETURNING_NONE = frozenset(
     {"append", "extend", "insert", "update", "add", "clear", "sort", "reverse", "discard"}
 )
@@ -283,13 +294,16 @@ def _select(paths, member):
 
 def _template_built(node, state):
     """The member-name shortcuts below read a field off an untracked value, so they
-    only mean anything when the base is one. A base the template constructed is
-    tracked, and its provenance already lives in `aliases`."""
-    if isinstance(node, nodes.Name):
-        origin = state.origins.get(node.name)
-        return origin is not None and origin[:-1] in state.constructed
-    base = node.node.node if _reading_call(node) else node.node
-    return _reference_key(base) in state.constructed
+    only mean anything when the field is one the template wrote itself.
+
+    Asked of the field rather than its container: `{% set ns = namespace() %}
+    {% set ns.role = message.role %}` leaves ns template-built but ns.role external,
+    and the role check on it has to count.
+    """
+    key = state.origins.get(node.name) if isinstance(node, nodes.Name) else _reference_key(node)
+    if key is None or len(key) < 2:
+        return False
+    return key[:-1] in state.constructed and key in state.constructed
 
 
 def _tool_reference(node, state):
@@ -416,12 +430,26 @@ def _known_empty(node, state):
 
 
 def _raises(node):
-    """`{{ raise_exception(...) }}` aborts the render, so the path stops here."""
-    return (
+    """Whether evaluating this expression always reaches `raise_exception`.
+
+    Only the positions certain to be evaluated: the left operand that `and` and `or`
+    short-circuit on, the input of a filter, and every part of a concatenation.
+    `{{ tools|tojson or raise_exception(...) }}` does NOT raise when the catalog is
+    present, so a right operand does not count.
+    """
+    if (
         isinstance(node, nodes.Call)
         and isinstance(node.node, nodes.Name)
         and node.node.name == "raise_exception"
-    )
+    ):
+        return True
+    if isinstance(node, (nodes.And, nodes.Or)):
+        return _raises(node.left)
+    if isinstance(node, (nodes.Filter, nodes.Not)) and node.node is not None:
+        return _raises(node.node)
+    if isinstance(node, nodes.Concat):
+        return any(_raises(item) for item in node.nodes)
+    return False
 
 
 def _is_payload(node):
@@ -467,10 +495,14 @@ def _value_aliases(value, state, active):
     if isinstance(value, nodes.CondExpr):
         return set().union(
             *(
-                _value_aliases(expression, branch, active)
+                set()
+                if _known_empty(expression, branch)
+                else _value_aliases(expression, branch, active)
                 for expression, truth in ((value.expr1, True), (value.expr2, False))
+                if expression is not None
                 for branch in _assume(value.test, truth, state)
-            )
+            ),
+            set(),
         )
     if isinstance(value, nodes.And):
         return set().union(
@@ -514,7 +546,7 @@ def _value_aliases(value, state, active):
             return result
         # append/extend/update and the other in-place mutators return None: the data
         # goes into the receiver, not into the rendered result.
-        if value.node.attr in _MUTATORS_RETURNING_NONE:
+        if value.node.attr in _MUTATORS_RETURNING_NONE | _SCALAR_RETURNING_METHODS:
             return set()
     if isinstance(value, nodes.Call) and isinstance(value.node, nodes.Name):
         if value.node.name in ("namespace", "dict"):
@@ -524,7 +556,9 @@ def _value_aliases(value, state, active):
             return result
         macro = state.macros.get(value.node.name)
         if macro is not None:
-            if macro.name in active:
+            if active.count(macro.name) >= _RECURSION_LIMIT:
+                # Deep enough. A macro that recurses without bound renders nothing
+                # either, so giving up here costs only unbounded recursion.
                 return set()
             local = state.copy(scoped = True)
             parameters = [argument.name for argument in macro.args]
@@ -577,7 +611,7 @@ def _value_aliases(value, state, active):
                     )
             _replace(local.aliases, ("kwargs",), extra_keywords)
             # The macro's own names stay live: nothing outside it constrains its body.
-            emits, children = _scan(macro.body, local, active | {macro.name}, tail = _names(macro))
+            emits, children = _scan(macro.body, local, (*active, macro.name), tail = _names(macro))
             # A namespace write inside a macro escapes it, so the caller sees it:
             # {% macro load() %}{% set ns.catalog = tools %}{% endmacro %}{{ load() }}
             # leaves the catalog in ns. _export_scope already knows which of a
@@ -640,7 +674,11 @@ def _bind(
             if isinstance(value, (nodes.Name, nodes.Getattr, nodes.Getitem))
             else None
         )
-        if _constructs_object(value):
+        if isinstance(value, nodes.Const):
+            # `{% set ns.role = 'tool' %}` writes a literal, so the field is the
+            # template's own and a role check on it means nothing.
+            state.constructed.add(key)
+        elif _constructs_object(value):
             # The replacement populates its own members, so the old subtree goes
             # first: otherwise `{% set w={'message': message} %}` keeps the previous
             # literal's `w.message` marked template-built while it now holds input.
@@ -675,11 +713,30 @@ def _bind(
             state.origins.pop(target.name, None)
         # `{% set render = show %}` hands the name the macro, so calling it runs the
         # same body. _bind_paths has already dropped any macro under this name.
-        if isinstance(value, nodes.Name) and value.name in state.macros:
-            state.macros[target.name] = state.macros[value.name]
+        # A conditional picks one of its arms, and either may be a macro.
+        for candidate in _macro_sources(value):
+            macro = state.macros.get(candidate)
+            if macro is not None:
+                state.macros[target.name] = macro
+                break
     truth = _constant_truth(value, source) if value is not None else None
     if isinstance(target, nodes.Name) and truth is not None:
         state.facts[repr(nodes.Name(target.name, "load"))] = (truth, {target.name})
+
+
+def _macro_sources(value):
+    """The names an assigned expression could evaluate to, for carrying a macro across
+    `{% set render = show %}` and `{% set render = show if flag else other %}`."""
+    if isinstance(value, nodes.Name):
+        return [value.name]
+    if isinstance(value, nodes.CondExpr):
+        return [
+            name
+            for arm in (value.expr1, value.expr2)
+            if arm is not None
+            for name in _macro_sources(arm)
+        ]
+    return []
 
 
 def _mark_constructed(key, value, state):
@@ -798,6 +855,20 @@ def _mutate(call, state, active):
     elif removed is not None:
         # pop/remove/discard take the value back out, so its provenance goes too.
         _replace(state.aliases, (*key, removed), set())
+        if isinstance(removed, int) and not isinstance(removed, bool):
+            # A list closes the gap, so everything after the hole moves down one.
+            shifted = {
+                alias
+                for alias in state.aliases
+                if alias[: len(key)] == key
+                and len(alias) > len(key)
+                and isinstance(alias[len(key)], int)
+                and alias[len(key)] > removed
+            }
+            state.aliases.difference_update(shifted)
+            state.aliases.update(
+                (*key, alias[len(key)] - 1, *alias[len(key) + 1 :]) for alias in shifted
+            )
     else:
         state.aliases.update((*key, *suffix) for suffix in paths)
     if key[0] not in state.assigned:
@@ -986,11 +1057,17 @@ def _scan_loop(node, state, active, guarded, tail):
     # A filter can reject every item of a literal iterable, in which case the body
     # never runs and Jinja takes the else. Only an unfiltered literal is guaranteed
     # to iterate.
-    if not literal or (node.test is not None and else_reachable) or finished:
-        emits, children = _scan(node.else_, state.copy(scoped = True), active, guarded, inner_tail)
+    # An else arm reached after a break must see the mutations that path already made,
+    # so it is scanned from each parked state as well as from the pre-loop one.
+    entries = []
+    if not literal or (node.test is not None and else_reachable):
+        entries.append(state)
+    entries.extend(finished)
+    for entry in entries:
+        emits, children = _scan(node.else_, entry.copy(scoped = True), active, guarded, inner_tail)
         if emits:
             return True, []
-        states.extend(_export_scope(state, child) for child in children)
+        states.extend(_export_scope(entry, child) for child in children)
     return False, states + finished
 
 
@@ -1018,6 +1095,12 @@ def _scan(
                 # does not, and a mutating call lands before the next statement.
                 aborted = False
                 for value in node.nodes:
+                    if _raises(value):
+                        # Checked first: the raise happens before this expression's
+                        # own payload would be rendered, not after it.
+                        _mutate(value, current, active)
+                        aborted = True
+                        break
                     if (
                         _is_payload(value)
                         and (guarded or _value_aliases(value, current, active))
@@ -1025,9 +1108,6 @@ def _scan(
                     ):
                         return True, []
                     _mutate(value, current, active)
-                    if _raises(value):
-                        aborted = True
-                        break
                 if aborted:
                     # The render stops here, so this path reaches no later output.
                     continue
@@ -1140,7 +1220,7 @@ def _analyse_template(template: str) -> bool:
         return False
     try:
         tree = _ENVIRONMENT.parse(template)
-        emits, _ = _scan(tree.body, _State({("tools",), ("tool_calls",)}), set())
+        emits, _ = _scan(tree.body, _State({("tools",), ("tool_calls",)}), ())
         return emits
     except Exception:
         # Fail closed. Besides the expected TemplateSyntaxError and _AnalysisLimit, a

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -106,11 +106,7 @@ def _as_const(node, state):
     """The literal a node is known to be, either written out or bound to a name."""
     if isinstance(node, nodes.Const):
         return node
-    if (
-        state is not None
-        and isinstance(node, nodes.Name)
-        and node.name in state.consts
-    ):
+    if state is not None and isinstance(node, nodes.Name) and node.name in state.consts:
         return nodes.Const(state.consts[node.name])
     return None
 
@@ -131,10 +127,7 @@ def _constant_truth(node, state = None):
         if folded is not None and all(operand is not None for operand in operands):
             replacement = nodes.Compare(
                 folded,
-                [
-                    nodes.Operand(operand.op, value)
-                    for operand, value in zip(node.ops, operands)
-                ],
+                [nodes.Operand(operand.op, value) for operand, value in zip(node.ops, operands)],
             )
             try:
                 # The rebuilt node is synthetic, so it carries no environment of its
@@ -219,9 +212,7 @@ def _collapse(states, live):
     for state in states:
         if state.facts:
             state.facts = {
-                expression: fact
-                for expression, fact in state.facts.items()
-                if fact[1] & live
+                expression: fact for expression, fact in state.facts.items() if fact[1] & live
             }
         seen.setdefault(_signature(state), state)
     return list(seen.values()) if len(seen) < len(states) else states
@@ -456,9 +447,7 @@ def _value_aliases(value, state, active):
                     source = state if parameter.name in arguments else local.copy(),
                 )
             # The macro's own names stay live: nothing outside it constrains its body.
-            emits, children = _scan(
-                macro.body, local, active | {macro.name}, tail = _names(macro)
-            )
+            emits, children = _scan(macro.body, local, active | {macro.name}, tail = _names(macro))
             # A namespace write inside a macro escapes it, so the caller sees it:
             # {% macro load() %}{% set ns.catalog = tools %}{% endmacro %}{{ load() }}
             # leaves the catalog in ns. _export_scope already knows which of a

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -60,6 +60,9 @@ class _State:
     # Names bound straight to a field of something else, so `{% set role =
     # message.role %}` still reads as a role check when the comparison uses `role`.
     origins: dict = field(default_factory = dict)
+    # Keys holding a mapping the template built, so `{% for name in by_name %}` is
+    # known to walk its keys rather than its values.
+    mappings: set = field(default_factory = set)
     # Set when the path hit break, so a literal loop stops simulating further items
     # for it. `continue` only ends the current iteration, so it is tracked apart:
     # the path skips the rest of the body but still sees the next item.
@@ -77,6 +80,7 @@ class _State:
             self.constructed.copy(),
             self.consts.copy(),
             self.origins.copy(),
+            self.mappings.copy(),
             self.terminated,
             self.continued,
             self.budget,
@@ -246,6 +250,7 @@ def _signature(state):
         frozenset(state.constructed),
         frozenset((name, repr(value)) for name, value in state.consts.items()),
         frozenset(state.origins.items()),
+        frozenset(state.mappings),
         state.terminated,
         state.continued,
     )
@@ -290,6 +295,22 @@ def _select(paths, member):
         for suffix in paths
         if not suffix or member is _UNKNOWN or suffix[0] in (member, _UNKNOWN)
     }
+
+
+def _empty_slice(node):
+    """`tools[0:0]` renders an empty list whatever the catalog holds."""
+    if not (isinstance(node, nodes.Getitem) and isinstance(node.arg, nodes.Slice)):
+        return False
+    start, stop = node.arg.start, node.arg.stop
+    start_value = 0 if start is None else (start.value if isinstance(start, nodes.Const) else None)
+    stop_value = stop.value if isinstance(stop, nodes.Const) else None
+    return (
+        isinstance(start_value, int)
+        and isinstance(stop_value, int)
+        and start_value >= 0
+        and stop_value >= 0
+        and stop_value <= start_value
+    )
 
 
 def _template_built(node, state):
@@ -449,6 +470,11 @@ def _raises(node):
         return _raises(node.node)
     if isinstance(node, nodes.Concat):
         return any(_raises(item) for item in node.nodes)
+    if isinstance(node, nodes.Call):
+        # Arguments are evaluated before the call, so one that raises aborts it.
+        return any(_raises(argument) for argument in node.args) or any(
+            _raises(keyword.value) for keyword in node.kwargs
+        )
     return False
 
 
@@ -477,6 +503,8 @@ def _value_aliases(value, state, active):
     if isinstance(value, nodes.Name):
         return {key[1:] for key in state.aliases if key[0] == value.name}
     if isinstance(value, (nodes.Getattr, nodes.Getitem)):
+        if _empty_slice(value):
+            return set()
         if _field(value) == "tool_calls" and not _template_built(value, state):
             return {()}
         return _select(_value_aliases(value.node, state, active), _member(value, state))
@@ -674,6 +702,10 @@ def _bind(
             if isinstance(value, (nodes.Name, nodes.Getattr, nodes.Getitem))
             else None
         )
+        if isinstance(value, nodes.Dict):
+            state.mappings.add(key)
+        else:
+            state.mappings.discard(key)
         if isinstance(value, nodes.Const):
             # `{% set ns.role = 'tool' %}` writes a literal, so the field is the
             # template's own and a role check on it means nothing.
@@ -736,6 +768,13 @@ def _macro_sources(value):
             if arm is not None
             for name in _macro_sources(arm)
         ]
+    if isinstance(value, (nodes.List, nodes.Tuple)):
+        return [name for item in value.items for name in _macro_sources(item)]
+    if isinstance(value, nodes.Getitem):
+        # `{% set render = [show][0] %}`: a lookup table of formatters.
+        return _macro_sources(value.node)
+    if isinstance(value, nodes.Dict):
+        return [name for pair in value.items for name in _macro_sources(pair.value)]
     return []
 
 
@@ -992,8 +1031,11 @@ def _scan_loop(node, state, active, guarded, tail):
             local = parent.copy(scoped = True)
             if value is None:
                 # `{% for key in {'x': tools} %}` walks the keys, not the values, so
-                # nothing under the mapping reaches the target.
-                over_keys = isinstance(node.iter, nodes.Dict)
+                # nothing under the mapping reaches the target. The mapping may have
+                # been given a name first, which `state.mappings` records.
+                over_keys = isinstance(node.iter, nodes.Dict) or (
+                    _reference_key(node.iter) in parent.mappings
+                )
                 _bind_paths(
                     node.target,
                     set()

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -46,6 +46,9 @@ class _State:
     # Names bound to a constant, so a subscript written through one resolves to a
     # single field rather than to every field.
     consts: dict = field(default_factory = dict)
+    # Names bound straight to a field of something else, so `{% set role =
+    # message.role %}` still reads as a role check when the comparison uses `role`.
+    origins: dict = field(default_factory = dict)
     # Set when the path hit break, so a literal loop stops simulating further items
     # for it. `continue` only ends the current iteration, so it is tracked apart:
     # the path skips the rest of the body but still sees the next item.
@@ -62,6 +65,7 @@ class _State:
             set() if scoped else self.mutated.copy(),
             self.constructed.copy(),
             self.consts.copy(),
+            self.origins.copy(),
             self.terminated,
             self.continued,
             self.budget,
@@ -81,6 +85,16 @@ def _reading_call(node):
         and len(node.args) == 1
         and not node.kwargs
     )
+
+
+def _origin_field(node, state):
+    """The field a plain name was bound from, so `{% set role = message.role %}`
+    still answers `role` when the comparison names the alias."""
+    if isinstance(node, nodes.Name):
+        origin = state.origins.get(node.name)
+        if origin is not None:
+            return origin[-1]
+    return _UNKNOWN
 
 
 def _field(node):
@@ -220,6 +234,7 @@ def _signature(state):
         frozenset(state.mutated),
         frozenset(state.constructed),
         frozenset((name, repr(value)) for name, value in state.consts.items()),
+        frozenset(state.origins.items()),
         state.terminated,
         state.continued,
     )
@@ -270,6 +285,9 @@ def _template_built(node, state):
     """The member-name shortcuts below read a field off an untracked value, so they
     only mean anything when the base is one. A base the template constructed is
     tracked, and its provenance already lives in `aliases`."""
+    if isinstance(node, nodes.Name):
+        origin = state.origins.get(node.name)
+        return origin is not None and origin[:-1] in state.constructed
     base = node.node.node if _reading_call(node) else node.node
     return _reference_key(base) in state.constructed
 
@@ -374,7 +392,7 @@ def _positive_test(node, state):
         operand = node.ops[0]
         if operand.op == "eq":
             return any(
-                _field(role) == "role"
+                (_field(role) == "role" or _origin_field(role, state) == "role")
                 and not _template_built(role, state)
                 and (literal := _as_const(value, state)) is not None
                 and literal.value == "tool"
@@ -650,6 +668,15 @@ def _bind(
             state.consts[target.name] = value.value
         else:
             state.consts.pop(target.name, None)
+        origin = _reference_key(value) if value is not None else None
+        if origin is not None and len(origin) > 1 and origin not in state.constructed:
+            state.origins[target.name] = origin
+        else:
+            state.origins.pop(target.name, None)
+        # `{% set render = show %}` hands the name the macro, so calling it runs the
+        # same body. _bind_paths has already dropped any macro under this name.
+        if isinstance(value, nodes.Name) and value.name in state.macros:
+            state.macros[target.name] = state.macros[value.name]
     truth = _constant_truth(value, source) if value is not None else None
     if isinstance(target, nodes.Name) and truth is not None:
         state.facts[repr(nodes.Name(target.name, "load"))] = (truth, {target.name})

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -68,11 +68,28 @@ class _State:
         )
 
 
+def _reading_call(node):
+    """`d.get('k')` reads field k, so it is the mapping spelling of `d.k` and `d['k']`.
+
+    Only the single-argument form: with a default the value may come from elsewhere,
+    and `_value_aliases` handles that case on its own.
+    """
+    return (
+        isinstance(node, nodes.Call)
+        and isinstance(node.node, nodes.Getattr)
+        and node.node.attr == "get"
+        and len(node.args) == 1
+        and not node.kwargs
+    )
+
+
 def _field(node):
     if isinstance(node, nodes.Getattr):
         return node.attr
     if isinstance(node, nodes.Getitem) and isinstance(node.arg, nodes.Const):
         return node.arg.value
+    if _reading_call(node):
+        return node.args[0].value if isinstance(node.args[0], nodes.Const) else _UNKNOWN
     return _UNKNOWN
 
 
@@ -94,8 +111,9 @@ def _reference_key(node):
         return (node.name,)
     if isinstance(node, nodes.NSRef):
         return (node.name, node.attr)
-    if isinstance(node, (nodes.Getattr, nodes.Getitem)):
-        parent = _reference_key(node.node)
+    if isinstance(node, (nodes.Getattr, nodes.Getitem)) or _reading_call(node):
+        base = node.node.node if _reading_call(node) else node.node
+        parent = _reference_key(base)
         member = _field(node)
         if parent is not None and isinstance(member, (str, int)):
             return (*parent, member)
@@ -138,6 +156,16 @@ def _constant_truth(node, state = None):
             try:
                 # The rebuilt node is synthetic, so it carries no environment of its
                 # own and has to be handed an evaluation context explicitly.
+                return bool(replacement.as_const(nodes.EvalContext(_ENVIRONMENT)))
+            except Exception:
+                pass
+    if isinstance(node, nodes.Test):
+        # `{% if false is true %}` and `{% if 1 in [] %}` never run their bodies.
+        folded = _as_const(node.node, state)
+        arguments = [_as_const(argument, state) for argument in node.args]
+        if folded is not None and all(argument is not None for argument in arguments):
+            try:
+                replacement = nodes.Test(folded, node.name, arguments, [], None, None)
                 return bool(replacement.as_const(nodes.EvalContext(_ENVIRONMENT)))
             except Exception:
                 pass
@@ -242,7 +270,8 @@ def _template_built(node, state):
     """The member-name shortcuts below read a field off an untracked value, so they
     only mean anything when the base is one. A base the template constructed is
     tracked, and its provenance already lives in `aliases`."""
-    return _reference_key(node.node) in state.constructed
+    base = node.node.node if _reading_call(node) else node.node
+    return _reference_key(base) in state.constructed
 
 
 def _tool_reference(node, state):
@@ -445,9 +474,12 @@ def _value_aliases(value, state, active):
         removed = _removed_key(value.node.attr, value)
         if removed is not None:
             result = _select(_value_aliases(value.node.node, state, active), removed)
-            # `d.pop('missing', tools)` renders the default when the field is absent.
-            for fallback in value.args[1:]:
-                result |= _value_aliases(fallback, state, active)
+            # `d.pop('missing', tools)` renders the default, but only when the field
+            # can actually be absent: a literal that visibly holds the key never
+            # reaches it.
+            if not _definitely_has(value.node.node, removed, state):
+                for fallback in value.args[1:]:
+                    result |= _value_aliases(fallback, state, active)
             return result
         # A shallow copy is the receiver again as far as provenance goes; without this
         # the fallback reads `copy` as a data field and loses everything under it.
@@ -456,9 +488,11 @@ def _value_aliases(value, state, active):
         if value.node.attr == "get" and value.args:
             member = value.args[0].value if isinstance(value.args[0], nodes.Const) else _UNKNOWN
             result = _select(_value_aliases(value.node.node, state, active), member)
-            # The default is what a missing field falls back to, so it counts too.
-            for fallback in value.args[1:]:
-                result |= _value_aliases(fallback, state, active)
+            # The default is what a missing field falls back to, so it counts - unless
+            # the receiver is a literal that visibly holds the key.
+            if not _definitely_has(value.node.node, member, state):
+                for fallback in value.args[1:]:
+                    result |= _value_aliases(fallback, state, active)
             return result
         # append/extend/update and the other in-place mutators return None: the data
         # goes into the receiver, not into the rendered result.
@@ -502,6 +536,28 @@ def _value_aliases(value, state, active):
                     active,
                     source = state if parameter.name in arguments else local.copy(),
                 )
+            # Jinja collects arguments the signature does not name into the implicit
+            # `varargs` and `kwargs`, so `{% macro show() %}{{ kwargs|tojson }}` sees
+            # what was passed by keyword.
+            extra_positional = value.args[len(parameters) :]
+            _replace(
+                local.aliases,
+                ("varargs",),
+                {
+                    (index, *suffix)
+                    for index, argument in enumerate(extra_positional)
+                    for suffix in _value_aliases(argument, state, active)
+                },
+            )
+            extra_keywords = set()
+            for keyword in value.kwargs:
+                if keyword.key not in parameters:
+                    _replace(
+                        extra_keywords,
+                        (keyword.key,),
+                        _value_aliases(keyword.value, state, active),
+                    )
+            _replace(local.aliases, ("kwargs",), extra_keywords)
             # The macro's own names stay live: nothing outside it constrains its body.
             emits, children = _scan(macro.body, local, active | {macro.name}, tail = _names(macro))
             # A namespace write inside a macro escapes it, so the caller sees it:
@@ -616,6 +672,13 @@ def _mark_constructed(key, value, state):
     for member, item in pairs:
         if _constructs_object(item):
             _mark_constructed((*key, member), item, state)
+        elif isinstance(item, nodes.Const):
+            # A literal scalar member is template-built too, and recording it is what
+            # says this record HAS the field, which decides whether a get/pop default
+            # can ever be reached. A member holding an expression is NOT recorded: it
+            # may carry external data, and `{% set w={'message': message} %}` must
+            # leave w.message external.
+            state.constructed.add((*key, member))
 
 
 def _constructs_object(value):
@@ -683,6 +746,23 @@ def _mutate(call, state, active):
         for keyword in call.kwargs
         for suffix in _value_aliases(keyword.value, state, active)
     }
+    if method in ("reverse", "sort") and not call.args:
+        # The members are the same but their positions are not, so every index under
+        # the receiver becomes unknown. This over-approximates - selecting the index
+        # the catalog moved away from also matches - which is the safe direction for
+        # a detector whose failure mode is silently hiding tool controls.
+        moved = {
+            alias for alias in state.aliases if alias[: len(key)] == key and len(alias) > len(key)
+        }
+        if moved:
+            _replace(
+                state.aliases,
+                key,
+                {(_UNKNOWN, *alias[len(key) + 1 :]) for alias in moved},
+            )
+            state.mutated.add(key)
+            _forget(key, state)
+        return
     removed = _removed_key(method, call)
     if method != "clear" and removed is None and not paths:
         return
@@ -721,6 +801,19 @@ def _unknown_callee(call, state):
     for reasons not visible here, so the block is scanned unconditionally.
     """
     return not (isinstance(call.node, nodes.Name) and call.node.name in state.macros)
+
+
+def _definitely_has(node, member, state):
+    """Whether the receiver is a literal this template built that visibly holds
+    `member`, so a `get`/`pop` default can never be reached."""
+    if member is _UNKNOWN:
+        return False
+    if isinstance(node, nodes.Dict):
+        return any(
+            isinstance(pair.key, nodes.Const) and pair.key.value == member for pair in node.items
+        )
+    key = _reference_key(node)
+    return key is not None and key in state.constructed and (*key, member) in state.constructed
 
 
 def _removed_key(method, call):
@@ -866,7 +959,7 @@ def _scan_loop(node, state, active, guarded, tail):
     # A filter can reject every item of a literal iterable, in which case the body
     # never runs and Jinja takes the else. Only an unfiltered literal is guaranteed
     # to iterate.
-    if not literal or (node.test is not None and else_reachable):
+    if not literal or (node.test is not None and else_reachable) or finished:
         emits, children = _scan(node.else_, state.copy(scoped = True), active, guarded, inner_tail)
         if emits:
             return True, []
@@ -919,6 +1012,9 @@ def _scan(
                 _bind(node.target, node.node, current, active)
                 _mutate(node.node, current, active)
             elif isinstance(node, nodes.ExprStmt):
+                # `{% do load() %}` discards the return value but still runs the
+                # macro, so it is evaluated for the state it leaves behind.
+                _value_aliases(node.node, current, active)
                 _mutate(node.node, current, active)
             elif isinstance(node, nodes.Macro):
                 current.macros[node.name] = node
@@ -969,7 +1065,17 @@ def _scan(
                     if emits:
                         return True, []
             elif isinstance(node, nodes.AssignBlock):
-                emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded, rest)
+                emits, captured = _scan(node.body, current.copy(scoped = True), active, guarded, rest)
+                # Jinja keeps a namespace write made inside the capture, so the
+                # escaping mutations are exported before the target is bound.
+                escaped = set()
+                for child in captured:
+                    exported = _export_scope(current, child)
+                    escaped |= exported.aliases
+                    current.mutated.update(exported.mutated)
+                if captured:
+                    current.aliases.clear()
+                    current.aliases.update(escaped)
                 _bind_paths(node.target, {()} if emits else set(), current)
             elif isinstance(node, nodes.With):
                 local = current.copy(scoped = True)

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -261,6 +261,8 @@ def _negated_guard(node, state):
     """
     if isinstance(node, nodes.Not):
         return _positive_test(node.node, state)
+    if _counts_tools(node, state):
+        return True
     if isinstance(node, nodes.Test) and node.name in ("none", "undefined"):
         return _tool_reference(node.node, state)
     if isinstance(node, nodes.Compare) and len(node.ops) == 1 and node.ops[0].op == "eq":
@@ -335,6 +337,8 @@ def _positive_test(node, state):
             and node.node.name in ("none", "undefined")
             and _tool_reference(node.node.node, state)
         )
+    if _counts_tools(node, state):
+        return True
     if _non_empty_tools(node, state):
         return True
     if isinstance(node, nodes.Compare) and len(node.ops) == 1:
@@ -343,11 +347,34 @@ def _positive_test(node, state):
             return any(
                 _field(role) == "role"
                 and not _template_built(role, state)
-                and isinstance(value, nodes.Const)
-                and value.value == "tool"
+                and (literal := _as_const(value, state)) is not None
+                and literal.value == "tool"
                 for role, value in ((node.expr, operand.expr), (operand.expr, node.expr))
             )
     return False
+
+
+def _known_empty(node, state):
+    """True when this path already established that the value renders as empty.
+
+    `{% if not tools %}{{ tools|tojson }}{% endif %}` emits `[]`, which is no schema:
+    the guard proves the catalog is falsy on the only path that reaches the output.
+    """
+    inner = node
+    while isinstance(inner, nodes.Filter) and inner.node is not None:
+        inner = inner.node
+    if not isinstance(inner, (nodes.Name, nodes.Getattr, nodes.Getitem)):
+        return False
+    return _constant_truth(inner, state) is False
+
+
+def _raises(node):
+    """`{{ raise_exception(...) }}` aborts the render, so the path stops here."""
+    return (
+        isinstance(node, nodes.Call)
+        and isinstance(node.node, nodes.Name)
+        and node.node.name == "raise_exception"
+    )
 
 
 def _is_payload(node):
@@ -417,7 +444,11 @@ def _value_aliases(value, state, active):
         # `catalog.pop('schema')` evaluates to whatever sat at that field.
         removed = _removed_key(value.node.attr, value)
         if removed is not None:
-            return _select(_value_aliases(value.node.node, state, active), removed)
+            result = _select(_value_aliases(value.node.node, state, active), removed)
+            # `d.pop('missing', tools)` renders the default when the field is absent.
+            for fallback in value.args[1:]:
+                result |= _value_aliases(fallback, state, active)
+            return result
         # A shallow copy is the receiver again as far as provenance goes; without this
         # the fallback reads `copy` as a data field and loses everything under it.
         if value.node.attr == "copy" and not value.args and not value.kwargs:
@@ -450,11 +481,19 @@ def _value_aliases(value, state, active):
             defaults = dict(
                 zip(parameters[len(parameters) - len(macro.defaults) :], macro.defaults)
             )
+            # `{% macro wrap(caller=None) %}` declares the parameter only to document
+            # it; inside a {% call %} Jinja binds `caller` to the block regardless, so
+            # the declaration must not clear a binding the caller supplied.
+            supplied_caller = state.macros.get("caller")
             for name in parameters:
+                if name == "caller" and supplied_caller is not None:
+                    continue
                 _replace(local.aliases, (name,), set())
                 local.macros.pop(name, None)
                 _forget((name,), local)
             for parameter in macro.args:
+                if parameter.name == "caller" and supplied_caller is not None:
+                    continue
                 expression = arguments.get(parameter.name, defaults.get(parameter.name))
                 _bind(
                     parameter,
@@ -528,6 +567,12 @@ def _bind(
             else None
         )
         if _constructs_object(value):
+            # The replacement populates its own members, so the old subtree goes
+            # first: otherwise `{% set w={'message': message} %}` keeps the previous
+            # literal's `w.message` marked template-built while it now holds input.
+            state.constructed.difference_update(
+                [built for built in state.constructed if built[: len(key)] == key]
+            )
             _mark_constructed(key, value, state)
         elif source_key is not None and source_key in state.constructed:
             # The nested members were built by the template too, so the alias has to
@@ -668,17 +713,14 @@ def _keeps_content(node):
     return True
 
 
-def _invokes_caller(call, state):
-    """Whether the macro a `{% call %}` targets actually runs its caller block."""
-    macro = state.macros.get(call.node.name) if isinstance(call.node, nodes.Name) else None
-    if macro is None:
-        # An unknown callee could invoke it, so assume the block runs.
-        return True
-    return any(
-        isinstance(found.node, nodes.Name) and found.node.name == "caller"
-        for statement in macro.body
-        for found in statement.find_all(nodes.Call)
-    )
+def _unknown_callee(call, state):
+    """Whether a `{% call %}` targets something this analyser cannot read.
+
+    A macro it knows is scanned, and the caller block bound into it as `caller`, so
+    reachability falls out of the ordinary scan. Anything else could invoke the block
+    for reasons not visible here, so the block is scanned unconditionally.
+    """
+    return not (isinstance(call.node, nodes.Name) and call.node.name in state.macros)
 
 
 def _removed_key(method, call):
@@ -773,10 +815,12 @@ def _scan_loop(node, state, active, guarded, tail):
             # `loop.first` reprs the same in every loop, so an outer loop's facts would
             # otherwise prune branches of a nested one.
             _forget(("loop",), local)
-            if literal:
-                # A literal iterable is simulated item by item, so which iteration this
-                # is happens to be known: `{% for x in [1] %}{% if not loop.first %}`
-                # never runs its body.
+            if literal and node.test is None:
+                # A literal iterable is simulated item by item, so which iteration
+                # this is happens to be known: `{% for x in [1] %}{% if not
+                # loop.first %}` never runs its body. With a filter the position
+                # describes the accepted sequence, not the source, so it stays
+                # unknown rather than being read off the source index.
                 position = values.index(value)
                 for member, truth in (
                     ("first", position == 0),
@@ -849,11 +893,24 @@ def _scan(
             if current.budget[0] < 0:
                 raise _AnalysisLimit
             if isinstance(node, nodes.Output):
-                if any(
-                    _is_payload(value) and (guarded or _value_aliases(value, current, active))
-                    for value in node.nodes
-                ):
-                    return True, []
+                # Consecutive `{{ }}` are parsed into one Output, so its children are
+                # walked in order: what precedes a raise renders, what follows it
+                # does not, and a mutating call lands before the next statement.
+                aborted = False
+                for value in node.nodes:
+                    if (
+                        _is_payload(value)
+                        and (guarded or _value_aliases(value, current, active))
+                        and not _known_empty(value, current)
+                    ):
+                        return True, []
+                    _mutate(value, current, active)
+                    if _raises(value):
+                        aborted = True
+                        break
+                if aborted:
+                    # The render stops here, so this path reaches no later output.
+                    continue
             elif isinstance(node, nodes.Assign):
                 # `{% set _ = xs.append(...) %}` is how templates mutate without the do
                 # extension, so the call mutates even though this is an assignment.
@@ -893,10 +950,14 @@ def _scan(
                 # {% call macro(...) %}: the body is the caller block, so the generic
                 # handler below would only ever see an empty one. The invocation is
                 # where the catalog actually reaches the output.
-                if _value_aliases(node.call, current, active):
+                # Binding the block as a macro named `caller` lets the ordinary scan
+                # decide whether it runs, so a caller() sitting in a branch that
+                # cannot execute does not drag the block in with it.
+                invoked = current.copy()
+                invoked.macros["caller"] = nodes.Macro("caller", [], [], node.body)
+                if _value_aliases(node.call, invoked, active):
                     return True, []
-                # The caller block runs only if the macro invokes caller().
-                if _invokes_caller(node.call, current):
+                if _unknown_callee(node.call, current):
                     emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded, rest)
                     if emits:
                         return True, []

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -340,15 +340,27 @@ def _bind(
     _bind_paths(target, _value_aliases(value, source, active), state)
     key = _reference_key(target)
     if key is not None:
-        source_key = _reference_key(value) if isinstance(value, nodes.Name) else None
+        source_key = (
+            _reference_key(value)
+            if isinstance(value, (nodes.Name, nodes.Getattr, nodes.Getitem))
+            else None
+        )
+        # Rebinding a name detaches it from whatever it shared, in BOTH directions: an
+        # alias made earlier still refers to the old container, not to this one.
         state.same.pop(key, None)
+        for name in [n for n, other in state.same.items() if other == key]:
+            state.same.pop(name, None)
         if _constructs_object(value):
             state.constructed.add(key)
-        elif source_key is not None and source_key in state.constructed:
-            # Binding one name to another does not copy the container, so both names
-            # now denote the same object.
-            state.constructed.add(key)
+        elif source_key is not None:
+            # Binding one reference to another does not copy the container, so both
+            # now denote the same object. This holds for a member as much as a name:
+            # `{% set alias = ns.catalog %}` shares the list, not a copy of it.
             state.same[key] = state.same.get(source_key, source_key)
+            if source_key in state.constructed:
+                state.constructed.add(key)
+            else:
+                state.constructed.discard(key)
         else:
             state.constructed.discard(key)
     if isinstance(target, nodes.Name):
@@ -403,26 +415,73 @@ def _mutate(call, state, active):
     if key is None:
         return
     method = call.node.attr
-    paths = set().union(*(_value_aliases(arg, state, active) for arg in call.args))
-    if method == "clear":
-        paths = set()
-    elif not paths:
+    positional = {suffix for arg in call.args for suffix in _value_aliases(arg, state, active)}
+    if method != "extend":
+        # append, insert, add, setdefault: the argument lands somewhere under the
+        # receiver rather than being spliced into it. Any unrecognised method handed
+        # tool data is treated the same way rather than ignored.
+        positional = {(_UNKNOWN, *suffix) for suffix in positional}
+    # A keyword names the field its value lands under: d.update(catalog=tools) puts
+    # the catalog at d.catalog.
+    paths = positional | {
+        (keyword.key, *suffix)
+        for keyword in call.kwargs
+        for suffix in _value_aliases(keyword.value, state, active)
+    }
+    removed = _removed_key(method, call)
+    if method != "clear" and removed is None and not paths:
         return
-    elif method != "extend":
-        # append, insert, add, update, setdefault: the argument lands somewhere under
-        # the receiver rather than being spliced into it. Any unrecognised method that
-        # is handed tool data is treated the same way rather than ignored.
-        paths = {(_UNKNOWN, *suffix) for suffix in paths}
     # Mutation goes through the object, not the name, so every name currently bound
     # to this container sees it.
     for target in _same_object(key, state):
-        if method == "clear":
+        if method == "clear" or removed is _UNKNOWN:
             _replace(state.aliases, target, set())
+        elif removed is not None:
+            # pop/remove/discard take the value back out, so its provenance goes too.
+            _replace(state.aliases, (*target, removed), set())
         else:
             state.aliases.update((*target, *suffix) for suffix in paths)
         if target[0] not in state.assigned:
             state.mutated.add(target)
         _forget(target, state)
+
+
+# Filters that reduce their input to a measurement or a single element, so whatever
+# went in is no longer readable on the other side.
+_REDUCING = frozenset(
+    {"length", "count", "first", "last", "min", "max", "sum", "random", "wordcount"}
+)
+
+
+def _keeps_content(node):
+    while isinstance(node, nodes.Filter):
+        if node.name in _REDUCING:
+            return False
+        node = node.node
+    return True
+
+
+def _invokes_caller(call, state):
+    """Whether the macro a `{% call %}` targets actually runs its caller block."""
+    macro = state.macros.get(call.node.name) if isinstance(call.node, nodes.Name) else None
+    if macro is None:
+        # An unknown callee could invoke it, so assume the block runs.
+        return True
+    return any(
+        isinstance(found.node, nodes.Name) and found.node.name == "caller"
+        for statement in macro.body
+        for found in statement.find_all(nodes.Call)
+    )
+
+
+def _removed_key(method, call):
+    """The field a destructive call takes back out, or None. `_UNKNOWN` when the call
+    removes something we cannot name, which drops the whole receiver's provenance."""
+    if method not in ("pop", "remove", "discard", "popitem"):
+        return None
+    if not call.args:
+        return _UNKNOWN
+    return call.args[0].value if isinstance(call.args[0], nodes.Const) else _UNKNOWN
 
 
 def _export_scope(parent, child):
@@ -519,6 +578,7 @@ def _scan(
     guarded = False,
 ):
     states = [state]
+    stopped = []
     for node in body:
         results = []
         for current in states:
@@ -540,6 +600,9 @@ def _scan(
                 _mutate(node.node, current, active)
             elif isinstance(node, nodes.Macro):
                 current.macros[node.name] = node
+                # The declaration binds the name, so `{% macro tools() %}` shadows the
+                # catalog and `{{ tools }}` renders the macro object instead.
+                _replace(current.aliases, (node.name,), set())
             elif isinstance(node, nodes.If):
                 emits, children = _scan_if(node, current, active, guarded)
                 if emits:
@@ -553,8 +616,9 @@ def _scan(
                 results.extend(children)
                 continue
             elif isinstance(node, (nodes.Break, nodes.Continue)):
-                # Everything after this in the body is unreachable, so the path stops
-                # here instead of carrying on into the next statement.
+                # Nothing after this in the body runs, so the path stops being scanned.
+                # It still carries whatever it already mutated, which outlives the loop.
+                stopped.append(current)
                 continue
             elif isinstance(node, nodes.CallBlock):
                 # {% call macro(...) %}: the body is the caller block, so the generic
@@ -562,9 +626,18 @@ def _scan(
                 # where the catalog actually reaches the output.
                 if _value_aliases(node.call, current, active):
                     return True, []
-                emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded)
-                if emits:
-                    return True, []
+                # The caller block runs only if the macro invokes caller().
+                if _invokes_caller(node.call, current):
+                    emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded)
+                    if emits:
+                        return True, []
+            elif isinstance(node, nodes.FilterBlock):
+                # The block's own filter decides what survives: `{% filter first %}`
+                # emits one character of the catalog, which is no schema at all.
+                if _keeps_content(node.filter):
+                    emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded)
+                    if emits:
+                        return True, []
             elif isinstance(node, nodes.AssignBlock):
                 emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded)
                 _bind_paths(node.target, {()} if emits else set(), current)
@@ -583,7 +656,7 @@ def _scan(
                     return True, []
             results.append(current)
         states = results
-    return False, states
+    return False, states + stopped
 
 
 def template_supports_tools(template) -> bool:

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -185,6 +185,20 @@ def _tool_reference(node, state):
     return _field(node) == "tool_calls" and not _template_built(node, state)
 
 
+def _negated_guard(node, state):
+    """True when the branch that is NOT taken is the one with a tool catalog.
+
+    `{% if not tools %}plain{% else %}You may call tools.{% endif %}` advertises
+    tools in its else arm exactly as `{% if tools %}...{% endif %}` does in its
+    body, so the two spellings have to agree.
+    """
+    if isinstance(node, nodes.Not):
+        return _positive_test(node.node, state)
+    if isinstance(node, nodes.Test) and node.name in ("none", "undefined"):
+        return _tool_reference(node.node, state)
+    return False
+
+
 def _positive_test(node, state):
     if _constant_truth(node) is not None:
         return False
@@ -523,7 +537,12 @@ def _scan_if(node, state, active, guarded):
             next_remaining.extend(_assume(branch.test, False, current))
         remaining = next_remaining
     for current in remaining:
-        emits, states = _scan(node.else_, current, active, guarded)
+        # With an elif in the chain the else arm is reached for more than one
+        # reason, so only a plain if/else carries the negated guard across.
+        else_guarded = guarded or (
+            not node.elif_ and _negated_guard(node.test, current)
+        )
+        emits, states = _scan(node.else_, current, active, else_guarded)
         if emits:
             return True, []
         results.extend(states)

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -384,7 +384,9 @@ def _bind_paths(target, paths, state):
     if isinstance(target, nodes.Name):
         state.assigned.add(target.name)
         state.macros.pop(target.name, None)
-    else:
+    elif key[0] not in state.assigned:
+        # Recorded when the write happens, not when the scope closes: a mutation that
+        # ran BEFORE a local rebind hit the outer object and still has to escape.
         state.mutated.add(key)
 
 
@@ -401,19 +403,25 @@ def _mutate(call, state, active):
     if key is None:
         return
     method = call.node.attr
-    if method not in ("append", "extend", "clear"):
-        return
     paths = set().union(*(_value_aliases(arg, state, active) for arg in call.args))
-    if method == "append":
+    if method == "clear":
+        paths = set()
+    elif not paths:
+        return
+    elif method != "extend":
+        # append, insert, add, update, setdefault: the argument lands somewhere under
+        # the receiver rather than being spliced into it. Any unrecognised method that
+        # is handed tool data is treated the same way rather than ignored.
         paths = {(_UNKNOWN, *suffix) for suffix in paths}
     # Mutation goes through the object, not the name, so every name currently bound
     # to this container sees it.
     for target in _same_object(key, state):
         if method == "clear":
             _replace(state.aliases, target, set())
-        elif paths:
+        else:
             state.aliases.update((*target, *suffix) for suffix in paths)
-        state.mutated.add(target)
+        if target[0] not in state.assigned:
+            state.mutated.add(target)
         _forget(target, state)
 
 
@@ -427,8 +435,6 @@ def _export_scope(parent, child):
         }
     )
     for key in child.mutated:
-        if key[0] in child.assigned:
-            continue
         _replace(
             result.aliases,
             key,
@@ -479,6 +485,9 @@ def _scan_loop(node, state, active, guarded):
                 )
             else:
                 _bind(node.target, value, local, active)
+            # `loop.first` reprs the same in every loop, so an outer loop's facts would
+            # otherwise prune branches of a nested one.
+            _forget(("loop",), local)
             candidates = [local] if node.test is None else _assume(node.test, True, local)
             for candidate in candidates:
                 emits, children = _scan(
@@ -523,6 +532,9 @@ def _scan(
                 ):
                     return True, []
             elif isinstance(node, nodes.Assign):
+                # `{% set _ = xs.append(...) %}` is how templates mutate without the do
+                # extension, so the call mutates even though this is an assignment.
+                _mutate(node.node, current, active)
                 _bind(node.target, node.node, current, active)
             elif isinstance(node, nodes.ExprStmt):
                 _mutate(node.node, current, active)

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -28,11 +28,28 @@ def _field(node):
     return None
 
 
+def _reference_key(node):
+    if isinstance(node, nodes.Name):
+        return (node.name,)
+    if isinstance(node, nodes.NSRef):
+        return (node.name, node.attr)
+    if isinstance(node, (nodes.Getattr, nodes.Getitem)):
+        parent = _reference_key(node.node)
+        field = _field(node)
+        if parent is not None and isinstance(field, str):
+            return (*parent, field)
+    return None
+
+
 def _tool_reference(node, aliases):
-    return (isinstance(node, nodes.Name) and node.name in aliases) or _field(node) in (
-        "tools",
-        "tool_calls",
-    )
+    return _reference_key(node) in aliases or _field(node) == "tool_calls"
+
+
+def _walk(node):
+    yield node
+    if not isinstance(node, nodes.Macro):
+        for child in node.iter_child_nodes():
+            yield from _walk(child)
 
 
 def _positive_test(node, aliases):
@@ -70,25 +87,83 @@ def _is_payload(node):
     )
 
 
-def _emits_tools(node, aliases):
+def _emits_tools(node, aliases, macros, active):
     if not _is_payload(node):
         return False
+    if isinstance(node, nodes.Call) and isinstance(node.node, nodes.Name):
+        macro = macros.get(node.node.name)
+        if macro is not None:
+            if macro.name in active:
+                return False
+            parameters = [argument.name for argument in macro.args]
+            local_aliases = {key for key in aliases if key[0] not in parameters}
+            arguments = dict(zip(parameters, node.args))
+            arguments.update((keyword.key, keyword.value) for keyword in node.kwargs)
+            defaults = dict(
+                zip(parameters[len(parameters) - len(macro.defaults) :], macro.defaults)
+            )
+            for name in parameters:
+                value = arguments.get(name, defaults.get(name))
+                source_aliases = aliases if name in arguments else local_aliases.copy()
+                if value is not None and _emits_tools(value, source_aliases, macros, active):
+                    local_aliases.add((name,))
+                source = _reference_key(value)
+                if source is not None:
+                    for key in source_aliases:
+                        if key[: len(source)] == source:
+                            local_aliases.add((name, *key[len(source) :]))
+            local_macros = {name: value for name, value in macros.items() if name not in parameters}
+            return _scan(macro.body, local_aliases, local_macros, active | {macro.name})
     return _tool_reference(node, aliases) or any(
-        _emits_tools(child, aliases) for child in node.iter_child_nodes()
+        _emits_tools(child, aliases, macros, active) for child in node.iter_child_nodes()
     )
 
 
 def _emits(body):
     for statement in body:
-        outputs = (
-            [statement] if isinstance(statement, nodes.Output) else statement.find_all(nodes.Output)
-        )
+        outputs = (node for node in _walk(statement) if isinstance(node, nodes.Output))
         for output in outputs:
             for value in output.nodes:
                 if not _is_payload(value):
                     continue
                 if isinstance(value, nodes.TemplateData) and not value.data.strip():
                     continue
+                return True
+    return False
+
+
+def _scan(body, aliases, macros, active):
+    syntax = [node for statement in body for node in _walk(statement)]
+    macros = {**macros, **{node.name: node for node in syntax if isinstance(node, nodes.Macro)}}
+    assignments = [node for node in syntax if isinstance(node, nodes.Assign)]
+    for _ in assignments:
+        previous = len(aliases)
+        for assignment in assignments:
+            key = _reference_key(assignment.target)
+            if key is not None and _tool_reference(assignment.node, aliases):
+                aliases.add(key)
+            value = assignment.node
+            if (
+                key is not None
+                and isinstance(value, nodes.Call)
+                and isinstance(value.node, nodes.Name)
+                and value.node.name == "namespace"
+            ):
+                for keyword in value.kwargs:
+                    if _tool_reference(keyword.value, aliases):
+                        aliases.add((*key, keyword.key))
+        if len(aliases) == previous:
+            break
+
+    for node in syntax:
+        if isinstance(node, nodes.Output):
+            if any(_emits_tools(value, aliases, macros, active) for value in node.nodes):
+                return True
+        elif isinstance(node, nodes.For):
+            if _tool_reference(node.iter, aliases) and _emits(node.body):
+                return True
+        elif isinstance(node, nodes.If):
+            if _positive_test(node.test, aliases) and _emits(node.body):
                 return True
     return False
 
@@ -102,26 +177,4 @@ def template_supports_tools(template: str) -> bool:
         tree = _ENVIRONMENT.parse(template)
     except TemplateSyntaxError:
         return False
-
-    aliases = {"tools", "tool_calls"}
-    assignments = list(tree.find_all(nodes.Assign))
-    for _ in assignments:
-        previous = len(aliases)
-        for assignment in assignments:
-            if isinstance(assignment.target, nodes.Name) and _tool_reference(
-                assignment.node, aliases
-            ):
-                aliases.add(assignment.target.name)
-        if len(aliases) == previous:
-            break
-
-    for output in tree.find_all(nodes.Output):
-        if any(_emits_tools(value, aliases) for value in output.nodes):
-            return True
-    for loop in tree.find_all(nodes.For):
-        if _tool_reference(loop.iter, aliases) and _emits(loop.body):
-            return True
-    return any(
-        _positive_test(branch.test, aliases) and _emits(branch.body)
-        for branch in tree.find_all(nodes.If)
-    )
+    return _scan(tree.body, {("tools",), ("tool_calls",)}, {}, set())

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -6,7 +6,7 @@
 from dataclasses import dataclass, field
 from functools import lru_cache
 
-from jinja2 import Environment, TemplateSyntaxError, nodes
+from jinja2 import Environment, nodes
 from jinja2.ext import Extension
 
 
@@ -483,14 +483,38 @@ def _scan(
     return False, states
 
 
-@lru_cache(maxsize = 128)
-def template_supports_tools(template: str) -> bool:
+def template_supports_tools(template) -> bool:
     """Inspect syntax only; rendering and parser support remain backend checks."""
+    # Outside the cache: lru_cache hashes its argument before the body runs, so a
+    # dict- or list-valued chat template (a Hugging Face named-template map, or the
+    # Hermes-3 [{"name", "template"}] list) would raise "unhashable type" past every
+    # fail-closed branch below. routes.inference passes the raw value through when
+    # template selection yields nothing, so this is reachable, not theoretical.
+    if not isinstance(template, str):
+        return False
+    return _analyse_template(template)
+
+
+@lru_cache(maxsize = 128)
+def _analyse_template(template: str) -> bool:
     if "tool" not in template:
         return False
     try:
         tree = _ENVIRONMENT.parse(template)
         emits, _ = _scan(tree.body, _State({("tools",), ("tool_calls",)}), set())
         return emits
-    except (TemplateSyntaxError, _AnalysisLimit):
+    except Exception:
+        # Fail closed. Besides the expected TemplateSyntaxError and _AnalysisLimit, a
+        # deeply nested template exhausts the interpreter stack -- in Jinja's own
+        # recursive-descent parser (`{% if %}` nesting, parenthesised guards), in
+        # _value_aliases (a long attribute chain), or in the node repr used as a fact
+        # key (a wide boolean guard). detect_reasoning_flags runs on the GGUF metadata
+        # read and the llama-server launch, so a capability hint must leave tools
+        # disabled rather than stop the model from loading, which the substring scan
+        # this replaced could never do.
         return False
+
+
+# Callers that measure or reset the analysis cache reach it through the public name.
+template_supports_tools.cache_clear = _analyse_template.cache_clear
+template_supports_tools.cache_info = _analyse_template.cache_info

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -90,6 +90,26 @@ def _is_payload(node):
 def _emits_tools(node, aliases, macros, active):
     if not _is_payload(node):
         return False
+    if isinstance(node, nodes.CondExpr):
+        truth = _constant_truth(node.test)
+        return any(
+            value is not None and _emits_tools(value, aliases, macros, active)
+            for value, possible in (
+                (node.expr1, truth is not False),
+                (node.expr2, truth is not True),
+            )
+            if possible
+        )
+    if isinstance(node, nodes.And):
+        return _constant_truth(node.left) is not False and _emits_tools(
+            node.right, aliases, macros, active
+        )
+    if isinstance(node, nodes.Or):
+        if _constant_truth(node.left) is True:
+            return _emits_tools(node.left, aliases, macros, active)
+        return _emits_tools(node.left, aliases, macros, active) or _emits_tools(
+            node.right, aliases, macros, active
+        )
     if isinstance(node, nodes.Call) and isinstance(node.node, nodes.Name):
         macro = macros.get(node.node.name)
         if macro is not None:
@@ -132,38 +152,122 @@ def _emits(body):
     return False
 
 
-def _scan(body, aliases, macros, active):
-    syntax = [node for statement in body for node in _walk(statement)]
-    macros = {**macros, **{node.name: node for node in syntax if isinstance(node, nodes.Macro)}}
-    assignments = [node for node in syntax if isinstance(node, nodes.Assign)]
-    for _ in assignments:
-        previous = len(aliases)
-        for assignment in assignments:
-            key = _reference_key(assignment.target)
-            if key is not None and _tool_reference(assignment.node, aliases):
-                aliases.add(key)
-            value = assignment.node
-            if (
-                key is not None
-                and isinstance(value, nodes.Call)
-                and isinstance(value.node, nodes.Name)
-                and value.node.name == "namespace"
-            ):
-                for keyword in value.kwargs:
-                    if _tool_reference(keyword.value, aliases):
-                        aliases.add((*key, keyword.key))
-        if len(aliases) == previous:
-            break
+def _value_aliases(value, aliases, macros, active):
+    if (
+        isinstance(value, nodes.Call)
+        and isinstance(value.node, nodes.Name)
+        and value.node.name == "namespace"
+    ):
+        return {
+            (keyword.key, *suffix)
+            for keyword in value.kwargs
+            for suffix in _value_aliases(keyword.value, aliases, macros, active)
+        }
+    result = {()} if _emits_tools(value, aliases, macros, active) else set()
+    source = _reference_key(value)
+    if source is not None:
+        result.update(key[len(source) :] for key in aliases if key[: len(source)] == source)
+    return result
 
-    for node in syntax:
+
+def _bind(
+    target,
+    value,
+    aliases,
+    macros,
+    active,
+    source_aliases = None,
+):
+    key = _reference_key(target)
+    if key is None:
+        return
+    derived = _value_aliases(
+        value, aliases if source_aliases is None else source_aliases, macros, active
+    )
+    aliases.difference_update({old for old in aliases if old[: len(key)] == key})
+    aliases.update((*key, *suffix) for suffix in derived)
+
+
+def _constant_truth(node):
+    if isinstance(node, nodes.Const):
+        return bool(node.value)
+    if isinstance(node, nodes.Not):
+        value = _constant_truth(node.node)
+        return None if value is None else not value
+    return None
+
+
+def _scan_if(node, aliases, macros, active):
+    states = []
+    for branch in [node, *node.elif_]:
+        truth = _constant_truth(branch.test)
+        if truth is False:
+            continue
+        if _positive_test(branch.test, aliases) and _emits(branch.body):
+            return True
+        local_aliases, local_macros = aliases.copy(), macros.copy()
+        if _scan(branch.body, local_aliases, local_macros, active):
+            return True
+        states.append((local_aliases, local_macros))
+        if truth is True:
+            break
+    else:
+        local_aliases, local_macros = aliases.copy(), macros.copy()
+        if _scan(node.else_, local_aliases, local_macros, active):
+            return True
+        states.append((local_aliases, local_macros))
+    aliases.clear()
+    for local_aliases, local_macros in states:
+        aliases.update(local_aliases)
+        macros.update(local_macros)
+    return False
+
+
+def _scan(body, aliases, macros, active):
+    for node in body:
         if isinstance(node, nodes.Output):
             if any(_emits_tools(value, aliases, macros, active) for value in node.nodes):
                 return True
+        elif isinstance(node, nodes.Assign):
+            _bind(node.target, node.node, aliases, macros, active)
+        elif isinstance(node, nodes.Macro):
+            macros[node.name] = node
         elif isinstance(node, nodes.For):
             if _tool_reference(node.iter, aliases) and _emits(node.body):
                 return True
+            local_aliases = aliases.copy()
+            _bind(node.target, node.iter, local_aliases, macros, active)
+            if _scan(node.body, local_aliases, macros.copy(), active):
+                return True
+            # Loop-local names do not escape, but namespace writes do.
+            local_names = {
+                item.target.name
+                for statement in node.body
+                for item in _walk(statement)
+                if isinstance(item, nodes.Assign) and isinstance(item.target, nodes.Name)
+            }
+            aliases.update(
+                key for key in local_aliases if len(key) > 1 and key[0] not in local_names
+            )
+            if _scan(node.else_, aliases.copy(), macros.copy(), active):
+                return True
         elif isinstance(node, nodes.If):
-            if _positive_test(node.test, aliases) and _emits(node.body):
+            if _scan_if(node, aliases, macros, active):
+                return True
+        elif isinstance(node, nodes.AssignBlock):
+            contains_tools = _scan(node.body, aliases.copy(), macros.copy(), active)
+            _bind(node.target, nodes.Const(None), aliases, macros, active)
+            key = _reference_key(node.target)
+            if contains_tools and key is not None:
+                aliases.add(key)
+        elif isinstance(node, nodes.With):
+            local_aliases = aliases.copy()
+            for target, value in zip(node.targets, node.values):
+                _bind(target, value, local_aliases, macros, active, source_aliases = aliases)
+            if _scan(node.body, local_aliases, macros.copy(), active):
+                return True
+        elif hasattr(node, "body"):
+            if _scan(node.body, aliases.copy(), macros.copy(), active):
                 return True
     return False
 

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -40,9 +40,9 @@ class _State:
     # Names bound to a constant, so a subscript written through one resolves to a
     # single field rather than to every field.
     consts: dict = field(default_factory = dict)
-    # name -> the name it shares a container with, so a mutation through one alias
-    # is seen through the others.
-    same: dict = field(default_factory = dict)
+    # Set when the path hit break or continue, so a literal loop stops simulating
+    # further items for it.
+    terminated: bool = False
     budget: list = field(default_factory = lambda: [8192])
 
     def copy(self, scoped = False):
@@ -54,7 +54,7 @@ class _State:
             set() if scoped else self.mutated.copy(),
             self.constructed.copy(),
             self.consts.copy(),
-            self.same.copy(),
+            self.terminated,
             self.budget,
         )
 
@@ -280,6 +280,11 @@ def _value_aliases(value, state, active):
                 for branch in _assume(value.left, truth, state)
             )
         )
+    if isinstance(value, nodes.Call) and isinstance(value.node, nodes.Getattr):
+        # `catalog.pop('schema')` evaluates to whatever sat at that field.
+        removed = _removed_key(value.node.attr, value)
+        if removed is not None:
+            return _select(_value_aliases(value.node.node, state, active), removed)
     if isinstance(value, nodes.Call) and isinstance(value.node, nodes.Name):
         if value.node.name == "namespace":
             result = set().union(*(_value_aliases(arg, state, active) for arg in value.args))
@@ -345,22 +350,10 @@ def _bind(
             if isinstance(value, (nodes.Name, nodes.Getattr, nodes.Getitem))
             else None
         )
-        # Rebinding a name detaches it from whatever it shared, in BOTH directions: an
-        # alias made earlier still refers to the old container, not to this one.
-        state.same.pop(key, None)
-        for name in [n for n, other in state.same.items() if other == key]:
-            state.same.pop(name, None)
         if _constructs_object(value):
+            _mark_constructed(key, value, state)
+        elif source_key is not None and source_key in state.constructed:
             state.constructed.add(key)
-        elif source_key is not None:
-            # Binding one reference to another does not copy the container, so both
-            # now denote the same object. This holds for a member as much as a name:
-            # `{% set alias = ns.catalog %}` shares the list, not a copy of it.
-            state.same[key] = state.same.get(source_key, source_key)
-            if source_key in state.constructed:
-                state.constructed.add(key)
-            else:
-                state.constructed.discard(key)
         else:
             state.constructed.discard(key)
     if isinstance(target, nodes.Name):
@@ -371,6 +364,25 @@ def _bind(
     truth = _constant_truth(value, source) if value is not None else None
     if isinstance(target, nodes.Name) and truth is not None:
         state.facts[repr(nodes.Name(target.name, "load"))] = (truth, {target.name})
+
+
+def _mark_constructed(key, value, state):
+    """A literal and everything nested in it were all built by the template."""
+    state.constructed.add(key)
+    pairs = []
+    if isinstance(value, nodes.Dict):
+        pairs = [
+            (pair.key.value, pair.value)
+            for pair in value.items
+            if isinstance(pair.key, nodes.Const)
+        ]
+    elif isinstance(value, (nodes.List, nodes.Tuple)):
+        pairs = list(enumerate(value.items))
+    elif isinstance(value, nodes.Call):
+        pairs = [(keyword.key, keyword.value) for keyword in value.kwargs]
+    for member, item in pairs:
+        if _constructs_object(item):
+            _mark_constructed((*key, member), item, state)
 
 
 def _constructs_object(value):
@@ -402,12 +414,6 @@ def _bind_paths(target, paths, state):
         state.mutated.add(key)
 
 
-def _same_object(key, state):
-    """Every name bound to the same container as `key`, `key` included."""
-    root = state.same.get(key, key)
-    return {key, root} | {name for name, other in state.same.items() if other == root}
-
-
 def _mutate(call, state, active):
     if not isinstance(call, nodes.Call) or not isinstance(call.node, nodes.Getattr):
         return
@@ -431,19 +437,16 @@ def _mutate(call, state, active):
     removed = _removed_key(method, call)
     if method != "clear" and removed is None and not paths:
         return
-    # Mutation goes through the object, not the name, so every name currently bound
-    # to this container sees it.
-    for target in _same_object(key, state):
-        if method == "clear" or removed is _UNKNOWN:
-            _replace(state.aliases, target, set())
-        elif removed is not None:
-            # pop/remove/discard take the value back out, so its provenance goes too.
-            _replace(state.aliases, (*target, removed), set())
-        else:
-            state.aliases.update((*target, *suffix) for suffix in paths)
-        if target[0] not in state.assigned:
-            state.mutated.add(target)
-        _forget(target, state)
+    if method == "clear" or removed is _UNKNOWN:
+        _replace(state.aliases, key, set())
+    elif removed is not None:
+        # pop/remove/discard take the value back out, so its provenance goes too.
+        _replace(state.aliases, (*key, removed), set())
+    else:
+        state.aliases.update((*key, *suffix) for suffix in paths)
+    if key[0] not in state.assigned:
+        state.mutated.add(key)
+    _forget(key, state)
 
 
 # Filters that reduce their input to a measurement or a single element, so whatever
@@ -531,6 +534,7 @@ def _scan_loop(node, state, active, guarded):
     literal = isinstance(node.iter, (nodes.List, nodes.Tuple))
     values = node.iter.items if literal else [None]
     states = [state]
+    finished = []
     if not values:
         emits, children = _scan(node.else_, state.copy(scoped = True), active, guarded)
         return emits, [_export_scope(state, child) for child in children]
@@ -554,7 +558,15 @@ def _scan_loop(node, state, active, guarded):
                 )
                 if emits:
                     return True, []
-                results.extend(_export_scope(parent, child) for child in children)
+                for child in children:
+                    exported = _export_scope(parent, child)
+                    if child.terminated:
+                        # break/continue ended this path, so later items of a literal
+                        # iterable never run for it: park it instead of simulating on.
+                        exported.terminated = False
+                        finished.append(exported)
+                    else:
+                        results.append(exported)
             if node.test is not None:
                 results.extend(
                     _export_scope(parent, child) for child in _assume(node.test, False, local)
@@ -568,7 +580,7 @@ def _scan_loop(node, state, active, guarded):
         if emits:
             return True, []
         states.extend(_export_scope(state, child) for child in children)
-    return False, states
+    return False, states + finished
 
 
 def _scan(
@@ -594,8 +606,10 @@ def _scan(
             elif isinstance(node, nodes.Assign):
                 # `{% set _ = xs.append(...) %}` is how templates mutate without the do
                 # extension, so the call mutates even though this is an assignment.
-                _mutate(node.node, current, active)
+                # Bind first: `{% set x = catalog.pop('schema') %}` hands x the value the
+                # mutation is about to take out of catalog.
                 _bind(node.target, node.node, current, active)
+                _mutate(node.node, current, active)
             elif isinstance(node, nodes.ExprStmt):
                 _mutate(node.node, current, active)
             elif isinstance(node, nodes.Macro):
@@ -618,6 +632,7 @@ def _scan(
             elif isinstance(node, (nodes.Break, nodes.Continue)):
                 # Nothing after this in the body runs, so the path stops being scanned.
                 # It still carries whatever it already mutated, which outlives the loop.
+                current.terminated = True
                 stopped.append(current)
                 continue
             elif isinstance(node, nodes.CallBlock):

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -3,6 +3,7 @@
 
 """Tool-capability hints from executable Jinja syntax."""
 
+from dataclasses import dataclass, field
 from functools import lru_cache
 
 from jinja2 import Environment, TemplateSyntaxError, nodes
@@ -18,6 +19,31 @@ class _Generation(Extension):
 
 
 _ENVIRONMENT = Environment(extensions = [_Generation, "jinja2.ext.loopcontrols", "jinja2.ext.do"])
+_UNKNOWN = object()
+
+
+class _AnalysisLimit(Exception):
+    pass
+
+
+@dataclass
+class _State:
+    aliases: set
+    macros: dict = field(default_factory = dict)
+    facts: dict = field(default_factory = dict)
+    assigned: set = field(default_factory = set)
+    mutated: set = field(default_factory = set)
+    budget: list = field(default_factory = lambda: [8192])
+
+    def copy(self, scoped = False):
+        return _State(
+            self.aliases.copy(),
+            self.macros.copy(),
+            self.facts.copy(),
+            set() if scoped else self.assigned.copy(),
+            set() if scoped else self.mutated.copy(),
+            self.budget,
+        )
 
 
 def _field(node):
@@ -25,7 +51,7 @@ def _field(node):
         return node.attr
     if isinstance(node, nodes.Getitem) and isinstance(node.arg, nodes.Const):
         return node.arg.value
-    return None
+    return _UNKNOWN
 
 
 def _reference_key(node):
@@ -35,35 +61,113 @@ def _reference_key(node):
         return (node.name, node.attr)
     if isinstance(node, (nodes.Getattr, nodes.Getitem)):
         parent = _reference_key(node.node)
-        field = _field(node)
-        if parent is not None and isinstance(field, str):
-            return (*parent, field)
+        member = _field(node)
+        if parent is not None and isinstance(member, (str, int)):
+            return (*parent, member)
     return None
 
 
-def _tool_reference(node, aliases):
-    return _reference_key(node) in aliases or _field(node) == "tool_calls"
+def _names(node):
+    return {item.name for item in node.find_all(nodes.Name)} | (
+        {node.name} if isinstance(node, nodes.Name) else set()
+    )
 
 
-def _walk(node):
-    yield node
-    if not isinstance(node, nodes.Macro):
-        for child in node.iter_child_nodes():
-            yield from _walk(child)
-
-
-def _positive_test(node, aliases):
-    if _tool_reference(node, aliases):
-        return True
+def _constant_truth(node, state = None):
+    fact = state.facts.get(repr(node)) if state is not None else None
+    if fact is not None:
+        return fact[0]
+    if isinstance(node, nodes.Const):
+        return bool(node.value)
+    if isinstance(node, (nodes.List, nodes.Tuple, nodes.Dict)):
+        return bool(node.items)
+    if (
+        isinstance(node, nodes.Compare)
+        and isinstance(node.expr, nodes.Const)
+        and all(isinstance(operand.expr, nodes.Const) for operand in node.ops)
+    ):
+        try:
+            return bool(node.as_const())
+        except nodes.Impossible:
+            pass
+    if isinstance(node, nodes.Not):
+        value = _constant_truth(node.node, state)
+        return None if value is None else not value
     if isinstance(node, (nodes.And, nodes.Or)):
-        return _positive_test(node.left, aliases) or _positive_test(node.right, aliases)
+        left = _constant_truth(node.left, state)
+        right = _constant_truth(node.right, state)
+        decisive = isinstance(node, nodes.Or)
+        if left is decisive or right is decisive:
+            return decisive
+        if left is not None and right is not None:
+            return not decisive
+    return None
+
+
+def _assume(node, truth, state):
+    state.budget[0] -= 1
+    if state.budget[0] < 0:
+        raise _AnalysisLimit
+    known = _constant_truth(node, state)
+    if known is not None:
+        return [state.copy()] if known is truth else []
+    if isinstance(node, nodes.Not):
+        return _assume(node.node, not truth, state)
+    if isinstance(node, (nodes.And, nodes.Or)):
+        both = truth if isinstance(node, nodes.And) else not truth
+        if both:
+            return [
+                right
+                for left in _assume(node.left, truth, state)
+                for right in _assume(node.right, truth, left)
+            ]
+        return _assume(node.left, truth, state) + [
+            right
+            for left in _assume(node.left, not truth, state)
+            for right in _assume(node.right, truth, left)
+        ]
+    result = state.copy()
+    result.facts[repr(node)] = (truth, _names(node))
+    return [result]
+
+
+def _forget(key, state):
+    state.facts = {
+        expression: fact for expression, fact in state.facts.items() if key[0] not in fact[1]
+    }
+
+
+def _select(paths, member):
+    return {
+        suffix[1:] if suffix else ()
+        for suffix in paths
+        if not suffix or member is _UNKNOWN or suffix[0] in (member, _UNKNOWN)
+    }
+
+
+def _tool_reference(node, state):
+    key = _reference_key(node)
+    return key in state.aliases or _field(node) == "tool_calls"
+
+
+def _positive_test(node, state):
+    if _constant_truth(node) is not None:
+        return False
+    if _tool_reference(node, state):
+        return True
+    if isinstance(node, nodes.And):
+        return _positive_test(node.left, state) or _positive_test(node.right, state)
+    if isinstance(node, nodes.Or):
+        return (
+            _constant_truth(node.right, state) is not True and _positive_test(node.left, state)
+        ) or (_constant_truth(node.left, state) is not True and _positive_test(node.right, state))
     if isinstance(node, nodes.Test):
-        return node.name == "defined" and _tool_reference(node.node, aliases)
+        return node.name == "defined" and _tool_reference(node.node, state)
     if isinstance(node, nodes.Not):
         return (
             isinstance(node.node, nodes.Test)
             and node.node.name in ("none", "undefined")
-            and _tool_reference(node.node.node, aliases)
+            and _tool_reference(node.node.node, state)
         )
     if isinstance(node, nodes.Compare) and len(node.ops) == 1:
         operand = node.ops[0]
@@ -80,6 +184,8 @@ def _is_payload(node):
         return False
     if isinstance(node, nodes.Filter) and node.name in ("length", "count"):
         return False
+    if isinstance(node, nodes.TemplateData):
+        return bool(node.data.strip())
     return not (
         isinstance(node, nodes.Call)
         and isinstance(node.node, nodes.Name)
@@ -87,189 +193,294 @@ def _is_payload(node):
     )
 
 
-def _emits_tools(node, aliases, macros, active):
-    if not _is_payload(node):
-        return False
-    if isinstance(node, nodes.CondExpr):
-        truth = _constant_truth(node.test)
-        return any(
-            value is not None and _emits_tools(value, aliases, macros, active)
-            for value, possible in (
-                (node.expr1, truth is not False),
-                (node.expr2, truth is not True),
+def _replace(paths, key, derived):
+    paths.difference_update({old for old in paths if old[: len(key)] == key})
+    paths.update((*key, *suffix) for suffix in derived)
+
+
+def _value_aliases(value, state, active):
+    if value is None or not _is_payload(value):
+        return set()
+    if isinstance(value, nodes.Name):
+        return {key[1:] for key in state.aliases if key[0] == value.name}
+    if isinstance(value, (nodes.Getattr, nodes.Getitem)):
+        if _field(value) == "tool_calls":
+            return {()}
+        return _select(_value_aliases(value.node, state, active), _field(value))
+    if isinstance(value, nodes.Dict):
+        result = set()
+        for pair in value.items:
+            key = pair.key.value if isinstance(pair.key, nodes.Const) else _UNKNOWN
+            _replace(result, (key,), _value_aliases(pair.value, state, active))
+        return result
+    if isinstance(value, (nodes.List, nodes.Tuple)):
+        return {
+            (index, *suffix)
+            for index, item in enumerate(value.items)
+            for suffix in _value_aliases(item, state, active)
+        }
+    if isinstance(value, nodes.CondExpr):
+        return set().union(
+            *(
+                _value_aliases(expression, branch, active)
+                for expression, truth in ((value.expr1, True), (value.expr2, False))
+                for branch in _assume(value.test, truth, state)
             )
-            if possible
         )
-    if isinstance(node, nodes.And):
-        return _constant_truth(node.left) is not False and _emits_tools(
-            node.right, aliases, macros, active
+    if isinstance(value, nodes.And):
+        return set().union(
+            *(
+                _value_aliases(value.right, branch, active)
+                for branch in _assume(value.left, True, state)
+            )
         )
-    if isinstance(node, nodes.Or):
-        if _constant_truth(node.left) is True:
-            return _emits_tools(node.left, aliases, macros, active)
-        return _emits_tools(node.left, aliases, macros, active) or _emits_tools(
-            node.right, aliases, macros, active
+    if isinstance(value, nodes.Or):
+        return set().union(
+            *(
+                _value_aliases(expression, branch, active)
+                for expression, truth in ((value.left, True), (value.right, False))
+                for branch in _assume(value.left, truth, state)
+            )
         )
-    if isinstance(node, nodes.Call) and isinstance(node.node, nodes.Name):
-        macro = macros.get(node.node.name)
+    if isinstance(value, nodes.Call) and isinstance(value.node, nodes.Name):
+        if value.node.name == "namespace":
+            result = set().union(*(_value_aliases(arg, state, active) for arg in value.args))
+            for keyword in value.kwargs:
+                _replace(result, (keyword.key,), _value_aliases(keyword.value, state, active))
+            return result
+        macro = state.macros.get(value.node.name)
         if macro is not None:
             if macro.name in active:
-                return False
+                return set()
+            local = state.copy(scoped = True)
             parameters = [argument.name for argument in macro.args]
-            local_aliases = {key for key in aliases if key[0] not in parameters}
-            arguments = dict(zip(parameters, node.args))
-            arguments.update((keyword.key, keyword.value) for keyword in node.kwargs)
+            arguments = dict(zip(parameters, value.args))
+            arguments.update((keyword.key, keyword.value) for keyword in value.kwargs)
             defaults = dict(
                 zip(parameters[len(parameters) - len(macro.defaults) :], macro.defaults)
             )
             for name in parameters:
-                value = arguments.get(name, defaults.get(name))
-                source_aliases = aliases if name in arguments else local_aliases.copy()
-                if value is not None and _emits_tools(value, source_aliases, macros, active):
-                    local_aliases.add((name,))
-                source = _reference_key(value)
-                if source is not None:
-                    for key in source_aliases:
-                        if key[: len(source)] == source:
-                            local_aliases.add((name, *key[len(source) :]))
-            local_macros = {name: value for name, value in macros.items() if name not in parameters}
-            return _scan(macro.body, local_aliases, local_macros, active | {macro.name})
-    return _tool_reference(node, aliases) or any(
-        _emits_tools(child, aliases, macros, active) for child in node.iter_child_nodes()
+                _replace(local.aliases, (name,), set())
+                local.macros.pop(name, None)
+                _forget((name,), local)
+            for parameter in macro.args:
+                expression = arguments.get(parameter.name, defaults.get(parameter.name))
+                _bind(
+                    parameter,
+                    expression,
+                    local,
+                    active,
+                    source = state if parameter.name in arguments else local.copy(),
+                )
+            emits, _ = _scan(macro.body, local, active | {macro.name})
+            return {()} if emits else set()
+    # Other expressions serialize or transform their inputs.
+    return (
+        {()}
+        if any(_value_aliases(child, state, active) for child in value.iter_child_nodes())
+        else set()
     )
-
-
-def _emits(body):
-    for statement in body:
-        outputs = (node for node in _walk(statement) if isinstance(node, nodes.Output))
-        for output in outputs:
-            for value in output.nodes:
-                if not _is_payload(value):
-                    continue
-                if isinstance(value, nodes.TemplateData) and not value.data.strip():
-                    continue
-                return True
-    return False
-
-
-def _value_aliases(value, aliases, macros, active):
-    if (
-        isinstance(value, nodes.Call)
-        and isinstance(value.node, nodes.Name)
-        and value.node.name == "namespace"
-    ):
-        return {
-            (keyword.key, *suffix)
-            for keyword in value.kwargs
-            for suffix in _value_aliases(keyword.value, aliases, macros, active)
-        }
-    result = {()} if _emits_tools(value, aliases, macros, active) else set()
-    source = _reference_key(value)
-    if source is not None:
-        result.update(key[len(source) :] for key in aliases if key[: len(source)] == source)
-    return result
 
 
 def _bind(
     target,
     value,
-    aliases,
-    macros,
+    state,
     active,
-    source_aliases = None,
+    source = None,
 ):
+    source = state.copy() if source is None else source
+    if isinstance(target, (nodes.Tuple, nodes.List)):
+        if isinstance(value, (nodes.Tuple, nodes.List)):
+            for item, expression in zip(target.items, value.items):
+                _bind(item, expression, state, active, source = source)
+        else:
+            paths = _value_aliases(value, source, active)
+            for index, item in enumerate(target.items):
+                _bind_paths(item, _select(paths, index), state)
+        return
+    _bind_paths(target, _value_aliases(value, source, active), state)
+    truth = _constant_truth(value, source) if value is not None else None
+    if isinstance(target, nodes.Name) and truth is not None:
+        state.facts[repr(nodes.Name(target.name, "load"))] = (truth, {target.name})
+
+
+def _bind_paths(target, paths, state):
+    if isinstance(target, (nodes.Tuple, nodes.List)):
+        for index, item in enumerate(target.items):
+            _bind_paths(item, _select(paths, index), state)
+        return
     key = _reference_key(target)
     if key is None:
         return
-    derived = _value_aliases(
-        value, aliases if source_aliases is None else source_aliases, macros, active
-    )
-    aliases.difference_update({old for old in aliases if old[: len(key)] == key})
-    aliases.update((*key, *suffix) for suffix in derived)
-
-
-def _constant_truth(node):
-    if isinstance(node, nodes.Const):
-        return bool(node.value)
-    if isinstance(node, nodes.Not):
-        value = _constant_truth(node.node)
-        return None if value is None else not value
-    return None
-
-
-def _scan_if(node, aliases, macros, active):
-    states = []
-    for branch in [node, *node.elif_]:
-        truth = _constant_truth(branch.test)
-        if truth is False:
-            continue
-        if _positive_test(branch.test, aliases) and _emits(branch.body):
-            return True
-        local_aliases, local_macros = aliases.copy(), macros.copy()
-        if _scan(branch.body, local_aliases, local_macros, active):
-            return True
-        states.append((local_aliases, local_macros))
-        if truth is True:
-            break
+    _replace(state.aliases, key, paths)
+    _forget(key, state)
+    if isinstance(target, nodes.Name):
+        state.assigned.add(target.name)
+        state.macros.pop(target.name, None)
     else:
-        local_aliases, local_macros = aliases.copy(), macros.copy()
-        if _scan(node.else_, local_aliases, local_macros, active):
-            return True
-        states.append((local_aliases, local_macros))
-    aliases.clear()
-    for local_aliases, local_macros in states:
-        aliases.update(local_aliases)
-        macros.update(local_macros)
-    return False
+        state.mutated.add(key)
 
 
-def _scan(body, aliases, macros, active):
+def _mutate(call, state, active):
+    if not isinstance(call, nodes.Call) or not isinstance(call.node, nodes.Getattr):
+        return
+    key = _reference_key(call.node.node)
+    if key is None:
+        return
+    method = call.node.attr
+    if method not in ("append", "extend", "clear"):
+        return
+    paths = set().union(*(_value_aliases(arg, state, active) for arg in call.args))
+    if method == "clear":
+        _replace(state.aliases, key, set())
+    elif paths:
+        if method == "append":
+            paths = {(_UNKNOWN, *suffix) for suffix in paths}
+        state.aliases.update((*key, *suffix) for suffix in paths)
+    state.mutated.add(key)
+    _forget(key, state)
+
+
+def _export_scope(parent, child):
+    result = parent.copy()
+    result.facts.update(
+        {
+            expression: fact
+            for expression, fact in child.facts.items()
+            if not fact[1] & child.assigned
+        }
+    )
+    for key in child.mutated:
+        if key[0] in child.assigned:
+            continue
+        _replace(
+            result.aliases,
+            key,
+            {alias[len(key) :] for alias in child.aliases if alias[: len(key)] == key},
+        )
+        result.mutated.add(key)
+        _forget(key, result)
+    return result
+
+
+def _scan_if(node, state, active, guarded):
+    remaining = [state]
+    results = []
+    for branch in [node, *node.elif_]:
+        next_remaining = []
+        for current in remaining:
+            for positive in _assume(branch.test, True, current):
+                emits, states = _scan(
+                    branch.body, positive, active, guarded or _positive_test(branch.test, current)
+                )
+                if emits:
+                    return True, []
+                results.extend(states)
+            next_remaining.extend(_assume(branch.test, False, current))
+        remaining = next_remaining
+    for current in remaining:
+        emits, states = _scan(node.else_, current, active, guarded)
+        if emits:
+            return True, []
+        results.extend(states)
+    return False, results
+
+
+def _scan_loop(node, state, active, guarded):
+    literal = isinstance(node.iter, (nodes.List, nodes.Tuple))
+    values = node.iter.items if literal else [None]
+    states = [state]
+    if not values:
+        emits, children = _scan(node.else_, state.copy(scoped = True), active, guarded)
+        return emits, [_export_scope(state, child) for child in children]
+    for value in values:
+        results = []
+        for parent in states:
+            local = parent.copy(scoped = True)
+            if value is None:
+                _bind_paths(
+                    node.target, _select(_value_aliases(node.iter, parent, active), _UNKNOWN), local
+                )
+            else:
+                _bind(node.target, value, local, active)
+            candidates = [local] if node.test is None else _assume(node.test, True, local)
+            for candidate in candidates:
+                emits, children = _scan(
+                    node.body, candidate, active, guarded or _tool_reference(node.iter, parent)
+                )
+                if emits:
+                    return True, []
+                results.extend(_export_scope(parent, child) for child in children)
+            if node.test is not None:
+                results.extend(
+                    _export_scope(parent, child) for child in _assume(node.test, False, local)
+                )
+        states = results
+    if not literal:
+        emits, children = _scan(node.else_, state.copy(scoped = True), active, guarded)
+        if emits:
+            return True, []
+        states.extend(_export_scope(state, child) for child in children)
+    return False, states
+
+
+def _scan(
+    body,
+    state,
+    active,
+    guarded = False,
+):
+    states = [state]
     for node in body:
-        if isinstance(node, nodes.Output):
-            if any(_emits_tools(value, aliases, macros, active) for value in node.nodes):
-                return True
-        elif isinstance(node, nodes.Assign):
-            _bind(node.target, node.node, aliases, macros, active)
-        elif isinstance(node, nodes.Macro):
-            macros[node.name] = node
-        elif isinstance(node, nodes.For):
-            if _tool_reference(node.iter, aliases) and _emits(node.body):
-                return True
-            local_aliases = aliases.copy()
-            _bind(node.target, node.iter, local_aliases, macros, active)
-            if _scan(node.body, local_aliases, macros.copy(), active):
-                return True
-            # Loop-local names do not escape, but namespace writes do.
-            local_names = {
-                item.target.name
-                for statement in node.body
-                for item in _walk(statement)
-                if isinstance(item, nodes.Assign) and isinstance(item.target, nodes.Name)
-            }
-            aliases.update(
-                key for key in local_aliases if len(key) > 1 and key[0] not in local_names
-            )
-            if _scan(node.else_, aliases.copy(), macros.copy(), active):
-                return True
-        elif isinstance(node, nodes.If):
-            if _scan_if(node, aliases, macros, active):
-                return True
-        elif isinstance(node, nodes.AssignBlock):
-            contains_tools = _scan(node.body, aliases.copy(), macros.copy(), active)
-            _bind(node.target, nodes.Const(None), aliases, macros, active)
-            key = _reference_key(node.target)
-            if contains_tools and key is not None:
-                aliases.add(key)
-        elif isinstance(node, nodes.With):
-            local_aliases = aliases.copy()
-            for target, value in zip(node.targets, node.values):
-                _bind(target, value, local_aliases, macros, active, source_aliases = aliases)
-            if _scan(node.body, local_aliases, macros.copy(), active):
-                return True
-        elif hasattr(node, "body"):
-            if _scan(node.body, aliases.copy(), macros.copy(), active):
-                return True
-    return False
+        results = []
+        for current in states:
+            current.budget[0] -= 1
+            if current.budget[0] < 0:
+                raise _AnalysisLimit
+            if isinstance(node, nodes.Output):
+                if any(
+                    _is_payload(value) and (guarded or _value_aliases(value, current, active))
+                    for value in node.nodes
+                ):
+                    return True, []
+            elif isinstance(node, nodes.Assign):
+                _bind(node.target, node.node, current, active)
+            elif isinstance(node, nodes.ExprStmt):
+                _mutate(node.node, current, active)
+            elif isinstance(node, nodes.Macro):
+                current.macros[node.name] = node
+            elif isinstance(node, nodes.If):
+                emits, children = _scan_if(node, current, active, guarded)
+                if emits:
+                    return True, []
+                results.extend(children)
+                continue
+            elif isinstance(node, nodes.For):
+                emits, children = _scan_loop(node, current, active, guarded)
+                if emits:
+                    return True, []
+                results.extend(children)
+                continue
+            elif isinstance(node, nodes.AssignBlock):
+                emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded)
+                _bind_paths(node.target, {()} if emits else set(), current)
+            elif isinstance(node, nodes.With):
+                local = current.copy(scoped = True)
+                for target, value in zip(node.targets, node.values):
+                    _bind(target, value, local, active, source = current)
+                emits, children = _scan(node.body, local, active, guarded)
+                if emits:
+                    return True, []
+                results.extend(_export_scope(current, child) for child in children)
+                continue
+            elif hasattr(node, "body"):
+                emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded)
+                if emits:
+                    return True, []
+            results.append(current)
+        states = results
+    return False, states
 
 
 @lru_cache(maxsize = 128)
@@ -279,6 +490,7 @@ def template_supports_tools(template: str) -> bool:
         return False
     try:
         tree = _ENVIRONMENT.parse(template)
-    except TemplateSyntaxError:
+        emits, _ = _scan(tree.body, _State({("tools",), ("tool_calls",)}), set())
+        return emits
+    except (TemplateSyntaxError, _AnalysisLimit):
         return False
-    return _scan(tree.body, {("tools",), ("tool_calls",)}, {}, set())

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -33,6 +33,16 @@ class _State:
     facts: dict = field(default_factory = dict)
     assigned: set = field(default_factory = set)
     mutated: set = field(default_factory = set)
+    # Objects the template built itself, so a field named `tool_calls` or `role` on
+    # them carries no meaning. Survives a scope change: a namespace built outside a
+    # loop is still template-built inside it.
+    constructed: set = field(default_factory = set)
+    # Names bound to a constant, so a subscript written through one resolves to a
+    # single field rather than to every field.
+    consts: dict = field(default_factory = dict)
+    # name -> the name it shares a container with, so a mutation through one alias
+    # is seen through the others.
+    same: dict = field(default_factory = dict)
     budget: list = field(default_factory = lambda: [8192])
 
     def copy(self, scoped = False):
@@ -42,6 +52,9 @@ class _State:
             self.facts.copy(),
             set() if scoped else self.assigned.copy(),
             set() if scoped else self.mutated.copy(),
+            self.constructed.copy(),
+            self.consts.copy(),
+            self.same.copy(),
             self.budget,
         )
 
@@ -52,6 +65,19 @@ def _field(node):
     if isinstance(node, nodes.Getitem) and isinstance(node.arg, nodes.Const):
         return node.arg.value
     return _UNKNOWN
+
+
+def _member(node, state):
+    """`_field`, plus subscripts whose key is a name bound to a constant."""
+    member = _field(node)
+    if (
+        member is _UNKNOWN
+        and isinstance(node, nodes.Getitem)
+        and isinstance(node.arg, nodes.Name)
+        and node.arg.name in state.consts
+    ):
+        return state.consts[node.arg.name]
+    return member
 
 
 def _reference_key(node):
@@ -145,9 +171,18 @@ def _select(paths, member):
     }
 
 
+def _template_built(node, state):
+    """The member-name shortcuts below read a field off an untracked value, so they
+    only mean anything when the base is one. A base the template constructed is
+    tracked, and its provenance already lives in `aliases`."""
+    return _reference_key(node.node) in state.constructed
+
+
 def _tool_reference(node, state):
     key = _reference_key(node)
-    return key in state.aliases or _field(node) == "tool_calls"
+    if key in state.aliases:
+        return True
+    return _field(node) == "tool_calls" and not _template_built(node, state)
 
 
 def _positive_test(node, state):
@@ -173,7 +208,10 @@ def _positive_test(node, state):
         operand = node.ops[0]
         if operand.op == "eq":
             return any(
-                _field(role) == "role" and isinstance(value, nodes.Const) and value.value == "tool"
+                _field(role) == "role"
+                and not _template_built(role, state)
+                and isinstance(value, nodes.Const)
+                and value.value == "tool"
                 for role, value in ((node.expr, operand.expr), (operand.expr, node.expr))
             )
     return False
@@ -204,9 +242,9 @@ def _value_aliases(value, state, active):
     if isinstance(value, nodes.Name):
         return {key[1:] for key in state.aliases if key[0] == value.name}
     if isinstance(value, (nodes.Getattr, nodes.Getitem)):
-        if _field(value) == "tool_calls":
+        if _field(value) == "tool_calls" and not _template_built(value, state):
             return {()}
-        return _select(_value_aliases(value.node, state, active), _field(value))
+        return _select(_value_aliases(value.node, state, active), _member(value, state))
     if isinstance(value, nodes.Dict):
         result = set()
         for pair in value.items:
@@ -300,9 +338,37 @@ def _bind(
                 _bind_paths(item, _select(paths, index), state)
         return
     _bind_paths(target, _value_aliases(value, source, active), state)
+    key = _reference_key(target)
+    if key is not None:
+        source_key = _reference_key(value) if isinstance(value, nodes.Name) else None
+        state.same.pop(key, None)
+        if _constructs_object(value):
+            state.constructed.add(key)
+        elif source_key is not None and source_key in state.constructed:
+            # Binding one name to another does not copy the container, so both names
+            # now denote the same object.
+            state.constructed.add(key)
+            state.same[key] = state.same.get(source_key, source_key)
+        else:
+            state.constructed.discard(key)
+    if isinstance(target, nodes.Name):
+        if isinstance(value, nodes.Const) and isinstance(value.value, (str, int)):
+            state.consts[target.name] = value.value
+        else:
+            state.consts.pop(target.name, None)
     truth = _constant_truth(value, source) if value is not None else None
     if isinstance(target, nodes.Name) and truth is not None:
         state.facts[repr(nodes.Name(target.name, "load"))] = (truth, {target.name})
+
+
+def _constructs_object(value):
+    if isinstance(value, (nodes.Dict, nodes.List, nodes.Tuple)):
+        return True
+    return (
+        isinstance(value, nodes.Call)
+        and isinstance(value.node, nodes.Name)
+        and value.node.name == "namespace"
+    )
 
 
 def _bind_paths(target, paths, state):
@@ -322,6 +388,12 @@ def _bind_paths(target, paths, state):
         state.mutated.add(key)
 
 
+def _same_object(key, state):
+    """Every name bound to the same container as `key`, `key` included."""
+    root = state.same.get(key, key)
+    return {key, root} | {name for name, other in state.same.items() if other == root}
+
+
 def _mutate(call, state, active):
     if not isinstance(call, nodes.Call) or not isinstance(call.node, nodes.Getattr):
         return
@@ -332,14 +404,17 @@ def _mutate(call, state, active):
     if method not in ("append", "extend", "clear"):
         return
     paths = set().union(*(_value_aliases(arg, state, active) for arg in call.args))
-    if method == "clear":
-        _replace(state.aliases, key, set())
-    elif paths:
-        if method == "append":
-            paths = {(_UNKNOWN, *suffix) for suffix in paths}
-        state.aliases.update((*key, *suffix) for suffix in paths)
-    state.mutated.add(key)
-    _forget(key, state)
+    if method == "append":
+        paths = {(_UNKNOWN, *suffix) for suffix in paths}
+    # Mutation goes through the object, not the name, so every name currently bound
+    # to this container sees it.
+    for target in _same_object(key, state):
+        if method == "clear":
+            _replace(state.aliases, target, set())
+        elif paths:
+            state.aliases.update((*target, *suffix) for suffix in paths)
+        state.mutated.add(target)
+        _forget(target, state)
 
 
 def _export_scope(parent, child):
@@ -417,7 +492,10 @@ def _scan_loop(node, state, active, guarded):
                     _export_scope(parent, child) for child in _assume(node.test, False, local)
                 )
         states = results
-    if not literal:
+    # A filter can reject every item of a literal iterable, in which case the body
+    # never runs and Jinja takes the else. Only an unfiltered literal is guaranteed
+    # to iterate.
+    if not literal or node.test is not None:
         emits, children = _scan(node.else_, state.copy(scoped = True), active, guarded)
         if emits:
             return True, []
@@ -462,6 +540,19 @@ def _scan(
                     return True, []
                 results.extend(children)
                 continue
+            elif isinstance(node, (nodes.Break, nodes.Continue)):
+                # Everything after this in the body is unreachable, so the path stops
+                # here instead of carrying on into the next statement.
+                continue
+            elif isinstance(node, nodes.CallBlock):
+                # {% call macro(...) %}: the body is the caller block, so the generic
+                # handler below would only ever see an empty one. The invocation is
+                # where the catalog actually reaches the output.
+                if _value_aliases(node.call, current, active):
+                    return True, []
+                emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded)
+                if emits:
+                    return True, []
             elif isinstance(node, nodes.AssignBlock):
                 emits, _ = _scan(node.body, current.copy(scoped = True), active, guarded)
                 _bind_paths(node.target, {()} if emits else set(), current)

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Tool-capability hints from executable Jinja syntax."""
+
+from functools import lru_cache
+
+from jinja2 import Environment, TemplateSyntaxError, nodes
+from jinja2.ext import Extension
+
+
+class _Generation(Extension):
+    tags = {"generation"}
+
+    def parse(self, parser):
+        next(parser.stream)
+        return parser.parse_statements(("name:endgeneration",), drop_needle = True)
+
+
+_ENVIRONMENT = Environment(extensions = [_Generation, "jinja2.ext.loopcontrols", "jinja2.ext.do"])
+
+
+def _field(node):
+    if isinstance(node, nodes.Getattr):
+        return node.attr
+    if isinstance(node, nodes.Getitem) and isinstance(node.arg, nodes.Const):
+        return node.arg.value
+    return None
+
+
+def _tool_reference(node, aliases):
+    return (isinstance(node, nodes.Name) and node.name in aliases) or _field(node) in (
+        "tools",
+        "tool_calls",
+    )
+
+
+def _positive_test(node, aliases):
+    if _tool_reference(node, aliases):
+        return True
+    if isinstance(node, (nodes.And, nodes.Or)):
+        return _positive_test(node.left, aliases) or _positive_test(node.right, aliases)
+    if isinstance(node, nodes.Test):
+        return node.name == "defined" and _tool_reference(node.node, aliases)
+    if isinstance(node, nodes.Not):
+        return (
+            isinstance(node.node, nodes.Test)
+            and node.node.name in ("none", "undefined")
+            and _tool_reference(node.node.node, aliases)
+        )
+    if isinstance(node, nodes.Compare) and len(node.ops) == 1:
+        operand = node.ops[0]
+        if operand.op == "eq":
+            return any(
+                _field(role) == "role" and isinstance(value, nodes.Const) and value.value == "tool"
+                for role, value in ((node.expr, operand.expr), (operand.expr, node.expr))
+            )
+    return False
+
+
+def _is_payload(node):
+    if isinstance(node, (nodes.Not, nodes.Test, nodes.Compare)):
+        return False
+    if isinstance(node, nodes.Filter) and node.name in ("length", "count"):
+        return False
+    return not (
+        isinstance(node, nodes.Call)
+        and isinstance(node.node, nodes.Name)
+        and node.node.name == "raise_exception"
+    )
+
+
+def _emits_tools(node, aliases):
+    if not _is_payload(node):
+        return False
+    return _tool_reference(node, aliases) or any(
+        _emits_tools(child, aliases) for child in node.iter_child_nodes()
+    )
+
+
+def _emits(body):
+    for statement in body:
+        outputs = (
+            [statement] if isinstance(statement, nodes.Output) else statement.find_all(nodes.Output)
+        )
+        for output in outputs:
+            for value in output.nodes:
+                if not _is_payload(value):
+                    continue
+                if isinstance(value, nodes.TemplateData) and not value.data.strip():
+                    continue
+                return True
+    return False
+
+
+@lru_cache(maxsize = 128)
+def template_supports_tools(template: str) -> bool:
+    """Inspect syntax only; rendering and parser support remain backend checks."""
+    if "tool" not in template:
+        return False
+    try:
+        tree = _ENVIRONMENT.parse(template)
+    except TemplateSyntaxError:
+        return False
+
+    aliases = {"tools", "tool_calls"}
+    assignments = list(tree.find_all(nodes.Assign))
+    for _ in assignments:
+        previous = len(aliases)
+        for assignment in assignments:
+            if isinstance(assignment.target, nodes.Name) and _tool_reference(
+                assignment.node, aliases
+            ):
+                aliases.add(assignment.target.name)
+        if len(aliases) == previous:
+            break
+
+    for output in tree.find_all(nodes.Output):
+        if any(_emits_tools(value, aliases) for value in output.nodes):
+            return True
+    for loop in tree.find_all(nodes.For):
+        if _tool_reference(loop.iter, aliases) and _emits(loop.body):
+            return True
+    return any(
+        _positive_test(branch.test, aliases) and _emits(branch.body)
+        for branch in tree.find_all(nodes.If)
+    )

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -539,9 +539,7 @@ def _scan_if(node, state, active, guarded):
     for current in remaining:
         # With an elif in the chain the else arm is reached for more than one
         # reason, so only a plain if/else carries the negated guard across.
-        else_guarded = guarded or (
-            not node.elif_ and _negated_guard(node.test, current)
-        )
+        else_guarded = guarded or (not node.elif_ and _negated_guard(node.test, current))
         emits, states = _scan(node.else_, current, active, else_guarded)
         if emits:
             return True, []

--- a/studio/backend/tests/data/chat_templates/granite-3.3.jinja
+++ b/studio/backend/tests/data/chat_templates/granite-3.3.jinja
@@ -1,0 +1,63 @@
+{# Source: https://huggingface.co/ibm-granite/granite-3.3-8b-instruct/blob/main/tokenizer_config.json #}
+{# Alias tools -> available_tools #}
+{%- if tools and not available_tools -%}
+    {%- set available_tools = tools -%}
+{%- endif -%}
+{%- if messages[0]['role'] == 'system' %}
+     {%- set system_message = messages[0]['content'] %}
+     {%- set loop_messages = messages[1:] %}
+ {%- else %}
+     {%- set system_message = "Knowledge Cutoff Date: April 2024.
+Today's Date: " + strftime_now('%B %d, %Y') + ".
+You are Granite, developed by IBM." %}
+     {%- if available_tools and documents %}
+         {%- set system_message = system_message + " You are a helpful assistant with access to the following tools. When a tool is required to answer the user's query, respond only with <|tool_call|> followed by a JSON list of tools used. If a tool does not exist in the provided list of tools, notify the user that you do not have the ability to fulfill the request.
+Write the response to the user's input by strictly aligning with the facts in the provided documents. If the information needed to answer the question is not available in the documents, inform the user that the question cannot be answered based on the available data." %}
+     {%- elif available_tools %}
+         {%- set system_message = system_message + " You are a helpful assistant with access to the following tools. When a tool is required to answer the user's query, respond only with <|tool_call|> followed by a JSON list of tools used. If a tool does not exist in the provided list of tools, notify the user that you do not have the ability to fulfill the request." %}
+     {%- elif documents %}
+         {%- set system_message = system_message + " Write the response to the user's input by strictly aligning with the facts in the provided documents. If the information needed to answer the question is not available in the documents, inform the user that the question cannot be answered based on the available data." %}
+    {%- elif thinking %}
+    {%- set system_message = system_message + " You are a helpful AI assistant.
+Respond to every user query in a comprehensive and detailed way. You can write down your thoughts and reasoning process before responding. In the thought process, engage in a comprehensive cycle of analysis, summarization, exploration, reassessment, reflection, backtracing, and iteration to develop well-considered thinking process. In the response section, based on various attempts, explorations, and reflections from the thoughts section, systematically present the final solution that you deem correct. The response should summarize the thought process. Write your thoughts between <think></think> and write your response between <response></response> for each user query." %}
+     {%- else %}
+         {%- set system_message = system_message + " You are a helpful AI assistant." %}
+     {%- endif %}
+     {%- if 'citations' in controls and documents %}
+         {%- set system_message = system_message + '
+Use the symbols <|start_of_cite|> and <|end_of_cite|> to indicate when a fact comes from a document in the search result, e.g <|start_of_cite|> {document_id: 1}my fact <|end_of_cite|> for a fact from document 1. Afterwards, list all the citations with their corresponding documents in an ordered list.' %}
+     {%- endif %}
+     {%- if 'hallucinations' in controls and documents %}
+         {%- set system_message = system_message + '
+Finally, after the response is written, include a numbered list of sentences from the response with a corresponding risk value that are hallucinated and not based in the documents.' %}
+     {%- endif %}
+     {%- set loop_messages = messages %}
+ {%- endif %}
+ {{- '<|start_of_role|>system<|end_of_role|>' + system_message + '<|end_of_text|>
+' }}
+ {%- if available_tools %}
+     {{- '<|start_of_role|>available_tools<|end_of_role|>' }}
+     {{- available_tools | tojson(indent=4) }}
+     {{- '<|end_of_text|>
+' }}
+ {%- endif %}
+ {%- if documents %}
+     {%- for document in documents %}
+         {{- '<|start_of_role|>document {"document_id": "' + document['doc_id'] | string + '"}<|end_of_role|>
+' }}
+         {{- document['text'] }}
+         {{- '<|end_of_text|>
+' }}
+              {%- endfor %}
+ {%- endif %}
+ {%- for message in loop_messages %}
+     {{- '<|start_of_role|>' + message['role'] + '<|end_of_role|>' + message['content'] + '<|end_of_text|>
+' }}
+     {%- if loop.last and add_generation_prompt %}
+         {{- '<|start_of_role|>assistant' }}
+             {%- if controls %}
+                 {{- ' ' + controls | tojson()}}
+             {%- endif %}
+         {{- '<|end_of_role|>' }}
+     {%- endif %}
+ {%- endfor %}

--- a/studio/backend/tests/data/chat_templates/phi-4-mini.jinja
+++ b/studio/backend/tests/data/chat_templates/phi-4-mini.jinja
@@ -1,0 +1,2 @@
+{# Source: https://huggingface.co/microsoft/Phi-4-mini-instruct/blob/main/tokenizer_config.json #}
+{% for message in messages %}{% if message['role'] == 'system' and 'tools' in message and message['tools'] is not none %}{{ '<|' + message['role'] + '|>' + message['content'] + '<|tool|>' + message['tools'] + '<|/tool|>' + '<|end|>' }}{% else %}{{ '<|' + message['role'] + '|>' + message['content'] + '<|end|>' }}{% endif %}{% endfor %}{% if add_generation_prompt %}{{ '<|assistant|>' }}{% else %}{{ eos_token }}{% endif %}

--- a/studio/backend/tests/data/refactor_guard/ast_inventory.json
+++ b/studio/backend/tests/data/refactor_guard/ast_inventory.json
@@ -335,9 +335,6 @@
       "_THREAD_OVERRIDE_FLAGS": {
         "kind": "assign"
       },
-      "_TOOL_TEMPLATE_MARKERS": {
-        "kind": "assign"
-      },
       "_UNRECOVERABLE_LOCAL_ERRNOS": {
         "kind": "assign"
       },

--- a/studio/backend/tests/test_safetensors_capability_advertise.py
+++ b/studio/backend/tests/test_safetensors_capability_advertise.py
@@ -173,12 +173,6 @@ def test_detect_reasoning_flags_none_template_returns_all_false():
             "granite_alias",
             "{%- if tools and not available_tools -%}{{- tools | tojson }}{%- endif -%}",
         ),
-        # Phi-4-mini carries the list on the system message, not as a kwarg.
-        (
-            "phi4_message_scoped",
-            "{% if message['role'] == 'system' and 'tools' in message"
-            " and message['tools'] is not none %}{{ message['tools'] }}{% endif %}",
-        ),
         # No spaces inside the tag.
         ("tight_whitespace", "{%-if tools%}{{- tools | tojson }}{%- endif -%}"),
         # `is not none` rather than a truth test.
@@ -203,6 +197,12 @@ def test_detect_reasoning_flags_reads_tool_guards_however_they_are_written(label
     [
         # Prose, not a tool block.
         ("prose_only", "{{- 'You are a helpful assistant with access to tools.' }}"),
+        # Studio passes tools as a kwarg, not a message field.
+        (
+            "phi4_message_scoped",
+            "{% if message['role'] == 'system' and 'tools' in message"
+            " and message['tools'] is not none %}{{ message['tools'] }}{% endif %}",
+        ),
         # Excluding tool turns is not handling them.
         (
             "negated_role_check",

--- a/studio/backend/tests/test_safetensors_capability_advertise.py
+++ b/studio/backend/tests/test_safetensors_capability_advertise.py
@@ -203,6 +203,18 @@ def test_detect_reasoning_flags_reads_tool_guards_however_they_are_written(label
     [
         # Prose, not a tool block.
         ("prose_only", "{{- 'You are a helpful assistant with access to tools.' }}"),
+        # Excluding tool turns is not handling them.
+        (
+            "negated_role_check",
+            "{% for m in messages %}{% if m.role != 'tool' %}{{ m.content }}"
+            "{% endif %}{% endfor %}",
+        ),
+        # The word in a Jinja comment is not a capability.
+        (
+            "tool_calls_in_comment",
+            "{# tool_calls are deliberately unsupported #}"
+            "{% for m in messages %}{{ m.content }}{% endfor %}",
+        ),
         # Llama 3.1's other switches: neither renders a schema.
         (
             "adjacent_switch_names",

--- a/studio/backend/tests/test_safetensors_capability_advertise.py
+++ b/studio/backend/tests/test_safetensors_capability_advertise.py
@@ -169,7 +169,10 @@ def test_detect_reasoning_flags_none_template_returns_all_false():
     "label, guard",
     [
         # Granite 3.3 aliases the list before branching on it.
-        ("granite_alias", "{%- if tools and not available_tools -%}{{- tools | tojson }}{%- endif -%}"),
+        (
+            "granite_alias",
+            "{%- if tools and not available_tools -%}{{- tools | tojson }}{%- endif -%}",
+        ),
         # Phi-4-mini carries the list on the system message, not as a kwarg.
         (
             "phi4_message_scoped",
@@ -183,12 +186,14 @@ def test_detect_reasoning_flags_none_template_returns_all_false():
         # No guard at all, straight into the loop.
         ("unguarded_loop", "{%- for tool in tools %}{{- tool | tojson }}{%- endfor %}"),
         # An elif arm.
-        ("elif_arm", "{%- if documents %}{{- documents }}{%- elif tools %}{{- tools }}{%- endif %}"),
+        (
+            "elif_arm",
+            "{%- if documents %}{{- documents }}{%- elif tools %}{{- tools }}{%- endif %}",
+        ),
     ],
 )
 def test_detect_reasoning_flags_reads_tool_guards_however_they_are_written(label, guard):
     from core.inference.llama_cpp import detect_reasoning_flags
-
     flags = detect_reasoning_flags(guard, f"vendor/{label}")
     assert flags["supports_tools"] is True
 
@@ -208,7 +213,6 @@ def test_detect_reasoning_flags_reads_tool_guards_however_they_are_written(label
 )
 def test_detect_reasoning_flags_does_not_invent_tool_support(label, template):
     from core.inference.llama_cpp import detect_reasoning_flags
-
     flags = detect_reasoning_flags(template, f"vendor/{label}")
     assert flags["supports_tools"] is False
 

--- a/studio/backend/tests/test_safetensors_capability_advertise.py
+++ b/studio/backend/tests/test_safetensors_capability_advertise.py
@@ -163,6 +163,56 @@ def test_detect_reasoning_flags_none_template_returns_all_false():
     assert flags["reasoning_style"] == "enable_thinking"
 
 
+# Tool guards shipped templates actually write, each read as "no tools" by the older
+# exact-substring scan. A false greys out the Search and Code pills, so the user cannot correct it.
+@pytest.mark.parametrize(
+    "label, guard",
+    [
+        # Granite 3.3 aliases the list before branching on it.
+        ("granite_alias", "{%- if tools and not available_tools -%}{{- tools | tojson }}{%- endif -%}"),
+        # Phi-4-mini carries the list on the system message, not as a kwarg.
+        (
+            "phi4_message_scoped",
+            "{% if message['role'] == 'system' and 'tools' in message"
+            " and message['tools'] is not none %}{{ message['tools'] }}{% endif %}",
+        ),
+        # No spaces inside the tag.
+        ("tight_whitespace", "{%-if tools%}{{- tools | tojson }}{%- endif -%}"),
+        # `is not none` rather than a truth test.
+        ("is_not_none", "{% if tools is not none %}{{ tools | tojson }}{% endif %}"),
+        # No guard at all, straight into the loop.
+        ("unguarded_loop", "{%- for tool in tools %}{{- tool | tojson }}{%- endfor %}"),
+        # An elif arm.
+        ("elif_arm", "{%- if documents %}{{- documents }}{%- elif tools %}{{- tools }}{%- endif %}"),
+    ],
+)
+def test_detect_reasoning_flags_reads_tool_guards_however_they_are_written(label, guard):
+    from core.inference.llama_cpp import detect_reasoning_flags
+
+    flags = detect_reasoning_flags(guard, f"vendor/{label}")
+    assert flags["supports_tools"] is True
+
+
+@pytest.mark.parametrize(
+    "label, template",
+    [
+        # Prose, not a tool block.
+        ("prose_only", "{{- 'You are a helpful assistant with access to tools.' }}"),
+        # Llama 3.1's other switches: neither renders a schema.
+        (
+            "adjacent_switch_names",
+            "{%- if builtin_tools %}{{- 'x' }}{%- endif %}"
+            "{%- if tools_in_user_message %}{{- 'y' }}{%- endif %}",
+        ),
+    ],
+)
+def test_detect_reasoning_flags_does_not_invent_tool_support(label, template):
+    from core.inference.llama_cpp import detect_reasoning_flags
+
+    flags = detect_reasoning_flags(template, f"vendor/{label}")
+    assert flags["supports_tools"] is False
+
+
 def test_detect_reasoning_flags_deepseek_v4_exposes_none_high_max():
     """DeepSeek-V4-Flash: enable_thinking gate + reasoning_effort 'max' preamble.
     Classified as the hybrid style with the full none/high/max ladder even

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -754,3 +754,104 @@ def test_mutation_through_an_alias_is_a_known_under_approximation(template):
 )
 def test_negated_tool_guard_matches_its_positive_spelling(template, expected):
     assert template_supports_tools(template) is expected
+
+
+@pytest.mark.parametrize(
+    ("template", "expected"),
+    [
+        # 3968600730: a positional mapping handed to update keeps its own keys.
+        ("{% set d={} %}{% do d.update({'catalog': tools}) %}{{ d.label|default('x') }}", False),
+        ("{% set d={} %}{% do d.update({'catalog': tools}) %}{{ d.catalog|tojson }}", True),
+        # 3968600737: a literal that always passes the filter never takes the else.
+        ("{% for x in [1] if true %}plain{% else %}{{ tools|tojson }}{% endfor %}", False),
+        ("{% for x in [1] if flag %}plain{% else %}{{ tools|tojson }}{% endfor %}", True),
+        ("{% for x in [] %}plain{% else %}{{ tools|tojson }}{% endfor %}", True),
+        # 3968600770: continue ends the iteration, not the loop.
+        (
+            "{% for value in [false, tools] %}{% if not value %}{% continue %}{% endif %}"
+            "{{ value|tojson }}{% endfor %}",
+            True,
+        ),
+        ("{% for m in messages %}{% break %}{{ tools|tojson }}{% endfor %}", False),
+        (
+            "{% set ns=namespace(catalog=[]) %}{% for x in [tools, []] %}{% set ns.catalog=x %}"
+            "{% break %}{% endfor %}{{ ns.catalog|tojson }}",
+            True,
+        ),
+        # 3968600779: an alias inherits every constructed descendant, not just the root.
+        (
+            "{% set wrapper={'message':{'role':'tool','content':'plain'}} %}"
+            "{% set current=wrapper %}{% if current.message.role == 'tool' %}"
+            "{{ current.message.content }}{% endif %}",
+            False,
+        ),
+        (
+            "{% set current=messages[0] %}{% if current.role == 'tool' %}"
+            "{{ current.content }}{% endif %}",
+            True,
+        ),
+        # 3968600789: a namespace write inside a macro escapes it.
+        (
+            "{% set ns=namespace(catalog=[]) %}{% macro load() %}{% set ns.catalog=tools %}"
+            "{% endmacro %}{{ load() }}{{ ns.catalog|tojson }}",
+            True,
+        ),
+        (
+            "{% set ns=namespace(catalog=[]) %}{% macro load(c) %}{% set ns.catalog=c %}"
+            "{% endmacro %}{% if tools %}{% set _=load(tools) %}{% endif %}{{ ns.catalog|tojson }}",
+            True,
+        ),
+        (
+            "{% set ns=namespace(catalog=[]) %}{% macro noop() %}plain{% endmacro %}"
+            "{{ noop() }}{{ ns.catalog|tojson }}",
+            False,
+        ),
+        # 3968600805: dict() keeps each keyword's field path, as namespace() does.
+        ("{% set wrapper=dict(catalog=tools, label='plain') %}{{ wrapper.label }}", False),
+        ("{% set wrapper=dict(catalog=tools) %}{{ wrapper.catalog|tojson }}", True),
+        # 3968600814: a shallow copy is the receiver again.
+        (
+            "{% set wrapper={'catalog':tools} %}{% set clone=wrapper.copy() %}"
+            "{{ clone.catalog|tojson }}",
+            True,
+        ),
+        (
+            "{% set wrapper={'catalog':tools} %}{% set clone=wrapper.copy() %}"
+            "{{ clone.label|default('x') }}",
+            False,
+        ),
+        # 3968600825: fold comparisons against names bound to a literal.
+        ("{% set flag=true %}{% if flag == false %}{{ tools|tojson }}{% endif %}", False),
+        ("{% set flag=true %}{% if flag == true %}{{ tools|tojson }}{% endif %}", True),
+        ("{% set n=3 %}{% if n > 5 %}{{ tools|tojson }}{% endif %}", False),
+        ("{% set n=3 %}{% if n < 5 %}{{ tools|tojson }}{% endif %}", True),
+        ("{% if flag == false %}{{ tools|tojson }}{% endif %}", True),
+        # 3968600841: the other spellings of a non-empty catalog guard.
+        ("{% if tools != [] %}You may use tools.{% endif %}", True),
+        ("{% if tools != none %}You may use tools.{% endif %}", True),
+        ("{% if tools|length > 0 %}You may use tools.{% endif %}", True),
+        ("{% if tools|length >= 1 %}You may use tools.{% endif %}", True),
+        ("{% if 0 < tools|length %}You may use tools.{% endif %}", True),
+        ("{% if tools == [] %}plain{% else %}You may use tools.{% endif %}", True),
+        ("{% if messages != [] %}nothing here{% endif %}", False),
+        ("{% if tools|length > 3 %}nothing here{% endif %}", False),
+        ("{% if tools == [] %}nothing here{% endif %}", False),
+    ],
+)
+def test_round_eleven_paths(template, expected):
+    assert template_supports_tools(template) is expected
+
+
+@pytest.mark.parametrize("blocks", [12, 40, 200])
+def test_unrelated_conditions_do_not_exhaust_the_budget(blocks):
+    """Paths that differ only in a fact nothing reads again are merged.
+
+    Without that a template pays the full Cartesian product of its conditions, and
+    the budget catch turns a tool-capable template off. Qwen3-Coder spends a large
+    share of the budget on its own, so the headroom is not theoretical.
+    """
+    template = (
+        "".join("{%% if flag%d %%}plain{%% endif %%}" % index for index in range(blocks))
+        + "{% if tools %}{{ tools|tojson }}{% endif %}"
+    )
+    assert template_supports_tools(template) is True

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -1008,3 +1008,69 @@ def test_round_twelve_paths(template, expected):
 )
 def test_round_thirteen_paths(template, expected):
     assert template_supports_tools(template) is expected
+
+
+@pytest.mark.parametrize(
+    ("template", "expected"),
+    [
+        # 3970832364: get() is the mapping spelling of a field read.
+        (
+            "{% if message.get('tool_calls') %}{{ message.get('tool_calls')|tojson }}{% endif %}",
+            True,
+        ),
+        ("{% if message.get('content') %}{{ message.get('content') }}{% endif %}", False),
+        ("{% set w={'role':'tool'} %}{% if w.get('role') == 'tool' %}plain{% endif %}", False),
+        # 3970832372: {% do load() %} discards the value but still runs the macro.
+        (
+            "{% set ns=namespace(catalog=[]) %}{% macro load() %}{% set ns.catalog=tools %}"
+            "{% endmacro %}{% do load() %}{{ ns.catalog|tojson }}",
+            True,
+        ),
+        # 3970832382: unmatched arguments arrive as the implicit varargs and kwargs.
+        ("{% macro show() %}{{ kwargs|tojson }}{% endmacro %}{{ show(catalog=tools) }}", True),
+        ("{% macro show() %}{{ varargs|tojson }}{% endmacro %}{{ show(tools) }}", True),
+        ("{% macro show() %}{{ kwargs|tojson }}{% endmacro %}{{ show(label='x') }}", False),
+        # 3970832395: a default is only reachable when the key can be absent.
+        ("{% set d={'present': []} %}{{ d.pop('present', tools)|tojson }}", False),
+        ("{% set d={'present': 'x'} %}{{ d.pop('present', tools)|tojson }}", False),
+        ("{% set d={} %}{{ d.pop('missing', tools)|tojson }}", True),
+        ("{% set d={'other': 1} %}{{ d.pop('missing', tools)|tojson }}", True),
+        ("{{ payload.pop('x', tools)|tojson }}", True),
+        ("{% set w={'label':'x'} %}{{ w.get('label', tools)|tojson }}", False),
+        # 3970832398: constant Jinja tests fold, so their branches are not scanned.
+        ("{% if false is true %}{{ tools|tojson }}{% endif %}", False),
+        ("{% if 1 is none %}{{ tools|tojson }}{% endif %}", False),
+        ("{% if true is true %}{{ tools|tojson }}{% endif %}", True),
+        ("{% if x is defined %}{{ tools|tojson }}{% endif %}", True),
+        # 3970832411: break leaves the loop incomplete, so Jinja renders the else arm.
+        ("{% for x in [1] %}{% break %}{% else %}{{ tools|tojson }}{% endfor %}", True),
+        ("{% for x in [1] %}plain{% else %}{{ tools|tojson }}{% endfor %}", False),
+        # 3970832421: a namespace write inside {% set %}...{% endset %} outlives it.
+        (
+            "{% set ns=namespace(catalog=[]) %}{% set captured %}{% set ns.catalog=tools %}x"
+            "{% endset %}{{ ns.catalog|tojson }}",
+            True,
+        ),
+        (
+            "{% set ns=namespace(catalog=[]) %}{% set captured %}plain{% endset %}"
+            "{{ ns.catalog|tojson }}",
+            False,
+        ),
+        # 3970832427: reverse and sort move the members, so the indices go unknown.
+        ("{% set c=[tools, []] %}{% do c.reverse() %}{{ c[1]|tojson }}", True),
+        ("{% set c=[[], []] %}{% do c.reverse() %}{{ c[1]|tojson }}", False),
+    ],
+)
+def test_round_fourteen_paths(template, expected):
+    assert template_supports_tools(template) is expected
+
+
+def test_reordering_a_list_over_approximates_rather_than_losing_the_catalog():
+    """`reverse` makes every index under the receiver unknown rather than tracking
+    where each member went, so selecting the index the catalog moved AWAY from also
+    matches. That is deliberate: this detector's damaging failure is hiding tool
+    controls on a template that supports them, so it errs towards showing them."""
+    assert (
+        template_supports_tools("{% set c=[tools, []] %}{% do c.reverse() %}{{ c[0]|tojson }}")
+        is True
+    )

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -1105,3 +1105,73 @@ def test_reordering_a_list_over_approximates_rather_than_losing_the_catalog():
 )
 def test_round_ten_leftovers_now_closed(template, expected):
     assert template_supports_tools(template) is expected
+
+
+@pytest.mark.parametrize(
+    ("template", "expected"),
+    [
+        # 3971620568: an arm selected only where the value is proved empty.
+        ("{{ tools if not tools else [] }}", False),
+        ("{{ tools if tools else [] }}", True),
+        ("{{ [] if not tools else tools }}", True),
+        # 3971620577: recursion is simulated to a bounded depth.
+        (
+            "{% macro show(n,c) %}{% if n %}{{ show(n-1,c) }}{% else %}{{ c|tojson }}"
+            "{% endif %}{% endmacro %}{{ show(1,tools) }}",
+            True,
+        ),
+        (
+            "{% macro show(n,c) %}{% if n %}{{ show(n-1,c) }}{% else %}plain{% endif %}"
+            "{% endmacro %}{{ show(1,tools) }}",
+            False,
+        ),
+        ("{% macro f(c) %}{{ f(c) }}{% endmacro %}{{ f(tools) }}", False),
+        # 3971620584: a macro chosen through an expression is still that macro.
+        (
+            "{% macro show() %}{{ tools|tojson }}{% endmacro %}"
+            "{% set render = show if flag else show %}{{ render() }}",
+            True,
+        ),
+        (
+            "{% macro show() %}plain{% endmacro %}{% set render = show if flag else show %}"
+            "{{ render() }}",
+            False,
+        ),
+        # 3971620595: an else arm reached after break keeps that path's mutations.
+        (
+            "{% set ns=namespace(catalog=[]) %}{% for x in [1] %}{% set ns.catalog=tools %}"
+            "{% break %}{% else %}{{ ns.catalog|tojson }}{% endfor %}",
+            True,
+        ),
+        (
+            "{% set ns=namespace(catalog=[]) %}{% for x in [1] %}{% break %}{% else %}"
+            "{{ ns.catalog|tojson }}{% endfor %}",
+            False,
+        ),
+        # 3971620599: template-built is asked of the field, not just its container.
+        (
+            "{% set ns=namespace() %}{% set ns.role=message.role %}"
+            "{% if ns.role == 'tool' %}{{ message.content }}{% endif %}",
+            True,
+        ),
+        ("{% set ns=namespace(role='tool') %}{% if ns.role == 'tool' %}plain{% endif %}", False),
+        (
+            "{% set ns=namespace() %}{% set ns.role='tool' %}{% if ns.role == 'tool' %}plain"
+            "{% endif %}",
+            False,
+        ),
+        # 3971620605: a scalar-returning method reduces its input.
+        ("{{ tools.count(tools[0]) }}", False),
+        # 3971620613: an indexed removal shifts the later indices down.
+        ("{% set c=[[],tools] %}{% do c.pop(0) %}{{ c[0]|tojson }}", True),
+        ("{% set c=[[],tools] %}{% do c.pop(0) %}{{ c[1]|tojson }}", False),
+        ("{% set c=[tools,[]] %}{% do c.pop(1) %}{{ c[0]|tojson }}", True),
+        # 3971620621: a raise in an always-evaluated position aborts the expression.
+        ("{{ raise_exception('unsupported') or tools|tojson }}", False),
+        ("{{ tools|tojson or raise_exception('never') }}", True),
+        ("{{ raise_exception('always') }}{{ tools|tojson }}", False),
+        ("{{ tools|tojson }}{{ raise_exception('after') }}", True),
+    ],
+)
+def test_round_fifteen_paths(template, expected):
+    assert template_supports_tools(template) is expected

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -936,3 +936,75 @@ def test_unrelated_conditions_do_not_exhaust_the_budget(blocks):
 )
 def test_round_twelve_paths(template, expected):
     assert template_supports_tools(template) is expected
+
+
+@pytest.mark.parametrize(
+    ("template", "expected"),
+    [
+        # 3969739986: caller() reached only on a dead path is not an invocation.
+        (
+            "{% macro wrap(caller=None) %}{% if false %}{{ caller() }}{% endif %}{% endmacro %}"
+            "{% call wrap() %}{{ tools|tojson }}{% endcall %}",
+            False,
+        ),
+        (
+            "{% macro wrap(caller=None) %}{{ caller() }}{% endmacro %}"
+            "{% call wrap() %}{{ tools|tojson }}{% endcall %}",
+            True,
+        ),
+        (
+            "{% macro w(caller=None) %}{% if flag %}{{ caller() }}{% endif %}{% endmacro %}"
+            "{% call w() %}{{ tools|tojson }}{% endcall %}",
+            True,
+        ),
+        ("{% call unknown() %}{{ tools|tojson }}{% endcall %}", True),
+        (
+            "{% macro w(caller=None) %}{{ caller() }}{% endmacro %}{% call w() %}plain{% endcall %}",
+            False,
+        ),
+        # 3969739997: with a filter the loop position describes the accepted sequence.
+        (
+            "{% for x in [false, true] if x %}{% if loop.first %}{{ tools|tojson }}{% endif %}"
+            "{% endfor %}",
+            True,
+        ),
+        # 3969740007: a mutator called in output position still mutates.
+        ("{% set catalog=tools|list %}{{ catalog.clear() }}{{ catalog|tojson }}", False),
+        ("{% set catalog=tools|list %}{{ catalog|tojson }}", True),
+        # 3969740018: a truth-tested count is a guard, in both spellings.
+        ("{% if tools|length %}You may call tools.{% endif %}", True),
+        ("{% if not tools|length %}plain{% else %}You may call tools.{% endif %}", True),
+        ("{% if messages|length %}nothing here{% endif %}", False),
+        # 3969740028: the role literal may be staged in a variable.
+        (
+            "{% set tool_role='tool' %}{% if message.role == tool_role %}{{ message.content }}"
+            "{% endif %}",
+            True,
+        ),
+        ("{% set r='user' %}{% if message.role == r %}{{ message.content }}{% endif %}", False),
+        # 3969740040: pop hands back its default when the field is missing.
+        ("{% set d={} %}{{ d.pop('missing', tools)|tojson }}", True),
+        ("{% set d={'a':tools} %}{% do d.pop('a') %}{{ d|tojson }}", False),
+        # 3969740046: rebuilding a container drops the old subtree.
+        (
+            "{% set wrapper={'message': {'role':'user'}} %}{% set wrapper={'message': message} %}"
+            "{% if wrapper.message.role == 'tool' %}{{ wrapper.message.content }}{% endif %}",
+            True,
+        ),
+        (
+            "{% set wrapper={'message': {'role':'user'}} %}"
+            "{% if wrapper.message.role == 'tool' %}{{ wrapper.message.content }}{% endif %}",
+            False,
+        ),
+        # 3969740055: raise_exception aborts the render, and a guard that proves the
+        # catalog empty means the output it reaches carries no schema.
+        ("{% if tools %}{{ raise_exception('unsupported') }}{% endif %}{{ tools|tojson }}", False),
+        ("{{ raise_exception('always') }}{{ tools|tojson }}", False),
+        ("{{ tools|tojson }}{{ raise_exception('after') }}", True),
+        ("{% if not tools %}{{ raise_exception('none') }}{% endif %}{{ tools|tojson }}", True),
+        ("{% if not tools %}{{ tools|tojson }}{% endif %}", False),
+        ("{% if tools %}{{ tools|tojson }}{% endif %}", True),
+    ],
+)
+def test_round_thirteen_paths(template, expected):
+    assert template_supports_tools(template) is expected

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -745,9 +745,10 @@ def test_mutation_through_an_alias_is_a_known_under_approximation(template):
         ("{% if not tools %}plain{% else %}You may call tools.{% endif %}", True),
         ("{% if tools is not defined %}plain{% else %}You may call tools.{% endif %}", True),
         ("{% if tools is none %}plain{% else %}You may call tools.{% endif %}", True),
-        # An elif makes the else reachable for more than one reason, so the guard
-        # does not carry across it.
-        ("{% if not tools %}plain{% elif other %}x{% else %}You may call tools.{% endif %}", False),
+        # The else arm runs only when every test was false, so `not tools` being false
+        # means the catalog IS present there and the arm is guarded by it. Rendering
+        # confirms it: this template emits the prose only when tools are supplied.
+        ("{% if not tools %}plain{% elif other %}x{% else %}You may call tools.{% endif %}", True),
         # A negated guard on something else is not a tool guard.
         ("{% if not messages %}plain{% else %}nothing here{% endif %}", False),
     ],
@@ -1374,3 +1375,52 @@ def test_a_macro_branching_internally_over_approximates_for_its_caller():
 )
 def test_round_eighteen_paths(template, expected):
     assert template_supports_tools(template) is expected
+
+
+@pytest.mark.parametrize(
+    ("template", "expected"),
+    [
+        # 3972689845: the two-argument get() reads the same field.
+        ("{{ message.get('tool_calls', [])|tojson }}", True),
+        ("{{ message.get('tool_calls')|tojson }}", True),
+        ("{{ message.get('content', '') }}", False),
+        ("{% set w={'tool_calls':'plain'} %}{{ w.get('tool_calls') }}", False),
+        # 3972689853: a parked path is represented by what its else arm produced.
+        (
+            "{% set ns=namespace(c=tools) %}{% for x in [1] %}{% break %}{% else %}"
+            "{% set ns.c=[] %}{% endfor %}{{ ns.c|tojson }}",
+            False,
+        ),
+        (
+            "{% set ns=namespace(catalog=[]) %}{% for x in [1] %}{% set ns.catalog=tools %}"
+            "{% break %}{% else %}{{ ns.catalog|tojson }}{% endfor %}",
+            True,
+        ),
+        # 3972689903: a raise in {% do %} aborts as the output form does.
+        ("{% do raise_exception('unsupported') %}{{ tools|tojson }}", False),
+        ("{% do noop('x') %}{{ tools|tojson }}", True),
+        # 3972689914: a negative index counts from the end of a literal.
+        ("{{ [tools, []][-1]|tojson }}", False),
+        ("{{ [tools, []][-2]|tojson }}", True),
+        ("{{ [tools, []][0]|tojson }}", True),
+        # 3972689921: the else arm runs only when every test was false.
+        ("{% if flag %}plain{% elif not tools %}plain{% else %}Use tools{% endif %}", True),
+        ("{% if flag %}plain{% elif not messages %}plain{% else %}nothing{% endif %}", False),
+    ],
+)
+def test_round_nineteen_paths(template, expected):
+    assert template_supports_tools(template) is expected
+
+
+def test_the_else_arm_of_a_negated_guard_is_guarded_even_behind_an_elif():
+    """Rendered rather than asserted from the analyser, because the round-11 version of
+    this test asserted the opposite and was wrong: the else arm of
+    `{% if not tools %}...{% elif other %}...{% else %}` is reached only when the
+    catalog IS present, so the prose in it advertises tools."""
+    template = "{% if not tools %}plain{% elif other %}x{% else %}You may call tools.{% endif %}"
+    render = Environment().from_string(template)
+    tools = [{"type": "function", "function": {"name": "get_weather"}}]
+    assert render.render(tools = [], other = False) == "plain"
+    assert render.render(tools = tools, other = True) == "x"
+    assert render.render(tools = tools, other = False) == "You may call tools."
+    assert template_supports_tools(template) is True

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -1074,3 +1074,34 @@ def test_reordering_a_list_over_approximates_rather_than_losing_the_catalog():
         template_supports_tools("{% set c=[tools, []] %}{% do c.reverse() %}{{ c[0]|tojson }}")
         is True
     )
+
+
+@pytest.mark.parametrize(
+    ("template", "expected"),
+    [
+        # 3968192941: a name bound to a macro calls the same body.
+        (
+            "{% macro show() %}{{ tools|tojson }}{% endmacro %}{% set render=show %}"
+            "{{ render() }}",
+            True,
+        ),
+        ("{% macro show() %}plain{% endmacro %}{% set render=show %}{{ render() }}", False),
+        # 3968192960: the role may be staged in a name before the comparison.
+        (
+            "{% set role=message.role %}{% if role == 'tool' %}{{ message.content }}{% endif %}",
+            True,
+        ),
+        (
+            "{% set role=message.role %}{% if role == 'user' %}{{ message.content }}{% endif %}",
+            False,
+        ),
+        # A role read off a template-built record still means nothing.
+        (
+            "{% set w={'role':'tool'} %}{% set role=w.role %}{% if role == 'tool' %}plain"
+            "{% endif %}",
+            False,
+        ),
+    ],
+)
+def test_round_ten_leftovers_now_closed(template, expected):
+    assert template_supports_tools(template) is expected

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -890,7 +890,10 @@ def test_unrelated_conditions_do_not_exhaust_the_budget(blocks):
             False,
         ),
         # 3969190349: an update replaces the fields it names.
-        ("{% set d={'catalog':tools} %}{% do d.update({'catalog':[]}) %}{{ d.catalog|tojson }}", False),
+        (
+            "{% set d={'catalog':tools} %}{% do d.update({'catalog':[]}) %}{{ d.catalog|tojson }}",
+            False,
+        ),
         ("{% set d={'catalog':tools} %}{% do d.update(catalog=[]) %}{{ d.catalog|tojson }}", False),
         (
             "{% set d={'catalog':tools,'other':tools} %}{% do d.update({'catalog':[]}) %}"
@@ -898,7 +901,10 @@ def test_unrelated_conditions_do_not_exhaust_the_budget(blocks):
             True,
         ),
         # 3969190360: a literal iterable knows which iteration is first and last.
-        ("{% for x in [1] %}{% if not loop.first %}{{ tools|tojson }}{% endif %}{% endfor %}", False),
+        (
+            "{% for x in [1] %}{% if not loop.first %}{{ tools|tojson }}{% endif %}{% endfor %}",
+            False,
+        ),
         ("{% for x in [1] %}{% if loop.first %}{{ tools|tojson }}{% endif %}{% endfor %}", True),
         (
             "{% for x in [1,2] %}{% if not loop.first %}{{ tools|tojson }}{% endif %}{% endfor %}",

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -1307,3 +1307,70 @@ def test_a_macro_branching_internally_over_approximates_for_its_caller():
         "{{ load() }}{% if not flag %}{{ ns.catalog|tojson }}{% endif %}"
     )
     assert template_supports_tools(template) is True
+
+
+@pytest.mark.parametrize(
+    ("template", "expected"),
+    [
+        # 3972440546: a destructive call makes the key set unknown again.
+        (
+            "{% set d={'label':'x'} %}{% do d.pop('label') %}{{ d.get('label', tools)|tojson }}",
+            True,
+        ),
+        ("{% set d={'label':'x'} %}{{ d.get('label', tools)|tojson }}", False),
+        # 3972440554: a literal record follows the name it was assigned to.
+        ("{% set a={'x':tools} %}{% set b=a %}{% for k in b %}{{ k }}{% endfor %}", False),
+        # 3972440560: a constant index picks one member, not the whole collection.
+        (
+            "{% macro plain() %}text{% endmacro %}{% macro show() %}{{ tools|tojson }}"
+            "{% endmacro %}{% set render=[plain,show][0] %}{{ render() }}",
+            False,
+        ),
+        (
+            "{% macro plain() %}text{% endmacro %}{% macro show() %}{{ tools|tojson }}"
+            "{% endmacro %}{% set render=[plain,show][1] %}{{ render() }}",
+            True,
+        ),
+        # 3972440564: a condition is evaluated before either arm is chosen.
+        ("{% set c=[] %}{% if c.append(tools) %}{% endif %}{{ c|tojson }}", True),
+        # 3972440571: duplicate literal items keep their own positions.
+        ("{% for x in [1,1] %}{% if loop.last %}{{ tools|tojson }}{% endif %}{% endfor %}", True),
+        (
+            "{% for x in [1] %}{% if not loop.first %}{{ tools|tojson }}{% endif %}{% endfor %}",
+            False,
+        ),
+        # 3972440579: a named empty literal never runs its loop body.
+        ("{% set xs=[] %}{% for x in xs %}{{ tools|tojson }}{% endfor %}", False),
+        ("{% set xs=[1] %}{% for x in xs %}{{ tools|tojson }}{% endfor %}", True),
+        # 3972440587: every reducing filter drops the catalog, not just length/count.
+        ("{{ tools|wordcount }}", False),
+        ("{{ tools|tojson }}", True),
+        # 3972440595: a negated role check puts the tool branch in the else arm.
+        ("{% if message.role != 'tool' %}plain{% else %}{{ message.content }}{% endif %}", True),
+        ("{% if message.role != 'user' %}plain{% else %}{{ message.content }}{% endif %}", False),
+        # 3972440599: a guard that proves the catalog empty by comparison.
+        ("{% if tools == [] %}{{ tools|tojson }}{% endif %}", False),
+        ("{% if tools is none %}{{ tools|tojson }}{% endif %}", False),
+        ("{% if tools != [] %}{{ tools|tojson }}{% endif %}", True),
+        ("{% if tools == [] %}plain{% else %}You may use tools.{% endif %}", True),
+        # 3972440602: a negative step reverses the ordering.
+        ("{{ tools[1:0:-1]|tojson }}", True),
+        ("{{ tools[0:0]|tojson }}", False),
+        # 3972440612: a filter block runs its body, so writes inside it escape.
+        (
+            "{% set ns=namespace(catalog=[]) %}{% filter upper %}{% set ns.catalog=tools %}"
+            "{% endfilter %}{{ ns.catalog|tojson }}",
+            True,
+        ),
+        ("{% filter first %}{{ tools|tojson }}{% endfilter %}", False),
+        ("{% filter upper %}{{ tools|tojson }}{% endfilter %}", True),
+        # 3972440619: every element of a literal container is evaluated first.
+        ("{{ {'error': raise_exception('x'), 'catalog': tools}|tojson }}", False),
+        # 3972440628: items() and values() are views onto the mapping's values.
+        ("{% set d={'catalog':tools} %}{% for k,v in d.items() %}{{ v|tojson }}{% endfor %}", True),
+        ("{% set d={'catalog':tools} %}{% for v in d.values() %}{{ v|tojson }}{% endfor %}", True),
+        ("{% set d={'label':'x'} %}{% for v in d.values() %}{{ v }}{% endfor %}", False),
+    ],
+)
+def test_round_eighteen_paths(template, expected):
+    assert template_supports_tools(template) is expected

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -1175,3 +1175,44 @@ def test_round_ten_leftovers_now_closed(template, expected):
 )
 def test_round_fifteen_paths(template, expected):
     assert template_supports_tools(template) is expected
+
+
+@pytest.mark.parametrize(
+    ("template", "expected"),
+    [
+        # 3971892918: a call's arguments are evaluated before the call.
+        ("{{ dict(error=raise_exception('unsupported'), catalog=tools)|tojson }}", False),
+        ("{{ dict(catalog=tools)|tojson }}", True),
+        # 3971892927: a macro selected out of a static collection.
+        (
+            "{% macro show() %}{{ tools|tojson }}{% endmacro %}{% set render=[show][0] %}"
+            "{{ render() }}",
+            True,
+        ),
+        ("{% macro show() %}plain{% endmacro %}{% set render=[show][0] %}{{ render() }}", False),
+        # 3971892936: iterating a mapping walks its keys, even when it was named first.
+        (
+            "{% set by_name={'weather': tools} %}{% for name in by_name %}{{ name }}{% endfor %}",
+            False,
+        ),
+        (
+            "{% set by_name={'weather': tools} %}{% for name in by_name %}"
+            "{{ by_name[name]|tojson }}{% endfor %}",
+            True,
+        ),
+        (
+            "{% set by_name={'w': tools} %}{% set by_name=tools %}{% for v in by_name %}"
+            "{{ v|tojson }}{% endfor %}",
+            True,
+        ),
+        ("{% set c=[tools] %}{% for v in c %}{{ v|tojson }}{% endfor %}", True),
+        # 3971892941: a statically empty slice renders nothing; other slices do not.
+        ("{{ tools[0:0]|tojson }}", False),
+        ("{{ tools[0:1]|tojson }}", True),
+        ("{{ tools[1:]|tojson }}", True),
+        ("{{ tools[:2]|tojson }}", True),
+        ("{% for m in messages[1:] %}{{ m.tool_calls|tojson }}{% endfor %}", True),
+    ],
+)
+def test_round_sixteen_paths(template, expected):
+    assert template_supports_tools(template) is expected

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -855,3 +855,78 @@ def test_unrelated_conditions_do_not_exhaust_the_budget(blocks):
         + "{% if tools %}{{ tools|tojson }}{% endif %}"
     )
     assert template_supports_tools(template) is True
+
+
+@pytest.mark.parametrize(
+    ("template", "expected"),
+    [
+        # 3969190325: every feasible macro outcome survives, not just the last scanned.
+        (
+            "{% macro load() %}{% if tools %}{% set ns.catalog=tools %}"
+            "{% else %}{% set ns.catalog=[] %}{% endif %}{% endmacro %}"
+            "{% set ns=namespace(catalog=[]) %}{{ load() }}{{ ns.catalog|tojson }}",
+            True,
+        ),
+        (
+            "{% set ns=namespace(catalog=[]) %}{% macro noop() %}plain{% endmacro %}"
+            "{{ noop() }}{{ ns.catalog|tojson }}",
+            False,
+        ),
+        # 3969190330: rebinding a root makes its members external again.
+        (
+            "{% set wrapper={'message':{'role':'plain'}} %}{% set wrapper=payload %}"
+            "{% if wrapper.message.role == 'tool' %}{{ wrapper.message.content }}{% endif %}",
+            True,
+        ),
+        (
+            "{% set wrapper={'message':{'role':'plain'}} %}"
+            "{% if wrapper.message.role == 'tool' %}{{ wrapper.message.content }}{% endif %}",
+            False,
+        ),
+        # 3969190339: dict() builds a record just as a literal does.
+        (
+            "{% set wrapper=dict(role='tool', content='plain') %}"
+            "{% if wrapper.role == 'tool' %}{{ wrapper.content }}{% endif %}",
+            False,
+        ),
+        # 3969190349: an update replaces the fields it names.
+        ("{% set d={'catalog':tools} %}{% do d.update({'catalog':[]}) %}{{ d.catalog|tojson }}", False),
+        ("{% set d={'catalog':tools} %}{% do d.update(catalog=[]) %}{{ d.catalog|tojson }}", False),
+        (
+            "{% set d={'catalog':tools,'other':tools} %}{% do d.update({'catalog':[]}) %}"
+            "{{ d.other|tojson }}",
+            True,
+        ),
+        # 3969190360: a literal iterable knows which iteration is first and last.
+        ("{% for x in [1] %}{% if not loop.first %}{{ tools|tojson }}{% endif %}{% endfor %}", False),
+        ("{% for x in [1] %}{% if loop.first %}{{ tools|tojson }}{% endif %}{% endfor %}", True),
+        (
+            "{% for x in [1,2] %}{% if not loop.first %}{{ tools|tojson }}{% endif %}{% endfor %}",
+            True,
+        ),
+        (
+            "{% for m in messages %}{% if not loop.first %}{{ tools|tojson }}{% endif %}{% endfor %}",
+            True,
+        ),
+        # 3969190379: in-place mutators render None, so the argument never reaches output.
+        ("{% set catalog=[] %}{{ catalog.append(tools) }}", False),
+        ("{{ tools.clear() }}", False),
+        ("{% set catalog=[] %}{% do catalog.append(tools) %}{{ catalog|tojson }}", True),
+        # 3969190387: get() selects the field, and its default counts too.
+        ("{% set wrapper={'catalog':tools} %}{{ wrapper.get('catalog')|tojson }}", True),
+        ("{% set wrapper={'label':'x'} %}{{ wrapper.get('label') }}", False),
+        ("{% set wrapper={} %}{{ wrapper.get('x', tools)|tojson }}", True),
+        # 3969190396: iterating a mapping walks its keys, not its values.
+        ("{% for key in {'x': tools} %}{{ key }}{% endfor %}", False),
+        ("{% for v in tools %}{{ v|tojson }}{% endfor %}", True),
+        # 3969190408: an inline loop filter guards the body, as GLM-4-32B spells it.
+        (
+            "{% for message in messages if message.role == 'tool' %}{{ message.content }}"
+            "{% endfor %}",
+            True,
+        ),
+        ("{% for m in messages if m.role != 'system' %}{{ m.content }}{% endfor %}", False),
+    ],
+)
+def test_round_twelve_paths(template, expected):
+    assert template_supports_tools(template) is expected

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -1216,3 +1216,94 @@ def test_round_fifteen_paths(template, expected):
 )
 def test_round_sixteen_paths(template, expected):
     assert template_supports_tools(template) is expected
+
+
+@pytest.mark.parametrize(
+    ("template", "expected"),
+    [
+        # 3972114169: an expression may select any of several macros.
+        (
+            "{% macro plain() %}text{% endmacro %}{% macro show() %}{{ tools|tojson }}"
+            "{% endmacro %}{% set render = plain if flag else show %}{{ render() }}",
+            True,
+        ),
+        (
+            "{% macro plain() %}text{% endmacro %}{% macro other() %}more{% endmacro %}"
+            "{% set render = plain if flag else other %}{{ render() }}",
+            False,
+        ),
+        # 3972114174: a filtered capture binds the filtered result.
+        ("{% set catalog|length %}{{ tools|tojson }}{% endset %}{{ catalog }}", False),
+        ("{% set catalog %}{{ tools|tojson }}{% endset %}{{ catalog }}", True),
+        # 3972114183: a macro reached through {% call %} exports its namespace writes.
+        (
+            "{% set ns=namespace(catalog=[]) %}{% macro load(caller=None) %}"
+            "{% set ns.catalog=tools %}{% endmacro %}{% call load() %}{% endcall %}"
+            "{{ ns.catalog|tojson }}",
+            True,
+        ),
+        # 3972114192: dict() builds a mapping too.
+        (
+            "{% set by_name=dict(weather=tools) %}{% for name in by_name %}{{ name }}"
+            "{% endfor %}",
+            False,
+        ),
+        (
+            "{% set by_name=dict(weather=tools) %}{% for n in by_name %}"
+            "{{ by_name[n]|tojson }}{% endfor %}",
+            True,
+        ),
+        # 3972114200: a macro whose body always raises aborts its caller.
+        (
+            "{% macro fail() %}{{ raise_exception('unsupported') }}{% endmacro %}{{ fail() }}"
+            "{{ tools|tojson }}",
+            False,
+        ),
+        (
+            "{% macro maybe() %}{% if flag %}{{ raise_exception('x') }}{% endif %}{% endmacro %}"
+            "{{ maybe() }}{{ tools|tojson }}",
+            True,
+        ),
+        # 3972114211: a scalar-returning method does not mutate its receiver.
+        ("{% set catalog=[] %}{% do catalog.count(tools) %}{{ catalog|tojson }}", False),
+        ("{% set catalog=[] %}{% do catalog.append(tools) %}{{ catalog|tojson }}", True),
+        # 3972114215: a key holding external data is still a key that is present.
+        ("{% set w={'label': payload} %}{{ w.get('label', tools)|tojson }}", False),
+        ("{% set w={'other': payload} %}{{ w.get('label', tools)|tojson }}", True),
+    ],
+)
+def test_round_seventeen_paths(template, expected):
+    assert template_supports_tools(template) is expected
+
+
+def test_jinja_renders_the_loop_else_arm_after_a_break():
+    """Jinja does NOT follow Python here: with the loopcontrols extension a loop that
+    breaks still renders its else arm. Asserted against a real render because the
+    claim has been made in both directions during review, and the render settles it."""
+    render = Environment(extensions = ["jinja2.ext.loopcontrols"]).from_string(
+        "{% for x in [1] %}A{% break %}{% else %}B{% endfor %}"
+    )
+    assert render.render() == "AB"
+    assert (
+        template_supports_tools(
+            "{% for x in [1] %}{% break %}{% else %}{{ tools|tojson }}{% endfor %}"
+        )
+        is True
+    )
+
+
+def test_a_macro_branching_internally_over_approximates_for_its_caller():
+    """A macro that writes different things on different internal branches has those
+    outcomes unioned into the caller, because value evaluation returns a set of
+    provenance paths with no room for the assumption each came under. The caller can
+    therefore pair one branch's write with another branch's condition.
+
+    Deliberate: the alternative is intersecting, which would drop a write the render
+    does make. Same root cause as the conditional-expression case, and the error runs
+    towards showing a tools pill rather than hiding one."""
+    template = (
+        "{% set ns=namespace(catalog=[]) %}{% macro load() %}{% if flag %}"
+        "{% set ns.catalog=tools %}{% else %}{% set ns.catalog=[] %}{% endif %}{% endmacro %}"
+        "{{ load() }}{% if not flag %}{{ ns.catalog|tojson }}{% endif %}"
+    )
+    assert template_supports_tools(template) is True

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -69,12 +69,12 @@ def _published_template(name):
     return (Path(__file__).parent / "data" / "chat_templates" / f"{name}.jinja").read_text()
 
 
-@pytest.mark.parametrize("name", ["granite-3.3", "phi-4-mini"])
-def test_detection_does_not_bypass_the_safetensors_parser_gate(name):
+@pytest.mark.parametrize("name, detected", [("granite-3.3", True), ("phi-4-mini", False)])
+def test_detection_does_not_bypass_the_safetensors_parser_gate(name, detected):
     from routes.inference import _detect_safetensors_features
 
     template = _published_template(name)
-    assert template_supports_tools(template) is True
+    assert template_supports_tools(template) is detected
     flags = _detect_safetensors_features(SimpleNamespace(active_model_name = name), template)
     assert flags["supports_tools"] is False
 
@@ -103,3 +103,106 @@ def test_published_templates_render_studios_tool_argument(name, emits_schema):
     without_tools = apply_chat_template_for_generation(tokenizer, messages)
     assert ("get_weather" in with_tools) is emits_schema
     assert (with_tools != without_tools) is emits_schema
+
+
+@pytest.mark.parametrize(
+    "template, expected",
+    [
+        (
+            "{% set ns = namespace(available_tools=[]) %}"
+            "{% if tools %}{% set ns = namespace(available_tools=tools) %}{% endif %}"
+            "{{ ns.available_tools | tojson }}",
+            True,
+        ),
+        (
+            "{% set ns = namespace(available_tools=[]) %}"
+            "{% if tools %}{% set ns.available_tools = tools %}{% endif %}"
+            "{{ ns.available_tools | tojson }}",
+            True,
+        ),
+        (
+            "{% set ns = namespace(available_tools=[]) %}"
+            "{% set ns.available_tools = tools %}"
+            "{% set catalog = ns['available_tools'] %}{{ catalog | tojson }}",
+            True,
+        ),
+        (
+            "{% set ns = namespace(available_tools=[]) %}"
+            "{% set other = namespace(available_tools=[]) %}"
+            "{% set ns.available_tools = tools %}{{ other.available_tools | tojson }}",
+            False,
+        ),
+        (
+            "{% macro format_metadata(tools) %}{{ tools | tojson }}{% endmacro %}"
+            "{{ message.content }}",
+            False,
+        ),
+        (
+            "{% macro format_metadata(tools) %}{{ tools | tojson }}{% endmacro %}"
+            "{{ format_metadata([]) }}",
+            False,
+        ),
+        (
+            "{% macro format_metadata(tools) %}{{ tools | tojson }}{% endmacro %}"
+            "{{ format_metadata(tools) }}",
+            True,
+        ),
+        (
+            "{% macro format_metadata(catalog) %}{{ catalog | tojson }}{% endmacro %}"
+            "{{ format_metadata(catalog=tools) }}",
+            True,
+        ),
+        (
+            "{% macro format_metadata(tools=[]) %}{{ tools | tojson }}{% endmacro %}"
+            "{{ format_metadata() }}",
+            False,
+        ),
+        (
+            "{% macro format_metadata(catalog=tools) %}{{ catalog | tojson }}{% endmacro %}"
+            "{{ format_metadata() }}",
+            True,
+        ),
+        (
+            "{% macro format_metadata(catalog, selected=catalog) %}"
+            "{{ selected | tojson }}{% endmacro %}{{ format_metadata(tools) }}",
+            True,
+        ),
+        (
+            "{% set ns = namespace(available_tools=tools) %}"
+            "{% macro format_metadata(data) %}{{ data.available_tools | tojson }}{% endmacro %}"
+            "{{ format_metadata(ns) }}",
+            True,
+        ),
+        (
+            "{% macro format_metadata() %}{{ tools | tojson }}{% endmacro %}"
+            "{{ format_metadata() }}",
+            True,
+        ),
+        (
+            "{% macro format_metadata(tools) %}plain{% endmacro %}{{ format_metadata(tools) }}",
+            False,
+        ),
+        (
+            "{% if tools %}{% macro unused(tools) %}{{ tools | tojson }}"
+            "{% endmacro %}{% endif %}{{ message.content }}",
+            False,
+        ),
+        (
+            "{% macro unused() %}{% set catalog = tools %}{% endmacro %}"
+            "{{ catalog | default('plain') }}",
+            False,
+        ),
+    ],
+)
+def test_alias_and_macro_detection_matches_rendered_catalog(template, expected):
+    from core.inference.llama_cpp import detect_reasoning_flags
+
+    render = Environment().from_string(template)
+    tools = [{"type": "function", "function": {"name": "get_weather", "parameters": {}}}]
+    common = {"message": {"role": "user", "content": "Hi"}}
+    with_tools = render.render(tools = tools, **common)
+    without_tools = render.render(tools = [], **common)
+    assert ("get_weather" in with_tools) is expected
+    assert (with_tools != without_tools) is expected
+    assert template_supports_tools(template) is expected
+    assert detect_reasoning_flags(template)["supports_tools"] is expected

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -195,6 +195,10 @@ def test_published_templates_render_studios_tool_argument(name, emits_schema):
     ],
 )
 def test_alias_and_macro_detection_matches_rendered_catalog(template, expected):
+    _assert_catalog_rendering(template, expected)
+
+
+def _assert_catalog_rendering(template, expected):
     from core.inference.llama_cpp import detect_reasoning_flags
 
     render = Environment().from_string(template)
@@ -203,6 +207,83 @@ def test_alias_and_macro_detection_matches_rendered_catalog(template, expected):
     with_tools = render.render(tools = tools, **common)
     without_tools = render.render(tools = [], **common)
     assert ("get_weather" in with_tools) is expected
-    assert (with_tools != without_tools) is expected
+    if expected:
+        assert with_tools != without_tools
     assert template_supports_tools(template) is expected
     assert detect_reasoning_flags(template)["supports_tools"] is expected
+
+
+@pytest.mark.parametrize(
+    "template, expected",
+    [
+        ("{% set catalog=[] %}{{ catalog|tojson }}{% set catalog=tools %}", False),
+        ("{% set catalog=tools %}{% set catalog=[] %}{{ catalog|tojson }}", False),
+        ("{% set catalog=tools %}{% set catalog=catalog|list %}{{ catalog|tojson }}", True),
+        ("{% set catalog=tools|length %}{{ catalog }}", False),
+        ("{% set tools=[] %}{{ tools|tojson }}", False),
+        (
+            "{% if tools %}{% set catalog=tools|list %}{% endif %}"
+            "{{ catalog|default([])|tojson }}",
+            True,
+        ),
+        ("{% set catalog=tools|default([])|list %}{{ catalog|tojson }}", True),
+        ("{% set catalog=tools or [] %}{{ catalog|tojson }}", True),
+        (
+            "{% set catalog=tools %}{% if tools %}{% set catalog=[] %}"
+            "{% else %}{% set catalog=[] %}{% endif %}{{ catalog|tojson }}",
+            False,
+        ),
+        (
+            "{% set catalog=[] %}{% with catalog=tools, output=catalog %}"
+            "{{ output|tojson }}{% endwith %}",
+            False,
+        ),
+        ("{% set catalog %}{{ tools|tojson }}{% endset %}{{ catalog }}", True),
+        ("{% set catalog %}{{ tools|tojson }}{% endset %}", False),
+        ("{% set catalog=[] if tools else [] %}{{ catalog|tojson }}", False),
+        ("{% set catalog=tools and [] %}{{ catalog|tojson }}", False),
+        (
+            "{% set ns=namespace(catalog=tools) %}{% set ns.catalog=[] %}"
+            "{{ ns.catalog|tojson }}",
+            False,
+        ),
+        (
+            "{% set ns=namespace(catalog=tools) %}{% set ns=namespace(catalog=[]) %}"
+            "{{ ns.catalog|tojson }}",
+            False,
+        ),
+        (
+            "{% set catalog=tools %}{% if true %}{% set catalog=[] %}{% endif %}"
+            "{{ catalog|tojson }}",
+            False,
+        ),
+        (
+            "{% set catalog=tools %}{% if false %}{% set catalog=[] %}{% endif %}"
+            "{{ catalog|tojson }}",
+            True,
+        ),
+        (
+            "{% set catalog=[] %}{% macro show() %}{{ catalog|tojson }}{% endmacro %}"
+            "{{ show() }}{% set catalog=tools %}",
+            False,
+        ),
+        (
+            "{% set catalog=[] %}{% macro show() %}{{ catalog|tojson }}{% endmacro %}"
+            "{% set catalog=tools %}{{ show() }}",
+            True,
+        ),
+        (
+            "{% set catalog=[] %}{% for item in tools %}{% set catalog=item %}{% endfor %}"
+            "{{ catalog|tojson }}",
+            False,
+        ),
+        (
+            "{% set ns=namespace(catalog=[]) %}"
+            "{% for item in tools %}{% set ns.catalog=item %}{% endfor %}"
+            "{{ ns.catalog|tojson }}",
+            True,
+        ),
+    ],
+)
+def test_alias_assignment_flow_matches_rendered_catalog(template, expected):
+    _assert_catalog_rendering(template, expected)

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -605,6 +605,48 @@ def test_reviewed_round_seven_paths_match_rendered_catalog(template, expected):
     assert detect_reasoning_flags(template)["supports_tools"] is expected
 
 
+@pytest.mark.parametrize(
+    "template, expected",
+    [
+        # `loop.first` reprs identically in every loop, so an outer loop's condition
+        # facts must not prune a branch of a nested one.
+        (
+            "{% for m in messages %}{% if loop.first %}{% for t in tools %}"
+            "{% if not loop.first %}{{ tools|tojson }}{% endif %}{% endfor %}"
+            "{% endif %}{% endfor %}",
+            True,
+        ),
+        (
+            "{% for m in messages %}{% if loop.first %}{% for t in tools %}"
+            "{% if loop.first %}{{ tools|tojson }}{% endif %}{% endfor %}"
+            "{% endif %}{% endfor %}",
+            True,
+        ),
+        # A template without the do extension mutates through `{% set _ = ... %}`.
+        ("{% set catalog=[] %}{% set _x = catalog.append(tools) %}{{ catalog|tojson }}", True),
+        # Methods outside append/extend/clear still move tool data into the receiver.
+        ("{% set catalog=[] %}{% do catalog.insert(0, tools) %}{{ catalog|tojson }}", True),
+        ("{% set d={} %}{% do d.update({'c': tools}) %}{{ d.c|tojson }}", True),
+        # An unrecognised method handed nothing tool-shaped still changes nothing.
+        ("{% set catalog=[] %}{% do catalog.insert(0, 'plain') %}{{ catalog|tojson }}", False),
+    ],
+)
+def test_loop_facts_and_mutation_shapes_match_rendered_catalog(template, expected):
+    render = Environment(extensions = ["jinja2.ext.loopcontrols", "jinja2.ext.do"]).from_string(
+        template
+    )
+    tools = [
+        {"type": "function", "function": {"name": "get_weather", "parameters": {}}},
+        {"type": "function", "function": {"name": "get_time", "parameters": {}}},
+    ]
+    output = render.render(
+        tools = tools,
+        messages = [{"role": "user", "content": "a"}, {"role": "user", "content": "b"}],
+    )
+    assert ("get_weather" in output) is expected
+    assert template_supports_tools(template) is expected
+
+
 def test_an_unresolved_subscript_key_still_selects_every_field():
     """The constant-key resolution narrows a subscript only when the key is known.
     An unknown key has to keep selecting every field, or a catalog reached through a

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -647,6 +647,75 @@ def test_loop_facts_and_mutation_shapes_match_rendered_catalog(template, expecte
     assert template_supports_tools(template) is expected
 
 
+@pytest.mark.parametrize(
+    "template, expected",
+    [
+        # Aliasing a member shares the container, not a copy of it.
+        (
+            "{% set ns=namespace(catalog=[]) %}{% set alias=ns.catalog %}"
+            "{% do alias.extend(tools) %}{{ ns.catalog|tojson }}",
+            True,
+        ),
+        # Rebinding the root detaches it in both directions: the earlier alias still
+        # refers to the old container, so the new one stays empty.
+        ("{% set a=[] %}{% set b=a %}{% set a=[] %}{% do b.extend(tools) %}{{ a|tojson }}", False),
+        ("{% set a=[] %}{% set b=a %}{% do b.extend(tools) %}{{ a|tojson }}", True),
+        # A caller block runs only if the macro invokes caller().
+        (
+            "{% macro render(caller=None) %}plain{% endmacro %}"
+            "{% call render() %}{{ tools|tojson }}{% endcall %}",
+            False,
+        ),
+        (
+            "{% macro render(caller=None) %}{{ caller() }}{% endmacro %}"
+            "{% call render() %}{{ tools|tojson }}{% endcall %}",
+            True,
+        ),
+        # A keyword argument names the field its value lands under.
+        (
+            "{% set d={} %}{% if tools %}{% do d.update(catalog=tools) %}{% endif %}"
+            "{{ d.catalog|tojson }}",
+            True,
+        ),
+        (
+            "{% set d={} %}{% do d.update(catalog=tools) %}{{ d.label|default('x') }}",
+            False,
+        ),
+        # A destructive call takes the provenance back out with the value.
+        (
+            "{% set catalog={'schema':tools,'label':'plain'} %}{% do catalog.pop('schema') %}"
+            "{{ catalog|tojson }}",
+            False,
+        ),
+        (
+            "{% set catalog={'schema':tools,'label':'plain'} %}{% do catalog.pop('label') %}"
+            "{{ catalog|tojson }}",
+            True,
+        ),
+        # break and continue stop the scan but keep what the path already mutated.
+        (
+            "{% set ns=namespace(catalog=[]) %}{% for x in [1] %}{% if tools %}"
+            "{% set ns.catalog=tools %}{% endif %}{% continue %}{% endfor %}"
+            "{{ ns.catalog|tojson }}",
+            True,
+        ),
+        # A filter block that reduces its input leaves no schema behind.
+        ("{% filter first %}{{ tools|tojson }}{% endfilter %}", False),
+        ("{% filter upper %}{{ tools|tojson }}{% endfilter %}", True),
+        # A macro declaration binds its name, shadowing the catalog.
+        ("{% macro tools() %}plain{% endmacro %}{{ tools }}", False),
+    ],
+)
+def test_round_nine_paths_match_rendered_catalog(template, expected):
+    render = Environment(extensions = ["jinja2.ext.loopcontrols", "jinja2.ext.do"]).from_string(
+        template
+    )
+    tools = [{"type": "function", "function": {"name": "get_weather", "parameters": {}}}]
+    output = render.render(tools = tools, messages = [{"role": "user", "content": "hi"}])
+    assert ("get_weather" in output.lower() or "GET_WEATHER" in output) is expected
+    assert template_supports_tools(template) is expected
+
+
 def test_an_unresolved_subscript_key_still_selects_every_field():
     """The constant-key resolution narrows a subscript only when the key is known.
     An unknown key has to keep selecting every field, or a catalog reached through a

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from jinja2 import Environment
+
+from core.inference.template_capabilities import template_supports_tools
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        "{# message.tool_calls are unsupported #}{{ message.content }}",
+        "{{ 'message.tool_calls are unsupported' }}",
+        "{{ \"message['tool_calls'] is unsupported\" }}",
+        "{{ '{% if tools %}example{% endif %}' }}",
+        "{# {% if tools %}example{% endif %} #}",
+        "{% raw %}{% if tools %}example{% endif %}{% endraw %}",
+        "{% if not tools %}plain{% endif %}",
+        "{% if tools is none %}plain{% endif %}",
+        "{% if tools is undefined %}plain{% endif %}",
+        "{{ not tools }}",
+        "{{ tools is not none }}",
+        "{{ tools | length }}",
+        "{% if tools %}{{ tools is defined }}{% endif %}",
+        "{% if tools is not none %}{{ raise_exception('tools unsupported') }}{% endif %}",
+        "{% if tools %}{{ raise_exception('unsupported: ' ~ tools) }}{% endif %}",
+        "{% if message.role == 'tool' %}{{ raise_exception('unsupported role') }}{% endif %}",
+        "{% if message.role != 'tool' %}{{ message.content }}{% endif %}",
+        "{% if not message.tool_calls %}{{ message.content }}{% endif %}",
+        "{% if builtin_tools or tools_in_user_message %}plain{% endif %}",
+        "{% set unused = tools %}{{ message.content }}",
+        "{% if tools %}",
+    ],
+)
+def test_non_tool_templates_stay_disabled(template):
+    assert template_supports_tools(template) is False
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        "{{ tools | tojson }}",
+        "{% set available_tools = tools %}{{ available_tools | tojson }}",
+        "{% if tools and not available_tools %}{% set available_tools = tools %}"
+        "{% endif %}{% if available_tools %}{{ available_tools | tojson }}{% endif %}",
+        "{% for tool in tools %}{{ tool | tojson }}{% endfor %}",
+        "{% if tools is not none %}{{ tools | tojson }}{% endif %}",
+        "{% if documents %}docs{% elif tools %}{{ tools | tojson }}{% endif %}",
+        "{%+ if tools +%}{{ tools | tojson }}{% endif %}",
+        "{% if message.role == 'tool' %}{{ message.content }}{% endif %}",
+        "{% if 'tool' == message['role'] %}{{ message.content }}{% endif %}",
+        "{% if message.tool_calls %}{{ message.tool_calls | tojson }}{% endif %}",
+        "{% if tool_calls is defined %}{{ tool_calls | tojson }}{% endif %}",
+        "{% generation %}{{ message.tool_calls | tojson }}{% endgeneration %}",
+        "{% for message in messages %}{% if loop.index > 1 %}{% break %}{% endif %}"
+        "{{ message.tool_calls | tojson }}{% endfor %}",
+        "{{ '{% raw %}' }}{{ tools | tojson }}{{ '{% endraw %}' }}",
+    ],
+)
+def test_executable_tool_templates_are_detected(template):
+    assert template_supports_tools(template) is True
+
+
+def _published_template(name):
+    return (Path(__file__).parent / "data" / "chat_templates" / f"{name}.jinja").read_text()
+
+
+@pytest.mark.parametrize("name", ["granite-3.3", "phi-4-mini"])
+def test_detection_does_not_bypass_the_safetensors_parser_gate(name):
+    from routes.inference import _detect_safetensors_features
+
+    template = _published_template(name)
+    assert template_supports_tools(template) is True
+    flags = _detect_safetensors_features(SimpleNamespace(active_model_name = name), template)
+    assert flags["supports_tools"] is False
+
+
+@pytest.mark.parametrize("name, emits_schema", [("granite-3.3", True), ("phi-4-mini", False)])
+def test_published_templates_render_studios_tool_argument(name, emits_schema):
+    from core.inference.chat_template_helpers import apply_chat_template_for_generation
+
+    class Tokenizer:
+        chat_template = _published_template(name)
+
+        def apply_chat_template(self, messages, **kwargs):
+            return (
+                Environment()
+                .from_string(self.chat_template)
+                .render(messages = messages, eos_token = "", **kwargs)
+            )
+
+    tokenizer = Tokenizer()
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Hi"},
+    ]
+    tools = [{"type": "function", "function": {"name": "get_weather", "parameters": {}}}]
+    with_tools = apply_chat_template_for_generation(tokenizer, messages, tools = tools)
+    without_tools = apply_chat_template_for_generation(tokenizer, messages)
+    assert ("get_weather" in with_tools) is emits_schema
+    assert (with_tools != without_tools) is emits_schema

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -517,3 +517,97 @@ def test_named_template_containers_reach_the_classifier_without_raising(template
     yields nothing, so a named-template map or list reaches detect_reasoning_flags."""
     from core.inference.llama_cpp import detect_reasoning_flags
     assert detect_reasoning_flags(template, "vendor/named")["supports_tools"] is False
+
+
+@pytest.mark.parametrize(
+    "template, expected",
+    [
+        # A filter can reject every item of a literal iterable, so the body never runs
+        # and Jinja takes the else.
+        (
+            "{% if tools %}{% for x in [1] if false %}x{% else %}{{ tools|tojson }}"
+            "{% endfor %}{% endif %}",
+            True,
+        ),
+        ("{% for x in [1] if true %}{{ tools|tojson }}{% else %}plain{% endfor %}", True),
+        # break and continue end the path: nothing after them in the body runs.
+        ("{% for x in [1] %}{% break %}{{ tools|tojson }}{% endfor %}", False),
+        ("{% for x in [1] %}{% continue %}{{ tools|tojson }}{% endfor %}", False),
+        ("{% for x in [1] %}{{ tools|tojson }}{% break %}{% endfor %}", True),
+        # Binding a name to a container does not copy it, so a mutation through either
+        # name is visible through both.
+        (
+            "{% set catalog=[] %}{% set alias=catalog %}{% do alias.extend(tools) %}"
+            "{{ catalog|tojson }}",
+            True,
+        ),
+        (
+            "{% set catalog=[] %}{% set alias=catalog %}{% do catalog.extend(tools) %}"
+            "{{ alias|tojson }}",
+            True,
+        ),
+        (
+            "{% set catalog=[] %}{% set alias=catalog %}{% do alias.extend(tools) %}"
+            "{% do catalog.clear() %}{{ catalog|tojson }}",
+            False,
+        ),
+        # A rebind breaks the sharing.
+        (
+            "{% set catalog=[] %}{% set alias=catalog %}{% set alias=[] %}"
+            "{% do alias.extend(tools) %}{{ catalog|tojson }}",
+            False,
+        ),
+        # A field named tool_calls on an object the template built itself proves
+        # nothing; on an untracked message value it still does.
+        ("{% set ns=namespace(tool_calls='plain') %}{{ ns.tool_calls }}", False),
+        ("{% set holder={'tool_calls': 'plain'} %}{{ holder.tool_calls }}", False),
+        ("{{ message.tool_calls|tojson }}", True),
+        ("{% set ns=namespace(role='tool') %}{% if ns.role == 'tool' %}plain{% endif %}", False),
+        ("{% if message.role == 'tool' %}{{ message.content }}{% endif %}", True),
+        # A subscript whose key is a name bound to a constant selects one field.
+        (
+            "{% set key='label' %}{% set wrapper={'catalog':tools,'label':'plain'} %}"
+            "{{ wrapper[key] }}",
+            False,
+        ),
+        (
+            "{% set key='catalog' %}{% set wrapper={'catalog':tools,'label':'plain'} %}"
+            "{{ wrapper[key]|tojson }}",
+            True,
+        ),
+        # {% call %} renders through the macro, not through the caller block.
+        (
+            "{% macro render(catalog, caller=None) %}{{ catalog|tojson }}{% endmacro %}"
+            "{% if tools %}{% call render(tools) %}{% endcall %}{% endif %}",
+            True,
+        ),
+        (
+            "{% macro render(catalog, caller=None) %}plain{% endmacro %}"
+            "{% if tools %}{% call render(tools) %}{% endcall %}{% endif %}",
+            False,
+        ),
+    ],
+)
+def test_reviewed_round_seven_paths_match_rendered_catalog(template, expected):
+    from core.inference.llama_cpp import detect_reasoning_flags
+
+    render = Environment(extensions = ["jinja2.ext.loopcontrols", "jinja2.ext.do"]).from_string(
+        template
+    )
+    tools = [{"type": "function", "function": {"name": "get_weather", "parameters": {}}}]
+    output = render.render(
+        tools = tools,
+        messages = [{"role": "user", "content": "Hi"}],
+        message = {"role": "tool", "content": "get_weather said sunny", "tool_calls": tools},
+    )
+    assert ("get_weather" in output) is expected
+    assert template_supports_tools(template) is expected
+    assert detect_reasoning_flags(template)["supports_tools"] is expected
+
+
+def test_an_unresolved_subscript_key_still_selects_every_field():
+    """The constant-key resolution narrows a subscript only when the key is known.
+    An unknown key has to keep selecting every field, or a catalog reached through a
+    computed key would be missed."""
+    template = "{% set wrapper={'catalog':tools,'label':'plain'} %}{{ wrapper[key]|tojson }}"
+    assert template_supports_tools(template) is True

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -735,3 +735,22 @@ def test_mutation_through_an_alias_is_a_known_under_approximation(template):
     tools = [{"type": "function", "function": {"name": "get_weather", "parameters": {}}}]
     assert "get_weather" in render.render(tools = tools)
     assert template_supports_tools(template) is False
+
+
+@pytest.mark.parametrize(
+    ("template", "expected"),
+    [
+        # The else arm of a negated guard is reached exactly when the catalog is
+        # present, so it has to read the same as the positive spelling.
+        ("{% if not tools %}plain{% else %}You may call tools.{% endif %}", True),
+        ("{% if tools is not defined %}plain{% else %}You may call tools.{% endif %}", True),
+        ("{% if tools is none %}plain{% else %}You may call tools.{% endif %}", True),
+        # An elif makes the else reachable for more than one reason, so the guard
+        # does not carry across it.
+        ("{% if not tools %}plain{% elif other %}x{% else %}You may call tools.{% endif %}", False),
+        # A negated guard on something else is not a tool guard.
+        ("{% if not messages %}plain{% else %}nothing here{% endif %}", False),
+    ],
+)
+def test_negated_tool_guard_matches_its_positive_spelling(template, expected):
+    assert template_supports_tools(template) is expected

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -287,3 +287,172 @@ def _assert_catalog_rendering(template, expected):
 )
 def test_alias_assignment_flow_matches_rendered_catalog(template, expected):
     _assert_catalog_rendering(template, expected)
+
+
+@pytest.mark.parametrize(
+    "template, schema_flags",
+    [
+        ("{% if tools and false %}tool instructions{% endif %}", ()),
+        ("{% if false and tools %}tool instructions{% endif %}", ()),
+        ("{% if tools and (false or false) %}tool instructions{% endif %}", ()),
+        ("{% if tools and 1 == 2 %}tool instructions{% endif %}", ()),
+        ("{% if tools or true %}plain{% endif %}", ()),
+        (
+            "{% set flag=true %}{% if tools or flag %}plain{% endif %}",
+            (),
+        ),
+        (
+            "{% if tools and false %}plain{% elif tools %}{{ tools|tojson }}{% endif %}",
+            (False, True),
+        ),
+        (
+            "{% if flag %}{% set catalog=tools %}{% endif %}"
+            "{% if not flag %}{{ catalog|default([])|tojson }}{% endif %}",
+            (),
+        ),
+        (
+            "{% if flag %}{% set catalog=tools %}{% endif %}"
+            "{% if flag %}{{ catalog|default([])|tojson }}{% endif %}",
+            (True,),
+        ),
+        (
+            "{% if not flag %}{% set catalog=tools %}{% endif %}"
+            "{% if flag %}{{ catalog|default([])|tojson }}{% endif %}",
+            (),
+        ),
+        (
+            "{% if flag %}{% set catalog=tools %}{% endif %}{% set flag=false %}"
+            "{% if not flag %}{{ catalog|default([])|tojson }}{% endif %}",
+            (True,),
+        ),
+        (
+            "{% if flag and other %}{% set catalog=tools %}{% endif %}"
+            "{% if not flag or not other %}{{ catalog|default([])|tojson }}{% endif %}",
+            (),
+        ),
+        (
+            "{% if flag or other %}{% set catalog=tools %}{% endif %}"
+            "{% if not flag and not other %}{{ catalog|default([])|tojson }}{% endif %}",
+            (),
+        ),
+        (
+            "{% set catalog=[] %}{% if tools %}{% do catalog.extend(tools) %}"
+            "{% endif %}{{ catalog|tojson }}",
+            (False, True),
+        ),
+        (
+            "{% set catalog=[] %}{% do catalog.append(tools[0]) %}{{ catalog|tojson }}",
+            (False, True),
+        ),
+        (
+            "{% set catalog=[] %}{% do catalog.extend(tools) %}"
+            "{% do catalog.clear() %}{{ catalog|tojson }}",
+            (),
+        ),
+        (
+            "{% set catalog=[] %}{% if flag %}{% do catalog.extend(tools) %}{% endif %}"
+            "{% if not flag %}{{ catalog|tojson }}{% endif %}",
+            (),
+        ),
+        (
+            "{% set catalog=[] %}{% for tool in tools %}{% do catalog.append(tool) %}"
+            "{% endfor %}{{ catalog|tojson }}",
+            (False, True),
+        ),
+        (
+            "{% if tools %}{% set ns=namespace({'catalog': tools}) %}{% endif %}"
+            "{{ ns.catalog|default([])|tojson }}",
+            (False, True),
+        ),
+        (
+            "{% set mapping={'catalog': tools, 'label': 'plain'} %}"
+            "{% set ns=namespace(mapping) %}{{ ns.catalog|tojson }}",
+            (False, True),
+        ),
+        (
+            "{% set ns=namespace({'catalog': tools}, catalog=[]) %}{{ ns.catalog|tojson }}",
+            (),
+        ),
+        (
+            "{% set ns=namespace({'catalog': tools, 'label': 'plain'}) %}{{ ns.label }}",
+            (),
+        ),
+        (
+            "{% set ns=namespace(catalog=tools) %}{% for x in [1] %}"
+            "{% set ns.catalog=[] %}{% endfor %}{{ ns.catalog|tojson }}",
+            (),
+        ),
+        (
+            "{% set ns=namespace(catalog=tools) %}{% for x in [] %}"
+            "{% set ns.catalog=[] %}{% endfor %}{{ ns.catalog|tojson }}",
+            (False, True),
+        ),
+        (
+            "{% set ns=namespace(catalog=tools) %}{% for x in [1] if false %}"
+            "{% set ns.catalog=[] %}{% endfor %}{{ ns.catalog|tojson }}",
+            (False, True),
+        ),
+        (
+            "{% set ns=namespace(catalog=tools) %}{% for x in [1] %}"
+            "{% set ns=namespace(catalog=[]) %}{% set ns.catalog=[] %}"
+            "{% endfor %}{{ ns.catalog|tojson }}",
+            (False, True),
+        ),
+        (
+            "{% set ns=namespace(catalog=tools) %}{% for value in [tools, []] %}"
+            "{% set ns.catalog=value %}{% endfor %}{{ ns.catalog|tojson }}",
+            (),
+        ),
+        (
+            "{% set catalog=[] %}{% if tools %}{% set catalog, ignored=tools, none %}"
+            "{% endif %}{{ catalog|tojson }}",
+            (False, True),
+        ),
+        (
+            "{% set catalog=tools %}{% set catalog, ignored=[], tools %}{{ catalog|tojson }}",
+            (),
+        ),
+        (
+            "{% set catalog=tools %}{% set ignored=[] %}"
+            "{% set ignored, catalog=catalog, ignored %}{{ catalog|tojson }}",
+            (),
+        ),
+        (
+            "{% set pair=[tools, 'plain'] %}{% set catalog, label=pair %}{{ catalog|tojson }}",
+            (False, True),
+        ),
+        (
+            "{% set wrapper={'catalog': tools, 'label': 'plain'} %}{{ wrapper['label'] }}",
+            (),
+        ),
+        (
+            "{% set wrapper={'catalog': tools, 'label': 'plain'} %}{{ wrapper.catalog|tojson }}",
+            (False, True),
+        ),
+        (
+            "{% set wrapper={'inner': {'catalog': tools, 'label': 'plain'}} %}"
+            "{{ wrapper.inner.label }}",
+            (),
+        ),
+        ("{% set wrapper=[tools, 'plain'] %}{{ wrapper[1] }}", ()),
+        ("{% set wrapper=[tools, 'plain'] %}{{ wrapper[0]|tojson }}", (False, True)),
+        (
+            "{% set ns=namespace(catalog=[]) %}{% with %}{% if flag %}"
+            "{% set ns.catalog=tools %}{% endif %}{% endwith %}"
+            "{% if not flag %}{{ ns.catalog|tojson }}{% endif %}",
+            (),
+        ),
+    ],
+)
+def test_reviewed_paths_match_rendered_catalog(template, schema_flags):
+    from core.inference.llama_cpp import detect_reasoning_flags
+
+    render = Environment(extensions = ["jinja2.ext.do"]).from_string(template)
+    tools = [{"type": "function", "function": {"name": "get_weather", "parameters": {}}}]
+    for flag in (False, True):
+        for other in (False, True):
+            output = render.render(tools = tools, flag = flag, other = other)
+            assert ("get_weather" in output) is (flag in schema_flags)
+    expected = bool(schema_flags)
+    assert template_supports_tools(template) is expected
+    assert detect_reasoning_flags(template)["supports_tools"] is expected

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -66,7 +66,9 @@ def test_executable_tool_templates_are_detected(template):
 
 
 def _published_template(name):
-    return (Path(__file__).parent / "data" / "chat_templates" / f"{name}.jinja").read_text()
+    return (Path(__file__).parent / "data" / "chat_templates" / f"{name}.jinja").read_text(
+        encoding = "utf-8"
+    )
 
 
 @pytest.mark.parametrize("name, detected", [("granite-3.3", True), ("phi-4-mini", False)])
@@ -458,32 +460,34 @@ def test_reviewed_paths_match_rendered_catalog(template, schema_flags):
     assert detect_reasoning_flags(template)["supports_tools"] is expected
 
 
-@pytest.mark.parametrize(
-    "label, template",
-    [
-        # Jinja parses expressions by recursive descent, so nesting alone exhausts the
-        # stack before this module ever sees a tree.
-        ("nested_if", "{% if tools %}" * 5000 + "{{ tools|tojson }}" + "{% endif %}" * 5000),
-        (
-            "parenthesised_guard",
-            "{% if " + "(" * 200 + "tools" + ")" * 200 + " %}{{ tools|tojson }}{% endif %}",
-        ),
+def _pathological(label):
+    """Built here rather than parametrized: pytest puts the node id in
+    PYTEST_CURRENT_TEST, and Windows caps an environment variable at 32767
+    characters, so a 70 KB template in the id errors the test at setup."""
+    if label == "nested_if":
+        # Jinja parses by recursive descent, so nesting alone exhausts the stack
+        # before this module ever sees a tree.
+        return "{% if tools %}" * 5000 + "{{ tools|tojson }}" + "{% endif %}" * 5000
+    if label == "parenthesised_guard":
+        return "{% if " + "(" * 200 + "tools" + ")" * 200 + " %}{{ tools|tojson }}{% endif %}"
+    if label == "wide_or":
         # A wide boolean guard recurses in the node repr used as a condition-fact key.
-        (
-            "wide_or",
+        return (
             "{% if " + " or ".join(f"v{i}" for i in range(2000)) + " %}"
-            "{{ tools|tojson }}{% endif %}",
-        ),
-        # A long attribute chain recurses in _value_aliases.
-        ("deep_attribute", "{{ tools" + ".a" * 3000 + " }}"),
-    ],
-)
-def test_pathological_templates_disable_tools_instead_of_raising(label, template):
+            "{{ tools|tojson }}{% endif %}"
+        )
+    # A long attribute chain recurses in _value_aliases.
+    return "{{ tools" + ".a" * 3000 + " }}"
+
+
+@pytest.mark.parametrize("label", ["nested_if", "parenthesised_guard", "wide_or", "deep_attribute"])
+def test_pathological_templates_disable_tools_instead_of_raising(label):
     """detect_reasoning_flags runs on the GGUF metadata read and the llama-server launch,
     so a template too deep to analyse must leave tools off rather than break the load.
     The substring scan this replaced could not raise at all."""
     from core.inference.llama_cpp import detect_reasoning_flags
 
+    template = _pathological(label)
     assert template_supports_tools(template) is False
     assert detect_reasoning_flags(template, f"vendor/{label}")["supports_tools"] is False
 

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -538,18 +538,6 @@ def test_named_template_containers_reach_the_classifier_without_raising(template
         ("{% for x in [1] %}{% break %}{{ tools|tojson }}{% endfor %}", False),
         ("{% for x in [1] %}{% continue %}{{ tools|tojson }}{% endfor %}", False),
         ("{% for x in [1] %}{{ tools|tojson }}{% break %}{% endfor %}", True),
-        # Binding a name to a container does not copy it, so a mutation through either
-        # name is visible through both.
-        (
-            "{% set catalog=[] %}{% set alias=catalog %}{% do alias.extend(tools) %}"
-            "{{ catalog|tojson }}",
-            True,
-        ),
-        (
-            "{% set catalog=[] %}{% set alias=catalog %}{% do catalog.extend(tools) %}"
-            "{{ alias|tojson }}",
-            True,
-        ),
         (
             "{% set catalog=[] %}{% set alias=catalog %}{% do alias.extend(tools) %}"
             "{% do catalog.clear() %}{{ catalog|tojson }}",
@@ -654,16 +642,9 @@ def test_loop_facts_and_mutation_shapes_match_rendered_catalog(template, expecte
 @pytest.mark.parametrize(
     "template, expected",
     [
-        # Aliasing a member shares the container, not a copy of it.
-        (
-            "{% set ns=namespace(catalog=[]) %}{% set alias=ns.catalog %}"
-            "{% do alias.extend(tools) %}{{ ns.catalog|tojson }}",
-            True,
-        ),
         # Rebinding the root detaches it in both directions: the earlier alias still
         # refers to the old container, so the new one stays empty.
         ("{% set a=[] %}{% set b=a %}{% set a=[] %}{% do b.extend(tools) %}{{ a|tojson }}", False),
-        ("{% set a=[] %}{% set b=a %}{% do b.extend(tools) %}{{ a|tojson }}", True),
         # A caller block runs only if the macro invokes caller().
         (
             "{% macro render(caller=None) %}plain{% endmacro %}"
@@ -726,3 +707,31 @@ def test_an_unresolved_subscript_key_still_selects_every_field():
     computed key would be missed."""
     template = "{% set wrapper={'catalog':tools,'label':'plain'} %}{{ wrapper[key]|tojson }}"
     assert template_supports_tools(template) is True
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        "{% set catalog=[] %}{% set alias=catalog %}{% do alias.extend(tools) %}"
+        "{{ catalog|tojson }}",
+        "{% set catalog=[] %}{% set alias=catalog %}{% do catalog.extend(tools) %}"
+        "{{ alias|tojson }}",
+        "{% set ns=namespace(catalog=[]) %}{% set alias=ns.catalog %}"
+        "{% do alias.extend(tools) %}{{ ns.catalog|tojson }}",
+        "{% set a=[] %}{% set b=a %}{% do b.extend(tools) %}{{ a|tojson }}",
+    ],
+)
+def test_mutation_through_an_alias_is_a_known_under_approximation(template):
+    """These templates DO render the catalog. State is keyed by name, so a mutation
+    made through one name is not seen through another bound to the same container,
+    and detection stays off.
+
+    This is deliberate. An identity map was tried and withdrawn: it needs the whole
+    state to be keyed by object rather than by name, and the partial version produced
+    three further divergences of its own. Erring off costs a template that already
+    renders its catalog, which is the safe direction, and no published template does
+    this: it appears in none of the 120 checked from 106 repositories."""
+    render = Environment(extensions = ["jinja2.ext.do"]).from_string(template)
+    tools = [{"type": "function", "function": {"name": "get_weather", "parameters": {}}}]
+    assert "get_weather" in render.render(tools = tools)
+    assert template_supports_tools(template) is False

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -456,3 +456,64 @@ def test_reviewed_paths_match_rendered_catalog(template, schema_flags):
     expected = bool(schema_flags)
     assert template_supports_tools(template) is expected
     assert detect_reasoning_flags(template)["supports_tools"] is expected
+
+
+@pytest.mark.parametrize(
+    "label, template",
+    [
+        # Jinja parses expressions by recursive descent, so nesting alone exhausts the
+        # stack before this module ever sees a tree.
+        ("nested_if", "{% if tools %}" * 5000 + "{{ tools|tojson }}" + "{% endif %}" * 5000),
+        (
+            "parenthesised_guard",
+            "{% if " + "(" * 200 + "tools" + ")" * 200 + " %}{{ tools|tojson }}{% endif %}",
+        ),
+        # A wide boolean guard recurses in the node repr used as a condition-fact key.
+        (
+            "wide_or",
+            "{% if " + " or ".join(f"v{i}" for i in range(2000)) + " %}"
+            "{{ tools|tojson }}{% endif %}",
+        ),
+        # A long attribute chain recurses in _value_aliases.
+        ("deep_attribute", "{{ tools" + ".a" * 3000 + " }}"),
+    ],
+)
+def test_pathological_templates_disable_tools_instead_of_raising(label, template):
+    """detect_reasoning_flags runs on the GGUF metadata read and the llama-server launch,
+    so a template too deep to analyse must leave tools off rather than break the load.
+    The substring scan this replaced could not raise at all."""
+    from core.inference.llama_cpp import detect_reasoning_flags
+
+    assert template_supports_tools(template) is False
+    assert detect_reasoning_flags(template, f"vendor/{label}")["supports_tools"] is False
+
+
+_TOOL_BODY = "{% if tools %}{{ tools|tojson }}{% endif %}"
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        # A Hugging Face named-template map and the Hermes-3 list form: both are
+        # unhashable, so lru_cache would raise on them before any fail-closed branch.
+        {"default": _TOOL_BODY, "tool_use": "x"},
+        [{"name": "default", "template": _TOOL_BODY}],
+        # Hashable but not a template: `"tool" not in template` would raise instead.
+        _TOOL_BODY.encode(),
+        None,
+        object(),
+    ],
+)
+def test_non_string_templates_are_turned_away_before_the_cache(template):
+    assert template_supports_tools(template) is False
+
+
+@pytest.mark.parametrize(
+    "template",
+    [{"default": _TOOL_BODY, "tool_use": "x"}, [{"name": "default", "template": _TOOL_BODY}]],
+)
+def test_named_template_containers_reach_the_classifier_without_raising(template):
+    """routes.inference passes the raw chat_template through when template selection
+    yields nothing, so a named-template map or list reaches detect_reasoning_flags."""
+    from core.inference.llama_cpp import detect_reasoning_flags
+    assert detect_reasoning_flags(template, "vendor/named")["supports_tools"] is False


### PR DESCRIPTION
Studio's whitespace-exact marker scan can miss tool-capable templates that use compound guards or aliases. This change detects tool-capability hints from executable Jinja syntax.

### Changes

- Inspect schema output, tool-list loops, and positive tool guards or role checks. Ignore comments, quoted examples, raw blocks, and rejection-only branches.
- Track the global `tools` catalog through aliases and individual container fields, including positional mappings and keyword arguments passed to `namespace`.
- Process assignments in statement order, support tuple targets, and clear overwritten aliases.
- Keep conditional paths separate, reject impossible compound guards, and discard old condition facts when their variables change.
- Track `do` calls to `append`, `extend`, and `clear`. Propagate namespace writes and removals through literal loops while respecting local bindings.
- Inspect macro bodies at call sites with their arguments and defaults. Uncalled macros and unused catalog arguments do not advertise support.
- Keep message-local `tools` fields separate from the global catalog. Tool-call history remains separate evidence.
- Support `generation`, `do`, and loop-control tags, and cache 128 template verdicts.
- Update the refactor-guard inventory for the removed marker constant.

### Backend scope

Granite 3.3 now gains template detection, but its safetensors capability remains disabled because its emission format does not pass that backend's parser check.

Phi-4-mini remains disabled. Its published template expects the catalog in `message['tools']`, which Studio's separate `tools=` argument does not populate. A message field alone is no longer counted as catalog support.

The fixtures and rendering checks cover both behaviors. This change does not add backend parser support or inject new message fields.

Analysis is bounded to 8,192 statement and condition steps. Exceeding that bound leaves tool support disabled.

### Validation

- Verified 75 focused rendering cases, including 37 new review regressions and related cases checked across all four combinations of two boolean flags.
- Checked 35 additional syntax classifications directly.
- Verified the published Granite and Phi templates and the safetensors parser gate: Granite consumes `tools=`, while Phi does not.
- Compared 22 published templates with the original detector: 21 unchanged, Granite gained detection, and none lost detection.
- Checked bounded analysis with 20 independent conditions.
- The repository's pinned formatter, Ruff checks, refactor inventory check, and `git diff --check` pass.

This follow-up was verified with focused reproductions without running CI or full suites.
