### PR TITLE
Studio: remember confirmed SWA config misses per repo

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2177,8 +2177,8 @@ _BOOTSTRAP_SWA_DEFAULTS: dict[str, int] = {
     "cohere2": 4,  # Cohere2Config.sliding_window_pattern
 }
 
-# Process-wide cache backed by JSON on disk. Values are int period or
-# list[bool] mask. Lazy-loaded.
+# Process-wide cache backed by JSON on disk. Values are int period,
+# list[bool] mask, or false for a remembered Hub miss. Lazy-loaded.
 _SWA_CACHE: Optional[dict] = None
 _SWA_CACHE_LOCK = threading.Lock()
 
@@ -2484,9 +2484,8 @@ def _resolve_swa_pattern(
             cache[arch] = entry
         _save_swa_cache(cache)
 
-    if (entry := cache.get(arch)) is not None:
-        if (mask := _entry_to_mask(entry)) is not None:
-            return mask
+    if arch in cache:
+        return _entry_to_mask(cache[arch])
 
     if (entry := _BOOTSTRAP_SWA_DEFAULTS.get(arch)) is not None:
         return _entry_to_mask(entry)
@@ -2496,15 +2495,24 @@ def _resolve_swa_pattern(
         _persist(entry)
         return _entry_to_mask(entry)
 
-    # Tier 3: live HF fetch (result persistently cached)
+    # Tier 3: live HF fetch (hit or miss persistently cached)
     if allow_network:
+        seen = set()
+        fetched = False
         for repo_id in source_repo_candidates:
             if not repo_id:
                 continue
+            folded = repo_id.casefold()
+            if folded in seen:
+                continue
+            seen.add(folded)
+            fetched = True
             entry = _fetch_swa_entry_from_hf(repo_id)
             if entry is not None:
                 _persist(entry)
                 return _entry_to_mask(entry)
+        if fetched:
+            _persist(False)
 
     return None
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2177,8 +2177,9 @@ _BOOTSTRAP_SWA_DEFAULTS: dict[str, int] = {
     "cohere2": 4,  # Cohere2Config.sliding_window_pattern
 }
 
-# Process-wide cache backed by JSON on disk. Values are int period,
-# list[bool] mask, or false for a remembered Hub miss. Lazy-loaded.
+# Process-wide cache backed by JSON on disk. Values are int period or
+# list[bool] mask. `__missed_repos__` is a list of casefolded Hub ids whose
+# config.json was read (or confirmed absent) and had no SWA field. Lazy-loaded.
 _SWA_CACHE: Optional[dict] = None
 _SWA_CACHE_LOCK = threading.Lock()
 
@@ -2360,15 +2361,39 @@ def _swa_entry_from_layer_types(lt) -> Optional[object]:
     return None
 
 
+# JSON-serializable: config.json was read or confirmed absent, and has no SWA field.
+_SWA_CONFIRMED_MISS = False
+_SWA_MISSED_REPOS_KEY = "__missed_repos__"
+
+
+def _swa_missed_repos(cache: dict) -> set:
+    missed = cache.get(_SWA_MISSED_REPOS_KEY)
+    if not isinstance(missed, list):
+        return set()
+    return {item.casefold() for item in missed if isinstance(item, str)}
+
+
+def _remember_swa_repo_miss(cache: dict, repo_id: str) -> None:
+    folded = repo_id.casefold()
+    missed = _swa_missed_repos(cache)
+    if folded in missed:
+        return
+    missed.add(folded)
+    with _SWA_CACHE_LOCK:
+        cache[_SWA_MISSED_REPOS_KEY] = sorted(missed)
+    _save_swa_cache(cache)
+
+
 def _fetch_swa_entry_from_hf(repo_id: str) -> Optional[object]:
     try:
         from huggingface_hub import hf_hub_download
         from utils.hf_cache_settings import active_hf_hub_cache
         from utils.hf_probe import hf_file_definitely_absent
 
-        # Avoid caching the expected 404 for GGUF repos without config.json.
+        # A confirmed 404 is a miss we can remember. Anything else (timeout,
+        # 429, gated, DNS) must stay None so the next load can retry.
         if hf_file_definitely_absent(repo_id, "config.json"):
-            return None
+            return _SWA_CONFIRMED_MISS
         cfg_path = hf_hub_download(
             repo_id,
             "config.json",
@@ -2384,7 +2409,8 @@ def _fetch_swa_entry_from_hf(repo_id: str) -> Optional[object]:
     period = src.get("sliding_window_pattern")
     if isinstance(period, int) and period > 0:
         return period
-    return _swa_entry_from_layer_types(src.get("layer_types"))
+    entry = _swa_entry_from_layer_types(src.get("layer_types"))
+    return entry if entry is not None else _SWA_CONFIRMED_MISS
 
 
 def _arch_aliases(arch: str) -> tuple:
@@ -2484,8 +2510,9 @@ def _resolve_swa_pattern(
             cache[arch] = entry
         _save_swa_cache(cache)
 
-    if arch in cache:
-        return _entry_to_mask(cache[arch])
+    if (entry := cache.get(arch)) is not None:
+        if (mask := _entry_to_mask(entry)) is not None:
+            return mask
 
     if (entry := _BOOTSTRAP_SWA_DEFAULTS.get(arch)) is not None:
         return _entry_to_mask(entry)
@@ -2495,24 +2522,25 @@ def _resolve_swa_pattern(
         _persist(entry)
         return _entry_to_mask(entry)
 
-    # Tier 3: live HF fetch (hit or miss persistently cached)
+    # Tier 3: live HF fetch. Confirmed misses are remembered per repo so a
+    # later GGUF of the same arch can still try a new candidate.
     if allow_network:
         seen = set()
-        fetched = False
+        missed = _swa_missed_repos(cache)
         for repo_id in source_repo_candidates:
             if not repo_id:
                 continue
             folded = repo_id.casefold()
-            if folded in seen:
+            if folded in seen or folded in missed:
                 continue
             seen.add(folded)
-            fetched = True
             entry = _fetch_swa_entry_from_hf(repo_id)
+            if entry is _SWA_CONFIRMED_MISS:
+                _remember_swa_repo_miss(cache, folded)
+                continue
             if entry is not None:
                 _persist(entry)
                 return _entry_to_mask(entry)
-        if fetched:
-            _persist(False)
 
     return None
 

--- a/studio/backend/tests/test_kv_cache_estimation.py
+++ b/studio/backend/tests/test_kv_cache_estimation.py
@@ -594,33 +594,81 @@ class TestDynamicSwaResolver:
             general = {"general.source.huggingface.repository": "vendor/does-not-exist"},
         )
         assert b._sliding_window_pattern is None
-        with open(tmp_path / "swa_cache.json") as f:
-            assert json.load(f) == {"newmodel": False}
+        assert not (tmp_path / "swa_cache.json").exists()
 
     def test_remembered_miss_skips_hf_refetch(self, monkeypatch, tmp_path):
         self._isolate_cache(monkeypatch, tmp_path)
-        from core.inference import llama_cpp as lc
-
         calls = []
         monkeypatch.setattr(
-            lc, "_fetch_swa_entry_from_hf", lambda repo_id: calls.append(repo_id) or None
+            lc,
+            "_fetch_swa_entry_from_hf",
+            lambda repo_id: calls.append(repo_id) or lc._SWA_CONFIRMED_MISS,
         )
         monkeypatch.setattr(lc, "_resolve_swa_entry_from_transformers", lambda arch: None)
         general = {"general.source.huggingface.repository": "vendor/does-not-exist"}
         first = _backend_from_gguf("newmodel", _SWA_FIELDS, general = general)
         assert first._sliding_window_pattern is None
         assert calls == ["vendor/does-not-exist"]
+        with open(tmp_path / "swa_cache.json") as f:
+            assert json.load(f) == {"__missed_repos__": ["vendor/does-not-exist"]}
         monkeypatch.setattr(lc, "_SWA_CACHE", None)
         second = _backend_from_gguf("newmodel", _SWA_FIELDS, general = general)
         assert second._sliding_window_pattern is None
         assert calls == ["vendor/does-not-exist"]
 
+    def test_transient_hf_error_is_retried(self, monkeypatch, tmp_path):
+        self._isolate_cache(monkeypatch, tmp_path)
+        calls = []
+        monkeypatch.setattr(
+            lc, "_fetch_swa_entry_from_hf", lambda repo_id: calls.append(repo_id) or None
+        )
+        monkeypatch.setattr(lc, "_resolve_swa_entry_from_transformers", lambda arch: None)
+        general = {"general.source.huggingface.repository": "vendor/newmodel-base"}
+        first = _backend_from_gguf("newmodel", _SWA_FIELDS, general = general)
+        assert first._sliding_window_pattern is None
+        assert not (tmp_path / "swa_cache.json").exists()
+        monkeypatch.setattr(lc, "_SWA_CACHE", None)
+        monkeypatch.setattr(
+            lc, "_fetch_swa_entry_from_hf", lambda repo_id: calls.append(repo_id) or 4
+        )
+        second = _backend_from_gguf("newmodel", _SWA_FIELDS, general = general)
+        assert second._sliding_window_pattern == [(i + 1) % 4 != 0 for i in range(12)]
+        assert calls == ["vendor/newmodel-base", "vendor/newmodel-base"]
+
+    def test_repo_miss_does_not_block_another_candidate(self, monkeypatch, tmp_path):
+        self._isolate_cache(monkeypatch, tmp_path)
+        calls = []
+
+        def fake_fetch(repo_id):
+            calls.append(repo_id)
+            return 4 if repo_id == "vendor/newmodel-base" else lc._SWA_CONFIRMED_MISS
+
+        monkeypatch.setattr(lc, "_fetch_swa_entry_from_hf", fake_fetch)
+        monkeypatch.setattr(lc, "_resolve_swa_entry_from_transformers", lambda arch: None)
+        b = _backend_from_gguf(
+            "newmodel",
+            _SWA_FIELDS,
+            general = {
+                "general.source.huggingface.repository": "quanter/newmodel-GGUF",
+                "general.base_model.0.repo_url": "https://huggingface.co/vendor/newmodel-base",
+            },
+        )
+        assert b._sliding_window_pattern == [(i + 1) % 4 != 0 for i in range(12)]
+        assert calls == ["quanter/newmodel-GGUF", "vendor/newmodel-base"]
+
+    def test_stale_arch_false_does_not_shadow_bootstrap(self, monkeypatch, tmp_path):
+        self._isolate_cache(monkeypatch, tmp_path)
+        with open(tmp_path / "swa_cache.json", "w") as f:
+            json.dump({"gemma3": False}, f)
+        b = _backend_from_gguf("gemma3", dict(_SWA_FIELDS, block_count = 18))
+        assert b._sliding_window_pattern == [(i + 1) % 6 != 0 for i in range(18)]
+
     def test_casefold_duplicate_repos_are_fetched_once(self, monkeypatch, tmp_path):
         self._isolate_cache(monkeypatch, tmp_path)
-        from core.inference import llama_cpp as lc
-
         calls = []
-        monkeypatch.setattr(lc, "_fetch_swa_entry_from_hf", lambda repo_id: calls.append(repo_id) or None)
+        monkeypatch.setattr(
+            lc, "_fetch_swa_entry_from_hf", lambda repo_id: calls.append(repo_id) or None
+        )
         monkeypatch.setattr(lc, "_resolve_swa_entry_from_transformers", lambda arch: None)
         b = _backend_from_gguf(
             "newmodel",
@@ -639,8 +687,6 @@ class TestTransformersIntrospection:
     """Tier 2.5: default-init the matching Config; on failure, parse via inspect."""
 
     def _isolate_cache(self, monkeypatch, tmp_path):
-        from core.inference import llama_cpp as lc
-
         monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path))
         monkeypatch.setattr(lc, "_SWA_CACHE", None)
         return tmp_path

--- a/studio/backend/tests/test_kv_cache_estimation.py
+++ b/studio/backend/tests/test_kv_cache_estimation.py
@@ -594,13 +594,53 @@ class TestDynamicSwaResolver:
             general = {"general.source.huggingface.repository": "vendor/does-not-exist"},
         )
         assert b._sliding_window_pattern is None
-        assert not (tmp_path / "swa_cache.json").exists()
+        with open(tmp_path / "swa_cache.json") as f:
+            assert json.load(f) == {"newmodel": False}
+
+    def test_remembered_miss_skips_hf_refetch(self, monkeypatch, tmp_path):
+        self._isolate_cache(monkeypatch, tmp_path)
+        from core.inference import llama_cpp as lc
+
+        calls = []
+        monkeypatch.setattr(
+            lc, "_fetch_swa_entry_from_hf", lambda repo_id: calls.append(repo_id) or None
+        )
+        monkeypatch.setattr(lc, "_resolve_swa_entry_from_transformers", lambda arch: None)
+        general = {"general.source.huggingface.repository": "vendor/does-not-exist"}
+        first = _backend_from_gguf("newmodel", _SWA_FIELDS, general = general)
+        assert first._sliding_window_pattern is None
+        assert calls == ["vendor/does-not-exist"]
+        monkeypatch.setattr(lc, "_SWA_CACHE", None)
+        second = _backend_from_gguf("newmodel", _SWA_FIELDS, general = general)
+        assert second._sliding_window_pattern is None
+        assert calls == ["vendor/does-not-exist"]
+
+    def test_casefold_duplicate_repos_are_fetched_once(self, monkeypatch, tmp_path):
+        self._isolate_cache(monkeypatch, tmp_path)
+        from core.inference import llama_cpp as lc
+
+        calls = []
+        monkeypatch.setattr(lc, "_fetch_swa_entry_from_hf", lambda repo_id: calls.append(repo_id) or None)
+        monkeypatch.setattr(lc, "_resolve_swa_entry_from_transformers", lambda arch: None)
+        b = _backend_from_gguf(
+            "newmodel",
+            _SWA_FIELDS,
+            general = {
+                "general.source.huggingface.repository": "DeepSeek-AI/Flash",
+                "general.organization": "deepseek-ai",
+                "general.basename": "Flash",
+            },
+        )
+        assert b._sliding_window_pattern is None
+        assert calls == ["DeepSeek-AI/Flash"]
 
 
 class TestTransformersIntrospection:
     """Tier 2.5: default-init the matching Config; on failure, parse via inspect."""
 
     def _isolate_cache(self, monkeypatch, tmp_path):
+        from core.inference import llama_cpp as lc
+
         monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path))
         monkeypatch.setattr(lc, "_SWA_CACHE", None)
         return tmp_path


### PR DESCRIPTION
A DeepSeek GGUF that declares a sliding window but no per-layer pattern re-fetches the base repo `config.json` on every load (https://github.com/unslothai/unsloth/issues/10047). `_resolve_swa_pattern` wrote `swa_cache.json` only on a hit.

A confirmed miss (config.json read, or `hf_file_definitely_absent`) is now stored per casefolded repo id under `__missed_repos__`. Timeouts, 429s, and ids that do not exist stay uncached so the next load can retry. Arch-level tiers are untouched.

`.venv/bin/python -m pytest -q studio/backend/tests/test_kv_cache_estimation.py::TestDynamicSwaResolver` passed (15). Checking out `llama_cpp.py` from `dd2b0f6ac` failed `test_remembered_miss_skips_hf_refetch` (no `swa_cache.json`), `test_repo_miss_does_not_block_another_candidate`, and `test_casefold_duplicate_repos_are_fetched_once` (also fetched `deepseek-ai/Flash`).
