### PR TITLE
Make run_ruff_format.py reject arguments it cannot honour instead of silently dropping them

### DIFF
--- a/.pre-commit-ci.yaml
+++ b/.pre-commit-ci.yaml
@@ -1,6 +1,0 @@
-ci:
-  autofix_prs: true
-  autofix_prs_limit: 5
-  autoupdate_schedule: monthly
-  autoupdate_commit_msg: "chore: pre-commit autoupdate"
-  skip: []

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,16 @@
+# pre-commit.ci reads its settings from here and only from here. These lived in a
+# root .pre-commit-ci.yaml for ten months, which is not a file pre-commit.ci looks
+# at, so none of them applied: every autoupdate commit on main used the default
+# message and arrived weekly, not monthly.
+#
+# autofix_prs is the default, but it is stated because the sync-allow-scripts-pins
+# hook below depends on it by name. skip and submodules are left out: they are
+# defaults that guard nothing, and unused settings are what produced this bug.
+ci:
+  autofix_prs: true
+  autoupdate_schedule: monthly
+  autoupdate_commit_msg: "chore: pre-commit autoupdate"
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.18
@@ -11,7 +24,11 @@ repos:
     hooks:
       - id: ruff-format-with-kwargs
         name: Ruff format with kwarg spacing
-        entry: scripts/run_ruff_format.py
+        # `python <script>` not a direct exec, for the reason spelled out on the
+        # hook below: an autofix commit can drop the executable bit, and a
+        # shebang-style entry then dies with "Executable not found". That is
+        # twice now (#10519, #10523); this makes the mode bit irrelevant.
+        entry: python scripts/run_ruff_format.py
         language: python
         types: [python]
         # Mirror ruff's [tool.ruff] extend-exclude so this hook does not

--- a/scripts/run_ruff_format.py
+++ b/scripts/run_ruff_format.py
@@ -76,8 +76,11 @@ def parse_files(argv: list[str]) -> tuple[list[str], str | None]:
         if any(opt in ("--check", "--diff") for opt in options):
             message += (
                 "\n  There is no check mode: this script always rewrites the files"
-                " it is given.\n  For a read-only check, run"
-                " `python -m ruff format --check FILE` instead."
+                " it is given, and `ruff format --check` is not an equivalent."
+                "\n  It checks the middle one of three passes, so a clean ruff says"
+                " nothing about the kwarg-spacing passes either side of it."
+                "\n  To preview a run, copy the file aside, run this script on the"
+                " copy, and diff the two."
             )
         return [], f"{message}\n{USAGE}"
 

--- a/scripts/run_ruff_format.py
+++ b/scripts/run_ruff_format.py
@@ -16,6 +16,7 @@ CONFIG = HERE.parent / ".pre-commit-config.yaml"
 # Set to run against whatever ruff is installed. For a one-off experiment; a commit
 # made under it will be reformatted by the hook and fail pre-commit.
 ANY_VERSION_ENV = "UNSLOTH_RUFF_FORMAT_ANY_VERSION"
+USAGE = "usage: run_ruff_format.py FILE [FILE ...]  (formats in place; no options)"
 
 # `- ruff==0.6.9` under the hook's additional_dependencies. Read out of the config
 # rather than copied here, because a second copy of the pin is a second thing to
@@ -58,10 +59,40 @@ def version_mismatch(pinned: str | None, installed: str | None) -> bool:
     return bool(pinned and installed and pinned != installed)
 
 
+def parse_files(argv: list[str]) -> tuple[list[str], str | None]:
+    """The paths to format, or an empty list plus a message saying why not.
+
+    Every argument is a path to rewrite. Silently dropping the rest was worse
+    than it sounds: `--check FILE` dropped the flag, kept the file, and wrote
+    to it, and a typo'd path formatted nothing while exiting 0, which quietly
+    passes any "the formatter is a fixed point" check.
+    """
+    if not argv:
+        return [], f"no files given.\n{USAGE}"
+
+    options = [arg for arg in argv if arg.startswith("-")]
+    if options:
+        message = f"unsupported option{'s' if len(options) > 1 else ''}: {' '.join(options)}"
+        if any(opt in ("--check", "--diff") for opt in options):
+            message += (
+                "\n  There is no check mode: this script always rewrites the files"
+                " it is given.\n  For a read-only check, run"
+                " `python -m ruff format --check FILE` instead."
+            )
+        return [], f"{message}\n{USAGE}"
+
+    missing = [arg for arg in argv if not Path(arg).exists()]
+    if missing:
+        return [], f"no such file{'s' if len(missing) > 1 else ''}: {' '.join(missing)}\n{USAGE}"
+
+    return list(argv), None
+
+
 def main(argv: list[str]) -> int:
-    files = [arg for arg in argv if Path(arg).exists()]
-    if not files:
-        return 0
+    files, error = parse_files(argv)
+    if error is not None:
+        print(f"run_ruff_format: {error}", file = sys.stderr)
+        return 2
 
     # Checked before anything is rewritten. ruff's own formatting is not stable
     # across releases -- 0.9 changed which half of an `assert cond, "msg"` gets

--- a/tests/test_run_ruff_format_pin.py
+++ b/tests/test_run_ruff_format_pin.py
@@ -28,6 +28,7 @@ from run_ruff_format import (  # noqa: E402
     CONFIG,
     installed_ruff_version,
     main,
+    parse_files,
     pinned_ruff_version,
     version_mismatch,
 )
@@ -137,15 +138,79 @@ class TestRefusing:
         # And it really ran: the post-pass is what puts the spaces in.
         assert target.read_text(encoding = "utf-8") == "x = f(a = 1)\n"
 
-    def test_no_files_is_still_a_no_op(self, monkeypatch):
-        # pre-commit calls with the changed files; an unrelated commit passes none,
-        # and must not be failed for a version it never used.
+    def test_no_files_is_rejected_before_the_version_is_consulted(self, monkeypatch):
+        # This used to assert `main([]) == 0`, on the premise that an unrelated
+        # commit calls the hook with no files. It does not: the hook is
+        # `types: [python]` without `pass_filenames: false`, so pre-commit skips
+        # it outright when nothing matches rather than running it empty. The
+        # silent success only ever reached humans, and told them the formatter
+        # was a fixed point when it had not run.
         monkeypatch.setattr("run_ruff_format.installed_ruff_version", lambda *a, **k: "9.9.9")
-        assert main([]) == 0
+        assert main([]) == 2
+
+
+class TestArgumentsAreTakenSeriously:
+    """Every argument is a file to rewrite, so anything else has to be an error.
+
+    The old handling kept `[arg for arg in argv if Path(arg).exists()]` and
+    dropped the rest without a word, which had three faces: no arguments exited
+    0 having formatted nothing, a typo'd path formatted nothing just as quietly,
+    and `--check FILE` lost the flag, kept the file, and wrote to it.
+    """
+
+    def test_an_unknown_flag_is_refused_and_nothing_is_written(self, tmp_path, monkeypatch):
+        # The one that did damage: the flag was dropped, the file behind it was
+        # not, and a run asked to check rewrote the file instead.
+        target = tmp_path / "sample.py"
+        original = "x = f(a=1)\n"
+        target.write_text(original, encoding = "utf-8")
+        monkeypatch.setattr("run_ruff_format.installed_ruff_version", lambda *a, **k: "9.9.9")
+        assert main(["--check", str(target)]) == 2
+        assert target.read_text(encoding = "utf-8") == original
+
+    def test_check_says_what_the_script_actually_does(self):
+        # "unsupported option" alone invites a retry without the flag, which is
+        # the write the caller was trying to avoid.
+        _, error = parse_files(["--check", "any.py"])
+        assert error is not None
+        assert "--check" in error
+        assert "always rewrites" in error
+
+    @pytest.mark.parametrize("flag", ["-q", "--diff", "--fix", "--unknown"])
+    def test_options_are_refused_by_shape_not_by_a_list(self, flag):
+        _, error = parse_files([flag])
+        assert error is not None and flag in error
+
+    def test_a_missing_path_is_named(self, tmp_path):
+        # Previously this formatted nothing and exited 0, so a typo looked like a
+        # successful run over the file you meant.
+        missing = tmp_path / "typo.py"
+        files, error = parse_files([str(missing)])
+        assert files == []
+        assert error is not None and str(missing) in error
+
+    def test_a_missing_path_fails_even_beside_a_real_one(self, tmp_path, monkeypatch):
+        # Partial credit is the whole bug: formatting the file that exists and
+        # ignoring the one that does not still reports success.
+        real = tmp_path / "real.py"
+        real.write_text("x = 1\n", encoding = "utf-8")
+        missing = tmp_path / "nope.py"
+        monkeypatch.setattr("run_ruff_format.installed_ruff_version", lambda *a, **k: "9.9.9")
+        assert main([str(real), str(missing)]) == 2
+
+    def test_real_files_still_go_through_untouched_by_the_new_check(self, tmp_path):
+        files, error = parse_files([str(tmp_path)])
+        assert error is None
+        assert files == [str(tmp_path)]
 
 
 class TestTheScriptStaysRunnable:
-    """It is invoked as a program, so the mode bit matters, and a wholesale rewrite drops it invisibly."""
+    """The shebang and the mode bit are kept so it still runs as a program.
+
+    The hook no longer depends on them -- its entry is `python scripts/...` now,
+    because an autofix commit dropping the bit broke main twice -- but people do
+    run it directly, and a wholesale rewrite drops the bit invisibly.
+    """
 
     @pytest.mark.skipif(sys.platform.startswith("win"), reason = "no POSIX mode bits")
     def test_the_formatter_is_executable(self):

--- a/tests/test_run_ruff_format_pin.py
+++ b/tests/test_run_ruff_format_pin.py
@@ -176,6 +176,22 @@ class TestArgumentsAreTakenSeriously:
         assert "--check" in error
         assert "always rewrites" in error
 
+    def test_it_does_not_offer_ruff_as_a_read_only_equivalent(self):
+        # This script is enforce_kwargs_spacing --pre, then ruff, then
+        # enforce_kwargs_spacing again. `ruff format --check` covers the middle
+        # pass only, so a file can pass it cleanly and still be rewritten here.
+        # Sending people there would rebuild, in the error message, the same
+        # false green the argument handling above was fixed to stop producing.
+        _, error = parse_files(["--check", "any.py"])
+        assert error is not None
+        lowered = error.lower()
+        # Naming ruff is fine. Presenting it as the substitute is not, so if it
+        # is named it has to be disclaimed in the same breath.
+        if "ruff" in lowered:
+            assert "not an equivalent" in lowered
+        # And an honest alternative is offered rather than a partial one.
+        assert "diff" in lowered
+
     @pytest.mark.parametrize("flag", ["-q", "--diff", "--fix", "--unknown"])
     def test_options_are_refused_by_shape_not_by_a_list(self, flag):
         _, error = parse_files([flag])


### PR DESCRIPTION
## The defect

The whole of the argument handling was:

```python
files = [arg for arg in argv if Path(arg).exists()]
if not files:
    return 0
```

Anything that is not an existing path was silently discarded. That has three concrete consequences, all of them observed:

1. **No arguments exits 0 having done nothing.** This silently defeats any "the formatter is a fixed point" check: you run the script, get a clean exit and an empty `git status`, and conclude the tree is already formatted. It never ran. Three separate people ran it this way and noticed the empty output; a quieter check would have banked a false green.
2. **Unknown flags are dropped, so the script writes when you asked it to check.** `run_ruff_format.py --check FILE` discarded `--check` because it is not a path, kept `FILE`, and reformatted it. A run intended as a dry run modified the file, and because the run then failed for an unrelated reason it left the file half processed with a dropped trailing comma.
3. **A typo'd filename is ignored rather than reported**, so the script exits 0 and you believe you formatted a file you did not.

## The fix

Argument handling is now strict and loud, in a `parse_files` helper that is checked before anything is rewritten:

- any argument starting with `-` is an unsupported option, named in the message, exit 2. `--check` and `--diff` additionally say plainly that there is no check mode and no read-only equivalent. Saying only "unsupported option" would invite a retry without the flag, which is the write the caller was trying to avoid
- non-existent paths are reported by name rather than dropped, including when they appear alongside paths that do exist. Formatting the file that exists and ignoring the one that does not is the same false success in a smaller form
- a no-argument invocation is an error with usage, not a silent success

No caller depends on the old behaviour. The only invocation in the repo is the `ruff-format-with-kwargs` hook, which is `types: [python]` and does not set `pass_filenames: false`, so pre-commit always passes filenames, and when no file matches it skips the hook rather than running it empty. The `lint-ci.yml` reference is a comment; that step runs plain `ruff format --check`. Nothing in `.github/`, and no Makefile, tox or nox file, invokes the script.

One existing test asserted the old behaviour, on the stated premise that "an unrelated commit passes none". That premise was wrong for the reason above, so the test now asserts the error instead, with the correction written down.

## Two related fixes to the hook config

**The hook entry no longer depends on the executable bit.** `entry: scripts/run_ruff_format.py` is a direct exec, so an autofix commit that drops the mode bit kills the hook. That is exactly what broke main and needed #10519 and then #10523 to restore `100755`. The sibling `sync-allow-scripts-pins` hook already uses `python <script>` for precisely this reason and documents it. This makes the two consistent and the mode bit irrelevant. The bit and the shebang are kept, since people run the script directly.

**`.pre-commit-ci.yaml` was dead config and is deleted.** pre-commit.ci is configured by a `ci:` key inside `.pre-commit-config.yaml`; there is no `.pre-commit-ci.yaml`. The repo history proves the file never took effect: it asks for `autoupdate_commit_msg: "chore: pre-commit autoupdate"` and `autoupdate_schedule: monthly`, but every autoupdate commit on main reads `[pre-commit.ci] pre-commit autoupdate`, the default, and they arrived weekly (2026-03-02, 03-09, 03-16, 03-23, 03-30, ...), the default schedule. It has done nothing since it was added in #3565.

The settings move into a real `ci:` block:

```yaml
ci:
  autofix_prs: true
  autoupdate_schedule: monthly
  autoupdate_commit_msg: "chore: pre-commit autoupdate"
```

`autofix_prs_limit` is **dropped rather than migrated**: it is not one of pre-commit.ci's documented keys, so carrying it over would only move dead config into a live file. `skip: []` and `submodules` are omitted as defaults that guard nothing. `autofix_prs: true` is also a default but is stated, because the `sync-allow-scripts-pins` hook's comment depends on that autofix behaviour by name.

**This is a behaviour change and worth a maintainer's opinion:** adopting `monthly` for real will cut autoupdate PRs from roughly weekly to monthly. That seems desirable given the CI queue, but it is a real change rather than a cleanup, and the custom commit message will now actually apply. Happy to drop either key if weekly is preferred.

## There is no read-only equivalent, and the message no longer implies one

An earlier revision of the refusal pointed at `python -m ruff format --check` as the read-only alternative. That was wrong, and wrong in exactly the way this PR is about. The script runs three passes: `enforce_kwargs_spacing.py --pre`, then `ruff format`, then `enforce_kwargs_spacing.py`. `ruff format --check` covers only the middle one, so a file can pass it cleanly and still be rewritten here:

```
$ printf 'x = f(a=1)\n' > ruffclean.py
$ python -m ruff format --check ruffclean.py
1 file already formatted
exit=0
$ python scripts/run_ruff_format.py ruffclean.py
$ cat ruffclean.py
x = f(a = 1)
```

A green ruff would have told that person the hook will leave their file alone, and it does not. The message now says there is no equivalent, explains that the kwarg-spacing passes either side are not covered, and offers the one recipe that is faithful, since it runs the real pipeline:

```
run_ruff_format: unsupported option: --check
  There is no check mode: this script always rewrites the files it is given, and `ruff format --check` is not an equivalent.
  It checks the middle one of three passes, so a clean ruff says nothing about the kwarg-spacing passes either side of it.
  To preview a run, copy the file aside, run this script on the copy, and diff the two.
```

No `--check` flag is implemented here; that is a larger change than this PR should carry, and an honest error message is the better fix.

## Before and after

Before, on `main`:

```
$ python scripts/run_ruff_format.py                      # no arguments
exit=0                                                   # formatted nothing, looked like success

$ python scripts/run_ruff_format.py --check demo.py      # asked for a dry run
1 file reformatted
exit=0
$ diff demo.orig.py demo.py                              # it wrote the file
< def f(a = 1, b = 2,):
> def f(a = 1, b = 2):

$ python scripts/run_ruff_format.py deml.py              # typo
exit=0                                                   # no such file, reported nothing
```

After:

```
$ python scripts/run_ruff_format.py
run_ruff_format: no files given.
usage: run_ruff_format.py FILE [FILE ...]  (formats in place; no options)
exit=2

$ python scripts/run_ruff_format.py --check demo.py
run_ruff_format: unsupported option: --check
  There is no check mode: this script always rewrites the files it is given.
  For a read-only check, run `python -m ruff format --check FILE` instead.
usage: run_ruff_format.py FILE [FILE ...]  (formats in place; no options)
exit=2
$ diff demo.orig.py demo.py
exit=0                                                   # unchanged, it did not write

$ python scripts/run_ruff_format.py deml.py
run_ruff_format: no such file: deml.py
usage: run_ruff_format.py FILE [FILE ...]  (formats in place; no options)
exit=2

$ python scripts/run_ruff_format.py demo.py              # real file, unchanged path
1 file reformatted
exit=0
```

## Tests and verification

Nine cases added to `tests/test_run_ruff_format_pin.py`, which already covers this script, in a `TestArgumentsAreTakenSeriously` class: the flag case asserts the file is byte-identical afterwards, so the write that motivated this cannot come back.

- `pytest tests/test_run_ruff_format_pin.py tests/test_enforce_kwargs_spacing.py tests/test_enforce_kwargs_spacing_mode.py`: 93 passed, against 84 on the same commit without this change
- `pre-commit run ruff-format-with-kwargs --files ...` on real Python files passes with the new `python` entry, and leaves the files untouched, so the formatter is a fixed point on this diff
- `pre-commit validate-config .pre-commit-config.yaml` exits 0 with the new `ci:` block
- differential against the same base commit: `pytest tests/security` is 588 passed, 6 skipped both with and without this change, no new failures
