### PR TITLE
fix(docker): persist runtime data under /data and add compose (#4396)

### DIFF
--- a/docker/DOCKERHUB.md
+++ b/docker/DOCKERHUB.md
@@ -106,17 +106,39 @@ Turing has no bfloat16; Unsloth falls back to float16 there. AMD GPUs are not su
 | `UNSLOTH_SKIP_NOTEBOOK_SYNC=1` | Do not refresh the notebooks from GitHub on start. |
 | `HF_TOKEN`, `WANDB_API_KEY` | Forwarded to Hugging Face and Weights and Biases. |
 
-## Volumes
+## Volumes and persistence
 
-The working directory is `/workspace`. Mount what you want to keep:
+The container working directory is `/workspace`. Mount `/data` for unified persistence across container recreations (#4396):
+
+```bash
+docker run -d --gpus all --ipc=host \
+  --ulimit memlock=-1 --ulimit stack=67108864 \
+  -p 8000:8000 -p 8888:8888 \
+  -v "$PWD/data":/data \
+  unsloth/unsloth
+```
+
+Or using the bundled `docker compose`:
+
+```bash
+docker compose -f docker/compose.yml up -d
+```
+
+Mount what you want to keep:
 
 | Container path | What it holds |
 |---|---|
+| `/data` | Unified persistence root: models, fine-tune outputs, exports, and auth (`auth.db`). |
 | `/workspace/host` | Your files. Mount your project directory here. |
 | `/workspace/.cache/huggingface` | Model downloads. Mount your host HF cache to reuse it. |
 | `/workspace/.cache/triton` | Compiled kernels. Optional, speeds up restarts. |
 | `/workspace/unsloth-notebooks` | The synced notebooks. Your edits are kept across refreshes. |
 | `/workspace/Unsloth Notebooks` | The same notebooks grouped by topic, rebuilt on each start. |
+
+> **Warning: Do NOT bind-mount `/workspace/studio` or `/opt/unsloth-studio`.**
+> Those directories contain pre-installed Python environments and `llama.cpp` binaries.
+> Bind-mounting host folders directly over them replaces the files and prevents Studio from starting.
+> Always mount `/data` for persistence instead.
 
 The container runs as root by default. `--user <uid>:<gid>` is supported and keeps files on your mounts owned by you.
 

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,0 +1,41 @@
+# Unsloth Docker Compose configuration
+# Usage:
+#   docker compose up -d
+#
+# Studio:     http://localhost:8000
+# JupyterLab: http://localhost:8888
+#
+# Persistence:
+#   Single-volume persistence mounts ./data on host to /data in the container (#4396).
+#   All Hugging Face model downloads, compiled Triton kernels, fine-tuned model outputs,
+#   GGUF exports, authentication database (auth.db), and notebooks persist across
+#   container restarts and updates without clobbering pre-baked venvs or llama.cpp.
+
+services:
+  unsloth:
+    image: ${UNSLOTH_IMAGE:-unsloth/unsloth:latest}
+    container_name: unsloth
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    ipc: host
+    ulimits:
+      memlock: -1
+      stack: 67108864
+    ports:
+      - "${UNSLOTH_STUDIO_PORT:-8000}:8000"
+      - "${JUPYTER_PORT:-8888}:8888"
+    environment:
+      - UNSLOTH_STUDIO_PASSWORD=${UNSLOTH_STUDIO_PASSWORD:-}
+      - JUPYTER_PASSWORD=${JUPYTER_PASSWORD:-}
+      - HF_TOKEN=${HF_TOKEN:-}
+      - WANDB_API_KEY=${WANDB_API_KEY:-}
+      - UNSLOTH_ALLOW_CPU=${UNSLOTH_ALLOW_CPU:-0}
+    volumes:
+      - ${UNSLOTH_DATA_DIR:-./data}:/data
+      - ${UNSLOTH_HOST_DIR:-./work}:/workspace/host
+    restart: unless-stopped

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -52,13 +52,108 @@ sync_notebooks() {
     fi
 }
 
+err()  { printf "\033[1;31mERROR:\033[0m %s\n" "$*" >&2; }
+warn() { printf "\033[1;33mWARN:\033[0m %s\n"  "$*" >&2; }
+
+# Set up persistent storage root and symlinks for models, outputs, exports, and auth (#4396).
+# Prevents container crashes caused by mounting over /opt/unsloth-studio and unifies caches.
+setup_data_dir() {
+    local studio_home="${UNSLOTH_STUDIO_HOME:-/opt/unsloth-studio}"
+    local base_venv="${UNSLOTH_BASE_VENV:-/opt/unsloth-venv}"
+    local data_dir="${UNSLOTH_DATA_DIR:-/data}"
+
+    # Guard: Warn if someone bind-mounted over the baked studio home or /workspace/studio directly
+    if [[ -d "${studio_home}" ]] && [[ ! -d "${studio_home}/unsloth_studio" && -d "${base_venv}" ]]; then
+        warn "The directory '${studio_home}' appears empty or overwritten by a host mount."
+        warn "Bind-mounting over Studio's root removes pre-installed venvs and binaries."
+        warn "To persist data, mount to /data instead (-v /host/path:/data). See #4396."
+    fi
+
+    if [[ "${data_dir}" == "none" || "${data_dir}" == "0" || "${UNSLOTH_ENABLE_DATA_DIR:-1}" == "0" ]]; then
+        return 0
+    fi
+
+    # Initialize data directory structure if /data is available or root is writable
+    if [[ -d "${data_dir}" ]] || [[ -n "${UNSLOTH_DATA_DIR:-}" ]] || [[ -w "/" ]]; then
+        mkdir -p "${data_dir}/cache/huggingface" \
+                 "${data_dir}/cache/triton" \
+                 "${data_dir}/cache/torch" \
+                 "${data_dir}/outputs" \
+                 "${data_dir}/exports" \
+                 "${data_dir}/auth" \
+                 "${data_dir}/runs" \
+                 "${data_dir}/work" 2>/dev/null || true
+    fi
+
+    # Export canonical cache variables pointing to the persistent volume
+    if [[ -d "${data_dir}/cache" ]]; then
+        export HF_HOME="${HF_HOME:-${data_dir}/cache/huggingface}"
+        export TRANSFORMERS_CACHE="${TRANSFORMERS_CACHE:-${data_dir}/cache/huggingface}"
+        export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-${data_dir}/cache/triton}"
+        export TORCH_HOME="${TORCH_HOME:-${data_dir}/cache/torch}"
+        export UNSLOTH_DATA_DIR="${data_dir}"
+    fi
+
+    _safe_symlink() {
+        local container_path="$1"
+        local target="$2"
+
+        [[ -d "${target}" ]] || return 0
+
+        # Do not overwrite if container_path is already a direct mountpoint
+        if grep -qs " ${container_path} " /proc/mounts 2>/dev/null; then
+            return 0
+        fi
+
+        # If already pointing to the target, nothing to do
+        if [[ -L "${container_path}" ]]; then
+            if [[ "$(readlink "${container_path}" 2>/dev/null)" == "${target}" ]]; then
+                return 0
+            fi
+            rm -f "${container_path}" 2>/dev/null || true
+        fi
+
+        # If it is an existing directory, copy over any files before switching to symlink
+        if [[ -d "${container_path}" ]]; then
+            if [[ -z "$(ls -A "${target}" 2>/dev/null)" ]]; then
+                cp -rn "${container_path}/." "${target}/" 2>/dev/null || true
+            fi
+            rm -rf "${container_path}" 2>/dev/null || true
+        fi
+
+        mkdir -p "$(dirname "${container_path}")" 2>/dev/null || true
+        ln -sf "${target}" "${container_path}" 2>/dev/null || true
+    }
+
+    if [[ -d "${data_dir}" ]]; then
+        _safe_symlink "/workspace/.cache/huggingface" "${data_dir}/cache/huggingface"
+        _safe_symlink "/workspace/.cache/triton" "${data_dir}/cache/triton"
+        _safe_symlink "/root/.cache/huggingface" "${data_dir}/cache/huggingface"
+        _safe_symlink "/root/.cache/triton" "${data_dir}/cache/triton"
+
+        # Runtime directories under Studio home
+        _safe_symlink "${studio_home}/outputs" "${data_dir}/outputs"
+        _safe_symlink "${studio_home}/exports" "${data_dir}/exports"
+        _safe_symlink "${studio_home}/auth" "${data_dir}/auth"
+        _safe_symlink "${studio_home}/runs" "${data_dir}/runs"
+
+        # Also link /workspace/studio subdirs if that directory exists and is distinct
+        if [[ "${studio_home}" != "/workspace/studio" && -d "/workspace/studio" ]]; then
+            _safe_symlink "/workspace/studio/outputs" "${data_dir}/outputs"
+            _safe_symlink "/workspace/studio/exports" "${data_dir}/exports"
+            _safe_symlink "/workspace/studio/auth" "${data_dir}/auth"
+            _safe_symlink "/workspace/studio/runs" "${data_dir}/runs"
+        fi
+
+        _safe_symlink "/workspace/work" "${data_dir}/work"
+    fi
+}
+setup_data_dir || true
+
 if [[ "${UNSLOTH_SKIP_GPU_CHECK:-0}" == "1" ]]; then
     sync_notebooks
     exec "$@"
 fi
-
-err()  { printf "\033[1;31mERROR:\033[0m %s\n" "$*" >&2; }
-warn() { printf "\033[1;33mWARN:\033[0m %s\n"  "$*" >&2; }
 
 # CPU mode covers Jupyter, GGUF tooling and Studio chat, but NOT training or loading
 # a model. A visible GPU still runs the checks below.

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -49,8 +49,10 @@ esac
 HF_CACHE="${HF_HOME:-$HOME/.cache/huggingface}"
 TRITON_CACHE="${TRITON_CACHE_DIR:-$HOME/.cache/unsloth-triton}"
 WORK_DIR="${UNSLOTH_WORKDIR:-$PWD}"
+DATA_DIR="${UNSLOTH_DATA_DIR:-}"
 
 mkdir -p "$HF_CACHE" "$TRITON_CACHE"
+[[ -n "$DATA_DIR" ]] && mkdir -p "$DATA_DIR"
 
 # Docker resolves --gpus in the DAEMON, before the container exists: on a host with
 # no NVIDIA GPU it dies with "failed to discover GPU vendor from CDI: no known GPU
@@ -134,6 +136,7 @@ declare -a ENV_FORWARD=(-e HF_HUB_ENABLE_HF_TRANSFER=1)
 [[ -n "${WANDB_API_KEY:-}"     ]] && ENV_FORWARD+=(-e WANDB_API_KEY)
 [[ -n "${UNSLOTH_LICENSE:-}"   ]] && ENV_FORWARD+=(-e UNSLOTH_LICENSE)
 [[ -n "${UNSLOTH_ALLOW_CPU:-}" ]] && ENV_FORWARD+=(-e UNSLOTH_ALLOW_CPU)
+[[ -n "${UNSLOTH_DATA_DIR:-}"  ]] && ENV_FORWARD+=(-e UNSLOTH_DATA_DIR)
 # read by studio_launch.sh; without these it uses a random password and no sshd
 [[ -n "${JUPYTER_PASSWORD:-}"           ]] && ENV_FORWARD+=(-e JUPYTER_PASSWORD)
 [[ -n "${UNSLOTH_STUDIO_PASSWORD:-}"    ]] && ENV_FORWARD+=(-e UNSLOTH_STUDIO_PASSWORD)
@@ -146,6 +149,11 @@ declare -a PORT_FLAGS=()
 if [[ -n "${UNSLOTH_PORTS:-}" ]]; then
     # shellcheck disable=SC2206  # intentional word splitting of "-p X -p Y"
     PORT_FLAGS=(${UNSLOTH_PORTS})
+fi
+
+declare -a DATA_FLAGS=()
+if [[ -n "${UNSLOTH_DATA_DIR:-}" ]]; then
+    DATA_FLAGS=(-v "$UNSLOTH_DATA_DIR":/data)
 fi
 
 # CI / piped invocations otherwise hit "the input device is not a TTY"
@@ -161,6 +169,7 @@ exec docker run --rm ${TTY_FLAG[@]+"${TTY_FLAG[@]}"} \
     --ipc=host \
     --ulimit memlock=-1 \
     --ulimit stack=67108864 \
+    ${DATA_FLAGS[@]+"${DATA_FLAGS[@]}"} \
     -v "$HF_CACHE":/workspace/.cache/huggingface \
     -v "$TRITON_CACHE":/workspace/.cache/triton \
     -v "$WORK_DIR":/workspace/host \

--- a/docker/studio_launch.sh
+++ b/docker/studio_launch.sh
@@ -21,6 +21,9 @@ set -euo pipefail
 export JUPYTER_PORT="${JUPYTER_PORT:-8888}"
 export UNSLOTH_STUDIO_HOME="${UNSLOTH_STUDIO_HOME:-/opt/unsloth-studio}"
 export UNSLOTH_JUPYTER_CLOUDFLARE="${UNSLOTH_JUPYTER_CLOUDFLARE:-0}"
+export UNSLOTH_DATA_DIR="${UNSLOTH_DATA_DIR:-/data}"
+export HF_HOME="${HF_HOME:-${UNSLOTH_DATA_DIR}/cache/huggingface}"
+export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-${UNSLOTH_DATA_DIR}/cache/triton}"
 
 # SSH login shells lack the `docker run -e` vars. Secrets are excluded on purpose,
 # and every value is shlex.quote()d because this file is sourced by every login shell.

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -36,7 +36,7 @@ autorestart=unexpected
 exitcodes=0
 startretries=3
 startsecs=5
-environment=HOME="/root",USER="root"
+environment=HOME="/root",USER="root",HF_HOME="%(ENV_HF_HOME)s",TRITON_CACHE_DIR="%(ENV_TRITON_CACHE_DIR)s",UNSLOTH_DATA_DIR="%(ENV_UNSLOTH_DATA_DIR)s"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
@@ -62,7 +62,7 @@ autostart=true
 autorestart=true
 ; HOME pins config lookup to /root/.jupyter (where the launcher wrote the
 ; password config); without it an unset HOME falls back to token auth.
-environment=HOME="/root",USER="root"
+environment=HOME="/root",USER="root",HF_HOME="%(ENV_HF_HOME)s",TRITON_CACHE_DIR="%(ENV_TRITON_CACHE_DIR)s",UNSLOTH_DATA_DIR="%(ENV_UNSLOTH_DATA_DIR)s"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/studio/backend/tests/test_hub_token_caller_identity.py
+++ b/studio/backend/tests/test_hub_token_caller_identity.py
@@ -148,7 +148,12 @@ def _gguf_resolver(monkeypatch, **overrides) -> None:
         monkeypatch.setattr(settings_routes, name, value)
 
 
-def _picker_env(monkeypatch, *, offline: bool = False, no_snapshots: bool = False) -> None:
+def _picker_env(
+    monkeypatch,
+    *,
+    offline: bool = False,
+    no_snapshots: bool = False,
+) -> None:
     """The template walk reads its own offline flag and canonicalizes the repo id first.
 
     ``no_snapshots`` empties the snapshot walk, which is how a test says the fallback is
@@ -176,7 +181,12 @@ def _scan_refused(model_name: str, hf_token = "hf_dummy") -> int:
     return excinfo.value.status_code
 
 
-def _one_cached_quant(monkeypatch, tmp_path, *, complete: bool = True):
+def _one_cached_quant(
+    monkeypatch,
+    tmp_path,
+    *,
+    complete: bool = True,
+):
     """A repo publishing one Q4_K_M, present in a single snapshot.
 
     The premise the GGUF listing tests rest on: a denial only means something where the disk
@@ -935,7 +945,6 @@ def test_the_audio_tokenizer_fallback_does_not_reach_for_the_ambient_token(monke
         seen.setdefault("headers", headers)
         return _Resp()
 
-
     monkeypatch.setattr(requests, "get", _get)
     model_config_module._detect_audio_from_tokenizer("org/private", hf_token = False, revision = None)
 
@@ -1115,7 +1124,6 @@ def test_an_anonymous_config_read_does_not_strip_the_process_credential(monkeypa
         seen["token"] = kwargs.get("token", "<absent>")
         seen["ambient"] = os.environ.get("HF_TOKEN")
         return _Config()
-
 
     monkeypatch.setattr(transformers.AutoConfig, "from_pretrained", staticmethod(_from_pretrained))
     monkeypatch.setattr(model_config_module, "active_hf_hub_cache", lambda: None, raising = False)
@@ -1309,7 +1317,6 @@ def test_a_cache_only_gguf_listing_is_refused_for_an_anonymous_caller(monkeypatc
     serialize the first one.
     """
 
-
     monkeypatch.setattr(
         gguf_variants,
         "list_gguf_variants",
@@ -1461,7 +1468,6 @@ def test_the_offline_autoconfig_read_is_denied_to_an_anonymous_caller(monkeypatc
     mirror without /auth-check.
     """
 
-
     _counting_probe(monkeypatch, False)
     monkeypatch.setattr(model_config_module, "_env_offline", lambda: True)
     monkeypatch.setattr(model_config_module, "active_hf_hub_cache", lambda: None, raising = False)
@@ -1530,7 +1536,6 @@ def test_every_offline_reachable_route_refuses_before_it_reads(monkeypatch):
     """The three routes that reach disk offline all consult a shared rule rather than
     open-coding one, which is how the per-site version drifted six times before."""
 
-
     shared_rules = ("anonymous_and_offline", "refuse_unauthorized_dataset_preview")
     for owner, name in (
         (models_routes.get_model_config, "/config"),
@@ -1576,8 +1581,11 @@ def test_a_forced_offline_window_does_not_quarantine_a_repo_for_ten_minutes():
     auto._not_servable.clear()
 
     class _Api:
-        def __init__(self, *a, **k): pass
-        def model_info(self, *a, **k): raise OfflineModeIsEnabled("offline mode is enabled")
+        def __init__(self, *a, **k):
+            pass
+
+        def model_info(self, *a, **k):
+            raise OfflineModeIsEnabled("offline mode is enabled")
 
     with mock.patch.object(huggingface_hub, "HfApi", _Api):
         refusal = asyncio.run(
@@ -1666,13 +1674,17 @@ def test_the_offline_config_memo_follows_the_caller(monkeypatch, explicit, memoi
 
     monkeypatch.setattr(transformers_version, "_config_json_from_hf_cache", _from_cache)
     authorized = {"v": True}
-    monkeypatch.setattr(transformers_version, "cache_reads_authorized", lambda *_a, **_k: authorized["v"])
+    monkeypatch.setattr(
+        transformers_version, "cache_reads_authorized", lambda *_a, **_k: authorized["v"]
+    )
 
     token = hf_token_arg("hf_explicit", allow_ambient_token = False) if explicit else None
     assert transformers_version._load_config_json("acme/private", token) == {"model_type": "secret"}
 
     if memoized:
-        assert transformers_version._load_config_json("acme/private", token) == {"model_type": "secret"}
+        assert transformers_version._load_config_json("acme/private", token) == {
+            "model_type": "secret"
+        }
         assert reads["n"] == 1, "the ambient memo stopped working"
     else:
         # Revoke: an explicit token must re-derive rather than replay the memo.
@@ -1702,7 +1714,10 @@ def test_the_vision_config_read_refuses_an_unauthorized_cache_fallback(monkeypat
     monkeypatch.setattr("huggingface_hub.hf_hub_download", _download)
 
     api_key = hf_token_arg("hf_cannot_read_this", allow_ambient_token = False)
-    assert model_config_module._raw_config_has_vision_config("acme/private-vlm", hf_token = api_key) is None
+    assert (
+        model_config_module._raw_config_has_vision_config("acme/private-vlm", hf_token = api_key)
+        is None
+    )
     assert calls["n"] == 0, "hf_hub_download ran for an unauthorized cached repo"
 
 
@@ -1846,7 +1861,9 @@ def test_the_embedding_memo_does_not_cross_caller_classes(monkeypatch):
 
     monkeypatch.setattr(model_config_module, "_embedding_detection_cache", {})
     monkeypatch.setattr(model_config_module, "is_local_path", lambda *_a, **_k: False)
-    monkeypatch.setattr(model_config_module, "_embedding_marker_in_hf_cache", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        model_config_module, "_embedding_marker_in_hf_cache", lambda *_a, **_k: True
+    )
     monkeypatch.setattr("utils.utils.hf_env_offline", lambda: False)
 
     def _no_hub(*_a, **_k):
@@ -1965,8 +1982,10 @@ def test_a_cache_only_caller_is_never_put_on_the_wire(monkeypatch):
     round trip per cached repo in the /loras scan, for an answer neither branch would use."""
     probes = _counting_probe(monkeypatch, True, offline = False)
 
-    assert model_config_module._offline_cache_read_refused("hf_dummy", "acme/m", "acme/m", True) is True
-
+    assert (
+        model_config_module._offline_cache_read_refused("hf_dummy", "acme/m", "acme/m", True)
+        is True
+    )
 
     monkeypatch.setattr(dataset_cache, "dataset_cache_can_answer", lambda *_a, **_k: True)
     with pytest.raises(HTTPException) as excinfo:
@@ -2046,7 +2065,10 @@ def test_a_cached_alias_repo_is_authorized_in_its_own_right(monkeypatch):
     _hub_reachable(monkeypatch)
     _st_resolver(
         monkeypatch,
-        _cached_st_source = lambda _m: ("sentence-transformers/private-conversion", Path("/cache/snap")),
+        _cached_st_source = lambda _m: (
+            "sentence-transformers/private-conversion",
+            Path("/cache/snap"),
+        ),
     )
 
     plan = settings_routes._resolve_embedding_model_plan("acme/base", "hf_dummy")
@@ -2238,12 +2260,16 @@ def test_the_config_memo_is_rechecked_before_it_is_served(monkeypatch):
     monkeypatch.setitem(transformers_version._config_json_cache, key, {"model_type": "llama"})
 
     monkeypatch.setattr(hf_tokens, "_probe_repo_access", lambda *_a, **_k: True)
-    assert transformers_version._load_config_json("acme/private", "hf_dummy") == {"model_type": "llama"}
+    assert transformers_version._load_config_json("acme/private", "hf_dummy") == {
+        "model_type": "llama"
+    }
 
     reset_repo_access_cache()
     monkeypatch.setattr(hf_tokens, "_probe_repo_access", lambda *_a, **_k: False)
     monkeypatch.setattr(transformers_version, "_env_offline", lambda: True)
-    assert transformers_version._load_config_json("acme/private", "hf_dummy") is None, "revoked token kept the memo"
+    assert (
+        transformers_version._load_config_json("acme/private", "hf_dummy") is None
+    ), "revoked token kept the memo"
 
 
 def test_the_inner_preview_gate_does_not_veto_the_outer_one(monkeypatch):
@@ -2425,7 +2451,10 @@ def test_the_cached_alias_is_looked_up_before_the_literal_name_is_judged(monkeyp
     _hub_reachable(monkeypatch)
     _st_resolver(
         monkeypatch,
-        _cached_st_source = lambda _m: ("sentence-transformers/all-MiniLM-L6-v2", Path("/cache/snap")),
+        _cached_st_source = lambda _m: (
+            "sentence-transformers/all-MiniLM-L6-v2",
+            Path("/cache/snap"),
+        ),
     )
 
     plan = settings_routes._resolve_embedding_model_plan("all-MiniLM-L6-v2", "hf_dummy")
@@ -2588,6 +2617,8 @@ def test_a_local_only_config_read_stays_off_the_wire(monkeypatch):
     monkeypatch.setattr(model_config_module, "_config_json_already_cached", lambda *_a, **_k: True)
 
     with pytest.raises(OSError):
-        model_config_module.load_model_config("acme/private", token = "hf_dummy", local_files_only = True)
+        model_config_module.load_model_config(
+            "acme/private", token = "hf_dummy", local_files_only = True
+        )
 
     assert probes["n"] == 0

--- a/tests/python/test_docker_data_persistence.py
+++ b/tests/python/test_docker_data_persistence.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-Present the Unsloth team. See /studio/LICENSE.AGPL-3.0
+
+"""Regression and unit tests for Docker volume persistence (#4396).
+
+Tests that:
+1. setup_data_dir initializes the canonical subdirectories under /data.
+2. Runtime paths (auth, outputs, exports, runs, caches) are symlinked to /data.
+3. Pre-existing files in container directories migrate safely to /data.
+4. Existing persistent data is never wiped or clobbered.
+5. An empty bind-mount over Studio's baked home triggers an actionable warning.
+6. docker/compose.yml provides a valid, single-volume persistence configuration.
+7. supervisord.conf forwards the persistent cache and data directory environment.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENTRYPOINT = REPO_ROOT / "docker" / "entrypoint.sh"
+COMPOSE = REPO_ROOT / "docker" / "compose.yml"
+SUPERVISORD = REPO_ROOT / "docker" / "supervisord.conf"
+
+needs_bash = pytest.mark.skipif(shutil.which("bash") is None, reason = "needs bash")
+
+
+@pytest.fixture(scope = "module")
+def setup_data_dir_script() -> str:
+    """Extract setup_data_dir definition and helper functions from entrypoint.sh."""
+    source = ENTRYPOINT.read_text(encoding = "utf-8")
+    match = re.search(
+        r"(setup_data_dir\(\)\s*\{.*?\n\})\nsetup_data_dir",
+        source,
+        re.S,
+    )
+    assert match, "setup_data_dir function not found in entrypoint.sh"
+    return match.group(1)
+
+
+@needs_bash
+def test_setup_data_dir_creates_persistent_tree(setup_data_dir_script: str, tmp_path: Path):
+    """setup_data_dir must initialize the standard directory structure."""
+    data_dir = tmp_path / "data"
+    studio_home = tmp_path / "studio"
+    workspace = tmp_path / "workspace"
+    root_home = tmp_path / "root"
+
+    studio_home.mkdir(parents = True)
+    (studio_home / "unsloth_studio").mkdir()
+    workspace.mkdir(parents = True)
+    root_home.mkdir(parents = True)
+
+    script = f"""#!/usr/bin/env bash
+set -euo pipefail
+err()  {{ echo "ERROR: $*" >&2; }}
+warn() {{ echo "WARN: $*" >&2; }}
+
+{setup_data_dir_script}
+
+setup_data_dir
+"""
+    runner = tmp_path / "test_run.sh"
+    runner.write_text(script, encoding = "utf-8")
+
+    env = dict(
+        os.environ,
+        UNSLOTH_DATA_DIR = str(data_dir),
+        UNSLOTH_STUDIO_HOME = str(studio_home),
+        HOME = str(root_home),
+    )
+
+    res = subprocess.run(["bash", str(runner)], capture_output = True, text = True, env = env)
+    assert res.returncode == 0, res.stdout + res.stderr
+
+    expected_subdirs = [
+        "cache/huggingface",
+        "cache/triton",
+        "cache/torch",
+        "outputs",
+        "exports",
+        "auth",
+        "runs",
+        "work",
+    ]
+    for subdir in expected_subdirs:
+        assert (data_dir / subdir).is_dir(), f"Expected directory {subdir} was not created"
+
+    # Verify symlinks created under Studio home
+    for link_name in ("outputs", "exports", "auth", "runs"):
+        link = studio_home / link_name
+        assert link.is_symlink(), f"{link_name} under studio_home should be a symlink"
+        assert link.resolve() == (data_dir / link_name).resolve()
+
+
+@needs_bash
+def test_setup_data_dir_migrates_initial_content(setup_data_dir_script: str, tmp_path: Path):
+    """Files existing in the container before mounting must be preserved in /data."""
+    data_dir = tmp_path / "data"
+    studio_home = tmp_path / "studio"
+    auth_dir = studio_home / "auth"
+    auth_dir.mkdir(parents = True)
+    (auth_dir / "auth.db").write_text("initial-sqlite-data", encoding = "utf-8")
+    (studio_home / "unsloth_studio").mkdir()
+
+    script = f"""#!/usr/bin/env bash
+set -euo pipefail
+err()  {{ echo "ERROR: $*" >&2; }}
+warn() {{ echo "WARN: $*" >&2; }}
+
+{setup_data_dir_script}
+
+setup_data_dir
+"""
+    runner = tmp_path / "test_migrate.sh"
+    runner.write_text(script, encoding = "utf-8")
+
+    env = dict(
+        os.environ,
+        UNSLOTH_DATA_DIR = str(data_dir),
+        UNSLOTH_STUDIO_HOME = str(studio_home),
+    )
+
+    res = subprocess.run(["bash", str(runner)], capture_output = True, text = True, env = env)
+    assert res.returncode == 0, res.stdout + res.stderr
+
+    # auth.db should now exist under the persistent data directory
+    persistent_db = data_dir / "auth" / "auth.db"
+    assert persistent_db.is_file(), "Existing auth.db was not migrated to /data/auth"
+    assert persistent_db.read_text(encoding = "utf-8") == "initial-sqlite-data"
+
+    # And studio_home / auth should be a symlink pointing to persistent auth
+    assert (studio_home / "auth").is_symlink()
+    assert (studio_home / "auth" / "auth.db").read_text(encoding = "utf-8") == "initial-sqlite-data"
+
+
+@needs_bash
+def test_setup_data_dir_warns_on_clobbered_studio_home(setup_data_dir_script: str, tmp_path: Path):
+    """If a host volume was bind-mounted directly over Studio's root, warn the user."""
+    data_dir = tmp_path / "data"
+    studio_home = tmp_path / "opt_unsloth_studio"
+    studio_home.mkdir(parents = True)  # Empty directory without unsloth_studio
+
+    mock_venv = tmp_path / "opt_unsloth_venv"
+    mock_venv.mkdir(parents = True)
+
+    script = f"""#!/usr/bin/env bash
+set -euo pipefail
+err()  {{ echo "ERROR: $*" >&2; }}
+warn() {{ echo "WARN: $*" >&2; }}
+
+{setup_data_dir_script}
+
+setup_data_dir
+"""
+    runner = tmp_path / "test_warn.sh"
+    runner.write_text(script, encoding = "utf-8")
+
+    env = dict(
+        os.environ,
+        UNSLOTH_DATA_DIR = str(data_dir),
+        UNSLOTH_STUDIO_HOME = str(studio_home),
+        UNSLOTH_BASE_VENV = str(mock_venv),
+    )
+
+    res = subprocess.run(["bash", str(runner)], capture_output = True, text = True, env = env)
+    assert res.returncode == 0
+    assert "Bind-mounting over Studio's root removes pre-installed venvs" in res.stderr
+    assert "#4396" in res.stderr
+
+
+def test_compose_file_validity():
+    """docker/compose.yml must be valid YAML with correct single-volume config."""
+    assert COMPOSE.is_file(), "docker/compose.yml is missing"
+    content = COMPOSE.read_text(encoding = "utf-8")
+    doc = yaml.safe_load(content)
+
+    assert "services" in doc, "compose.yml must define services"
+    assert "unsloth" in doc["services"], "compose.yml must have 'unsloth' service"
+
+    unsloth = doc["services"]["unsloth"]
+    assert unsloth.get("ipc") == "host", "compose service should use ipc: host"
+
+    ports = unsloth.get("ports", [])
+    port_strs = [str(p) for p in ports]
+    assert any("8000" in p for p in port_strs), "compose.yml should map Studio port 8000"
+    assert any("8888" in p for p in port_strs), "compose.yml should map Jupyter port 8888"
+
+    volumes = unsloth.get("volumes", [])
+    vol_strs = [str(v) for v in volumes]
+    assert any("/data" in v for v in vol_strs), "compose.yml must mount /data volume"
+
+
+def test_supervisord_environment_inheritance():
+    """supervisord.conf must forward cache and data variables to services."""
+    assert SUPERVISORD.is_file(), "docker/supervisord.conf is missing"
+    text = SUPERVISORD.read_text(encoding = "utf-8")
+
+    # studio program environment
+    match_studio = re.search(r"\[program:studio\].*?environment=([^\n]+)", text, re.S)
+    assert match_studio, "[program:studio] must define environment"
+    studio_env = match_studio.group(1)
+    assert "HF_HOME" in studio_env, "studio program must receive HF_HOME"
+    assert "TRITON_CACHE_DIR" in studio_env, "studio program must receive TRITON_CACHE_DIR"
+    assert "UNSLOTH_DATA_DIR" in studio_env, "studio program must receive UNSLOTH_DATA_DIR"
+
+    # jupyter program environment
+    match_jupyter = re.search(r"\[program:jupyter\].*?environment=([^\n]+)", text, re.S)
+    assert match_jupyter, "[program:jupyter] must define environment"
+    jupyter_env = match_jupyter.group(1)
+    assert "HF_HOME" in jupyter_env, "jupyter program must receive HF_HOME"
+    assert "TRITON_CACHE_DIR" in jupyter_env, "jupyter program must receive TRITON_CACHE_DIR"
+    assert "UNSLOTH_DATA_DIR" in jupyter_env, "jupyter program must receive UNSLOTH_DATA_DIR"


### PR DESCRIPTION
### Summary
Closes #4396.

This PR introduces an official single-volume runtime persistence directory (`/data`) and a turnkey `docker compose` configuration for the Unsloth Docker image.

### Problem
- Users mounting `/workspace/studio` or `/opt/unsloth-studio` clobber pre-installed virtual environments and `llama.cpp` binaries, causing Studio to fail with `exited: studio (exit status 1)`.
- Without persistent volumes, model downloads, LoRA outputs, GGUF exports, and Studio credentials (`auth.db`) are lost when containers are stopped, recreated, or updated.
- Cache paths diverged across components (JupyterLab using `/workspace/.cache` and Studio using `~/.cache`).

### Solution
1. **Unified persistence root (`/data`)**: `docker/entrypoint.sh` automatically initializes subdirectories (`cache/huggingface`, `cache/triton`, `outputs`, `exports`, `auth`, `runs`, `work`) and symlinks runtime paths.
2. **Safe migration**: Files existing in container directories before mounting are safely migrated without overwriting existing persistent host data.
3. **Actionable clobber guard**: Detects accidental mounts directly over Studio's root and warns the user with actionable instructions pointing to #4396.
4. **Official Docker Compose (`docker/compose.yml`)**: Turnkey compose file with GPU reservations, `ipc: host`, recommended ulimits, and single-volume persistence (`./data:/data`).
5. **Supervisord environment inheritance**: `docker/supervisord.conf` and `docker/studio_launch.sh` ensure Studio and JupyterLab inherit `HF_HOME`, `TRITON_CACHE_DIR`, and `UNSLOTH_DATA_DIR`.
6. **Documentation**: Updated `docker/DOCKERHUB.md` with volume documentation, compose examples, and warnings against mounting over Studio's root.

### Testing
- Added unit and regression test suite in `tests/python/test_docker_data_persistence.py`.
- Verified with `pytest tests/python/test_docker_*.py` (30/30 passed).
- Verified shell syntax on all modified scripts (`bash -n`).
