### PR TITLE
Studio: cover the unsigned 64-bit edge of a linked-folder identity

### DIFF
--- a/studio/backend/tests/test_rag_linked_folders.py
+++ b/studio/backend/tests/test_rag_linked_folders.py
@@ -60,6 +60,16 @@ def _mapping(folder: dict) -> dict | None:
     return _row("SELECT * FROM linked_folder_files WHERE folder_id=?", (folder["id"],))
 
 
+def _identity_mismatch(loaded: tuple, expected: tuple, stored: tuple) -> str:
+    """Name the half that diverged: a bare tuple comparison hides which id is wrong."""
+    parts = [
+        f"{label}: loaded {got!r} != expected {want!r} (column held {raw!r})"
+        for label, got, want, raw in zip(("device", "inode"), loaded, expected, stored)
+        if got != want
+    ]
+    return "; ".join(parts) or f"identity {loaded!r} != {expected!r}"
+
+
 class _CommitFails:
     """A connection whose commit always fails, to exercise rollback ordering."""
 
@@ -725,9 +735,11 @@ def test_reauthorizing_same_path_refreshes_root_identity_and_retains_mappings(
     assert refreshed["id"] == folder["id"]
     # Read back through the loader: an identity above SQLite's signed maximum is stored as
     # a hex string, which is the ordinary case for a Windows device id.
-    assert folder_sync._load_identity(refreshed["root_device"], refreshed["root_inode"]) == (
-        source_stat.st_dev,
-        source_stat.st_ino,
+    loaded = folder_sync._load_identity(refreshed["root_device"], refreshed["root_inode"])
+    assert loaded == (source_stat.st_dev, source_stat.st_ino), _identity_mismatch(
+        loaded,
+        (source_stat.st_dev, source_stat.st_ino),
+        (refreshed["root_device"], refreshed["root_inode"]),
     )
     with _connection() as conn:
         mapping_after = dict(
@@ -838,9 +850,65 @@ def test_large_windows_file_identity_round_trips_through_sqlite(
 
     assert _run(folder["id"])["status"] == "completed"
     row = _mapping(folder)
-    assert folder_sync._load_identity(row["device"], row["inode"]) == identity
+    loaded = folder_sync._load_identity(row["device"], row["inode"])
+    assert loaded == identity, _identity_mismatch(loaded, identity, (row["device"], row["inode"]))
     # The same identity must still compare equal, so nothing re-embeds every sync.
     assert _run(folder["id"])["changed"] == 0
+
+
+@pytest.mark.parametrize(
+    "value",
+    [0, 1, (1 << 63) - 2, (1 << 63) - 1, 1 << 63, (1 << 63) + 1, (1 << 64) - 1, 1 << 127],
+    ids = ["zero", "one", "below-max", "at-max", "at-2-63", "above-2-63", "uint64-max", "refs-128"],
+)
+def test_identities_round_trip_across_the_sqlite_integer_boundary(value):
+    """os.stat ids are unsigned, SQLite INTEGER is signed, and the encoding straddles that edge."""
+    stored = folder_sync._store_identity((value, value))
+    with closing(sqlite3.connect(":memory:")) as conn:
+        # Same declared affinity as linked_folders and linked_folder_files.
+        conn.execute("CREATE TABLE ids(device INTEGER, inode INTEGER)")
+        conn.execute("INSERT INTO ids VALUES(?,?)", stored)
+        read = tuple(conn.execute("SELECT device, inode FROM ids").fetchone())
+
+    loaded = folder_sync._load_identity(*read)
+    assert loaded == (value, value), _identity_mismatch(loaded, (value, value), read)
+    # Anything SQLite can hold stays an integer, so rows written by older builds still load.
+    fits = value <= folder_sync._SQLITE_INTEGER_MAX
+    assert isinstance(read[0], int) is fits, (
+        f"{value} was stored as {read[0]!r}; a value that {'fits' if fits else 'overflows'} "
+        f"SQLite's signed range must be written as {'an integer' if fits else 'text'}"
+    )
+
+
+@requires_sqlite_vec
+def test_reauthorizing_encodes_a_root_identity_above_the_sqlite_maximum(
+    rag_home, stub_embeddings, monkeypatch
+):
+    """A Windows volume serial fills all 64 bits, so half of them overflow SQLite INTEGER.
+
+    The reauthorize path writes root_device with its own UPDATE, so it needs its own case: a
+    real st_dev on this host is far too small to reach the encoding at all.
+    """
+    source, folder = _folder(rag_home)
+    (source / "notes.txt").write_text("kept across the remount", encoding = "utf-8")
+    assert _run(folder["id"])["status"] == "completed"
+    identity = (0xAC8C2FEF8C2FB32E, 1 << 127)
+
+    monkeypatch.setattr(folder_sync, "_root_identity", lambda path: identity)
+
+    refreshed = folder_sync.create_folder(
+        scope_type = "knowledge_base",
+        scope_id = "scope-1",
+        path = str(source),
+    )
+
+    assert refreshed["id"] == folder["id"]
+    stored = (refreshed["root_device"], refreshed["root_inode"])
+    loaded = folder_sync._load_identity(*stored)
+    assert loaded == identity, _identity_mismatch(loaded, identity, stored)
+    # Reconciliation reloads the row as the identity to expect, so an undecoded column would
+    # fail the whole sync rather than round-trip.
+    assert _run(folder["id"])["status"] == "completed"
 
 
 def test_validate_folder_rejects_symlink_root(rag_home):


### PR DESCRIPTION
## What this is

Follow-up hardening for the intermittent `Uploads (windows-latest)` failure in `rag-upload-compatibility.yml`:

```
test_reauthorizing_same_path_refreshes_root_identity_and_retains_mappings
assert ('xac8c2fef8c2fb32e', 281474976725560) == (12433365377158722350, 281474976725560)
```

The assertion itself was already corrected in #10536. This adds the coverage that would have caught it, and the coverage that still would not catch the same class of regression in the two neighbouring code paths.

## Diagnosis

`linked_folders.root_device` and `linked_folder_files.device` are declared `INTEGER`, and SQLite's `INTEGER` is signed 64-bit. `os.stat` identities are unsigned, so `folder_sync._store_identity` writes anything above `(1 << 63) - 1` as `f"x{value:x}"` and `folder_sync._load_identity` decodes it back. That encoding has been there since the feature landed; the failure was a test reading the raw column instead of going through the loader.

Confirmed by exercising it rather than by reading:

- `sqlite3` raises `OverflowError: Python int too large to convert to SQLite INTEGER` for `1 << 63`, `(1 << 64) - 1` and `12433365377158722350`, and stores `(1 << 63) - 1` fine.
- `_store_identity((12433365377158722350, 281474976725560))` returns exactly `('xac8c2fef8c2fb32e', 281474976725560)`, byte for byte the value in the CI failure. `0xac8c2fef8c2fb32e == 12433365377158722350`.

### Why it is intermittent

The workflow pins Python 3.12. Since python/cpython#102149, Windows `os.stat` reads `FILE_ID_INFO`, so `st_dev` is the full 64-bit `VolumeSerialNumber` and `st_ino` is the 128-bit `FileId`. A volume serial is effectively random, so its top bit is set roughly half the time. When it is set, `st_dev > (1 << 63) - 1`, the column holds hex text and the raw comparison fails; when it is clear, the value fits, the column holds an integer and the same test passes. Both observed instances have the top bit set: `0xac8c2fef8c2fb32e` here and `0xb2f8ffc4f8ff84bf` in #10536. On Linux and macOS `st_dev` is small, so the encoding is never reached and the case is invisible. On NTFS the 128-bit file id keeps its index in the low 64 bits, which is why the inode half of the tuple matched while the device half did not.

## Who was wrong

The test, not the production code. The stored form is a deliberate, documented encoding whose round trip through `_load_identity` is lossless across the whole unsigned 64-bit range and beyond, and the column value is an opaque OS token that nothing outside `folder_sync` interprets. Asserting the raw column against `st_dev` over-specified the storage representation rather than the contract, which is that the identity read back equals the identity written and still compares equal on the next scan. Changing production code to keep the raw integer readable would mean widening the column to `TEXT` and rewriting every existing row, which is strictly worse than the flake for a persisted store.

That verdict is only sound because the round trip really is lossless, so this branch proves that instead of assuming it.

## What this adds

- `test_reauthorizing_encodes_a_root_identity_above_the_sqlite_maximum` forces `_root_identity` to return `(0xAC8C2FEF8C2FB32E, 1 << 127)` and drives the reauthorize path, which writes `root_device` through its own `UPDATE`. It then reconciles once more, because the reconciler reloads that row as the identity to expect. Neither of those two steps had a test that reached the encoding at all on a host whose `st_dev` is small.
- `test_identities_round_trip_across_the_sqlite_integer_boundary` parametrises `0`, `1`, `2**63 - 2`, `2**63 - 1`, `2**63`, `2**63 + 1`, `2**64 - 1` and `1 << 127` through a real `INTEGER` column, and asserts that values SQLite can hold stay integers so rows written by older builds keep loading.
- Assertions now name the half that diverged and what the column actually held, instead of printing a two-element tuple and leaving the reader to spot which end moved.
- The sibling exposure, `st_ino`, is covered by the same parametrisation and by the existing file-identity case; a 128-bit ReFS file id is included.

## Before and after

Mutation differential, whole `test_rag_linked_folders.py`, control worktree pinned to `f452d415edce3dc937b4da1f450ed878151813af`:

| Mutation | main | this branch |
| --- | --- | --- |
| none | 91 passed | 100 passed |
| `_reauthorize_folder` writes `*identity` instead of `*_store_identity(identity)` | 91 passed, survives | 1 failed, killed by `test_reauthorizing_encodes_a_root_identity_above_the_sqlite_maximum` |
| reconciler uses the raw columns instead of `_load_identity` | 91 passed, survives | 1 failed, killed by the same test |
| `_store_identity` boundary `<=` becomes `<` | 91 passed, survives | 1 failed, killed by `...boundary[at-max]` |
| `_load_identity` drops the hex branch | 2 failed | 7 failed |

Three mutations that main does not notice are now caught, and the fourth is caught much more loudly.

Full RAG suite differential, run sequentially against the same pinned control:

- control: 7 failed, 794 passed, 38 skipped
- branch: 7 failed, 803 passed, 38 skipped

The seven are the same `test_rag_captioning.py` cases on both sides, a missing optional module on this host, unrelated to this change. `test_rag_ocr_fallback.py` fails to collect identically on both sides for the same reason and was excluded from both runs.

## Caveat

This host is Linux. A genuine Windows `st_dev` cannot be produced here, so the out-of-range identity is simulated by substituting `_root_identity`, using the exact value from the CI failure. What was actually observed here is the `sqlite3` overflow, the encoded form matching the CI string byte for byte, the lossless round trip through a real `INTEGER` column, and the mutation differential above. What only Windows CI can confirm is that a real runner's volume serial takes the same path end to end and that the previously flaking case is now stable across runs whose serial has its top bit set.
