### PR TITLE
Trim the comments in scripts/uninstall.sh and scripts/uninstall.ps1

### DIFF
--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -43,8 +43,8 @@ Environment:
 '@
     }
 
-    # Reject unknown arguments before destructive work. Use throw so embedded
-    # invocations report failure without exiting the caller's PowerShell session.
+    # Reject unknown arguments before destructive work. throw, not exit, so an embedded run reports
+    # failure without killing the caller's PowerShell session.
     foreach ($arg in $args) {
         if ($arg -in @('-h', '-help', '--help', '-?', '/?')) { _Usage; return }
         Write-Host "uninstall.ps1: unrecognized argument: $arg" -ForegroundColor Red
@@ -71,9 +71,8 @@ Environment:
                 $script:RemoveFailed = $true
                 return
             }
-            # Remove-Item -Recurse can report success yet leave a transiently-locked
-            # child (e.g. unsloth.ico in Explorer's icon cache); verify + retry so we
-            # never falsely claim "removed" or orphan the dir.
+            # Remove-Item -Recurse can report success yet leave a transiently-locked child (e.g.
+            # unsloth.ico in Explorer's icon cache); verify + retry so "removed" is never a lie.
             if (-not (Test-Path -LiteralPath $Path)) {
                 _Substep "removed: $Path" "Green"
                 return
@@ -94,14 +93,12 @@ Environment:
         return $p
     }
 
-    # Remove an install root and record whether its studio.db really went with it. That file
-    # holds chat_threads/chat_messages (backend/storage/studio_db.py), not the provider API
-    # keys, which providers_db.py keeps in the browser's localStorage only. It sits under the
-    # install root, so an env-mode install keeps it in a custom root a bare run cannot find.
-    # The check runs on the RESOLVED target: a relocated install (junction or symlink to
-    # another disk) passes the before-check through the link, but the delete unlinks only the
-    # reparse point, and afterwards the path stops resolving and reads as absent either way.
-    # Verifying rather than chasing the link is deliberate: following a reparse point out of
+    # Remove an install root and record whether its studio.db really went with it. That file holds
+    # the chat history (backend/storage/studio_db.py), not the provider API keys, which
+    # providers_db.py keeps in the browser's localStorage only; an env-mode install keeps it in a
+    # custom root a bare run cannot find. The check runs on the RESOLVED target: a relocated
+    # install passes the before-check through the link, but the delete unlinks only the reparse
+    # point. Verifying rather than chasing the link is deliberate: following a reparse point out of
     # the expected location to delete its target is what the deny list exists to stop.
     function _RemoveRootRecordingDb {
         param([string]$Path)
@@ -142,12 +139,11 @@ Environment:
         }
     }
 
-    # Reclaim ONLY what install.ps1 puts under "<LocalAppData>\Unsloth Studio\temp":
-    # directories named ust-<pid>-<hex>, then the temp dir and its parent if they are
-    # left empty. Deliberately narrow. This runs against every LocalAppData spelling,
-    # including one that can name a different user's profile, so it must never be a
-    # recursive delete of anything it did not create. Nothing here follows a link:
-    # Directory.Delete with $false removes a reparse point without touching its target.
+    # Reclaim ONLY what install.ps1 puts under "<LocalAppData>\Unsloth Studio\temp": directories
+    # named ust-<pid>-<hex>, then the temp dir and its parent if left empty. Deliberately narrow:
+    # this runs against every LocalAppData spelling, including one that can name a different user's
+    # profile, so it must never recursively delete anything it did not create. Nothing here follows
+    # a link (Directory.Delete with $false unlinks a reparse point without touching its target).
     function _RemoveStudioPrivateTempTrees {
         param(
             [string[]]$Paths,
@@ -155,40 +151,33 @@ Environment:
             # a different user's profile, so it gets the stricter rule below.
             [string]$PrimaryPath
         )
-        # Every directory this sweep decided to keep, returned so the callers can
-        # keep it too. The wholesale data-directory removal runs over the same
-        # tree, and a live owner preserved here and deleted there is not
-        # preserved at all.
+        # Every directory this sweep kept, returned so the callers keep it too: the wholesale
+        # data-directory removal runs over the same tree, and a live owner preserved here but
+        # deleted there is not preserved at all.
         $preserved = @()
         foreach ($temp in @($Paths)) {
             if ([string]::IsNullOrWhiteSpace($temp)) { continue }
             if (-not (Test-Path -LiteralPath $temp -PathType Container)) { continue }
             $isPrimary = (-not [string]::IsNullOrWhiteSpace($PrimaryPath)) -and
                 [string]::Equals($temp.TrimEnd('\','/'), $PrimaryPath.TrimEnd('\','/'), [System.StringComparison]::OrdinalIgnoreCase)
-            # Never descend through a link. Get-ChildItem on a reparse point
-            # enumerates the TARGET, and the target's ordinary children do not
-            # carry the ReparsePoint attribute, so the recursive delete below
-            # would take somebody else's tree by way of a redirected temp dir.
+            # Never descend through a link. Get-ChildItem on a reparse point enumerates the
+            # TARGET, whose ordinary children carry no ReparsePoint attribute, so the recursive
+            # delete below would take somebody else's tree by way of a redirected temp dir.
             #
-            # How far up to look differs by spelling. For the profile this
-            # uninstall is FOR, the temp directory and the "Unsloth Studio"
-            # directory above it are the two this script created and the two
-            # that decide whose tree the enumeration lands in; a redirected
-            # LocalAppData higher up is still that same user's own storage, and
-            # refusing there would leave the installer's own temp tree behind on
-            # every host that uses folder redirection.
-            # Any OTHER spelling may be another profile entirely, and a junction
-            # anywhere along it -- LocalAppData, Users, the drive root -- is
-            # enough to make an ordinary-looking "Unsloth Studio\temp" resolve
-            # into a directory this uninstall has no claim on. There, every
-            # ancestor up to the root has to be ordinary.
+            # How far up to look differs by spelling. For the profile this uninstall is FOR, the
+            # temp directory and the "Unsloth Studio" directory above it are the two this script
+            # created and the two that decide where the enumeration lands; a redirected
+            # LocalAppData higher up is still that same user's own storage, and refusing there
+            # would leave the installer's own temp tree behind on every host that uses folder
+            # redirection. Any OTHER spelling may be another profile entirely, and a junction
+            # anywhere along it -- LocalAppData, Users, the drive root -- is enough to redirect an
+            # ordinary-looking "Unsloth Studio\temp", so there every ancestor has to be ordinary.
             $ancestors = @()
             if ($isPrimary) {
                 $ancestors = @($temp, [System.IO.Path]::GetDirectoryName($temp))
             } else {
                 $walk = $temp
-                # Bounded: GetDirectoryName returns $null at the root, and the
-                # cap keeps a pathological spelling from spinning.
+                # Bounded: GetDirectoryName returns $null at the root, and the cap stops a spin.
                 for ($depth = 0; $depth -lt 64; $depth++) {
                     if ([string]::IsNullOrWhiteSpace($walk)) { break }
                     $ancestors += $walk
@@ -207,8 +196,7 @@ Environment:
             }
             if ($linked) {
                 _Substep "skipped (reparse point): $temp" "Yellow"
-                # Whatever is behind the link is not ours to delete here, and it is
-                # not ours to delete from the data-directory pass either.
+                # Not ours to delete here, nor in the data-directory pass either.
                 $preserved += $temp
                 continue
             }
@@ -218,10 +206,9 @@ Environment:
                 # Shape, not prefix: "ust-legacy" and "ust-notapid-x" are not ours.
                 if ($entry.Name -notmatch '^ust-[0-9]+-[0-9a-f]{8}$') { continue }
                 if (-not ($entry.PSIsContainer)) { continue }
-                # A LIVE owner keeps its directory, exactly as install.ps1's own
-                # sweep does. An uninstall stops the Unsloth instances under the roots it
-                # knows about; an Unsloth from another install root, or another
-                # user, is not among them and is still using this as its %TEMP%.
+                # A LIVE owner keeps its directory, exactly as install.ps1's own sweep does. An
+                # uninstall stops the Unsloth instances under the roots it knows about; one from
+                # another install root, or another user, is not among them and still needs %TEMP%.
                 $ownerPid = 0
                 try {
                     $ownerFile = Join-Path $entry.FullName "owner.pid"
@@ -240,12 +227,11 @@ Environment:
                         continue
                     }
                 } elseif (-not $isPrimary) {
-                    # No recorded owner, and this is not the profile being uninstalled.
-                    # install.ps1 reads that state as UNKNOWN rather than abandoned,
-                    # because an installer killed before writing owner.pid leaves a live
-                    # Unsloth holding the directory; deleting another user's live %TEMP%
-                    # is not this uninstall's business. Under our own profile the shape
-                    # is enough, since that is what is being removed.
+                    # No recorded owner, and not the profile being uninstalled. install.ps1 reads
+                    # that as UNKNOWN rather than abandoned, because an installer killed before
+                    # writing owner.pid leaves a live Unsloth holding the directory, and another
+                    # user's live %TEMP% is not this uninstall's business. Under our own profile
+                    # the shape is enough, since that is what is being removed.
                     _Substep "no recorded owner in another profile, left alone: $($entry.FullName)" "Yellow"
                     $preserved += $entry.FullName
                     continue
@@ -262,9 +248,8 @@ Environment:
                     $script:RemoveFailed = $true
                 }
             }
-            # Only when empty, so a temp directory holding anything else is left alone,
-            # and likewise the "Unsloth Studio" parent, which on the second spelling may
-            # be a data directory this run has no business deleting.
+            # Only when empty, so a temp dir holding anything else is left alone, and likewise the
+            # "Unsloth Studio" parent, which on the second spelling may not be ours to delete.
             foreach ($dir in @($temp, [System.IO.Path]::GetDirectoryName($temp))) {
                 try {
                     if ((Test-Path -LiteralPath $dir -PathType Container) -and
@@ -277,9 +262,8 @@ Environment:
         return $preserved
     }
 
-    # Delete a tree except for the paths in -Keep, and except for the directories
-    # above them, which have to survive to hold them. With an empty -Keep this is
-    # _RemovePath and nothing else, which is what every ordinary uninstall gets.
+    # Delete a tree except for the paths in -Keep and the directories above them, which have to
+    # survive to hold them. With an empty -Keep this is _RemovePath, which is the ordinary case.
     function _RemoveTreeKeeping {
         param(
             [string]$Path,
@@ -303,8 +287,7 @@ Environment:
             _RemovePath $Path
             return
         }
-        # Something below survives, so this directory does too; take the rest of
-        # its children one by one.
+        # Something below survives, so this directory does too; take the rest of its children.
         Get-ChildItem -LiteralPath $Path -Force -ErrorAction SilentlyContinue | ForEach-Object {
             _RemoveTreeKeeping -Path $_.FullName -Keep $Keep
         }
@@ -317,17 +300,14 @@ Environment:
             [string]$DataDir,
             # WSL-shortcut search dirs; default Start Menu + Desktop, overridable for tests.
             [string[]]$ShortcutDirs = $null,
-            # Paths under the data dir that a previous pass decided to keep, typically
-            # a private temp directory a live Unsloth is still using as its %TEMP%.
+            # Paths under the data dir a previous pass kept, typically a live Unsloth's %TEMP%.
             [string[]]$Preserve = @()
         )
         if ([string]::IsNullOrWhiteSpace($DataDir)) { return }
         if (-not (Test-Path -LiteralPath $DataDir)) { return }
-        # $null = not passed (use defaults); test $null not truthiness so an explicit
-        # @() is honored (-not @() is $true).
+        # $null = not passed (use defaults); test $null, not truthiness, so an explicit @() is honored.
         if ($null -eq $ShortcutDirs) {
-            # Guard $env:APPDATA: it can be unset in service/CI Windows contexts, where
-            # an unguarded Join-Path emits a noisy parameter-binding error.
+            # Guard $env:APPDATA: unset in service/CI contexts, where Join-Path errors noisily.
             $ShortcutDirs = @()
             if (-not [string]::IsNullOrWhiteSpace($env:APPDATA)) {
                 $ShortcutDirs += Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs"
@@ -357,16 +337,14 @@ Environment:
         _RemoveTreeKeeping -Path $DataDir -Keep $keep
     }
 
-    # Is this bin\unsloth.cmd the launcher install.ps1 wrote, or just a file with that
-    # name? The distinction decides whether a directory gets deleted recursively, so a
-    # name alone is not enough -- `unsloth.cmd` is a plausible wrapper for anyone who
-    # ships an unsloth-based tool, and pointing UNSLOTH_STUDIO_HOME at such a project
-    # must not hand its whole tree to _RemovePath.
+    # Is this bin\unsloth.cmd the launcher install.ps1 wrote, or just a file with that name? The
+    # distinction decides whether a directory gets deleted recursively, and `unsloth.cmd` is a
+    # plausible wrapper for anyone shipping an unsloth-based tool, so pointing UNSLOTH_STUDIO_HOME
+    # at such a project must not hand its whole tree to _RemovePath.
     #
-    # The trampoline is the marker: install.ps1 bakes that exact expression into the
-    # shim, no other file has a reason to carry it, and it survives every layout the
-    # shim has (relative %~dp0 or an absolute cross-volume path, unsloth_studio or the
-    # legacy .venv). Bounded read: the real shim is a few hundred bytes.
+    # The trampoline is the marker: install.ps1 bakes that exact expression into the shim, no other
+    # file has a reason to carry it, and it survives every layout the shim has. Bounded read: the
+    # real shim is a few hundred bytes.
     function _IsUnslothCmdShim {
         param([string]$Path)
         if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return $false }
@@ -384,9 +362,8 @@ Environment:
     # A path is an Unsloth-owned root iff one of install.ps1's sentinels exists:
     #   <root>\share\studio.conf, <root>\unsloth_studio\.unsloth-studio-owned,
     #   <root>\bin\unsloth.exe, or a <root>\bin\unsloth.cmd this installer wrote.
-    # The .cmd is the interpreter-based launcher install.ps1 writes beside the .exe for
-    # machines whose Application Control policy denies the generated console script. An
-    # install whose .exe was removed by that policy's quarantine still owns its root.
+    # The .cmd is the launcher written where an Application Control policy denies the generated
+    # console script, so an install whose .exe that policy quarantined still owns its root.
     function _IsStudioRoot {
         param([string]$Path)
         if ([string]::IsNullOrWhiteSpace($Path)) { return $false }
@@ -397,8 +374,7 @@ Environment:
         return $false
     }
 
-    # Hard deny list. Refuse to recursively delete drive roots, USERPROFILE
-    # itself, parent of USERPROFILE, or system directories.
+    # Hard deny list: never recursively delete a drive root, USERPROFILE, its parent or a system dir.
     function _IsUnsafeRoot {
         param([string]$Path)
         if ([string]::IsNullOrWhiteSpace($Path)) { return $true }
@@ -450,9 +426,8 @@ Environment:
         return $null
     }
 
-    # Expand a leading ~ or ~/ ~\ to $env:USERPROFILE so env-mode roots
-    # written with the tilde shape install.ps1 supports (lines 152-154) are
-    # found here too.
+    # Expand a leading ~ or ~/ ~\ to $env:USERPROFILE, so env-mode roots written with the tilde
+    # shape install.ps1 supports are found here too.
     function _ExpandTilde {
         param([string]$Path)
         if ([string]::IsNullOrWhiteSpace($Path)) { return $Path }
@@ -466,10 +441,9 @@ Environment:
         return $p
     }
 
-    # Discover non-default Unsloth roots from env vars + studio.conf files.
-    # Mirrors install.ps1's precedence: UNSLOTH_STUDIO_HOME wins, STUDIO_HOME
-    # is ignored when both are set, so uninstalling install A doesn't also
-    # delete install B if the user has a stale STUDIO_HOME pointing at B.
+    # Discover non-default Unsloth roots from env vars + studio.conf files. Mirrors install.ps1's
+    # precedence: UNSLOTH_STUDIO_HOME wins and STUDIO_HOME is ignored when both are set, or
+    # uninstalling install A would also delete install B from a stale STUDIO_HOME.
     function _CustomStudioRoots {
         $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
         $defaultRoot = $null
@@ -507,9 +481,8 @@ Environment:
         }
     }
 
-    # Return $true iff the PID's image path lives under one of $KnownRoots.
-    # Prevents killing an unrelated process that happens to listen on a stale
-    # Unsloth port.
+    # Return $true iff the PID's image path lives under one of $KnownRoots, so an unrelated
+    # process listening on a stale Unsloth port is never killed.
     function _PidUnderKnownRoot {
         param([int]$Pid_, [string[]]$KnownRoots)
         if (-not $KnownRoots -or $KnownRoots.Count -eq 0) { return $false }
@@ -545,9 +518,8 @@ Environment:
                 } catch { }
             }
         } catch {
-            # netstat fallback for older PowerShell. Require LISTENING state so
-            # we never kill a process whose remote endpoint just happens to be
-            # the cached port (browser -> :443 etc.).
+            # netstat fallback for older PowerShell. Require LISTENING so we never kill a process
+            # whose remote endpoint just happens to be the cached port (browser -> :443 etc.).
             try {
                 $lines = & netstat.exe -ano 2>$null |
                     Select-String -Pattern "LISTENING" |
@@ -591,27 +563,21 @@ Environment:
         } catch { }
     }
 
-    # The Unsloth-managed subtrees underneath the reparse-point TARGET of each Unsloth home, for the
-    # stop scan only.
+    # The Unsloth-managed subtrees underneath the reparse-point TARGET of each Unsloth home, for
+    # the stop scan only. A junction or symlinked home runs its native binaries out of the PHYSICAL
+    # path (the backend resolves the home before deriving <home>\stable-diffusion.cpp and launching
+    # sd-server there), while _CustomStudioRoots only normalizes the string: GetFullPath is lexical
+    # and leaves a reparse point untouched. The prefix scan below reads Win32_Process.ExecutablePath,
+    # the real image path, so without the target a running server never matches and survives an
+    # uninstall that took its tree.
     #
-    # A junction or directory symlink Unsloth home runs its native binaries out of the PHYSICAL
-    # path: the backend resolves the home (Path.resolve) before deriving <home>\stable-diffusion.cpp
-    # and launching sd-server there, while _CustomStudioRoots only normalizes the string --
-    # System.IO.Path.GetFullPath is lexical and never touches the filesystem, so it leaves a
-    # reparse point untouched. The prefix scan below reads Win32_Process.ExecutablePath, the real
-    # image path, so without the target the running server never matches and survives an uninstall
-    # that took its tree.
+    # The SUBTREES, never the bare target: the delete unlinks only the reparse point, so anything
+    # under the target that is not ours is neither locking nor being removed and must not be
+    # force-stopped. Homes only, for the same reason: a component dir ($defaultNode, ...) can
+    # itself be a link onto a shared runtime, and resolving it would scope in every process there.
     #
-    # The SUBTREES, never the bare target. The delete unlinks only the reparse point and leaves the
-    # target standing, so anything there that is not ours is neither locking nor being removed --
-    # a home relocated onto a directory that holds other software must not have those force-stopped.
-    # Homes only, for the same reason: the component dirs ($defaultNode, $defaultLlamaCpp, ...) can
-    # themselves be links onto a shared runtime, and resolving those would put every process out of
-    # it in scope.
-    #
-    # Stop scan only, deliberately. _RemoveRootRecordingDb and the deletes still refuse to chase a
-    # link out of the expected location -- following one to delete its target is exactly what the
-    # deny list exists to prevent. Ending our own process under the target is not destructive.
+    # Stop scan only, deliberately. The deletes still refuse to chase a link out of the expected
+    # location, which is what the deny list exists to prevent; ending our own process is not.
     function _ManagedPathsUnderReparseTargets {
         param([string[]]$Roots)
         # Everything setup.ps1 / the prebuilt installers place inside an Unsloth home.
@@ -642,11 +608,10 @@ Environment:
         return $out
     }
 
-    # Stop processes that would block deleting the paths we remove. Unlike
-    # _StopStudioProcesses (venv exe only), this also catches llama-server/llama-cli,
-    # the unsloth.exe shim, and orphaned mp workers under SYSTEM python holding a
-    # venv DLL (an open DLL handle blocks the dir delete) -- found by scanning each
-    # candidate's loaded modules, not just its image path.
+    # Stop processes that would block deleting the paths we remove. Unlike _StopStudioProcesses
+    # (venv exe only), this also catches llama-server/llama-cli, the unsloth.exe shim and orphaned
+    # mp workers holding a venv DLL (an open DLL handle blocks the dir delete), found by scanning
+    # each candidate's loaded modules as well as its image path.
     function _StopProcessesLockingRoots {
         param([string[]]$Roots)
         $clean = @($Roots | Where-Object { $_ } | ForEach-Object { $_.TrimEnd('\','/') })
@@ -683,19 +648,14 @@ Environment:
     $defaultStudioHome = if ($env:USERPROFILE) { Join-Path $env:USERPROFILE ".unsloth\studio" } else { $null }
     $defaultDataRoot = _AppDataRoot $env:LOCALAPPDATA 'LocalApplicationData'
     $defaultDataDir = if ($defaultDataRoot) { Join-Path $defaultDataRoot "Unsloth Studio" } else { $null }
-    # The SECOND LocalAppData spelling gets the private temp tree only, never the
-    # data directory. install.ps1 falls through from a set-but-unusable
-    # $env:LOCALAPPDATA to the known folder when it places "Unsloth Studio\temp",
-    # so that tree can outlive an uninstall; but the two spellings differ mainly
-    # when they name a DIFFERENT USER's profile (CreateProcessAsUser with a null
-    # environment block, runas /env, a service token), and the data-dir delete is
-    # recursive, sentinel-free and deny-list-free. Reclaiming what this installer
-    # actually put there is the whole requirement; taking a second "Unsloth Studio"
-    # with it is not.
+    # The SECOND LocalAppData spelling gets the private temp tree only, never the data directory.
+    # install.ps1 falls through from a set-but-unusable $env:LOCALAPPDATA to the known folder when
+    # it places "Unsloth Studio\temp", so that tree can outlive an uninstall; but the two spellings
+    # differ mainly when they name a DIFFERENT USER's profile, and the data-dir delete is
+    # recursive, sentinel-free and deny-list-free.
     $knownLocalAppData = $null
     try { $knownLocalAppData = [Environment]::GetFolderPath('LocalApplicationData') } catch { $knownLocalAppData = $null }
-    # The first non-blank spelling is the one _AppDataRoot would have resolved, so
-    # it is the profile this uninstall is for.
+    # The first non-blank spelling is the one _AppDataRoot resolved: the profile this run is for.
     $primaryPrivateTemp = if ($defaultDataDir) { Join-Path $defaultDataDir "temp" } else { $null }
     $privateTempDirs = @()
     foreach ($root in @($env:LOCALAPPDATA, $knownLocalAppData)) {
@@ -703,28 +663,23 @@ Environment:
         $candidate = Join-Path $root "Unsloth Studio\temp"
         if ($privateTempDirs -notcontains $candidate) { $privateTempDirs += $candidate }
     }
-    # Default-mode ~/.unsloth holds a SHARED llama.cpp build + .cache that are
-    # siblings of studio (not under it), so deleting <studio> misses them -- handle
-    # explicitly. No-op in env/custom mode (nested under the custom root, removed
-    # with it). A user-set UNSLOTH_LLAMA_CPP_PATH is left alone.
+    # Default-mode ~/.unsloth holds a SHARED llama.cpp build + .cache that are siblings of studio,
+    # so deleting <studio> misses them. No-op in env/custom mode (nested under the custom root,
+    # removed with it). A user-set UNSLOTH_LLAMA_CPP_PATH is left alone.
     $defaultUnslothHome = if ($env:USERPROFILE) { Join-Path $env:USERPROFILE ".unsloth" } else { $null }
     $defaultLlamaCpp = if ($defaultUnslothHome) { Join-Path $defaultUnslothHome "llama.cpp" } else { $null }
-    # Default-mode native diffusion build (install_sd_cpp_prebuilt.default_install_dir()),
-    # a sibling of studio like llama.cpp. No-op in env/custom mode and when absent. A
-    # user-set UNSLOTH_SD_CPP_PATH is left alone.
+    # Default-mode native diffusion build, a sibling of studio like llama.cpp. No-op in env/custom
+    # mode and when absent. A user-set UNSLOTH_SD_CPP_PATH is left alone.
     $defaultSdCpp = if ($defaultUnslothHome) { Join-Path $defaultUnslothHome "stable-diffusion.cpp" } else { $null }
     $defaultCache = if ($defaultUnslothHome) { Join-Path $defaultUnslothHome ".cache" } else { $null }
-    # Isolated Node.js runtime (install_node_prebuilt.py), a sibling of studio in
-    # default mode. No-op in env/custom mode (nested under the custom root) and absent.
+    # Isolated Node.js runtime (install_node_prebuilt.py), a default-mode sibling of studio.
     $defaultNode = if ($defaultUnslothHome) { Join-Path $defaultUnslothHome "node" } else { $null }
-    # llama.cpp atomic-install staging root (install_llama_prebuilt.py .staging,
-    # sibling of the install dir). Usually pruned after activate, but an interrupted
-    # build can leave a "<name>.staging-XXXX" tree; removing it lets the empty-dir
-    # cleanup of ~/.unsloth below succeed. No-op in env/custom mode and when absent.
+    # llama.cpp atomic-install staging root (install_llama_prebuilt.py), a sibling of the install
+    # dir. Usually pruned after activate, but an interrupted build leaves a "<name>.staging-XXXX"
+    # tree behind and that blocks the empty-dir cleanup of ~/.unsloth below.
     $defaultStaging = if ($defaultUnslothHome) { Join-Path $defaultUnslothHome ".staging" } else { $null }
-    # Managed whisper.cpp dictation engine (setup.ps1 PHASE 3.4 installs it at
-    # $UnslothHome\whisper.cpp), a sibling of studio in default mode. No-op in
-    # env/custom mode (nested under the custom root) and when absent.
+    # Managed whisper.cpp dictation engine (setup.ps1 installs it at $UnslothHome\whisper.cpp), a
+    # default-mode sibling of studio. No-op in env/custom mode and when absent.
     $defaultWhisperCpp = if ($defaultUnslothHome) { Join-Path $defaultUnslothHome "whisper.cpp" } else { $null }
 
     # Build known-root list FIRST so the port-file kill can verify ownership.
@@ -809,10 +764,9 @@ Environment:
     if ($defaultSdCpp -and (Test-Path -LiteralPath $defaultSdCpp) -and (Test-Path -LiteralPath (Join-Path $defaultSdCpp ".unsloth-studio-owned") -PathType Leaf)) {
         $defaultSdCppToStop = $defaultSdCpp
     }
-    # A custom/env-mode sd.cpp build now sits UNDER its root at <root>\stable-diffusion.cpp, which
-    # the $knownRoots prefix match below already covers. Older builds put it BESIDE the root at
-    # <parent>\stable-diffusion.cpp, outside $knownRoots. We delete those marker-owned dirs below,
-    # so add them to the handle scan too, gated on the same owner marker.
+    # A custom/env-mode sd.cpp build now sits UNDER its root, which the $knownRoots prefix match
+    # below already covers. Older builds put it BESIDE the root at <parent>\stable-diffusion.cpp,
+    # outside $knownRoots; we delete those marker-owned dirs below, so scan them too.
     $customSdCppToStop = @()
     foreach ($r in $customRoots) {
         $sdc = Join-Path (Split-Path -LiteralPath $r -Parent) "stable-diffusion.cpp"
@@ -840,14 +794,12 @@ Environment:
             continue
         }
         _RemoveRootRecordingDb $r
-        # Native diffusion (stable-diffusion.cpp) now installs UNDER the custom root, at
-        # <root>\stable-diffusion.cpp, so the removal above already took it. Older builds put it
-        # BESIDE the root at <parent>\stable-diffusion.cpp (find_sd_cpp_binary derived it from
-        # UNSLOTH_STUDIO_HOME.parent), and removing only the root would leave that build behind.
-        # Only remove a sibling Unsloth installed: <parent> is a user-chosen dir and
-        # "stable-diffusion.cpp" is exactly what a git clone of the upstream project produces, so
-        # require our owner marker (written by install_sd_cpp_prebuilt) before rm, and keep any
-        # unowned checkout. Guard the derived parent path the same way.
+        # Native diffusion now installs UNDER the custom root, so the removal above already took
+        # it. Older builds put it BESIDE the root at <parent>\stable-diffusion.cpp, which removing
+        # the root alone would leave behind. <parent> is user-chosen and "stable-diffusion.cpp" is
+        # exactly what a git clone of the upstream project produces, so require our owner marker
+        # (install_sd_cpp_prebuilt) before rm and keep any unowned checkout. The derived parent
+        # path gets the deny-list check too.
         $customSdCpp = Join-Path (Split-Path -LiteralPath $r -Parent) "stable-diffusion.cpp"
         if (_IsUnsafeRoot $customSdCpp) {
             _Substep "refusing to remove unsafe path: $customSdCpp" "Yellow"
@@ -859,47 +811,38 @@ Environment:
     }
     # Default install dir (always at %USERPROFILE%\.unsloth\studio when present).
     if ($defaultStudioHome) { _RemoveRootRecordingDb $defaultStudioHome }
-    # Default data dir. The private temp sweep goes FIRST and hands back what it
-    # kept: the primary temp directory lives under this data dir, so a wholesale
-    # removal here would erase a live Unsloth's %TEMP% before the sweep ever looked
-    # at its owner.pid.
+    # Default data dir. The private temp sweep goes FIRST and hands back what it kept: the primary
+    # temp directory lives under this data dir, so a wholesale removal here would erase a live
+    # Unsloth's %TEMP% before the sweep ever looked at its owner.pid.
     $preservedTemp = @(_RemoveStudioPrivateTempTrees -Paths $privateTempDirs -PrimaryPath $primaryPrivateTemp)
     if ($defaultDataDir) { _RemoveDataDirKeepingWslIcon $defaultDataDir -Preserve $preservedTemp }
-    # Default-mode shared llama.cpp build + cache (siblings of studio under
-    # ~/.unsloth). No-op in env/custom mode and when absent.
+    # Shared llama.cpp build + cache, siblings of studio under ~/.unsloth in default mode.
     if ($defaultLlamaCpp) { _RemovePath $defaultLlamaCpp }
-    # "stable-diffusion.cpp" is exactly what a git clone of leejet/stable-diffusion.cpp produces,
-    # so a user may keep their own checkout (or point UNSLOTH_SD_CPP_PATH) at this default path;
-    # require our owner marker (written by install_sd_cpp_prebuilt) before rm, mirroring the
-    # custom-root guard above, so a user's own checkout or a pre-marker Unsloth build is kept.
+    # "stable-diffusion.cpp" is exactly what a git clone of leejet/stable-diffusion.cpp produces
+    # and a user may keep their own checkout (or point UNSLOTH_SD_CPP_PATH) here, so require our
+    # owner marker before rm: an unowned checkout or a pre-marker Unsloth build is kept.
     if ($defaultSdCpp -and (Test-Path -LiteralPath $defaultSdCpp) -and -not (Test-Path -LiteralPath (Join-Path $defaultSdCpp ".unsloth-studio-owned") -PathType Leaf)) {
         _Substep "keeping sd.cpp without Unsloth owner marker: $defaultSdCpp" "Yellow"
     } elseif ($defaultSdCpp) {
         _RemovePath $defaultSdCpp
     }
     if ($defaultCache) { _RemovePath $defaultCache }
-    # Isolated Node.js runtime (sibling of studio under ~/.unsloth). No-op in env/
-    # custom mode (nested under the custom root, removed with it) and when absent.
+    # Isolated Node.js runtime, a sibling of studio under ~/.unsloth. Nested in env/custom mode.
     if ($defaultNode) { _RemovePath $defaultNode }
     if ($defaultStaging) { _RemovePath $defaultStaging }
-    # Managed whisper.cpp prebuilt (sibling of studio under ~/.unsloth). Only
-    # present when a whisper prebuilt matching the pinned llama.cpp build existed
-    # at install time, so many installs lack it.
+    # Managed whisper.cpp prebuilt, a sibling of studio under ~/.unsloth. Only present when one
+    # matching the pinned llama.cpp build existed at install time, so many installs lack it.
     if ($defaultWhisperCpp) { _RemovePath $defaultWhisperCpp }
-    # Prebuilt install locks. Every prebuilt serializes on
-    # <parent>\.<name>.install.lock (prebuilt_core.py install_lock_path), so
-    # llama.cpp, node and whisper.cpp each leave one; a stray lock keeps
-    # ~/.unsloth from being pruned below. No-op in env/custom mode and when absent.
+    # Prebuilt install locks: every prebuilt serializes on <parent>\.<name>.install.lock
+    # (prebuilt_core.py), and a stray lock keeps ~/.unsloth from being pruned below.
     if ($defaultUnslothHome) {
         foreach ($lockName in @(".llama.cpp.install.lock", ".node.install.lock", ".whisper.cpp.install.lock")) {
             _RemovePath (Join-Path $defaultUnslothHome $lockName)
         }
-        # Taking over an abandoned lock renames it to .stale.<pid> before unlinking
-        # (install_node_prebuilt.py); a crash between the two steps strands the
-        # rename, so sweep any leftovers. -Force to see the dot-prefixed names.
+        # Taking over an abandoned lock renames it to .stale.<pid> before unlinking; a crash
+        # between the two strands the rename, so sweep any leftovers. -Force sees dotted names.
         if (Test-Path -LiteralPath $defaultUnslothHome) {
-            # -like, not -Filter: the provider's Win32 filter is unreliable for
-            # dot-leading names with several dots.
+            # -like, not -Filter: the Win32 filter is unreliable for names with several dots.
             foreach ($stale in @(Get-ChildItem -LiteralPath $defaultUnslothHome -Force -ErrorAction SilentlyContinue |
                                  Where-Object { $_.Name -like "*.install.lock.stale.*" })) {
                 _RemovePath $stale.FullName
@@ -939,9 +882,8 @@ Environment:
     if ($env:APPDATA) {
         _RemovePath (Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Unsloth Studio.lnk")
     }
-    # Invalidate the Win11 Start Menu tile cache so the removed shortcut's tile
-    # disappears promptly instead of lingering stale (mirrors install.ps1's
-    # New-StudioShortcuts). Preserves start2.bin (the pin layout).
+    # Invalidate the Win11 Start Menu tile cache so the removed shortcut's tile disappears instead
+    # of lingering stale (mirrors install.ps1). Preserves start2.bin, the pin layout.
     try {
         $smehTemp = Join-Path $env:LOCALAPPDATA "Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\TempState"
         if (Test-Path -LiteralPath $smehTemp) {
@@ -952,9 +894,8 @@ Environment:
         }
     } catch { }
 
-    # Re-sweep: the first pass may have left unsloth.ico locked by Explorer/SMEH for
-    # the native shortcut; that handle is now freed. (A surviving WSL shortcut still
-    # keeps the icon -- see the helper.)
+    # Re-sweep: the first pass may have left unsloth.ico locked by Explorer/SMEH for the native
+    # shortcut; that handle is now freed. (A surviving WSL shortcut still keeps the icon.)
     $preservedTemp = @(_RemoveStudioPrivateTempTrees -Paths $privateTempDirs -PrimaryPath $primaryPrivateTemp)
     if ($defaultDataDir -and (Test-Path -LiteralPath $defaultDataDir)) {
         _RemoveDataDirKeepingWslIcon $defaultDataDir -Preserve $preservedTemp
@@ -971,10 +912,8 @@ Environment:
                     $entries = $rawPath -split ';'
                     $kept = New-Object System.Collections.ArrayList
                     $removedAny = $false
-                    # Only remove PATH entries that live inside an Unsloth root we
-                    # actually own (default or env-mode). A literal substring
-                    # match on `unsloth_studio` would clobber unrelated user
-                    # virtualenvs that happen to share the name.
+                    # Only remove PATH entries inside an Unsloth root we actually own. A literal
+                    # substring match on `unsloth_studio` would clobber unrelated user virtualenvs.
                     foreach ($e in $entries) {
                         if ([string]::IsNullOrWhiteSpace($e)) { continue }
                         $expanded = [Environment]::ExpandEnvironmentVariables($e).TrimEnd('\','/')

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -75,16 +75,12 @@ _pkill_escape() {
     printf '%s' "$1" | sed -e 's:[][\\.^$*+?{|}()/]:\\&:g'
 }
 
-# sd.cpp roots whose sd-server has to be stopped: the default
-# $HOME/.unsloth/stable-diffusion.cpp, plus for each custom root both
-# <root>/stable-diffusion.cpp, where the install now lives, and the legacy
-# <parent>/stable-diffusion.cpp sibling an older build wrote. The nested one matters most: a
-# resident sd-server survives unlinking its binary, and the custom root is removed wholesale
-# below, so without it the tree goes and the server keeps running.
-# The owner marker gates the paths that SURVIVE when unowned (the default and the sibling), so an
-# unrelated checkout there keeps its server. It does not gate the nested path of a root this run
-# deletes: the current-root finder can select an unmarked binary there, and deleting the tree out
-# from under a live server is exactly what leaves it holding its port.
+# sd.cpp roots whose sd-server has to be stopped: the default $HOME/.unsloth/stable-diffusion.cpp,
+# plus per custom root the nested <root>/stable-diffusion.cpp and the legacy <parent> sibling.
+# A resident sd-server survives unlinking its binary, and the custom root is removed wholesale
+# below, so without the nested path the tree goes and the server keeps running.
+# The owner marker gates only the paths that SURVIVE when unowned (the default and the sibling), so
+# an unrelated checkout keeps its server; the nested path of a root this run deletes is not gated.
 _owned_sd_cpp_roots() {
     _default_sd="$HOME/.unsloth/stable-diffusion.cpp"
     [ -f "$_default_sd/.unsloth-studio-owned" ] && printf '%s\n' "$_default_sd"
@@ -103,10 +99,9 @@ _owned_sd_cpp_roots() {
 }
 
 # Every root an older build could have hung its sd.cpp sibling off: the canonicalized custom roots
-# and the lexical ones. They differ only when the Unsloth home is itself a symlink, and there the
-# lexical form is the one the old `dirname "$UNSLOTH_STUDIO_HOME"` produced, so canonicalizing
-# first looked beside the link's target and missed the tree entirely. Every use is gated on the
-# owner marker, which is what keeps an unrelated checkout at either path safe.
+# and the lexical ones. They differ only when the Unsloth home is itself a symlink, and there only
+# the lexical form (what the old plain `dirname` produced) finds the tree. Every use is gated on
+# the owner marker, which is what keeps an unrelated checkout at either path safe.
 _sd_cpp_sibling_bases() {
     {
         _custom_studio_roots 2>/dev/null
@@ -177,9 +172,8 @@ _pkill_studio() {
     done
 
     if ! command -v pkill >/dev/null 2>&1; then
-        # No procps (install.sh never requires it): the PID sweep above is all we have.
-        # A live app's WebView helpers re-create the profile right after the delete, so
-        # the removal is incomplete and the summary must not claim otherwise.
+        # No procps (install.sh never requires it): the PID sweep above is all we have. A live
+        # app re-creates the profile right after the delete, so do not claim a clean removal.
         if _studio_app_running; then
             echo "  pkill not found and Unsloth Studio is running; close it and re-run" >&2
             _set_marker "$_REMOVE_FAILED_FLAG"
@@ -198,8 +192,7 @@ $_roots_from_conf"
         [ -n "$_root" ] || continue
         [ -d "$_root" ] || continue
         _re=$(_pkill_escape "$_root")
-        # `unsloth studio` (default port) + `-p N` + `--port N` forms, all
-        # anchored on the install root's venv path.
+        # `unsloth studio` default-port, `-p N` and `--port N` forms, anchored on the venv path.
         for _pat in \
             "${_re}/unsloth_studio/bin/[^ ]* studio( |\$|.*-p[ =][0-9])" \
             "${_re}/unsloth_studio/bin/[^ ]* studio.*--port[ =][0-9]" \
@@ -222,17 +215,15 @@ $_roots_from_conf"
         done
     done
 
-    # Native diffusion servers (sd-server / sd-cli) survive unlinking their binary,
-    # so stop the ones under an owned sd.cpp root before those trees are removed.
+    # sd-server / sd-cli survive unlinking their binary, so stop them before their trees go.
     _stop_owned_sd_cpp_processes TERM
     sleep 0.5
     _stop_owned_sd_cpp_processes KILL
 
-    # The app's WebView helpers re-create the caches removed below, so it has to die here.
-    # -x is exact, so the "unsloth" CLI shim never matches. -u takes the owner of the $HOME
-    # being cleared, not the caller (macOS sudo keeps HOME), so a root run spares other users;
-    # an unknown owner skips rather than signalling everyone. Numeric uid and signal-first
-    # suit BSD pkill, which reads the signal from argv[1] only.
+    # The app's WebView helpers re-create the caches removed below, so it has to die here. -x is
+    # exact, so the "unsloth" CLI shim never matches. -u takes the owner of the $HOME being
+    # cleared, not the caller (macOS sudo keeps HOME), so a root run spares other users and an
+    # unknown owner skips entirely. Numeric uid and signal-first for BSD pkill (signal in argv[1]).
     _studio_uid=$(_home_uid)
     if [ -n "$_studio_uid" ]; then
         pkill -TERM -x -u "$_studio_uid" unsloth-studio 2>/dev/null || true
@@ -241,16 +232,14 @@ $_roots_from_conf"
     fi
 }
 
-# Summary state in files, not variables: custom roots are removed inside a pipeline
-# subshell, where an assignment would never reach the summary.
+# Summary state in files, not variables: custom roots are removed inside a pipeline subshell,
+# where an assignment would never reach the summary.
 #   remove-failed  an rm failed, or a root was skipped while still holding data
 #   db-removed     a removed install root actually held studio.db
-# studio.db holds chat_threads/chat_messages (backend/storage/studio_db.py via studio_root()),
-# not the provider API keys: providers_db.py keeps those in the browser's localStorage only.
-# It sits under the install root, so an env-mode install keeps it in a custom root a bare run
-# cannot discover; claim the history is gone only if a database was really deleted.
-# mktemp -d, not a $TMPDIR name: private (0700) and unpredictable, so the markers cannot
-# collide with, or be pre-created by, anything else.
+# studio.db holds the chat history (backend/storage/studio_db.py), not the provider API keys:
+# providers_db.py keeps those in the browser's localStorage only. An env-mode install keeps it in
+# a custom root a bare run cannot discover, so claim the history is gone only if one was deleted.
+# mktemp -d, not a $TMPDIR name: private (0700) and unpredictable, so nothing else can pre-create.
 _MARKER_DIR=$(mktemp -d 2>/dev/null || true)
 _REMOVE_FAILED_FLAG=""
 _DB_REMOVED_FLAG=""
@@ -259,9 +248,8 @@ if [ -n "$_MARKER_DIR" ] && [ -d "$_MARKER_DIR" ]; then
     _DB_REMOVED_FLAG="$_MARKER_DIR/db-removed"
 fi
 
-# `printf`, never `: > "$f"`: `:` is a POSIX special builtin, so a redirection error on it
-# kills a non-interactive shell outright (dash 2, busybox ash 1) and `|| true` does not stop
-# it. printf is a regular builtin, so the same failure is just a nonzero status.
+# `printf`, never `: > "$f"`: `:` is a POSIX special builtin, so a redirection error on it kills a
+# non-interactive shell outright (dash, busybox ash) and `|| true` does not stop it.
 _set_marker() {
     [ -n "$1" ] || return 0
     printf '' > "$1" 2>/dev/null || true
@@ -269,8 +257,8 @@ _set_marker() {
 }
 _marker_set() { [ -n "$1" ] && [ -f "$1" ]; }
 # No marker storage means no record of what failed, so the summary must not claim success.
-# Re-checked, not trusted from startup: the directory can vanish or lose write access mid-run,
-# after which _set_marker silently drops every failure while the pathname still looks fine.
+# Re-checked, not trusted from startup: the dir can vanish or lose write access mid-run, after
+# which _set_marker silently drops every failure.
 _markers_unavailable() {
     [ -n "$_MARKER_DIR" ] || return 0
     [ -d "$_MARKER_DIR" ] || return 0
@@ -286,12 +274,11 @@ _cleanup_markers() {
 }
 trap _cleanup_markers EXIT
 
-# Remove an install root and record whether its studio.db really went with it.
-# The check runs on the RESOLVED path: a relocated install (~/.unsloth/studio a symlink to
-# another disk) passes `-f "$root/studio.db"` through the link, but `rm -rf` unlinks only the
-# link, and afterwards the path stops resolving and reads as absent either way.
-# Verifying rather than chasing the link is deliberate: following a symlink out of the
-# expected location to `rm -rf` its target is what the deny lists exist to prevent.
+# Remove an install root and record whether its studio.db really went with it. The check runs on
+# the RESOLVED path: a relocated install (~/.unsloth/studio a symlink to another disk) passes
+# `-f "$root/studio.db"` through the link, but `rm -rf` unlinks only the link, after which the
+# path reads as absent either way. Verifying rather than chasing the link is deliberate: following
+# a symlink out of the expected location to `rm -rf` its target is what the deny lists prevent.
 _remove_root_recording_db() {
     _rrd_root="$1"
     # shellcheck disable=SC1007
@@ -301,9 +288,8 @@ _remove_root_recording_db() {
     _rrd_db="$_rrd_real/studio.db"
     if [ -f "$_rrd_db" ]; then
         _rrd_had_db=1
-        # The db itself can be a symlink out of the tree: -f follows it but the rm below
-        # unlinks only the link, so track where the bytes are. readlink without -f: BSD
-        # gained -f in macOS 12.3, so use the raw link text plus cd -P, portable to both.
+        # The db itself can be a symlink out of the tree: -f follows it but the rm unlinks only
+        # the link, so track where the bytes are. readlink without -f (BSD got it in macOS 12.3).
         if [ -L "$_rrd_db" ]; then
             _rrd_link=$(readlink "$_rrd_db" 2>/dev/null || true)
             if [ -n "$_rrd_link" ]; then
@@ -349,10 +335,9 @@ _xdg_dir() {
     case "$1" in /*) printf '%s\n' "$1" ;; *) printf '%s\n' "$2" ;; esac
 }
 
-# Accept as Unsloth root only if Unsloth sentinels exist (matches install.sh's
-# env-mode ownership guard at install.sh:1358-1361). A bare unsloth_studio/
-# directory is NOT enough -- require the install-time owner marker so a user
-# directory that happens to contain a folder named "unsloth_studio" is safe.
+# Accept as Unsloth root only if an Unsloth sentinel exists (matching install.sh's env-mode
+# ownership guard). A bare unsloth_studio/ directory is NOT enough: require the install-time owner
+# marker so a user directory that happens to contain such a folder is safe.
 _is_studio_root() {
     _r="$1"
     [ -n "$_r" ] || return 1
@@ -387,9 +372,8 @@ _custom_studio_data_dirs() {
 #   1. UNSLOTH_STUDIO_HOME / STUDIO_HOME env vars at uninstall time
 #   2. Default-mode studio.conf at $HOME/.local/share/unsloth/studio.conf
 #   3. Env-mode studio.conf at $<root>/share/studio.conf (discovered via 1)
-# install.sh writes UNSLOTH_EXE='<root>/unsloth_studio/bin/unsloth', so
-# the install root is three dirnames up. Prints each discovered non-default
-# root on its own line; the caller iterates and de-duplicates.
+# install.sh writes UNSLOTH_EXE='<root>/unsloth_studio/bin/unsloth', so the install root is three
+# dirnames up. Each discovered non-default root is printed on its own line, de-duplicated.
 _custom_studio_roots() {
     # $1 = "lexical": skip the canonicalization (see the legacy sd.cpp sibling below). Reset on
     # every call, so a plain call is never affected by a preceding lexical one.
@@ -398,18 +382,16 @@ _custom_studio_roots() {
     _emit() {
         _r="$1"
         [ -z "$_r" ] && return 0
-        # Tilde expansion (env vars are not subject to it on quoted assignment),
-        # matches install.sh's _resolve_studio_destinations. The literal "~/"
-        # pattern is intentional; SC2088 is a false positive here.
+        # Tilde expansion (env vars are not subject to it on quoted assignment), matching
+        # install.sh's _resolve_studio_destinations. The literal "~/" pattern is intentional.
         # shellcheck disable=SC2088
         case "$_r" in
             "~") _r="$HOME" ;;
             "~/"*) _r="$HOME/${_r#'~/'}" ;;
         esac
-        # Canonicalize so syntactic variants ($HOME/../$USER, trailing slash)
-        # resolve to the same path and hit the _is_unsafe_root deny list.
-        # Skipped for the lexical pass, which exists only to rebuild the path an
-        # older build derived with a plain dirname (see _sd_cpp_sibling_bases).
+        # Canonicalize so syntactic variants ($HOME/../$USER, trailing slash) resolve to the same
+        # path and hit the _is_unsafe_root deny list. Skipped for the lexical pass, which rebuilds
+        # the path an older build derived with a plain dirname (see _sd_cpp_sibling_bases).
         if [ "${_studio_roots_lexical:-}" != "lexical" ]; then
             # shellcheck disable=SC1007
             _canon=$(CDPATH= cd -P -- "$_r" 2>/dev/null && pwd -P)
@@ -428,9 +410,8 @@ _custom_studio_roots() {
         [ -n "$_exe" ] || return 0
         _emit "$(dirname "$(dirname "$(dirname "$_exe")")")"
     }
-    # Mirror install.sh's precedence: UNSLOTH_STUDIO_HOME wins, STUDIO_HOME is
-    # ignored when both are set. Otherwise uninstalling install A could also
-    # delete install B if the user has STUDIO_HOME left over from B.
+    # Mirror install.sh's precedence: UNSLOTH_STUDIO_HOME wins, STUDIO_HOME is ignored when both
+    # are set, or uninstalling install A could also delete install B from a leftover STUDIO_HOME.
     if [ -n "${UNSLOTH_STUDIO_HOME:-}" ]; then
         _emit "$UNSLOTH_STUDIO_HOME"
         _from_conf "$UNSLOTH_STUDIO_HOME/share/studio.conf"
@@ -442,11 +423,9 @@ _custom_studio_roots() {
     _from_conf "$HOME/.local/share/unsloth/studio.conf"
 }
 
-# Remove $HOME/.local/bin/unsloth only if it's an Unsloth-managed symlink.
-# Unsloth's install.sh writes this as a symlink into the studio venv
-# (install.sh: `ln -sfn "$VENV_DIR/bin/unsloth" "$_shim_path"`). A
-# pip-installed `unsloth` CLI is a regular file — leave it alone to avoid
-# wiping an unrelated install.
+# Remove $HOME/.local/bin/unsloth only if it is the symlink install.sh created into the studio
+# venv. A pip-installed `unsloth` CLI is a regular file: leave it alone rather than wiping an
+# unrelated install.
 _remove_cli_shim() {
     _shim="$HOME/.local/bin/unsloth"
     [ -L "$_shim" ] || return 0
@@ -476,9 +455,8 @@ _owns_bundle_id() {
     [ "$(_plist_string "$1/Contents/Info.plist" CFBundleExecutable)" != "launch-studio" ]
 }
 
-# Path of the installed app owning bundle id $1, empty if there is none. A renamed
-# bundle or a subdirectory such as "/Applications/AI & ML/Unsloth.app" is a supported
-# layout, so match on the identifier rather than on a fixed set of paths.
+# Path of the installed app owning bundle id $1, empty if there is none. A renamed bundle or a
+# nested one ("/Applications/AI & ML/Unsloth.app") is supported, so match on the identifier.
 _bundle_id_owner() {
     # Overridable so tests can point the scan at a fixture dir.
     _bio_apps="${UNSLOTH_APPLICATIONS_DIR:-/Applications}"
@@ -542,15 +520,12 @@ _unsloth_uninstall_main() {
             continue
         fi
         _remove_root_recording_db "$_custom_root"
-        # Native diffusion (stable-diffusion.cpp) now installs UNDER the custom root, at
-        # <root>/stable-diffusion.cpp, so the removal above already took it. Older builds put it
-        # BESIDE the root at <parent>/stable-diffusion.cpp (find_sd_cpp_binary derived it from
-        # UNSLOTH_STUDIO_HOME.parent), and removing only the root would leave that build behind.
-        # Only remove a sibling Unsloth installed: <parent> is a user-chosen dir and
-        # "stable-diffusion.cpp" is exactly what `git clone` of the upstream project produces, so
-        # require our owner marker (written by install_sd_cpp_prebuilt) before rm, and keep any
-        # unowned checkout. A pre-marker Unsloth build is left behind, never a user file deleted.
-        # Guard the derived parent path the same way.
+        # Native diffusion now installs UNDER the custom root, so the removal above already took
+        # it. Older builds put it BESIDE the root at <parent>/stable-diffusion.cpp, which removing
+        # the root alone would leave behind. <parent> is user-chosen and "stable-diffusion.cpp" is
+        # exactly what `git clone` of the upstream project produces, so require our owner marker
+        # (install_sd_cpp_prebuilt) before rm: an unowned checkout or a pre-marker build is kept,
+        # never a user file deleted. The derived parent path gets the deny-list check too.
         _custom_sd_cpp="$(dirname "$_custom_root")/stable-diffusion.cpp"
         if _is_unsafe_root "$_custom_sd_cpp"; then
             echo "  refusing to remove unsafe path: $_custom_sd_cpp" >&2
@@ -561,21 +536,18 @@ _unsloth_uninstall_main() {
         fi
     done
     # The lexical parent as well. A home that is itself a symlink has its old sd.cpp tree beside
-    # the LINK, and the loop above only saw the canonicalized root, so that tree survived. Marker
-    # only, with no "keeping" notice: an unmarked directory at this path is somebody's checkout
-    # and the canonical pass has already reported the one it looked at.
+    # the LINK, which the canonicalized loop above never saw. Marker only, no "keeping" notice: an
+    # unmarked directory here is somebody's checkout, and the canonical pass already reported.
     _custom_studio_roots lexical 2>/dev/null | while IFS= read -r _lex_root; do
         [ -n "$_lex_root" ] || continue
-        # The same ownership check the canonical loop makes before it touches anything. A stale or
-        # mistyped UNSLOTH_STUDIO_HOME still reaches here (the lexical pass has no cd -P to filter
-        # a path that is not there), and without this "/parent/typo" would take the marked
-        # /parent/stable-diffusion.cpp of somebody else's Unsloth with it.
+        # The same ownership check the canonical loop makes. A stale or mistyped
+        # UNSLOTH_STUDIO_HOME still reaches here (the lexical pass has no cd -P to filter it), and
+        # without this "/parent/typo" would take somebody else's marked sd.cpp with it.
         _is_studio_root "$_lex_root" || continue
         _lex_sd_cpp="$(dirname "$_lex_root")/stable-diffusion.cpp"
         [ -f "$_lex_sd_cpp/.unsloth-studio-owned" ] || continue
         # The deny list is string-based, so it has to see the RESOLVED path: the lexical form can
-        # carry ".." or a symlinked ancestor and slip a protected tree ("/tmp/../usr/...") past it.
-        # Canonicalize a copy for the check only; the removal still uses the lexical path.
+        # carry ".." or a symlinked ancestor and slip a protected tree past it. The rm stays lexical.
         # shellcheck disable=SC1007
         _lex_sd_canon=$(CDPATH= cd -P -- "$_lex_sd_cpp" 2>/dev/null && pwd -P)
         [ -n "$_lex_sd_canon" ] || _lex_sd_canon="$_lex_sd_cpp"
@@ -586,17 +558,14 @@ _unsloth_uninstall_main() {
         fi
     done
     _remove_root_recording_db "$HOME/.unsloth/studio"
-    # Default-mode shared llama.cpp build + cache are siblings of studio (not removed
-    # by deleting it). No-op in env/custom mode (they nest under the custom root) and
-    # when absent. A user-set UNSLOTH_LLAMA_CPP_PATH is intentionally kept.
+    # Shared llama.cpp build + cache, siblings of studio in default mode (deleting studio misses
+    # them). No-op in env/custom mode and when absent. A user-set UNSLOTH_LLAMA_CPP_PATH is kept.
     _remove_path "$HOME/.unsloth/llama.cpp"
-    # Default-mode native diffusion (stable-diffusion.cpp / sd-cli) build, a sibling of
-    # studio like llama.cpp (install_sd_cpp_prebuilt.default_install_dir()). No-op in
-    # env/custom mode and when absent. "stable-diffusion.cpp" is exactly what a `git clone` of
-    # leejet/stable-diffusion.cpp produces, so a user may keep their own checkout (or point
-    # UNSLOTH_SD_CPP_PATH) at this default path; require our owner marker (written by
-    # install_sd_cpp_prebuilt) before rm, mirroring the custom-root guard above, so a user's own
-    # checkout or a pre-marker Unsloth build is kept rather than deleted.
+    # Default-mode native diffusion build, a sibling of studio like llama.cpp. No-op in env/custom
+    # mode and when absent. "stable-diffusion.cpp" is exactly what a `git clone` of
+    # leejet/stable-diffusion.cpp produces and a user may keep their own checkout (or point
+    # UNSLOTH_SD_CPP_PATH) here, so require our owner marker (install_sd_cpp_prebuilt) before rm,
+    # mirroring the custom-root guard above.
     _default_sd_cpp="$HOME/.unsloth/stable-diffusion.cpp"
     if [ -e "$_default_sd_cpp" ] && [ ! -f "$_default_sd_cpp/.unsloth-studio-owned" ]; then
         echo "  keeping sd.cpp without Unsloth owner marker: $_default_sd_cpp" >&2
@@ -604,33 +573,26 @@ _unsloth_uninstall_main() {
         _remove_path "$_default_sd_cpp"
     fi
     _remove_path "$HOME/.unsloth/.cache"
-    # Isolated Node.js runtime (install_node_prebuilt.py), a sibling of studio in
-    # default mode. No-op in env/custom mode (nested under the custom root) and absent.
+    # Isolated Node.js runtime (install_node_prebuilt.py), a default-mode sibling of studio.
     _remove_path "$HOME/.unsloth/node"
-    # llama.cpp atomic-install staging root (install_llama_prebuilt.py .staging).
-    # Normally pruned after activate, but an interrupted build can leave it behind;
-    # removing it lets the rmdir below succeed. No-op in env/custom mode and absent.
+    # llama.cpp atomic-install staging root (install_llama_prebuilt.py). Normally pruned after
+    # activate, but an interrupted build leaves it behind and it blocks the rmdir below.
     _remove_path "$HOME/.unsloth/.staging"
-    # Managed whisper.cpp dictation engine (install_whisper_prebuilt.py), a sibling
-    # of studio in default mode. Only present when a whisper prebuilt matching the
-    # pinned llama.cpp build existed at install time, so many installs lack it.
+    # Managed whisper.cpp dictation engine (install_whisper_prebuilt.py), a default-mode sibling.
+    # Only present when a prebuilt matching the pinned llama.cpp build existed at install time.
     _remove_path "$HOME/.unsloth/whisper.cpp"
-    # Prebuilt install locks. Every prebuilt serializes on
-    # <parent>/.<name>.install.lock (prebuilt_core.py:1129), so llama.cpp, node and
-    # whisper.cpp each leave one; a stray lock keeps ~/.unsloth from being pruned
-    # below. No-op in env/custom mode and when absent.
+    # Prebuilt install locks: every prebuilt serializes on <parent>/.<name>.install.lock
+    # (prebuilt_core.py), and a stray lock keeps ~/.unsloth from being pruned below.
     _remove_path "$HOME/.unsloth/.llama.cpp.install.lock"
     _remove_path "$HOME/.unsloth/.node.install.lock"
     _remove_path "$HOME/.unsloth/.whisper.cpp.install.lock"
     # Taking over an abandoned lock renames it to .stale.<pid> before unlinking
-    # (install_node_prebuilt.py); a crash between the two steps strands the rename,
-    # and a stranded one blocks the rmdir below. Unmatched globs stay literal,
-    # hence the existence test.
+    # (install_node_prebuilt.py); a crash between the two strands the rename, and a stranded one
+    # blocks the rmdir below. Unmatched globs stay literal, hence the existence test.
     for _stale in "$HOME"/.unsloth/.*.install.lock.stale.*; do
         [ -e "$_stale" ] && _remove_path "$_stale"
     done
-    # ROCm-on-WSL helper artifacts (librocdxg build clone + smoke-test venv). No-op
-    # where they don't exist; removing them lets the rmdir below succeed.
+    # ROCm-on-WSL helper artifacts (librocdxg clone, smoke-test venv); removing them frees the rmdir.
     _remove_path "$HOME/.unsloth/librocdxg"
     _remove_path "$HOME/.unsloth/rocm-smoketest"
     # Drop ~/.unsloth only if now empty (rmdir refuses non-empty, so user content is kept).
@@ -640,8 +602,7 @@ _unsloth_uninstall_main() {
     _remove_cli_shim
 
     echo "Removing desktop shortcut and launcher lock..."
-    # install.sh creates Desktop/Unsloth Studio as a symlink. If the user has an
-    # unrelated regular directory by that name, leave it alone.
+    # install.sh creates Desktop/Unsloth Studio as a symlink; an unrelated regular dir is kept.
     _desktop_link="$HOME/Desktop/Unsloth Studio"
     if [ -L "$_desktop_link" ] || [ ! -e "$_desktop_link" ]; then
         _remove_path "$_desktop_link"
@@ -663,10 +624,9 @@ _unsloth_uninstall_main() {
             if [ -x "$_lsr" ]; then
                 "$_lsr" -u "$HOME/Applications/Unsloth Studio.app" 2>/dev/null || true
             fi
-            # WKWebView data, keyed by bundle id. Created at first launch, not by install.sh.
-            # The packaged desktop app shares this bundle id and is the only thing that
-            # writes this data; the shell launcher just opens a browser. This script never
-            # removes that app, so it must not reset it either.
+            # WKWebView data, keyed by bundle id; created at first launch, not by install.sh. The
+            # packaged desktop app shares this id and is the only thing that writes the data, so
+            # while that app is still installed this script must not reset it either.
             _bid="ai.unsloth.studio"
             _bid_owner=$(_bundle_id_owner "$_bid")
             if [ -n "$_bid_owner" ]; then
@@ -692,21 +652,18 @@ _unsloth_uninstall_main() {
         Linux)
             if [ "$_is_wsl" = "1" ]; then
                 echo "Removing WSL Windows-side shortcuts..."
-                # install.sh creates per-distro 'Unsloth Studio (WSL - <distro>).lnk'
-                # on the Windows Desktop + Start Menu via powershell.exe. Scope removal
-                # to THIS distro (passed as $args[0]) so a multi-distro install keeps the
-                # other distros' launchers; the TARGET=wsl.exe check still spares a
-                # native install's "Unsloth Studio.lnk". Prefer powershell.exe; test it
-                # can EXECUTE (`command -v` succeeds even with interop OFF -- .exe then
-                # fails "Exec format error", common on systemd-enabled distros).
+                # install.sh creates per-distro 'Unsloth Studio (WSL - <distro>).lnk' on the
+                # Windows Desktop + Start Menu. Scope removal to THIS distro so a multi-distro
+                # install keeps the other distros' launchers; the TARGET=wsl.exe check spares a
+                # native install's "Unsloth Studio.lnk". Test powershell.exe can EXECUTE:
+                # `command -v` succeeds even with interop OFF and the .exe then fails to run.
                 _wsl_distro="${WSL_DISTRO_NAME:-}"
                 _ps_ran=0
                 if command -v powershell.exe >/dev/null 2>&1 && \
                    powershell.exe -NoProfile -Command "exit 0" >/dev/null 2>&1; then
                     _ps_ran=1
-                    # Inject the distro into the command: a -Command string does not
-                    # receive trailing tokens as $args. WSL distro names are safe to
-                    # embed (no quotes/$/backtick).
+                    # Inject the distro into the command: a -Command string does not receive
+                    # trailing tokens as $args. WSL distro names are safe to embed.
                     # shellcheck disable=SC2016
                     powershell.exe -NoProfile -Command '$distro = "'"$_wsl_distro"'";
                         $dirs = @(
@@ -748,10 +705,9 @@ _unsloth_uninstall_main() {
                             if ((Test-Path -LiteralPath $iconDir) -and -not (Get-ChildItem -LiteralPath $iconDir -Force -ErrorAction SilentlyContinue)) { Remove-Item -LiteralPath $iconDir -Recurse -Force -ErrorAction SilentlyContinue }
                         }' >/dev/null 2>&1 || true
                 fi
-                # Remove $1's shared unsloth.ico only if no Unsloth shortcut (native install
-                # or another WSL distro) still uses it, then drop the dir if empty. Reciprocal
-                # of uninstall.ps1's _RemoveDataDirKeepingWslIcon (keeps the icon for a
-                # surviving WSL shortcut when the native side is removed).
+                # Remove $1's shared unsloth.ico only if no Unsloth shortcut (native install or
+                # another WSL distro) still uses it, then drop the dir if empty. Reciprocal of
+                # uninstall.ps1's _RemoveDataDirKeepingWslIcon.
                 _drop_shared_icon_if_unused() {
                     _du="$1"
                     _icodir="$_du/AppData/Local/Unsloth Studio"
@@ -772,9 +728,8 @@ _unsloth_uninstall_main() {
                     fi
                     [ -d "$_icodir" ] && rmdir "$_icodir" 2>/dev/null || true
                 }
-                # Fallback when powershell.exe can't run (interop disabled): remove WSL .lnk
-                # files via drvfs. The "Unsloth Studio (WSL..." name is WSL-specific, so a
-                # native install's "Unsloth Studio.lnk" never matches.
+                # Fallback when interop is off: remove WSL .lnk files via drvfs. The
+                # "Unsloth Studio (WSL..." name never matches a native "Unsloth Studio.lnk".
                 if [ "$_ps_ran" = "0" ]; then
                     for _drive in /mnt/c /mnt/d /mnt/e; do
                         [ -d "$_drive/Users" ] || continue
@@ -841,16 +796,14 @@ _unsloth_uninstall_main() {
             echo "Removing Linux .desktop entry..."
             _remove_path "$HOME/.local/share/applications/unsloth-studio.desktop"
             # tauri-plugin-deep-link rewrites "<exe>-handler.desktop" on every launch for the
-            # unsloth:// scheme, so it exists on any machine the app has started on and would
-            # be left pointing at a binary we just deleted. Unlike install.sh's own shortcut,
-            # it uses Tauri's data_dir(), which honours XDG_DATA_HOME, so check both.
+            # unsloth:// scheme, so it exists on any machine the app has started on. Unlike
+            # install.sh's own shortcut it uses Tauri's data_dir(), which honours XDG_DATA_HOME.
             _un_appdir="$(_xdg_dir "${XDG_DATA_HOME:-}" "$HOME/.local/share")/applications"
             _remove_path "$_un_appdir/unsloth-studio-handler.desktop"
             if [ "$_un_appdir" != "$HOME/.local/share/applications" ]; then
                 _remove_path "$HOME/.local/share/applications/unsloth-studio-handler.desktop"
             fi
-            # Rebuild mimeinfo.cache wherever an entry was removed, or the stale cache keeps
-            # advertising it. Mirrors install.sh:1574 on the way out.
+            # Rebuild mimeinfo.cache wherever an entry was removed, or it keeps advertising it.
             if command -v update-desktop-database >/dev/null 2>&1; then
                 update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
                 if [ "$_un_appdir" != "$HOME/.local/share/applications" ]; then
@@ -887,9 +840,8 @@ _unsloth_uninstall_main() {
     echo "      http://localhost:<port> origin you used to remove them."
     echo "Note: Hugging Face model cache at ~/.cache/huggingface was left in place."
     echo "Remove it manually with 'rm -rf ~/.cache/huggingface/hub' if desired."
-    # Env-mode installs leave no breadcrumb in $HOME, so a custom root can
-    # only be located if the user re-exports the variable. Print a hint when
-    # neither var is set so the bare `curl | sh` flow doesn't silently miss.
+    # Env-mode installs leave no breadcrumb in $HOME, so a custom root is only found when the
+    # user re-exports the variable. Hint when neither is set, so `curl | sh` does not silently miss.
     if [ -z "${UNSLOTH_STUDIO_HOME:-}" ] && [ -z "${STUDIO_HOME:-}" ]; then
         echo ""
         echo "If you installed Unsloth Studio with UNSLOTH_STUDIO_HOME or STUDIO_HOME"


### PR DESCRIPTION
Comment-only cleanup of the two uninstallers. Long explanations are collapsed onto fewer lines, notes that the code already states are dropped, and stale pointers (`install.sh:1358-1361`, `prebuilt_core.py:1129`) are removed. Every caveat that explains why a path is or is not deleted is kept verbatim in substance: on an uninstaller a lost caveat is how someone deletes the wrong directory, so the owner-marker rules, the deny lists, the reparse-point and symlink rules, and the "do not claim success" summary rules are all still spelled out. The two here-blocks that carry user-facing text, `_usage`'s heredoc in the shell script and `_Usage`'s here-string in the PowerShell one, are untouched, as is the PowerShell snippet the WSL branch passes to `powershell.exe` as a quoted string.

| file | before | after | removed |
| --- | ---: | ---: | ---: |
| `scripts/uninstall.sh` | 906 | 858 | 48 |
| `scripts/uninstall.ps1` | 1052 | 991 | 61 |

### No code changed

Every changed line in the diff was classified against the merge base as comment, blank or code:

| file | changed comment lines | changed blank lines | changed CODE lines |
| --- | ---: | ---: | ---: |
| `scripts/uninstall.sh` | 250 | 0 | **0** |
| `scripts/uninstall.ps1` | 321 | 0 | **0** |

No changed line lands inside a heredoc (`<<TAG`) or a here-string (`@"`/`@'`), where a `#` line would be data rather than a comment. That was checked by tracking the open/close state of both forms across the whole file on each side and intersecting with the changed line numbers.

### Syntax checks

- `bash -n scripts/uninstall.sh`: exit 0 on the merge base and on this branch.
- `[System.Management.Automation.Language.Parser]::ParseFile` on `scripts/uninstall.ps1` under pwsh 7.6.0: no parse errors on the merge base or on this branch. `tests/studio/test_uninstall_prebuilt_parity.ps1` asserts this too, on the grounds that a syntax error makes every Windows uninstall a silent no-op.

### Anchors verified

These files are read and sliced as raw text in three different ways, so each was checked explicitly rather than assumed safe.

**sed ranges in `tests/sh/`.** Every slice was taken on the merge base and on this branch and compared after stripping comments and blanks; all thirteen are identical and none is empty: `_remove_path`, `_is_studio_root`, `_is_unsafe_root`, `_set_marker`, `_remove_root_recording_db`, `_owned_sd_cpp_roots`, `_sd_cpp_sibling_bases`, `_custom_studio_roots`, `_drop_shared_icon_if_unused`, the `_custom_studio_roots | while ... do`/`done` loop, the lexical loop, and the `_default_sd_cpp=` .. `fi` fragment. The ranges end on the first `^}` or `^[[:space:]]*}$`, and no reflowed comment or dropped blank moved that boundary. The other anchors in the same suite also still hold: exactly one line matches the `echo "Stopping any running Unsloth Studio servers..."` body marker, `_unsloth_uninstall_main` is still defined at top level, the last three non-comment non-blank lines are still the complete `{ ... }` block, and at 45,183 bytes the script still exceeds the 4 KiB pipe used by the truncated-download case, so that test does not go vacuous.

**`tests/python/test_windows_installer_addtype_fallback.py`.** All seven `read_text()` sites were read. Six match code, but one is load-bearing on a comment: `_extract(r"    # The SECOND LocalAppData spelling.*?\n    \}\n", uninstall)` anchors the extracted block on that comment line and then executes the block in PowerShell. That comment keeps its exact opening text; it is shortened only after the anchored phrase. The extraction was re-run on both sides and yields the same code (20 lines to 15, comments only). The three `function <name> { ... }` extractions used by the same file, `_RemoveStudioPrivateTempTrees`, `_RemoveTreeKeeping` and `_RemoveDataDirKeepingWslIcon`, were likewise re-run and are code-identical. The order assertion that filters script-body lines containing `_RemoveDataDirKeepingWslIcon $defaultDataDir` or `_RemoveStudioPrivateTempTrees -Paths` still selects the same four call lines in the same order, and no comment matches either string.

**`tests/studio/test_uninstall_prebuilt_parity.ps1`.** The artifact list derived from the shell script is unchanged, and every non-WSL artifact still appears in the PowerShell script from a code line, not a comment. `\.install\.lock\.stale\.` is present in both files from code, and `Get-ChildItem -LiteralPath $defaultUnslothHome` is untouched.

**`tests/test_installer_interactive_prompts.py`.** `find_prompts` calls `blank_comments`, which blanks whole-line `#` comments before scanning, so whole-line comments cannot be prompt sites in either direction. Inline comments are not blanked, so the check was that none of the removed or reworded text introduces a `[Y/n]` marker or a read API; it does not. The assertion still returns `[]` for both scripts.

Also checked: the five workflows that reference these scripts (`studio-windows-inference-smoke.yml`, `studio-update-smoke.yml`, `studio-mac-ui-smoke.yml`, `windows-application-control-ci.yml`, `studio-windows-update-smoke.yml`) only run the scripts and match on their runtime output, never on their source text; `studio/backend/core/inference/sd_cpp_engine.py` and `unsloth_cli/commands/studio.py` only mention them in their own comments. `tests/studio/test_application_control_cli_fallback.ps1` matches `_IsUnslothCmdShim (Join-Path $Path "bin\unsloth.cmd")` and `from unsloth_cli import app`, both code; `tests/studio/test_uninstall_reparse_stop_roots.ps1` matches the `_StopProcessesLockingRoots -Roots ($stopRoots + @(_ManagedPathsUnderReparseTargets $knownRoots))` call site, also code; `tests/sh/test_uninstall_webview_data.sh` takes the first line matching `Name = 'unsloth-studio.exe'`, which is still the same code line.

### Differential

Each of these was run sequentially, on this branch and on a control worktree pinned to the same merge base, and the exit codes compared. All thirteen are identical (`rc=0` on both sides), and the whole set was run twice, once after each of the two editing passes.

- `tests/sh/test_uninstall_arg_guard.sh`
- `tests/sh/test_uninstall_prebuilt_artifacts.sh`
- `tests/sh/test_uninstall_sd_cpp_custom_root.sh`
- `tests/sh/test_uninstall_shared_icon.sh`
- `tests/sh/test_uninstall_webview_data.sh`
- `tests/test_installer_interactive_prompts.py`
- `tests/python/test_windows_installer_addtype_fallback.py`
- `tests/studio/test_installer_av_shapes.py`
- `tests/studio/install/test_pr5940_followups.py`
- `tests/studio/test_uninstall_prebuilt_parity.ps1`
- `tests/studio/test_uninstall_reparse_stop_roots.ps1`
- `tests/studio/test_uninstall_dual_install_icon.ps1`
- `tests/studio/test_uninstall_arg_guard.ps1`

These ran on Linux with pwsh 7.6.0. The Windows-only halves of the round-trip smokes were not run here.
