### PR TITLE
Ask for nvidia-npp on CUDA 13, not the retired nvidia-npp-cu13 stub

### DIFF
--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -513,6 +513,30 @@ def _cuda_major_for_npp(torch_version: "str | None", index_url: str) -> str:
     return match.group(1)[:2] if match else ""
 
 
+def _npp_requirement(cuda_major: str) -> str:
+    """The NPP runtime for a CUDA major as a pip requirement, or `""` for no major.
+
+    NVIDIA retired the per-major `nvidia-npp-cuNN` names at CUDA 13. `nvidia-npp-cu13` on
+    PyPI is now a deprecation stub whose only release, 0.0.1, ships no wheel and whose sdist
+    build backend raises on purpose, so asking for it does not merely miss: it fails the
+    step, and on a clean machine it fails the whole install. From 13 the distribution is
+    plain `nvidia-npp`, whose own major IS the CUDA major, so the major moves out of the name
+    and into the specifier. cu12 and earlier keep the old name, which is still published.
+    """
+    if not cuda_major:
+        return ""
+    try:
+        major = int(cuda_major)
+    except ValueError:
+        # An unparseable major keeps the historical spelling rather than guessing a range.
+        return f"nvidia-npp-cu{cuda_major}"
+    if major < 13:
+        return f"nvidia-npp-cu{major}"
+    # Bounded above: `nvidia-npp` tracks the CUDA major, so an unbounded floor would let a
+    # future CUDA 14 wheel satisfy a CUDA 13 torch.
+    return f"nvidia-npp>={major},<{major + 1}"
+
+
 # Any sign of the CUDA runtime, versioned or not: nvcudart_hybrid64.dll is the Windows cu130
 # spelling and carries no major. Absent entirely from a cpu build, which is what makes "" safe.
 _CUDA_RUNTIME_MARKER_RE = re.compile(
@@ -8125,13 +8149,14 @@ def install_python_stack() -> int:
                         "which its torch tag implies -- matching NPP to the wheel"
                     )
                     _npp_major = _npp_probed
-            if _npp_major and not pip_install_try(
+            _npp_req = _npp_requirement(_npp_major)
+            if _npp_req and not pip_install_try(
                 "Installing torchcodec CUDA runtime (NPP)",
                 "--no-cache-dir",
-                f"nvidia-npp-cu{_npp_major}",
+                _npp_req,
             ):
                 _note(
-                    f"could not install nvidia-npp-cu{_npp_major} -- torchcodec may fail to "
+                    f"could not install {_npp_req} -- torchcodec may fail to "
                     "import on a host without the CUDA toolkit, leaving audio disabled"
                 )
 

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -1199,7 +1199,7 @@ def test_a_cuda_index_codec_also_installs_npp():
     dependency set, so a --no-deps install from a cuNNN index reports success and then fails
     to import. docker/Dockerfile installs nvidia-npp-cu12 beside the same wheel."""
     source = (REPO_ROOT / "studio" / "install_python_stack.py").read_text(encoding = "utf-8")
-    assert 'f"nvidia-npp-cu{_npp_major}"' in source
+    assert "_npp_req = _npp_requirement(_npp_major)" in source
     assert "Installing torchcodec CUDA runtime (NPP)" in source
 
     # The major follows the index leaf, and a cpu or rocm index asks for nothing.
@@ -1218,6 +1218,43 @@ def test_a_cuda_index_codec_also_installs_npp():
     # The Dockerfile this mirrors still pairs the two, so the rationale stays checkable.
     dockerfile = (REPO_ROOT / "docker" / "Dockerfile").read_text(encoding = "utf-8")
     assert "nvidia-npp-cu12" in dockerfile
+
+
+def test_cuda_13_asks_for_nvidia_npp_not_the_retired_cu13_name():
+    """`nvidia-npp-cu13` on PyPI is a deprecation stub: its only release, 0.0.1, ships no
+    wheel and its sdist build backend raises on purpose. So a cu13x host did not merely skip
+    NPP, it tried to build an sdist and failed, and the clean-machine CI job rejects the
+    source build outright ("built from source: nvidia-npp-cu13"). NVIDIA's replacement is
+    plain `nvidia-npp`, whose own major is the CUDA major."""
+    import re as _re
+
+    source = (REPO_ROOT / "studio" / "install_python_stack.py").read_text(encoding = "utf-8")
+    namespace: dict = {}
+    exec(
+        # Up to the next TOP-LEVEL statement of any kind: what follows this helper is a
+        # module-level assignment, not a def, so a `(?=\n\ndef )` stop swallows it.
+        _re.search(r"def _npp_requirement.*?\n(?=\n\n[^\s])", source, _re.S).group(0),
+        namespace,
+    )
+    npp_requirement = namespace["_npp_requirement"]
+
+    # CUDA 13 and later: the retired name must not appear at all.
+    assert npp_requirement("13") == "nvidia-npp>=13,<14"
+    assert npp_requirement("14") == "nvidia-npp>=14,<15"
+    for major in ("13", "14"):
+        assert "nvidia-npp-cu" not in npp_requirement(major), major
+    # Bounded above, or a CUDA 14 wheel would satisfy a CUDA 13 torch.
+    assert "<14" in npp_requirement("13")
+
+    # CUDA 12 and earlier keep the name that is still published.
+    assert npp_requirement("12") == "nvidia-npp-cu12"
+    assert npp_requirement("11") == "nvidia-npp-cu11"
+
+    # No major means no NPP, which is what keeps the caller's guard intact on a cpu host.
+    assert npp_requirement("") == ""
+    # _cuda_major_for_npp returns a string; an unparseable one keeps the old spelling
+    # rather than inventing a range.
+    assert npp_requirement("x") == "nvidia-npp-cux"
 
 
 def test_the_npp_major_comes_from_the_resident_torch_not_the_index_url():


### PR DESCRIPTION
`main` currently cannot complete a clean install on aarch64. The `linux ubuntu2404-arm-root` leg of `Clean machine install` has been failing on `main` itself, with no PR involved:

- run [34255272305](https://github.com/unslothai/unsloth/actions/runs/34255272305) at `5177a5b1d`, sole failing job `linux ubuntu2404-arm-root`
- the same job fails the same way on every PR branch that inherits it

The failing step:

```
   Building nvidia-npp-cu13==0.0.1
  x Failed to build `nvidia-npp-cu13==0.0.1`
  |-> The build backend returned an error
  `-> Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)

      [stderr]
      THIS PROJECT 'nvidia-npp-cu13' IS DEPRECATED.
      Please use 'nvidia-npp' instead.

##[error]built from source: nvidia-npp-cu13 -- these must resolve to wheels on a clean machine
```

## Cause

NVIDIA retired the per-major `nvidia-npp-cuNN` names at CUDA 13. `nvidia-npp-cu13` on PyPI is now a deprecation stub: its only release, `0.0.1` (uploaded 2025-10-31), publishes **no wheel at all**, only an sdist whose build backend raises on purpose. So the torchcodec NPP step does not merely miss the package, it attempts a source build and fails, and the clean-machine assertion rejects the source build outright.

It bites aarch64 only, which is why the break is easy to miss:

- `torchcodec>=0.11.0,<0.12.0` has no aarch64 wheel on `download.pytorch.org/whl/cpu`, so the installer falls back to the default index and lands the generic `torchcodec==0.11.1`, which links CUDA 13.
- The NPP step then computes major 13 and asks for `nvidia-npp-cu13`.
- On x86_64 the pinned torchcodec resolves from the pytorch index and the NPP step is never reached at all.

aarch64 is DGX Spark, so this affects every Spark install, not just CI.

## Fix

Add `_npp_requirement`, one place that maps a CUDA major to the distribution that actually exists:

- CUDA 12 and earlier keep `nvidia-npp-cu{major}`, which is still published and current (`nvidia-npp-cu12` 12.4.1.87).
- CUDA 13 and later ask for `nvidia-npp>={major},<{major+1}`. The replacement distribution's own major **is** the CUDA major, so the major moves out of the name and into the specifier. Bounded above so a future CUDA 14 wheel cannot satisfy a CUDA 13 torch.
- No major still means no NPP, so the caller's existing cpu/rocm guard is unchanged.

`docker/Dockerfile` is untouched: it installs `nvidia-npp-cu12`, which is on the unchanged branch.

## Verification

`nvidia-npp` 13.1.2.81 publishes the wheels this needs, including aarch64:

```
nvidia_npp-13.1.2.81-py3-none-manylinux_2_27_aarch64.whl
nvidia_npp-13.1.2.81-py3-none-manylinux_2_27_x86_64.whl
nvidia_npp-13.1.2.81-py3-none-win_amd64.whl
```

Installed on an aarch64 GB10 host, it lays down exactly the libraries torchcodec's CUDA build dlopens, under `nvidia/cu13/lib/`: `libnppc`, `libnppif`, `libnppig`, `libnppim`, `libnppist`, `libnppisu`, `libnppitc`, all `.so.13`.

Resolution on aarch64, for contrast:

```
nvidia-npp>=13,<14  ->  nvidia-npp==13.1.2.81      (wheel)
nvidia-npp-cu12     ->  nvidia-npp-cu12==12.4.1.87 (wheel)
nvidia-npp-cu13     ->  nvidia-npp-cu13==0.0.1     (sdist stub, build raises)
```

## Tests

`test_cuda_13_asks_for_nvidia_npp_not_the_retired_cu13_name` covers the mapping in both directions, that the retired name cannot appear for major 13 or later, that the range is bounded above, and that an empty major still asks for nothing. `test_a_cuda_index_codec_also_installs_npp` is updated to the new call site. Both fail against the current `main` and pass here; the file's other 88 tests are unchanged and still pass.

Minimal and self-contained: this only explains the red aarch64 CI seen on other branches, it does not depend on any of them.
