### PR TITLE
fix: resync torchao after Linux torch family repair

### DIFF
--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -3480,6 +3480,7 @@ def _ensure_cuda_torch() -> None:
     _ran, _importable, _version, _hip, _cuda = _probe_torch_runtime()
     if not _ran:
         return
+    _label_before = str(_version or "")
     if not _importable:
         # torch present but can't import. Without a pin the base install owns it; but an
         # explicit CUDA pin forces this pass (failed probe) and the base update won't
@@ -3503,6 +3504,8 @@ def _ensure_cuda_torch() -> None:
             index_url,
             constrain = False,
         )
+        # Re-pin torchao / xFormers when this repair moved the torch family (#10493).
+        _resync_torch_coupled_packages(_label_before)
         return
     if _version is None:
         # Nothing readable came back, so classify nothing: this is where the per-path
@@ -3576,6 +3579,8 @@ def _ensure_cuda_torch() -> None:
         index_url,
         constrain = False,
     )
+    # Re-pin torchao / xFormers when this repair moved the torch family (#10493).
+    _resync_torch_coupled_packages(_label_before)
 
 
 def _ensure_xpu_torch() -> None:
@@ -3596,6 +3601,7 @@ def _ensure_xpu_torch() -> None:
 
     # Un-importable either way installs from the pin below. One shared probe bounds it.
     _ran, _importable, _version, _hip, _cuda = _probe_torch_runtime()
+    _label_before = str(_version or "")
     if not _ran:
         # Inconclusive, so ask the disk, which answers without loading SYCL. An unsupported or
         # missing wheel does need the reinstall (the resolver keeps a too-old +xpu wheel because
@@ -3641,6 +3647,8 @@ def _ensure_xpu_torch() -> None:
         pin,
         constrain = False,
     )
+    # Re-pin torchao / xFormers when this repair moved the torch family (#10493).
+    _resync_torch_coupled_packages(_label_before)
 
 
 def _installed_torch_version_label() -> str:
@@ -3913,6 +3921,7 @@ def _ensure_cpu_torch() -> None:
     # Classify the torch family. Un-importable means missing or broken, and the
     # explicit CPU pin reinstalls it below.
     _ran, _importable, _version, _hip, _cuda = _probe_torch_runtime()
+    _label_before = str(_version or "")
     if not _ran:
         # A hung import is the wedged-driver case this pin exists to rescue, so returning here
         # made the pin a no-op on exactly that host. Classify off disk instead, and only go on
@@ -3939,6 +3948,8 @@ def _ensure_cpu_torch() -> None:
             pin,
             constrain = False,
         )
+        # Re-pin torchao / xFormers when this repair moved the torch family (#10493).
+        _resync_torch_coupled_packages(_label_before)
         return
     if _version is None:
         return  # unreadable -- the base install step handles a missing torch
@@ -3976,6 +3987,8 @@ def _ensure_cpu_torch() -> None:
         pin,
         constrain = False,
     )
+    # Re-pin torchao / xFormers when this repair moved the torch family (#10493).
+    _resync_torch_coupled_packages(_label_before)
 
 
 def _torch_flavor_tag(version: str) -> str:
@@ -5005,6 +5018,7 @@ def _ensure_rocm_torch() -> None:
     # detection. Marker is the HIP version, else a "rocm" sentinel when only the version
     # string flags ROCm; empty = CPU/CUDA torch, or un-probeable, which reinstalls.
     _ran, _importable, _version, _hip, _cuda = _probe_torch_runtime()
+    _label_before = str(_version or "")
     _installed_torch_ver = (_version or "").lower() if (_ran and _importable) else ""
     _hip_marker = ""
     if _ran and _importable:
@@ -5061,6 +5075,8 @@ def _ensure_rocm_torch() -> None:
                 index_url,
                 constrain = False,
             )
+            # Re-pin torchao / xFormers when this repair moved the torch family (#10493).
+            _resync_torch_coupled_packages(_label_before)
             rocm_torch_ready = True
             _inferred_arch_installed = True
             # The same reconciliation the reroutes below make: these wheels carry
@@ -5395,6 +5411,8 @@ def _ensure_rocm_torch() -> None:
             index_url,
             constrain = False,
         )
+        # Re-pin torchao / xFormers when this repair moved the torch family (#10493).
+        _resync_torch_coupled_packages(_label_before)
         rocm_torch_ready = True
     # gfx906 fires even when has_hip_torch is True: a +rocm7.x build IS the broken
     # combo it repairs. A torch already on rocm6.3 wheels is left alone (the tag
@@ -5418,6 +5436,8 @@ def _ensure_rocm_torch() -> None:
             index_url,
             constrain = False,
         )
+        # Re-pin torchao / xFormers when this repair moved the torch family (#10493).
+        _resync_torch_coupled_packages(_label_before)
         rocm_torch_ready = True
     elif not rocm_torch_ready:
         # Reinstall when torch is not ROCm yet, OR a ROCm build's family differs from a pin.
@@ -5462,6 +5482,8 @@ def _ensure_rocm_torch() -> None:
                 index_url,
                 constrain = False,
             )
+            # Re-pin torchao / xFormers when this repair moved the torch family (#10493).
+            _resync_torch_coupled_packages(_label_before)
             rocm_torch_ready = True
 
     # gfx906 has no prebuilt bitsandbytes: the continuous-release/PyPI wheels ship

--- a/tests/studio/install/test_cuda_repair.py
+++ b/tests/studio/install/test_cuda_repair.py
@@ -1748,6 +1748,116 @@ class TestThePackagesTiedToTheTorchReleaseAreResettled:
         assert "could not re-check xFormers" in out
 
 
+class TestLinuxRepairResyncsCoupledPackages:
+    """#10493: Linux family repair must call _resync_torch_coupled_packages the way
+    Windows already does from _ensure_expected_torch_flavor. A no-op must not."""
+
+    def test_a_cuda_family_repair_resyncs_torchao(self):
+        with patch.object(stack_mod, "_resync_torch_coupled_packages") as mock_resync:
+            mock_pip = _run_cuda_repair(torch_state = "hip")
+        assert mock_pip.call_count == 1
+        mock_resync.assert_called_once_with("2.9.1+rocm6.4")
+
+    def test_a_healthy_cuda_torch_does_not_resync(self):
+        with patch.object(stack_mod, "_resync_torch_coupled_packages") as mock_resync:
+            mock_pip = _run_cuda_repair(torch_state = "cuda")
+        mock_pip.assert_not_called()
+        mock_resync.assert_not_called()
+
+    def test_a_cpu_family_repair_resyncs_torchao(self):
+        mock_pip, mock_resync = self._run_cpu_repair("cuda|cu128")
+        assert mock_pip.call_count == 1
+        mock_resync.assert_called_once_with("2.9.1+cu128")
+
+    def test_an_already_cpu_torch_does_not_resync(self):
+        mock_pip, mock_resync = self._run_cpu_repair("cpu")
+        mock_pip.assert_not_called()
+        mock_resync.assert_not_called()
+
+    def test_an_xpu_family_repair_resyncs_torchao(self):
+        mock_pip, mock_resync = self._run_xpu_repair("2.9.1+cpu||")
+        assert mock_pip.call_count == 1
+        mock_resync.assert_called_once_with("2.9.1+cpu")
+
+    def test_an_already_xpu_torch_does_not_resync(self):
+        mock_pip, mock_resync = self._run_xpu_repair("2.9.1+xpu||")
+        mock_pip.assert_not_called()
+        mock_resync.assert_not_called()
+
+    def test_a_rocm_family_repair_resyncs_torchao(self):
+        mock_pip, mock_resync = self._run_linux_rocm_repair(_MARK + "2.10.0+cu126||\n")
+        assert mock_pip.call_count == 1
+        mock_resync.assert_called_once_with("2.10.0+cu126")
+
+    def test_an_already_rocm_torch_does_not_resync(self):
+        mock_pip, mock_resync = self._run_linux_rocm_repair(_MARK + "2.10.0+rocm7.1|7.1.12345|\n")
+        mock_pip.assert_not_called()
+        mock_resync.assert_not_called()
+
+    def _run_cpu_repair(self, torch_state):
+        stack_mod._invalidate_torch_runtime_probe()
+        with (
+            patch.object(stack_mod, "NO_TORCH", False),
+            patch.object(
+                stack_mod,
+                "_explicit_cpu_torch_index_url",
+                return_value = "https://download.pytorch.org/whl/cpu",
+            ),
+            patch.object(stack_mod, "pip_install") as mock_pip,
+            patch.object(stack_mod, "_resync_torch_coupled_packages") as mock_resync,
+            patch.object(
+                stack_mod.subprocess,
+                "run",
+                side_effect = _make_run(torch_state = torch_state),
+            ),
+        ):
+            stack_mod._ensure_cpu_torch()
+        return mock_pip, mock_resync
+
+    def _run_xpu_repair(self, fields):
+        stack_mod._invalidate_torch_runtime_probe()
+        probe = MagicMock(returncode = 0, stdout = _MARK + fields + "\n")
+        with (
+            patch.object(stack_mod, "NO_TORCH", False),
+            patch.object(stack_mod, "IS_MACOS", False),
+            patch.object(stack_mod, "IS_WINDOWS", False),
+            patch.object(
+                stack_mod,
+                "_explicit_xpu_torch_index_url",
+                return_value = "https://download.pytorch.org/whl/xpu",
+            ),
+            patch.object(stack_mod, "pip_install") as mock_pip,
+            patch.object(stack_mod, "_resync_torch_coupled_packages") as mock_resync,
+            patch.object(stack_mod.subprocess, "run", return_value = probe),
+        ):
+            stack_mod._ensure_xpu_torch()
+        return mock_pip, mock_resync
+
+    def _run_linux_rocm_repair(self, stdout):
+        stack_mod._invalidate_torch_runtime_probe()
+        probe = MagicMock(returncode = 0, stdout = stdout)
+        with (
+            patch.object(stack_mod, "IS_MACOS", False),
+            patch.object(stack_mod, "IS_WINDOWS", False),
+            patch.object(stack_mod, "_TORCH_BACKEND", ""),
+            patch.object(stack_mod.platform, "machine", return_value = "x86_64"),
+            patch.object(stack_mod, "_miscomputing_arch_host", return_value = False),
+            patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value = False),
+            patch.object(stack_mod, "_has_rocm_gpu", return_value = True),
+            patch.object(stack_mod, "_detect_rocm_version", return_value = (7, 1)),
+            patch.object(stack_mod, "_infer_linux_amd_gfx_arch", return_value = None),
+            patch.object(stack_mod, "_kfd_gfx_targets", return_value = []),
+            patch.object(stack_mod, "_detect_amd_gfx_codes", return_value = []),
+            patch.object(stack_mod, "pip_install") as mock_pip,
+            patch.object(stack_mod, "pip_install_try", return_value = True),
+            patch.object(stack_mod, "_resync_torch_coupled_packages") as mock_resync,
+            patch("os.path.isdir", return_value = True),
+            patch.object(stack_mod.subprocess, "run", return_value = probe),
+        ):
+            stack_mod._ensure_rocm_torch()
+        return mock_pip, mock_resync
+
+
 class TestTheResidentXformersBuildIsReadFromDisk:
     def test_the_recorded_torch_is_returned(self, tmp_path):
         pkg = tmp_path / "xformers"


### PR DESCRIPTION
## Summary
- Call `_resync_torch_coupled_packages` after Linux torch repair helpers change the accelerator family, matching the Windows path.
- Adds regression coverage so a family switch cannot leave torchao pinned to the previous index.

Fixes #10493

## Test plan
- [ ] Existing installer tests
- [ ] New unit tests for Linux repair resync / no-op