### PR TITLE
Ask for the NPP runtime by the name that has wheels on CUDA 13

### DIFF
--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -513,6 +513,33 @@ def _cuda_major_for_npp(torch_version: "str | None", index_url: str) -> str:
     return match.group(1)[:2] if match else ""
 
 
+# CUDA 13 is where NVIDIA dropped the `-cuNN` suffix from the math libraries. `nvidia-npp` is
+# the 13.x runtime, and the `nvidia-npp-cu13` this would otherwise ask for is a stub whose own
+# summary reads "DEPRECATED: Use nvidia-npp instead". Neither way of resolving it is any good:
+#
+#   - normally, pip prefers the stable 0.0.1 over the prerelease and gets an sdist with no
+#     wheels, so a clean machine builds NPP from source. That is the loud one, and the only
+#     reason it is visible at all is that CI fails the build-from-source gate on it.
+#   - under --only-binary it takes 0.0.0a0, a 1.1 kB "Zero version placeholder" wheel whose
+#     single module is an empty __init__.py. That one installs cleanly, ships no NPP at all,
+#     and leaves torchcodec failing to dlopen libnppicc with nothing anywhere saying why.
+#
+# Per package, not a blanket rule for 13. `nvidia-nccl-cu13` is a real wheel and keeps its
+# suffix; only the names that actually moved may drop it.
+_NPP_SUFFIXED_THROUGH_CUDA_MAJOR = 12
+
+
+def _npp_requirement(cuda_major: str) -> str:
+    """The NPP runtime for this CUDA major, spelled the way its publisher spells it.
+
+    Bounded to the major on the unsuffixed side, because that name keeps moving: it is 13.x
+    today, and a cu14 host must not silently take a 13 runtime or vice versa.
+    """
+    if int(cuda_major) <= _NPP_SUFFIXED_THROUGH_CUDA_MAJOR:
+        return f"nvidia-npp-cu{cuda_major}"
+    return f"nvidia-npp>={cuda_major},<{int(cuda_major) + 1}"
+
+
 # Any sign of the CUDA runtime, versioned or not: nvcudart_hybrid64.dll is the Windows cu130
 # spelling and carries no major. Absent entirely from a cpu build, which is what makes "" safe.
 _CUDA_RUNTIME_MARKER_RE = re.compile(
@@ -8111,7 +8138,8 @@ def install_python_stack() -> int:
             # torch's own dependency set, so a --no-deps install from a cuNNN index reports
             # success and then fails to import, disabling audio for a reason nothing here
             # would otherwise name. docker/Dockerfile installs nvidia-npp-cu12 beside the
-            # same wheel for exactly this. cu13x wheels want nvidia-npp-cu13.
+            # same wheel for exactly this. cu13x wheels want plain nvidia-npp; see
+            # _npp_requirement for why the suffix stops at 12.
             _npp_major = _cuda_major_for_npp(_codec_torch_ver, _codec_index)
             if _codec_fellback:
                 # The pin is gone, so the tag no longer describes this wheel. Probe EVERY
@@ -8125,13 +8153,14 @@ def install_python_stack() -> int:
                         "which its torch tag implies -- matching NPP to the wheel"
                     )
                     _npp_major = _npp_probed
-            if _npp_major and not pip_install_try(
+            _npp_spec = _npp_requirement(_npp_major) if _npp_major else ""
+            if _npp_spec and not pip_install_try(
                 "Installing torchcodec CUDA runtime (NPP)",
                 "--no-cache-dir",
-                f"nvidia-npp-cu{_npp_major}",
+                _npp_spec,
             ):
                 _note(
-                    f"could not install nvidia-npp-cu{_npp_major} -- torchcodec may fail to "
+                    f"could not install {_npp_spec} -- torchcodec may fail to "
                     "import on a host without the CUDA toolkit, leaving audio disabled"
                 )
 

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -524,16 +524,25 @@ def _cuda_major_for_npp(torch_version: "str | None", index_url: str) -> str:
 #     single module is an empty __init__.py. That one installs cleanly, ships no NPP at all,
 #     and leaves torchcodec failing to dlopen libnppicc with nothing anywhere saying why.
 #
-# Per package, not a blanket rule for 13. `nvidia-nccl-cu13` is a real wheel and keeps its
-# suffix; only the names that actually moved may drop it.
+# Per package, not a blanket rule for 13, and the generalisation is actively dangerous. The
+# CUDA Toolkit math and runtime libraries dropped the suffix; the separately versioned NVIDIA
+# products kept it, and for those the UNSUFFIXED name is the trap. `nvidia-cudnn` and
+# `nvidia-nccl` both resolve to 0.0.1.dev5, summary "A fake package to warn the user they are
+# not installing the correct package", while `nvidia-cudnn-cu13` and `nvidia-nccl-cu13` are
+# the real wheels. So this may only ever be widened one name at a time, against the index.
 _NPP_SUFFIXED_THROUGH_CUDA_MAJOR = 12
 
 
 def _npp_requirement(cuda_major: str) -> str:
     """The NPP runtime for this CUDA major, spelled the way its publisher spells it.
 
-    Bounded to the major on the unsuffixed side, because that name keeps moving: it is 13.x
-    today, and a cu14 host must not silently take a 13 runtime or vice versa.
+    Bounded to the major on the unsuffixed side for two reasons. The name keeps moving, so a
+    cu14 host must not silently take a 13 runtime or the reverse. And `nvidia-npp` carries the
+    same junk at the bottom of its version list that the stub is made of: 0.0.0a0 is a 1030
+    byte pure-Python wheel, and 0.0.1.dev4/dev5 are sdists. An unbounded request under
+    --only-binary, behind an exclude-newer cutoff or a partial mirror, can select 0.0.0a0 and
+    land the empty-payload case this whole function exists to avoid. The bound is load
+    bearing, not decoration.
 
     Both callers derive the major from a `\\d+` match, so the digit check never fires today.
     It is here because the old spelling was an f-string that could not raise, and an installer

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -544,13 +544,20 @@ def _npp_requirement(cuda_major: str) -> str:
     land the empty-payload case this whole function exists to avoid. The bound is load
     bearing, not decoration.
 
-    Both callers derive the major from a `\\d+` match, so the digit check never fires today.
-    It is here because the old spelling was an f-string that could not raise, and an installer
-    that dies resolving an optional audio dependency would be a worse bug than the one this
-    fixes: an unrecognised major keeps the previous behaviour rather than taking the process
-    down.
+    Neither major arrives as anything but ASCII today: both come off a `[:2]` or `[-2:]` slice
+    of a digit match. The check is here because the old spelling was an f-string that could not
+    raise, and an installer that dies resolving an OPTIONAL audio dependency would be a worse
+    bug than the one this fixes, so an unrecognised major keeps the previous behaviour instead.
+
+    `[0-9]+` rather than `str.isdigit()`, for the reason already recorded in
+    _hsa_override_gfx_arch: `isdigit()` and `\\d` both accept non-ASCII digits, and here that
+    leaks in two directions. The superscripts are `isdigit()` but not `int()`-able, so the
+    guard would pass and `int()` would raise out of the next line. The non-ASCII decimal digits
+    are both, so they would sail through to `nvidia-npp>=١٣,<14`, which pip cannot parse as a
+    requirement at all -- and that half is reachable rather than hypothetical, because
+    _cuda_major_for_npp matches with a str pattern, where `\\d` is every Unicode decimal digit.
     """
-    if not cuda_major.isdigit():
+    if not re.fullmatch(r"[0-9]+", cuda_major):
         return f"nvidia-npp-cu{cuda_major}"
     if int(cuda_major) <= _NPP_SUFFIXED_THROUGH_CUDA_MAJOR:
         return f"nvidia-npp-cu{cuda_major}"

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -534,7 +534,15 @@ def _npp_requirement(cuda_major: str) -> str:
 
     Bounded to the major on the unsuffixed side, because that name keeps moving: it is 13.x
     today, and a cu14 host must not silently take a 13 runtime or vice versa.
+
+    Both callers derive the major from a `\\d+` match, so the digit check never fires today.
+    It is here because the old spelling was an f-string that could not raise, and an installer
+    that dies resolving an optional audio dependency would be a worse bug than the one this
+    fixes: an unrecognised major keeps the previous behaviour rather than taking the process
+    down.
     """
+    if not cuda_major.isdigit():
+        return f"nvidia-npp-cu{cuda_major}"
     if int(cuda_major) <= _NPP_SUFFIXED_THROUGH_CUDA_MAJOR:
         return f"nvidia-npp-cu{cuda_major}"
     return f"nvidia-npp>={cuda_major},<{int(cuda_major) + 1}"

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -513,49 +513,19 @@ def _cuda_major_for_npp(torch_version: "str | None", index_url: str) -> str:
     return match.group(1)[:2] if match else ""
 
 
-# CUDA 13 is where NVIDIA dropped the `-cuNN` suffix from the math libraries. `nvidia-npp` is
-# the 13.x runtime, and the `nvidia-npp-cu13` this would otherwise ask for is a stub whose own
-# summary reads "DEPRECATED: Use nvidia-npp instead". Neither way of resolving it is any good:
-#
-#   - normally, pip prefers the stable 0.0.1 over the prerelease and gets an sdist with no
-#     wheels, so a clean machine builds NPP from source. That is the loud one, and the only
-#     reason it is visible at all is that CI fails the build-from-source gate on it.
-#   - under --only-binary it takes 0.0.0a0, a 1.1 kB "Zero version placeholder" wheel whose
-#     single module is an empty __init__.py. That one installs cleanly, ships no NPP at all,
-#     and leaves torchcodec failing to dlopen libnppicc with nothing anywhere saying why.
-#
-# Per package, not a blanket rule for 13, and the generalisation is actively dangerous. The
-# CUDA Toolkit math and runtime libraries dropped the suffix; the separately versioned NVIDIA
-# products kept it, and for those the UNSUFFIXED name is the trap. `nvidia-cudnn` and
-# `nvidia-nccl` both resolve to 0.0.1.dev5, summary "A fake package to warn the user they are
-# not installing the correct package", while `nvidia-cudnn-cu13` and `nvidia-nccl-cu13` are
-# the real wheels. So this may only ever be widened one name at a time, against the index.
+# `nvidia-npp-cu13` is a wheel-less stub ("DEPRECATED: Use nvidia-npp instead"); plain
+# `nvidia-npp` is the 13.x runtime. WRONG to widen into "13 drops the suffix": `nvidia-cudnn`
+# and `nvidia-nccl` kept theirs, and their unsuffixed names are fake warning packages.
 _NPP_SUFFIXED_THROUGH_CUDA_MAJOR = 12
 
 
 def _npp_requirement(cuda_major: str) -> str:
     """The NPP runtime for this CUDA major, spelled the way its publisher spells it.
 
-    Bounded to the major on the unsuffixed side for two reasons. The name keeps moving, so a
-    cu14 host must not silently take a 13 runtime or the reverse. And `nvidia-npp` carries the
-    same junk at the bottom of its version list that the stub is made of: 0.0.0a0 is a 1030
-    byte pure-Python wheel, and 0.0.1.dev4/dev5 are sdists. An unbounded request under
-    --only-binary, behind an exclude-newer cutoff or a partial mirror, can select 0.0.0a0 and
-    land the empty-payload case this whole function exists to avoid. The bound is load
-    bearing, not decoration.
-
-    Neither major arrives as anything but ASCII today: both come off a `[:2]` or `[-2:]` slice
-    of a digit match. The check is here because the old spelling was an f-string that could not
-    raise, and an installer that dies resolving an OPTIONAL audio dependency would be a worse
-    bug than the one this fixes, so an unrecognised major keeps the previous behaviour instead.
-
-    `[0-9]+` rather than `str.isdigit()`, for the reason already recorded in
-    _hsa_override_gfx_arch: `isdigit()` and `\\d` both accept non-ASCII digits, and here that
-    leaks in two directions. The superscripts are `isdigit()` but not `int()`-able, so the
-    guard would pass and `int()` would raise out of the next line. The non-ASCII decimal digits
-    are both, so they would sail through to `nvidia-npp>=١٣,<14`, which pip cannot parse as a
-    requirement at all -- and that half is reachable rather than hypothetical, because
-    _cuda_major_for_npp matches with a str pattern, where `\\d` is every Unicode decimal digit.
+    Bounded because `nvidia-npp` carries the same 0.0.0a0 junk the stub is made of, and a cu14
+    host must not take a 13 runtime. `[0-9]+` not `isdigit()`, as in _hsa_override_gfx_arch:
+    isdigit() also takes the superscripts, where `int()` below raises, and the non-ASCII digits,
+    which reach a str `\\d` and emit an unparseable `>=١٣`.
     """
     if not re.fullmatch(r"[0-9]+", cuda_major):
         return f"nvidia-npp-cu{cuda_major}"
@@ -8158,12 +8128,9 @@ def install_python_stack() -> int:
                 "the rest of the install is unaffected"
             )
         elif _codec_index:
-            # torchcodec's CUDA build dlopens libnppicc and libnppc, and NPP is NOT in
-            # torch's own dependency set, so a --no-deps install from a cuNNN index reports
-            # success and then fails to import, disabling audio for a reason nothing here
-            # would otherwise name. docker/Dockerfile installs nvidia-npp-cu12 beside the
-            # same wheel for exactly this. cu13x wheels want plain nvidia-npp; see
-            # _npp_requirement for why the suffix stops at 12.
+            # torchcodec's CUDA build dlopens libnppicc and libnppc, and NPP is not in torch's
+            # dependency set, so a --no-deps install from a cuNNN index imports and then fails.
+            # _npp_requirement spells the name, which stops being suffixed after 12.
             _npp_major = _cuda_major_for_npp(_codec_torch_ver, _codec_index)
             if _codec_fellback:
                 # The pin is gone, so the tag no longer describes this wheel. Probe EVERY

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -1199,7 +1199,7 @@ def test_a_cuda_index_codec_also_installs_npp():
     dependency set, so a --no-deps install from a cuNNN index reports success and then fails
     to import. docker/Dockerfile installs nvidia-npp-cu12 beside the same wheel."""
     source = (REPO_ROOT / "studio" / "install_python_stack.py").read_text(encoding = "utf-8")
-    assert 'f"nvidia-npp-cu{_npp_major}"' in source
+    assert '_npp_spec = _npp_requirement(_npp_major) if _npp_major else ""' in source
     assert "Installing torchcodec CUDA runtime (NPP)" in source
 
     # The major follows the index leaf, and a cpu or rocm index asks for nothing.
@@ -1218,6 +1218,45 @@ def test_a_cuda_index_codec_also_installs_npp():
     # The Dockerfile this mirrors still pairs the two, so the rationale stays checkable.
     dockerfile = (REPO_ROOT / "docker" / "Dockerfile").read_text(encoding = "utf-8")
     assert "nvidia-npp-cu12" in dockerfile
+
+
+def test_cuda_13_asks_for_the_unsuffixed_npp():
+    """`nvidia-npp-cu13` exists on PyPI but is a stub: version 0.0.1, summary "DEPRECATED: Use
+    nvidia-npp instead", sdist and no wheels. Asking for it does not fail, it builds NPP from
+    source on every clean machine, which is what the clean-machine gate caught:
+
+        ::error::built from source: nvidia-npp-cu13 -- these must resolve to wheels
+
+    Under --only-binary it is worse and silent: pip takes 0.0.0a0, a 1.1 kB placeholder whose
+    only module is an empty __init__.py, installs it happily, and torchcodec still cannot
+    dlopen libnppicc.
+
+    The 13.x runtime is plain `nvidia-npp`, which does publish manylinux aarch64 and x86_64
+    wheels."""
+    from studio.install_python_stack import _npp_requirement
+
+    # Suffixed through 12, where the suffixed names are the real ones.
+    assert _npp_requirement("11") == "nvidia-npp-cu11"
+    assert _npp_requirement("12") == "nvidia-npp-cu12"
+
+    # 13 and later take the unsuffixed name, bounded so the major cannot drift.
+    assert _npp_requirement("13") == "nvidia-npp>=13,<14"
+    assert _npp_requirement("14") == "nvidia-npp>=14,<15"
+
+    # No major may resolve to the stub, whatever _cuda_major_for_npp returns.
+    assert not any(
+        _npp_requirement(str(major)).startswith("nvidia-npp-cu13") for major in range(11, 20)
+    )
+
+
+def test_the_npp_rename_is_per_package_not_a_rule_about_13():
+    """NCCL kept its suffix at 13 while the math libraries dropped theirs, so this cannot be
+    generalised into "13 means no suffix". The boundary is a named constant rather than a bare
+    13 so that the next package to move is a one-line change with somewhere to say why."""
+    source = (REPO_ROOT / "studio" / "install_python_stack.py").read_text(encoding = "utf-8")
+    assert "_NPP_SUFFIXED_THROUGH_CUDA_MAJOR = 12" in source
+    # The counterexample is recorded where the rule is, so nobody widens it from memory.
+    assert "nvidia-nccl-cu13" in source
 
 
 def test_the_npp_major_comes_from_the_resident_torch_not_the_index_url():

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -1254,13 +1254,33 @@ def test_cuda_13_asks_for_the_unsuffixed_npp():
 
 
 def test_the_npp_rename_is_per_package_not_a_rule_about_13():
-    """NCCL kept its suffix at 13 while the math libraries dropped theirs, so this cannot be
-    generalised into "13 means no suffix". The boundary is a named constant rather than a bare
-    13 so that the next package to move is a one-line change with somewhere to say why."""
+    """NCCL and cuDNN kept their suffix at 13 while the math libraries dropped theirs, so this
+    cannot be generalised into "13 means no suffix". Over-correcting is worse than the bug: for
+    those two the UNSUFFIXED name is itself a trap, resolving to 0.0.1.dev5 whose summary reads
+    "A fake package to warn the user they are not installing the correct package".
+
+    The boundary is a named constant rather than a bare 13 so that the next package to move is
+    a one-line change with somewhere to record why it moved."""
     source = (REPO_ROOT / "studio" / "install_python_stack.py").read_text(encoding = "utf-8")
     assert "_NPP_SUFFIXED_THROUGH_CUDA_MAJOR = 12" in source
-    # The counterexample is recorded where the rule is, so nobody widens it from memory.
-    assert "nvidia-nccl-cu13" in source
+    # The counterexamples are recorded where the rule is, so nobody widens it from memory.
+    assert "nvidia-cudnn" in source and "nvidia-nccl" in source
+
+
+def test_the_unsuffixed_request_is_bounded_to_the_major():
+    """`nvidia-npp` carries the same junk at the bottom of its version list that the stub is
+    made of: 0.0.0a0 is a 1030 byte pure-Python wheel, 0.0.1.dev4/dev5 are sdists. Unbounded,
+    a resolver working under an exclude-newer cutoff or against a partial mirror can select
+    0.0.0a0 and install the empty payload this exists to avoid. So the request must always
+    carry a lower bound, never be a bare name."""
+    from studio.install_python_stack import _npp_requirement
+
+    for major in ("13", "14", "15"):
+        spec = _npp_requirement(major)
+        assert spec.startswith(f"nvidia-npp>={major}"), spec
+        assert spec != "nvidia-npp", "a bare name can resolve to the 0.0.0a0 placeholder"
+        # Upper bound too, so a cu14 host cannot take a 13 runtime or the reverse.
+        assert f",<{int(major) + 1}" in spec, spec
 
 
 def test_the_npp_major_comes_from_the_resident_torch_not_the_index_url():

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -1221,58 +1221,32 @@ def test_a_cuda_index_codec_also_installs_npp():
 
 
 def test_cuda_13_asks_for_the_unsuffixed_npp():
-    """`nvidia-npp-cu13` exists on PyPI but is a stub: version 0.0.1, summary "DEPRECATED: Use
-    nvidia-npp instead", sdist and no wheels. Asking for it does not fail, it builds NPP from
-    source on every clean machine, which is what the clean-machine gate caught:
-
-        ::error::built from source: nvidia-npp-cu13 -- these must resolve to wheels
-
-    Under --only-binary it is worse and silent: pip takes 0.0.0a0, a 1.1 kB placeholder whose
-    only module is an empty __init__.py, installs it happily, and torchcodec still cannot
-    dlopen libnppicc.
-
-    The 13.x runtime is plain `nvidia-npp`, which does publish manylinux aarch64 and x86_64
-    wheels."""
+    """`nvidia-npp-cu13` is a wheel-less stub, so asking for it builds from source (or takes a
+    1.1 kB placeholder under --only-binary); plain `nvidia-npp` is the 13.x runtime."""
     from studio.install_python_stack import _npp_requirement
 
-    # Suffixed through 12, where the suffixed names are the real ones.
     assert _npp_requirement("11") == "nvidia-npp-cu11"
     assert _npp_requirement("12") == "nvidia-npp-cu12"
-
-    # 13 and later take the unsuffixed name, bounded so the major cannot drift.
     assert _npp_requirement("13") == "nvidia-npp>=13,<14"
     assert _npp_requirement("14") == "nvidia-npp>=14,<15"
-
-    # No major may resolve to the stub, whatever _cuda_major_for_npp returns.
     assert not any(
         _npp_requirement(str(major)).startswith("nvidia-npp-cu13") for major in range(11, 20)
     )
-
-    # Resolving an optional audio dependency must not be able to kill the install, so a major
-    # that is not a number degrades to the old spelling instead of raising out of int().
     assert _npp_requirement("not-a-major") == "nvidia-npp-cunot-a-major"
 
 
 def test_the_npp_rename_is_per_package_not_a_rule_about_13():
-    """NCCL and cuDNN kept their suffix at 13 while the math libraries dropped theirs, so this
-    cannot be generalised into "13 means no suffix". Over-correcting is worse than the bug: for
-    those two the UNSUFFIXED name is itself a trap, resolving to 0.0.1.dev5 whose summary reads
-    "A fake package to warn the user they are not installing the correct package".
-
-    The boundary is a named constant rather than a bare 13 so that the next package to move is
-    a one-line change with somewhere to record why it moved."""
+    """ "13 means no suffix" is WRONG: NCCL and cuDNN kept theirs, and their unsuffixed names
+    resolve to "A fake package to warn the user they are not installing the correct package".
+    Hence a named constant with the counterexamples beside it, not a bare 13."""
     source = (REPO_ROOT / "studio" / "install_python_stack.py").read_text(encoding = "utf-8")
     assert "_NPP_SUFFIXED_THROUGH_CUDA_MAJOR = 12" in source
-    # The counterexamples are recorded where the rule is, so nobody widens it from memory.
     assert "nvidia-cudnn" in source and "nvidia-nccl" in source
 
 
 def test_the_unsuffixed_request_is_bounded_to_the_major():
-    """`nvidia-npp` carries the same junk at the bottom of its version list that the stub is
-    made of: 0.0.0a0 is a 1030 byte pure-Python wheel, 0.0.1.dev4/dev5 are sdists. Unbounded,
-    a resolver working under an exclude-newer cutoff or against a partial mirror can select
-    0.0.0a0 and install the empty payload this exists to avoid. So the request must always
-    carry a lower bound, never be a bare name."""
+    """`nvidia-npp` carries the same 0.0.0a0 junk the stub is made of, which an unbounded
+    resolve behind an exclude-newer cutoff or a partial mirror can select."""
     from studio.install_python_stack import _npp_requirement
     for major in ("13", "14", "15"):
         spec = _npp_requirement(major)
@@ -1283,28 +1257,16 @@ def test_the_unsuffixed_request_is_bounded_to_the_major():
 
 
 def test_no_major_can_kill_the_install_or_emit_an_unparseable_requirement():
-    """The whole point of the digit check is that audio is optional: an unrecognised major has
-    to keep the old spelling rather than take the install down. `isdigit()` alone does not
-    deliver that, because it is true for a wider set of characters than `int()` accepts.
-
-    Two separate gaps, and they fail in different directions:
-
-      - the superscripts are `isdigit()` but not `int()`-able, so `int(cuda_major)` raises
-        ValueError straight out of a helper resolving an OPTIONAL dependency;
-      - the non-ASCII decimal digits are both `isdigit()` and `int()`-able, so they sail past
-        the guard and emit `nvidia-npp>=١٣,<14`, which is not a PEP 440 requirement at all.
-
-    The second one is reachable rather than theoretical: `_cuda_major_for_npp` matches with a
-    str pattern, and `\\d` in a str pattern is every Unicode decimal digit, not `[0-9]`.
-
-    `_hsa_override_gfx_arch` already rejects `"١١.0.0"` for the same reason, so the fix is the
-    idiom already in this file rather than a new one."""
+    """`isdigit()` accepts more than `int()` does, and both gaps land here: the superscripts
+    raise ValueError out of an OPTIONAL dependency, and the non-ASCII decimal digits pass
+    `int()` but emit a non-PEP-440 `>=١٣`. The latter is reachable, since `_cuda_major_for_npp`
+    matches with a str pattern where `\\d` is every Unicode decimal digit."""
     from studio.install_python_stack import _npp_requirement
 
     source = (REPO_ROOT / "studio" / "install_python_stack.py").read_text(encoding = "utf-8")
-    assert 'if not re.fullmatch(r"[0-9]+", cuda_major):' in source, (
-        "the major check must be an explicit ASCII digit match, not str.isdigit()"
-    )
+    assert (
+        'if not re.fullmatch(r"[0-9]+", cuda_major):' in source
+    ), "the major check must be an explicit ASCII digit match, not str.isdigit()"
 
     # int()-hostile: must degrade, never raise.
     for major in ("²", "³", "⁵"):
@@ -1315,18 +1277,16 @@ def test_no_major_can_kill_the_install_or_emit_an_unparseable_requirement():
     for major in ("١٣", "۱۳", "१३"):
         assert major.isdigit() and int(major) == 13
         spec = _npp_requirement(major)
-        assert not spec.startswith("nvidia-npp>="), (
-            f"{major!r} reached a PEP 440 version bound as {spec!r}"
-        )
+        assert not spec.startswith(
+            "nvidia-npp>="
+        ), f"{major!r} reached a PEP 440 version bound as {spec!r}"
         assert spec == f"nvidia-npp-cu{major}"
 
-    # Every requirement this can emit for a real major must parse. Both majors reach the
-    # helper as a one or two character slice of an ASCII match, so that is the domain.
+    # The real domain: a one or two character slice of an ASCII match. All of it must parse.
     packaging_req = pytest.importorskip("packaging.requirements").Requirement
     for major in [str(n) for n in range(0, 100)]:
         packaging_req(_npp_requirement(major))
 
-    # And nothing may raise, whatever arrives.
     for major in ("", " ", "12.0", "-1", "+13", "13a", "1" * 64, "\U0001d7d9\U0001d7db"):
         assert isinstance(_npp_requirement(major), str)
 

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -1282,6 +1282,55 @@ def test_the_unsuffixed_request_is_bounded_to_the_major():
         assert f",<{int(major) + 1}" in spec, spec
 
 
+def test_no_major_can_kill_the_install_or_emit_an_unparseable_requirement():
+    """The whole point of the digit check is that audio is optional: an unrecognised major has
+    to keep the old spelling rather than take the install down. `isdigit()` alone does not
+    deliver that, because it is true for a wider set of characters than `int()` accepts.
+
+    Two separate gaps, and they fail in different directions:
+
+      - the superscripts are `isdigit()` but not `int()`-able, so `int(cuda_major)` raises
+        ValueError straight out of a helper resolving an OPTIONAL dependency;
+      - the non-ASCII decimal digits are both `isdigit()` and `int()`-able, so they sail past
+        the guard and emit `nvidia-npp>=١٣,<14`, which is not a PEP 440 requirement at all.
+
+    The second one is reachable rather than theoretical: `_cuda_major_for_npp` matches with a
+    str pattern, and `\\d` in a str pattern is every Unicode decimal digit, not `[0-9]`.
+
+    `_hsa_override_gfx_arch` already rejects `"١١.0.0"` for the same reason, so the fix is the
+    idiom already in this file rather than a new one."""
+    from studio.install_python_stack import _npp_requirement
+
+    source = (REPO_ROOT / "studio" / "install_python_stack.py").read_text(encoding = "utf-8")
+    assert 'if not re.fullmatch(r"[0-9]+", cuda_major):' in source, (
+        "the major check must be an explicit ASCII digit match, not str.isdigit()"
+    )
+
+    # int()-hostile: must degrade, never raise.
+    for major in ("²", "³", "⁵"):
+        assert major.isdigit(), "fixture is only meaningful if isdigit() accepts it"
+        assert _npp_requirement(major) == f"nvidia-npp-cu{major}"
+
+    # PEP 440-hostile: int()-able, so only an ASCII check keeps them out of a version bound.
+    for major in ("١٣", "۱۳", "१३"):
+        assert major.isdigit() and int(major) == 13
+        spec = _npp_requirement(major)
+        assert not spec.startswith("nvidia-npp>="), (
+            f"{major!r} reached a PEP 440 version bound as {spec!r}"
+        )
+        assert spec == f"nvidia-npp-cu{major}"
+
+    # Every requirement this can emit for a real major must parse. Both majors reach the
+    # helper as a one or two character slice of an ASCII match, so that is the domain.
+    packaging_req = pytest.importorskip("packaging.requirements").Requirement
+    for major in [str(n) for n in range(0, 100)]:
+        packaging_req(_npp_requirement(major))
+
+    # And nothing may raise, whatever arrives.
+    for major in ("", " ", "12.0", "-1", "+13", "13a", "1" * 64, "\U0001d7d9\U0001d7db"):
+        assert isinstance(_npp_requirement(major), str)
+
+
 def test_the_npp_major_comes_from_the_resident_torch_not_the_index_url():
     """Matching `/cuNNN$` against an authenticated mirror ending `/simple?token=...` skipped
     NPP on a `+cu128` host, so the codec then failed to import without a CUDA toolkit."""

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -1248,6 +1248,10 @@ def test_cuda_13_asks_for_the_unsuffixed_npp():
         _npp_requirement(str(major)).startswith("nvidia-npp-cu13") for major in range(11, 20)
     )
 
+    # Resolving an optional audio dependency must not be able to kill the install, so a major
+    # that is not a number degrades to the old spelling instead of raising out of int().
+    assert _npp_requirement("not-a-major") == "nvidia-npp-cunot-a-major"
+
 
 def test_the_npp_rename_is_per_package_not_a_rule_about_13():
     """NCCL kept its suffix at 13 while the math libraries dropped theirs, so this cannot be

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -1274,7 +1274,6 @@ def test_the_unsuffixed_request_is_bounded_to_the_major():
     0.0.0a0 and install the empty payload this exists to avoid. So the request must always
     carry a lower bound, never be a bare name."""
     from studio.install_python_stack import _npp_requirement
-
     for major in ("13", "14", "15"):
         spec = _npp_requirement(major)
         assert spec.startswith(f"nvidia-npp>={major}"), spec


### PR DESCRIPTION
## What this is

`nvidia-npp-cu13` is not the CUDA 13 NPP runtime. NVIDIA dropped the `-cuNN` suffix from the math libraries at 13, so the 13.x runtime is plain `nvidia-npp`, and the suffixed name is a stub. Its own summary on PyPI says so:

```
nvidia-npp-cu13   0.0.1   "DEPRECATED: Use nvidia-npp instead"
```

`studio/install_python_stack.py` builds the name as `f"nvidia-npp-cu{_npp_major}"`, so every CUDA 13 host asks for the stub.

## Why it is worth fixing rather than leaving

Neither way of resolving that name gives you NPP.

**Normally** pip prefers the stable `0.0.1` over the prerelease and gets an sdist with no wheels, so a clean machine builds NPP from source. That is the loud failure, and the only reason it is visible at all is the build-from-source gate:

```
::error::built from source: nvidia-npp-cu13 -- these must resolve to wheels on a clean machine
```

That is the current `linux ubuntu2404-arm-root` failure, and it reproduces on every open PR because it comes from the shared installer path rather than from any one branch.

**Under `--only-binary`** it is worse, because it is silent. pip takes `0.0.0a0` instead:

```
nvidia_npp_cu13-0.0.0a0-py2.py3-none-any.whl     1.1 kB
  Summary: Zero version placeholder for nvidia-npp-cu13
  nvidia_npp_cu13/__init__.py                    0 bytes
```

That installs cleanly, reports success, ships no NPP whatsoever, and leaves torchcodec failing to `dlopen` `libnppicc` with nothing anywhere naming the cause. This is exactly the import failure the NPP install was added to prevent, so the current code can produce the very symptom it exists to avoid.

## The fix

A `_npp_requirement` helper that spells the requirement the way its publisher does:

| CUDA major | requirement |
| --- | --- |
| 11 | `nvidia-npp-cu11` |
| 12 | `nvidia-npp-cu12` |
| 13 | `nvidia-npp>=13,<14` |
| 14 | `nvidia-npp>=14,<15` |

Two deliberate choices.

**The boundary is a named constant, not a bare `13`.** The rename is per package, not a rule about CUDA 13. `nvidia-nccl-cu13` is a real wheel and keeps its suffix, while `nvidia-cublas-cu13` is another deprecated stub. Only names that actually moved may drop the suffix, so the counterexample is recorded next to the constant rather than left to memory.

**The unsuffixed side is bounded to the major.** That name keeps moving: it is 13.x today, and a cu14 host must not silently take a 13 runtime or the reverse.

## Verification

Against PyPI, today:

```
nvidia-npp 13.1.2.81
  nvidia_npp-13.1.2.81-py3-none-manylinux_2_27_aarch64.whl
  nvidia_npp-13.1.2.81-py3-none-manylinux_2_27_x86_64.whl
  nvidia_npp-13.1.2.81-py3-none-win_amd64.whl
```

The aarch64 wheel is the one the failing leg needs. Resolved it end to end for that platform rather than reading the index:

```
pip download --no-deps --only-binary=:all: \
    --platform manylinux_2_27_aarch64 --python-version 3.12 "nvidia-npp>=13,<14"
-> nvidia_npp-13.1.2.81-py3-none-manylinux_2_27_aarch64.whl   151.5 MB
```

`tests/python/test_torchcodec_torch_compat.py` is 91/91. Two new tests cover the mapping and the per-package reasoning; confirmed they bite by flipping the boundary constant from 12 to 13, which fails both.

## Scope

`nvidia-npp-cu11` and `nvidia-npp-cu12` are real packages and are untouched, so CUDA 11 and 12 hosts resolve exactly what they resolve today. `docker/Dockerfile` pins cu12 by hand and is unaffected. The only behaviour that changes is CUDA 13 and later, which today cannot get a working NPP by either resolution path.


## What this unblocks

`linux ubuntu2404-arm-root` is red on `main` itself and on every branch that inherits it. This PR is what turns it green.

- Failing on `main`: run [34255272305](https://github.com/unslothai/unsloth/actions/runs/34255272305) at `5177a5b1d`, sole failing job, no PR involved.
- Blocked on this: **#10282**, whose aarch64 check is red for this reason alone and for nothing in its own diff.

Verified green rather than argued: staged on a throwaway repo and ran `Clean machine install`. `linux ubuntu2404-arm-root` completed **success** with zero `##[error]` lines, and the NPP step resolved to a wheel instead of a source build:

```
deps           Installing torchcodec CUDA runtime (NPP)...
Downloading nvidia-npp (144.5MiB)
 + nvidia-npp==13.1.2.81
```

That run was against the equivalent change on a since-closed duplicate branch (#10589), not this head; both emit the byte-identical `nvidia-npp>=13,<14` for major 13 at the same call site, so the command the job ran is the command this PR produces. Worth a re-stage pinned to this branch before merging if you want the run tied to it.

Worth noting this is not only a CI problem: aarch64 is DGX Spark, so the same path runs on a real install there. x86_64 never reaches the NPP step, because the pinned torchcodec resolves from the pytorch index, which is why only the ARM leg went red.
