### PR TITLE
Fix Deep Research JSON output on MLX and Transformers

### DIFF
--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -119,8 +119,6 @@ _MODEL_WAIT_POLL_SECONDS = 2.0
 # A model that keeps disappearing would re-send forever, so cap how many times one call may wait.
 _MAX_MODEL_WAITS = 3
 _NO_MODEL_LOADED_DETAIL = "No model loaded"
-# routes.inference's refusal for a backend with no grammar engine, the one guided-decoding
-# refusal a prompt-only re-send can answer. Two other refusals carry the same code and param.
 _NO_GRAMMAR_ENGINE_DETAIL = "needs the llama.cpp grammar engine"
 # routes.inference reports the same unloaded state this way when auto-switch finds no local match.
 _MODEL_NOT_FOUND_CODE = "model_not_found"
@@ -597,10 +595,7 @@ async def _response_format_unsupported(response: httpx.Response) -> bool:
         isinstance(error, dict)
         and error.get("code") == "unsupported_parameter"
         and error.get("param") == "response_format"
-        # The code/param pair alone is not this refusal: routes.inference sends the same pair
-        # when the contract cannot be honored for a reason a prompt-only re-send does not
-        # address -- an audio reply, or Unsloth's own tool loop. Re-sending those drops the
-        # contract and still gets refused, or worse reaches a route that answers with speech.
+        # Code and param alone also match the audio and tool-loop refusals, which no re-send fixes.
         and _NO_GRAMMAR_ENGINE_DETAIL in str(error.get("message") or "")
     )
 
@@ -1722,9 +1717,8 @@ class ResearchSupervisor:
                                 and isinstance(exc, httpx.HTTPStatusError)
                                 and await _response_format_unsupported(exc.response)
                             ):
-                                # MLX/transformers cannot enforce a grammar. Research already
-                                # prompts for JSON and validates it; retry once without guided
-                                # decoding. Negotiate after routing, including any model switch.
+                                # No grammar engine here, but the prompts ask for JSON and the
+                                # output is validated. Retry once without it, after routing.
                                 del payload["response_format"]
                                 await exc.response.aclose()
                                 response = None

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -396,35 +396,6 @@ def _loaded_context_length(inference: dict[str, Any] | None = None) -> int | Non
     return None
 
 
-def _local_audio_model_loaded(inference: dict[str, Any] | None = None) -> bool:
-    """Whether the local backend serving this run answers with speech rather than text.
-
-    Same two probes as _loaded_context_length, reading the flags routes.inference itself
-    branches on: llama.cpp's ``_is_audio`` and the orchestrator's ``is_audio`` model info.
-    Only the guided-decoding fallback consults this, and only to refuse to negotiate: a
-    text-to-speech route cannot answer a research prompt whether or not the format is sent,
-    and re-sending without it swaps a refusal that names the problem for a synthesized clip.
-    Unknown reads as "not audio", so an unprobeable backend keeps today's behaviour."""
-    if _external_provider_run(inference):
-        return False
-    try:
-        from routes.inference import get_llama_cpp_backend
-        llama = get_llama_cpp_backend()
-        if getattr(llama, "is_loaded", False):
-            return bool(getattr(llama, "_is_audio", False))
-    except Exception:
-        logger.debug("research.audio_probe_llama_failed", exc_info = True)
-    try:
-        backend = _peek_inference_backend()
-        name = getattr(backend, "active_model_name", None)
-        models = getattr(backend, "models", {}) or {}
-        info = models.get(name) if (name and isinstance(models, dict)) else None
-        return bool((info or {}).get("is_audio"))
-    except Exception:
-        logger.debug("research.audio_probe_failed", exc_info = True)
-    return False
-
-
 def _estimate_prompt_tokens(messages: list[dict]) -> int:
     """Conservative prompt token estimate for max_tokens clamping.
 
@@ -1724,7 +1695,11 @@ class ResearchSupervisor:
                             "POST",
                             self._endpoint(),
                             json = payload,
-                            headers = {"Authorization": f"Bearer {token}"},
+                            headers = {
+                                "Authorization": f"Bearer {token}",
+                                # Keep text-only intent across retries and model switches.
+                                "X-Unsloth-Require-Text": "1",
+                            },
                         )
                         try:
                             send_task = asyncio.create_task(client.send(request, stream = True))
@@ -1746,12 +1721,6 @@ class ResearchSupervisor:
                                 and payload.get("response_format") == {"type": "json_object"}
                                 and isinstance(exc, httpx.HTTPStatusError)
                                 and await _response_format_unsupported(exc.response)
-                                # The non-GGUF branch refuses the format before it reaches the
-                                # audio routing below it, so this refusal does not prove the
-                                # re-send would be answered as text.
-                                and not await asyncio.to_thread(
-                                    _local_audio_model_loaded, inference
-                                )
                             ):
                                 # MLX/transformers cannot enforce a grammar. Research already
                                 # prompts for JSON and validates it; retry once without guided

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -119,6 +119,9 @@ _MODEL_WAIT_POLL_SECONDS = 2.0
 # A model that keeps disappearing would re-send forever, so cap how many times one call may wait.
 _MAX_MODEL_WAITS = 3
 _NO_MODEL_LOADED_DETAIL = "No model loaded"
+# routes.inference's refusal for a backend with no grammar engine, the one guided-decoding
+# refusal a prompt-only re-send can answer. Two other refusals carry the same code and param.
+_NO_GRAMMAR_ENGINE_DETAIL = "needs the llama.cpp grammar engine"
 # routes.inference reports the same unloaded state this way when auto-switch finds no local match.
 _MODEL_NOT_FOUND_CODE = "model_not_found"
 # routes.inference 503s with this while an auto-switch to the run's model is still loading.
@@ -393,6 +396,35 @@ def _loaded_context_length(inference: dict[str, Any] | None = None) -> int | Non
     return None
 
 
+def _local_audio_model_loaded(inference: dict[str, Any] | None = None) -> bool:
+    """Whether the local backend serving this run answers with speech rather than text.
+
+    Same two probes as _loaded_context_length, reading the flags routes.inference itself
+    branches on: llama.cpp's ``_is_audio`` and the orchestrator's ``is_audio`` model info.
+    Only the guided-decoding fallback consults this, and only to refuse to negotiate: a
+    text-to-speech route cannot answer a research prompt whether or not the format is sent,
+    and re-sending without it swaps a refusal that names the problem for a synthesized clip.
+    Unknown reads as "not audio", so an unprobeable backend keeps today's behaviour."""
+    if _external_provider_run(inference):
+        return False
+    try:
+        from routes.inference import get_llama_cpp_backend
+        llama = get_llama_cpp_backend()
+        if getattr(llama, "is_loaded", False):
+            return bool(getattr(llama, "_is_audio", False))
+    except Exception:
+        logger.debug("research.audio_probe_llama_failed", exc_info = True)
+    try:
+        backend = _peek_inference_backend()
+        name = getattr(backend, "active_model_name", None)
+        models = getattr(backend, "models", {}) or {}
+        info = models.get(name) if (name and isinstance(models, dict)) else None
+        return bool((info or {}).get("is_audio"))
+    except Exception:
+        logger.debug("research.audio_probe_failed", exc_info = True)
+    return False
+
+
 def _estimate_prompt_tokens(messages: list[dict]) -> int:
     """Conservative prompt token estimate for max_tokens clamping.
 
@@ -594,6 +626,11 @@ async def _response_format_unsupported(response: httpx.Response) -> bool:
         isinstance(error, dict)
         and error.get("code") == "unsupported_parameter"
         and error.get("param") == "response_format"
+        # The code/param pair alone is not this refusal: routes.inference sends the same pair
+        # when the contract cannot be honored for a reason a prompt-only re-send does not
+        # address -- an audio reply, or Unsloth's own tool loop. Re-sending those drops the
+        # contract and still gets refused, or worse reaches a route that answers with speech.
+        and _NO_GRAMMAR_ENGINE_DETAIL in str(error.get("message") or "")
     )
 
 
@@ -1709,6 +1746,12 @@ class ResearchSupervisor:
                                 and payload.get("response_format") == {"type": "json_object"}
                                 and isinstance(exc, httpx.HTTPStatusError)
                                 and await _response_format_unsupported(exc.response)
+                                # The non-GGUF branch refuses the format before it reaches the
+                                # audio routing below it, so this refusal does not prove the
+                                # re-send would be answered as text.
+                                and not await asyncio.to_thread(
+                                    _local_audio_model_loaded, inference
+                                )
                             ):
                                 # MLX/transformers cannot enforce a grammar. Research already
                                 # prompts for JSON and validates it; retry once without guided

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -580,6 +580,23 @@ def _synthesis_length_limit_error(
     return "Local model report reached its output limit before completion"
 
 
+async def _response_format_unsupported(response: httpx.Response) -> bool:
+    """Only the API's explicit guided-decoding refusal permits a prompt-only retry."""
+    if response.status_code != 400:
+        return False
+    try:
+        await response.aread()
+        body = response.json()
+    except Exception:
+        return False
+    error = body.get("error") if isinstance(body, dict) else None
+    return (
+        isinstance(error, dict)
+        and error.get("code") == "unsupported_parameter"
+        and error.get("param") == "response_format"
+    )
+
+
 async def _model_unloaded(response: httpx.Response) -> str | None:
     """Which "not servable right now" refusal this is, or None for any other failure.
 
@@ -1687,6 +1704,20 @@ class ResearchSupervisor:
                             first_output_deadline = loop.time() + first_output_budget
                         except (httpx.TransportError, httpx.HTTPStatusError) as exc:
                             # Only reachable before a body byte is touched, so a re-send cannot duplicate report text.
+                            if (
+                                not _external_provider_run(inference)
+                                and payload.get("response_format") == {"type": "json_object"}
+                                and isinstance(exc, httpx.HTTPStatusError)
+                                and await _response_format_unsupported(exc.response)
+                            ):
+                                # MLX/transformers cannot enforce a grammar. Research already
+                                # prompts for JSON and validates it; retry once without guided
+                                # decoding. Negotiate after routing, including any model switch.
+                                del payload["response_format"]
+                                await exc.response.aclose()
+                                response = None
+                                await self._check_active(run["id"])
+                                continue
                             unloaded = (
                                 await _model_unloaded(exc.response)
                                 if isinstance(exc, httpx.HTTPStatusError)

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -21321,9 +21321,7 @@ def _ui_stream_events_enabled(request: Optional[Request]) -> bool:
     return (value or "").strip() == "1"
 
 
-# Research asks for JSON it then parses, so a spoken reply is not a degraded answer, it is no
-# answer. The model that serves a request is whichever one is loaded when it arrives, so the
-# caller cannot rule speech out by naming a model: it says so per request instead.
+# The loaded model serves the request, so a caller that cannot use speech says so per request.
 REQUIRE_TEXT_HEADER = "X-Unsloth-Require-Text"
 
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -21701,6 +21701,11 @@ async def produce_openai_chat_completions(
     monitor_id = None
 
     async def _monitored_generate_audio(model_label: str, context_length: Optional[int] = None):
+        if request.headers.get("X-Unsloth-Require-Text") == "1":
+            raise HTTPException(
+                status_code = 400,
+                detail = "This request requires text output; select a text model.",
+            )
         tts_monitor_id = None
         if not getattr(request.state, "skip_api_monitor", False):
             tts_monitor_id = api_monitor.start(
@@ -21785,7 +21790,14 @@ async def produce_openai_chat_completions(
         # load may: one SSE stream carries a single choice either way.
         if payload.stream and _wants_multiple_choices(payload):
             _raise_unsupported_n("streaming chat completions")
+        model_info = backend.models.get(backend.active_model_name, {})
         if _response_format_constrains_decoding(payload):
+            if model_info.get("is_audio") and model_info.get("audio_type") != "whisper":
+                _raise_unsupported_openai_parameter(
+                    "response_format",
+                    "response_format cannot be honored by an audio reply; send the request to a text model "
+                    "to use guided decoding.",
+                )
             _raise_unsupported_openai_parameter(
                 "response_format",
                 "response_format needs the llama.cpp grammar engine; load a GGUF model to use it.",
@@ -21793,7 +21805,6 @@ async def produce_openai_chat_completions(
 
         # ── Audio TTS path: auto-route to audio generation ────
         # (Whisper is ASR not TTS -- handled below in audio input path)
-        model_info = backend.models.get(backend.active_model_name, {})
         if model_info.get("is_audio") and model_info.get("audio_type") != "whisper":
             if _wants_multiple_choices(payload):
                 _raise_unsupported_n("non-GGUF audio chat completions")

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -21321,6 +21321,26 @@ def _ui_stream_events_enabled(request: Optional[Request]) -> bool:
     return (value or "").strip() == "1"
 
 
+# Research asks for JSON it then parses, so a spoken reply is not a degraded answer, it is no
+# answer. The model that serves a request is whichever one is loaded when it arrives, so the
+# caller cannot rule speech out by naming a model: it says so per request instead.
+REQUIRE_TEXT_HEADER = "X-Unsloth-Require-Text"
+
+
+def _text_output_required(request: Optional[Request]) -> bool:
+    """Whether this request refuses a spoken reply, whatever model ends up serving it."""
+    if request is None:
+        return False
+    headers = getattr(request, "headers", None)
+    if headers is None:
+        return False
+    try:
+        value = headers.get(REQUIRE_TEXT_HEADER)
+    except Exception:
+        return False
+    return (value or "").strip() == "1"
+
+
 class _DroppedFrameKeepalive:
     """Paces an SSE keepalive comment in place of dropped UI control frames.
 
@@ -21701,7 +21721,7 @@ async def produce_openai_chat_completions(
     monitor_id = None
 
     async def _monitored_generate_audio(model_label: str, context_length: Optional[int] = None):
-        if request.headers.get("X-Unsloth-Require-Text") == "1":
+        if _text_output_required(request):
             raise HTTPException(
                 status_code = 400,
                 detail = "This request requires text output; select a text model.",

--- a/studio/backend/tests/test_research_json_fallback.py
+++ b/studio/backend/tests/test_research_json_fallback.py
@@ -19,7 +19,36 @@ from utils.api_errors import install_api_error_handlers
 from .test_sf_client_tools_passthrough import _ScriptedBackend, _fixed, _install
 
 
-_REFUSAL = {"error": {"code": "unsupported_parameter", "param": "response_format"}}
+# The whole refusal routes.inference sends for a backend with no grammar engine, message
+# included: the code and param alone do not identify it, so a fixture without the message
+# would assert a retry the worker no longer performs.
+_NO_GRAMMAR_ENGINE = (
+    "response_format needs the llama.cpp grammar engine; load a GGUF model to use it."
+)
+# The two refusals that share the code and param but not the cause. Both are quoted from
+# routes.inference; the real-route cases above keep these strings honest.
+_AUDIO_REFUSAL_MESSAGE = (
+    "response_format cannot be honored by an audio reply; send the request to a text model "
+    "to use guided decoding."
+)
+_TOOL_LOOP_REFUSAL_MESSAGE = (
+    "response_format is not supported with Unsloth tool execution; send the request without "
+    "enable_tools to use guided decoding."
+)
+
+
+def _refusal(message = _NO_GRAMMAR_ENGINE):
+    return {
+        "error": {
+            "message": message,
+            "type": "invalid_request_error",
+            "code": "unsupported_parameter",
+            "param": "response_format",
+        }
+    }
+
+
+_REFUSAL = _refusal()
 
 
 @pytest.fixture
@@ -154,6 +183,18 @@ def test_supported_json_mode_keeps_the_format(research_call, provider):
         (422, _REFUSAL, False, True),
         (400, _REFUSAL, True, True),
         (400, _REFUSAL, False, False),
+        # Same code and param, a cause a prompt-only re-send does not address. Dropping the
+        # contract here would re-send into an audio reply or Unsloth's tool loop instead of
+        # surfacing the refusal that names the real problem.
+        (400, _refusal(_AUDIO_REFUSAL_MESSAGE), False, True),
+        (400, _refusal(_TOOL_LOOP_REFUSAL_MESSAGE), False, True),
+        (400, _refusal(""), False, True),
+        (400, _refusal(None), False, True),
+    ],
+    ids = [
+        "other-param", "other-code", "string-error", "list-body", "not-json",
+        "wrong-status", "external-provider", "no-json-mode",
+        "audio-reply", "unsloth-tool-loop", "empty-message", "null-message",
     ],
 )
 def test_unrelated_errors_and_provider_contracts_are_not_retried(
@@ -177,6 +218,74 @@ def test_unrelated_errors_and_provider_contracts_are_not_retried(
     assert caught.value.response.status_code == status
     assert len(sent) == 1
     assert research_call.revoked == [1]
+
+
+def test_an_audio_model_is_refused_rather_than_re_sent(monkeypatch, research_call):
+    """The non-GGUF branch refuses the format before it routes audio, so this refusal
+    alone does not prove a prompt-only re-send would be answered with text. Re-sending
+    reaches text-to-speech instead, which synthesizes the planner prompt and then stalls
+    the run on a reply that carries no SSE."""
+    backend = _ScriptedBackend(_fixed('{"ok": true}'))
+    backend.models[backend.active_model_name].update(is_audio = True, audio_type = "tts")
+    _install(monkeypatch, backend)
+    # _install replaces the getter routes.inference holds; the probe reads the orchestrator
+    # getter that one is imported from, so point the double at both.
+    monkeypatch.setattr(research_runs, "_peek_inference_backend", lambda: backend)
+    app = FastAPI()
+    app.include_router(inference_route.router, prefix = "/v1")
+    install_api_error_handlers(app)
+    app.dependency_overrides[get_current_subject] = lambda: "test-user"
+    statuses = []
+
+    class RecordingTransport(httpx.ASGITransport):
+        async def handle_async_request(self, request):
+            response = await super().handle_async_request(request)
+            statuses.append(response.status_code)
+            return response
+
+    research_call.install(RecordingTransport(app = app))
+    with pytest.raises(httpx.HTTPStatusError) as caught:
+        research_call.complete(phase = "planning", max_tokens = 32)
+    assert caught.value.response.status_code == 400
+    assert statuses == [400], "the guided-decoding refusal is the answer, not a retry"
+    assert not backend.calls
+    assert research_call.revoked == [1]
+
+
+def test_the_audio_probe_reads_both_local_backends(monkeypatch):
+    """Whichever backend is serving, the flag routes.inference branches on is the one read."""
+    from types import SimpleNamespace as _NS
+
+    monkeypatch.setattr(
+        inference_route, "get_llama_cpp_backend", lambda: _NS(is_loaded = True, _is_audio = True)
+    )
+    assert research_runs._local_audio_model_loaded() is True
+    monkeypatch.setattr(
+        inference_route, "get_llama_cpp_backend", lambda: _NS(is_loaded = True, _is_audio = False)
+    )
+    assert research_runs._local_audio_model_loaded() is False
+
+    monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: _NS(is_loaded = False))
+    monkeypatch.setattr(
+        research_runs,
+        "_peek_inference_backend",
+        lambda: _NS(active_model_name = "m", models = {"m": {"is_audio": True}}),
+    )
+    assert research_runs._local_audio_model_loaded() is True
+    monkeypatch.setattr(
+        research_runs,
+        "_peek_inference_backend",
+        lambda: _NS(active_model_name = "m", models = {"m": {}}),
+    )
+    assert research_runs._local_audio_model_loaded() is False
+    # A run on an external connection is not served by either local backend.
+    assert research_runs._local_audio_model_loaded({"providerType": "openai"}) is False
+    # An unprobeable backend keeps the fallback, rather than disabling it on a failed read.
+    def boom():
+        raise RuntimeError("no orchestrator")
+
+    monkeypatch.setattr(research_runs, "_peek_inference_backend", boom)
+    assert research_runs._local_audio_model_loaded() is False
 
 
 def test_format_fallback_is_attempted_only_once(research_call):
@@ -261,12 +370,16 @@ def test_planning_after_fallback_still_validates_before_saving(monkeypatch, rese
 
 
 def test_json_fallback_does_not_restart_the_total_timeout(research_call):
-    research_call.run["config"]["budgets"]["modelTimeoutSeconds"] = 0.4
+    # Real time, so the numbers carry the margin rather than the minimum. The refusal lands at
+    # 1.0s, the retry is dispatched there and would answer at 2.0s, and the 1.6s wall clock cuts
+    # it off in between: 600ms of slack for scheduling, against the 150ms a 0.4s/0.25s pairing
+    # leaves. Under `-n 4` on a loaded runner that difference is the whole flake.
+    research_call.run["config"]["budgets"]["modelTimeoutSeconds"] = 1.6
     sent = []
 
     async def serve(request):
         sent.append(json.loads(request.content))
-        await asyncio.sleep(0.25)
+        await asyncio.sleep(1.0)
         return httpx.Response(400, json = _REFUSAL) if len(sent) == 1 else _completion()
 
     research_call.install(httpx.MockTransport(serve))

--- a/studio/backend/tests/test_research_json_fallback.py
+++ b/studio/backend/tests/test_research_json_fallback.py
@@ -192,9 +192,18 @@ def test_supported_json_mode_keeps_the_format(research_call, provider):
         (400, _refusal(None), False, True),
     ],
     ids = [
-        "other-param", "other-code", "string-error", "list-body", "not-json",
-        "wrong-status", "external-provider", "no-json-mode",
-        "audio-reply", "unsloth-tool-loop", "empty-message", "null-message",
+        "other-param",
+        "other-code",
+        "string-error",
+        "list-body",
+        "not-json",
+        "wrong-status",
+        "external-provider",
+        "no-json-mode",
+        "audio-reply",
+        "unsloth-tool-loop",
+        "empty-message",
+        "null-message",
     ],
 )
 def test_unrelated_errors_and_provider_contracts_are_not_retried(
@@ -280,6 +289,7 @@ def test_the_audio_probe_reads_both_local_backends(monkeypatch):
     assert research_runs._local_audio_model_loaded() is False
     # A run on an external connection is not served by either local backend.
     assert research_runs._local_audio_model_loaded({"providerType": "openai"}) is False
+
     # An unprobeable backend keeps the fallback, rather than disabling it on a failed read.
     def boom():
         raise RuntimeError("no orchestrator")

--- a/studio/backend/tests/test_research_json_fallback.py
+++ b/studio/backend/tests/test_research_json_fallback.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 import httpx
 import pytest
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 
 from auth.authentication import get_current_subject
 from core import research_runs
@@ -230,16 +231,10 @@ def test_unrelated_errors_and_provider_contracts_are_not_retried(
 
 
 def test_an_audio_model_is_refused_rather_than_re_sent(monkeypatch, research_call):
-    """The non-GGUF branch refuses the format before it routes audio, so this refusal
-    alone does not prove a prompt-only re-send would be answered with text. Re-sending
-    reaches text-to-speech instead, which synthesizes the planner prompt and then stalls
-    the run on a reply that carries no SSE."""
+    """Audio refusal must remain distinct from unavailable grammar support."""
     backend = _ScriptedBackend(_fixed('{"ok": true}'))
     backend.models[backend.active_model_name].update(is_audio = True, audio_type = "tts")
     _install(monkeypatch, backend)
-    # _install replaces the getter routes.inference holds; the probe reads the orchestrator
-    # getter that one is imported from, so point the double at both.
-    monkeypatch.setattr(research_runs, "_peek_inference_backend", lambda: backend)
     app = FastAPI()
     app.include_router(inference_route.router, prefix = "/v1")
     install_api_error_handlers(app)
@@ -261,41 +256,109 @@ def test_an_audio_model_is_refused_rather_than_re_sent(monkeypatch, research_cal
     assert research_call.revoked == [1]
 
 
-def test_the_audio_probe_reads_both_local_backends(monkeypatch):
-    """Whichever backend is serving, the flag routes.inference branches on is the one read."""
-    from types import SimpleNamespace as _NS
+@pytest.mark.parametrize("requested_audio", [False, True])
+def test_fallback_uses_the_refused_request_not_an_intervening_model(
+    monkeypatch, research_call, requested_audio
+):
+    backend = _ScriptedBackend(_fixed('{"ok": true}'))
+    backend.models["sf-model"].update(is_audio = requested_audio, audio_type = "tts")
+    backend.models["intervening"] = {"is_audio": not requested_audio, "audio_type": "tts"}
+    _install(monkeypatch, backend)
+    monkeypatch.setattr(research_runs, "_peek_inference_backend", lambda: backend)
+    app = FastAPI()
+    app.include_router(inference_route.router, prefix = "/v1")
+    install_api_error_handlers(app)
+    app.dependency_overrides[get_current_subject] = lambda: "test-user"
+    statuses = []
+    audio_calls = []
 
-    monkeypatch.setattr(
-        inference_route, "get_llama_cpp_backend", lambda: _NS(is_loaded = True, _is_audio = True)
-    )
-    assert research_runs._local_audio_model_loaded() is True
-    monkeypatch.setattr(
-        inference_route, "get_llama_cpp_backend", lambda: _NS(is_loaded = True, _is_audio = False)
-    )
-    assert research_runs._local_audio_model_loaded() is False
+    async def audio(*args, **kwargs):
+        audio_calls.append(True)
+        return JSONResponse({"unexpected_audio": True})
 
-    monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: _NS(is_loaded = False))
-    monkeypatch.setattr(
-        research_runs,
-        "_peek_inference_backend",
-        lambda: _NS(active_model_name = "m", models = {"m": {"is_audio": True}}),
-    )
-    assert research_runs._local_audio_model_loaded() is True
-    monkeypatch.setattr(
-        research_runs,
-        "_peek_inference_backend",
-        lambda: _NS(active_model_name = "m", models = {"m": {}}),
-    )
-    assert research_runs._local_audio_model_loaded() is False
-    # A run on an external connection is not served by either local backend.
-    assert research_runs._local_audio_model_loaded({"providerType": "openai"}) is False
+    monkeypatch.setattr(inference_route, "generate_audio", audio)
 
-    # An unprobeable backend keeps the fallback, rather than disabling it on a failed read.
-    def boom():
-        raise RuntimeError("no orchestrator")
+    class SwitchingTransport(httpx.ASGITransport):
+        async def handle_async_request(self, request):
+            # Model loading is scripted; requests and the refusal use the real route.
+            backend.active_model_name = "sf-model"
+            response = await super().handle_async_request(request)
+            statuses.append(response.status_code)
+            if len(statuses) == 1:
+                backend.active_model_name = "intervening"
+            return response
 
-    monkeypatch.setattr(research_runs, "_peek_inference_backend", boom)
-    assert research_runs._local_audio_model_loaded() is False
+    research_call.install(SwitchingTransport(app = app))
+    if requested_audio:
+        with pytest.raises(httpx.HTTPStatusError):
+            research_call.complete()
+        assert statuses == [400]
+    else:
+        assert json.loads(research_call.complete()[0]) == {"ok": True}
+        assert statuses == [400, 200]
+    assert audio_calls == []
+    assert research_call.revoked == [1]
+
+
+@pytest.mark.parametrize("gguf", [False, True], ids = ["non-gguf", "gguf"])
+def test_text_requirement_survives_a_manual_switch_before_resend(monkeypatch, research_call, gguf):
+    backend = _ScriptedBackend(_fixed('{"ok": true}'))
+    backend.models["audio-model"] = {"is_audio": True, "audio_type": "tts"}
+    _install(monkeypatch, backend)
+    monkeypatch.setattr(research_runs, "_peek_inference_backend", lambda: backend)
+    app = FastAPI()
+    app.include_router(inference_route.router, prefix = "/v1")
+    install_api_error_handlers(app)
+    app.dependency_overrides[get_current_subject] = lambda: "test-user"
+    audio_calls = []
+    statuses = []
+
+    async def switch_after_check(*args):
+        backend.active_model_name = "audio-model"
+        if gguf:
+            monkeypatch.setattr(
+                inference_route,
+                "get_llama_cpp_backend",
+                lambda: SimpleNamespace(is_loaded = True, _is_audio = True, context_length = 8192),
+            )
+
+    async def audio(*args, **kwargs):
+        audio_calls.append(True)
+        return JSONResponse({"unexpected_audio": True})
+
+    monkeypatch.setattr(research_call.supervisor, "_check_active", switch_after_check)
+    monkeypatch.setattr(inference_route, "generate_audio", audio)
+
+    class RecordingTransport(httpx.ASGITransport):
+        async def handle_async_request(self, request):
+            response = await super().handle_async_request(request)
+            statuses.append(response.status_code)
+            return response
+
+    research_call.install(RecordingTransport(app = app))
+    with pytest.raises(httpx.HTTPStatusError) as caught:
+        research_call.complete()
+    assert "text output" in caught.value.response.text
+    assert statuses == [400, 400]
+    assert audio_calls == []
+    assert research_call.revoked == [1]
+
+
+def test_ordinary_audio_request_retains_audio_dispatch(monkeypatch):
+    from .test_sf_client_tools_passthrough import _call, _request
+
+    backend = _ScriptedBackend(_fixed("unused"))
+    backend.models["sf-model"].update(is_audio = True, audio_type = "tts")
+    audio_calls = []
+
+    async def audio(*args, **kwargs):
+        audio_calls.append(True)
+        return JSONResponse({"audio": "scripted"})
+
+    monkeypatch.setattr(inference_route, "generate_audio", audio)
+    response = _call(_request(), monkeypatch, backend)
+    assert response.status_code == 200
+    assert audio_calls == [True]
 
 
 def test_format_fallback_is_attempted_only_once(research_call):

--- a/studio/backend/tests/test_research_json_fallback.py
+++ b/studio/backend/tests/test_research_json_fallback.py
@@ -14,6 +14,8 @@ from fastapi.responses import JSONResponse
 
 from auth.authentication import get_current_subject
 from core import research_runs
+from core.inference.api_monitor import ApiMonitor
+from models.inference import ChatCompletionRequest, ChatMessage
 from routes import inference as inference_route
 from state import tool_policy
 from utils.api_errors import install_api_error_handlers
@@ -359,6 +361,57 @@ def test_ordinary_audio_request_retains_audio_dispatch(monkeypatch):
     response = _call(_request(), monkeypatch, backend)
     assert response.status_code == 200
     assert audio_calls == [True]
+
+
+@pytest.mark.parametrize("gguf", [True, False], ids = ["gguf", "non-gguf"])
+def test_a_request_without_headers_still_reaches_audio(monkeypatch, gguf):
+    """Not every caller of this route carries headers: the durable-run producer builds its
+    own request, and the audio monitor cases stand one in without them. Reading the opt-out
+    unguarded turned an audio reply into an AttributeError for all of them, so it goes
+    through the same guarded reader the UI-events header uses."""
+    backend = _ScriptedBackend(_fixed("unused"))
+    backend.models["sf-model"].update(is_audio = True, audio_type = "tts")
+    audio_calls = []
+
+    async def audio(*args, **kwargs):
+        audio_calls.append(True)
+        return JSONResponse({"audio": "scripted"})
+
+    monkeypatch.setattr(inference_route, "generate_audio", audio)
+    monkeypatch.setattr(inference_route, "api_monitor", ApiMonitor(max_entries = 4))
+    monkeypatch.setattr(
+        inference_route,
+        "get_llama_cpp_backend",
+        lambda: SimpleNamespace(
+            is_loaded = gguf,
+            _is_audio = gguf,
+            supports_tools = False,
+            is_vision = False,
+            model_identifier = "gguf-tts",
+            context_length = 2048,
+        ),
+    )
+    monkeypatch.setattr(inference_route, "get_inference_backend", lambda: backend)
+    monkeypatch.setattr(
+        inference_route, "_detect_safetensors_features", lambda *a, **k: {"supports_tools": False}
+    )
+    headerless = SimpleNamespace(
+        state = SimpleNamespace(),
+        url = SimpleNamespace(path = "/v1/chat/completions"),
+        method = "POST",
+    )
+    asyncio.run(
+        inference_route.openai_chat_completions(
+            ChatCompletionRequest(
+                model = "default",
+                messages = [ChatMessage(role = "user", content = "say hello")],
+            ),
+            request = headerless,
+            current_subject = "test",
+        )
+    )
+    assert audio_calls == [True]
+    assert inference_route._text_output_required(headerless) is False
 
 
 def test_format_fallback_is_attempted_only_once(research_call):

--- a/studio/backend/tests/test_research_json_fallback.py
+++ b/studio/backend/tests/test_research_json_fallback.py
@@ -22,14 +22,10 @@ from utils.api_errors import install_api_error_handlers
 from .test_sf_client_tools_passthrough import _ScriptedBackend, _fixed, _install
 
 
-# The whole refusal routes.inference sends for a backend with no grammar engine, message
-# included: the code and param alone do not identify it, so a fixture without the message
-# would assert a retry the worker no longer performs.
 _NO_GRAMMAR_ENGINE = (
     "response_format needs the llama.cpp grammar engine; load a GGUF model to use it."
 )
-# The two refusals that share the code and param but not the cause. Both are quoted from
-# routes.inference; the real-route cases above keep these strings honest.
+# Same code and param, different cause. The real-route cases keep these strings honest.
 _AUDIO_REFUSAL_MESSAGE = (
     "response_format cannot be honored by an audio reply; send the request to a text model "
     "to use guided decoding."
@@ -186,9 +182,6 @@ def test_supported_json_mode_keeps_the_format(research_call, provider):
         (422, _REFUSAL, False, True),
         (400, _REFUSAL, True, True),
         (400, _REFUSAL, False, False),
-        # Same code and param, a cause a prompt-only re-send does not address. Dropping the
-        # contract here would re-send into an audio reply or Unsloth's tool loop instead of
-        # surfacing the refusal that names the real problem.
         (400, _refusal(_AUDIO_REFUSAL_MESSAGE), False, True),
         (400, _refusal(_TOOL_LOOP_REFUSAL_MESSAGE), False, True),
         (400, _refusal(""), False, True),
@@ -365,10 +358,8 @@ def test_ordinary_audio_request_retains_audio_dispatch(monkeypatch):
 
 @pytest.mark.parametrize("gguf", [True, False], ids = ["gguf", "non-gguf"])
 def test_a_request_without_headers_still_reaches_audio(monkeypatch, gguf):
-    """Not every caller of this route carries headers: the durable-run producer builds its
-    own request, and the audio monitor cases stand one in without them. Reading the opt-out
-    unguarded turned an audio reply into an AttributeError for all of them, so it goes
-    through the same guarded reader the UI-events header uses."""
+    """The durable-run producer builds its own request without headers, so reading the
+    opt-out off request.headers turned every audio reply there into an AttributeError."""
     backend = _ScriptedBackend(_fixed("unused"))
     backend.models["sf-model"].update(is_audio = True, audio_type = "tts")
     audio_calls = []
@@ -496,10 +487,7 @@ def test_planning_after_fallback_still_validates_before_saving(monkeypatch, rese
 
 
 def test_json_fallback_does_not_restart_the_total_timeout(research_call):
-    # Real time, so the numbers carry the margin rather than the minimum. The refusal lands at
-    # 1.0s, the retry is dispatched there and would answer at 2.0s, and the 1.6s wall clock cuts
-    # it off in between: 600ms of slack for scheduling, against the 150ms a 0.4s/0.25s pairing
-    # leaves. Under `-n 4` on a loaded runner that difference is the whole flake.
+    # 600ms of scheduling slack: a 0.4s/0.25s pairing leaves 150ms, which flakes under -n 4.
     research_call.run["config"]["budgets"]["modelTimeoutSeconds"] = 1.6
     sent = []
 

--- a/studio/backend/tests/test_research_json_fallback.py
+++ b/studio/backend/tests/test_research_json_fallback.py
@@ -14,6 +14,7 @@ from fastapi import FastAPI
 from auth.authentication import get_current_subject
 from core import research_runs
 from routes import inference as inference_route
+from state import tool_policy
 from utils.api_errors import install_api_error_handlers
 from .test_sf_client_tools_passthrough import _ScriptedBackend, _fixed, _install
 
@@ -72,14 +73,17 @@ def research_call(monkeypatch):
     )
 
 
+@pytest.mark.parametrize("forced_tools", [False, True], ids = ["default-tools", "forced-tools"])
 @pytest.mark.parametrize("is_mlx", [True, False], ids = ["mlx", "transformers"])
 @pytest.mark.parametrize("phase", ["planning", "decision", "synthesis_audit"])
 def test_local_json_research_recovers_through_the_real_route(
-    monkeypatch, research_call, is_mlx, phase
+    monkeypatch, research_call, is_mlx, phase, forced_tools
 ):
     backend = _ScriptedBackend(_fixed('{"ok": true}'))
     backend.models[backend.active_model_name]["is_mlx"] = is_mlx
-    _install(monkeypatch, backend, supports_tools = False)
+    _install(monkeypatch, backend, supports_tools = forced_tools)
+    if forced_tools:
+        monkeypatch.setattr(tool_policy, "_tool_policy", True)
     app = FastAPI()
     app.include_router(inference_route.router, prefix = "/v1")
     install_api_error_handlers(app)
@@ -100,6 +104,7 @@ def test_local_json_research_recovers_through_the_real_route(
     assert finish == "stop"
     assert statuses == [400, 200]
     assert len(backend.calls) == 1
+    assert not backend.calls[0]["tools"]
     first, second = sent
     assert first.pop("response_format") == {"type": "json_object"}
     assert first == second

--- a/studio/backend/tests/test_research_json_fallback.py
+++ b/studio/backend/tests/test_research_json_fallback.py
@@ -253,3 +253,64 @@ def test_planning_after_fallback_still_validates_before_saving(monkeypatch, rese
     assert len(sent) == 2
     assert "Return only strict JSON" in sent[1]["messages"][0]["content"]
     assert "response_format" not in sent[1]
+
+
+def test_json_fallback_does_not_restart_the_total_timeout(research_call):
+    research_call.run["config"]["budgets"]["modelTimeoutSeconds"] = 0.4
+    sent = []
+
+    async def serve(request):
+        sent.append(json.loads(request.content))
+        await asyncio.sleep(0.25)
+        return httpx.Response(400, json = _REFUSAL) if len(sent) == 1 else _completion()
+
+    research_call.install(httpx.MockTransport(serve))
+    with pytest.raises(research_runs.ModelWallClockTimeout):
+        research_call.complete()
+    assert len(sent) == 2
+    assert "response_format" not in sent[1]
+    assert research_call.revoked == [1]
+
+
+def test_json_fallback_does_not_refund_transport_retries(monkeypatch, research_call):
+    statuses = iter([500, 400, 500, 500])
+    sent = []
+    delays = []
+    real_sleep = asyncio.sleep
+
+    async def sleep(delay):
+        delays.append(delay)
+        await real_sleep(0)
+
+    monkeypatch.setattr(research_runs.asyncio, "sleep", sleep)
+
+    def serve(request):
+        sent.append(json.loads(request.content))
+        status = next(statuses)
+        return httpx.Response(status, json = _REFUSAL if status == 400 else {"error": "server"})
+
+    research_call.install(httpx.MockTransport(serve))
+    with pytest.raises(httpx.HTTPStatusError) as caught:
+        research_call.complete()
+    assert caught.value.response.status_code == 500
+    assert len(sent) == 4
+    assert ["response_format" in body for body in sent] == [True, True, False, False]
+    assert delays == [1, 2]
+
+
+def test_json_fallback_never_replays_a_started_generation(research_call):
+    sent = []
+
+    def serve(request):
+        sent.append(request)
+        chunk = {"choices": [{"delta": {"content": "partial"}}]}
+        error = {"error": {**_REFUSAL["error"], "message": "late format error"}}
+        return httpx.Response(
+            200, text = f"data: {json.dumps(chunk)}\n\ndata: {json.dumps(error)}\n\ndata: [DONE]\n\n"
+        )
+
+    research_call.install(httpx.MockTransport(serve))
+    with pytest.raises(RuntimeError, match = "late format error"):
+        research_call.complete()
+    assert len(sent) == 1
+    assert research_call.revoked == [1]

--- a/studio/backend/tests/test_research_json_fallback.py
+++ b/studio/backend/tests/test_research_json_fallback.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Research may request JSON through prompts when local guided decoding is unavailable."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from auth.authentication import get_current_subject
+from core import research_runs
+from routes import inference as inference_route
+from utils.api_errors import install_api_error_handlers
+from .test_sf_client_tools_passthrough import _ScriptedBackend, _fixed, _install
+
+
+_REFUSAL = {"error": {"code": "unsupported_parameter", "param": "response_format"}}
+
+
+@pytest.fixture
+def research_call(monkeypatch):
+    supervisor = research_runs.ResearchSupervisor(
+        SimpleNamespace(state = SimpleNamespace(server_port = 1))
+    )
+
+    async def noop(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(supervisor, "_check_active", noop)
+    monkeypatch.setattr(supervisor, "_note_phase", noop)
+    monkeypatch.setattr(research_runs, "_loaded_context_length", lambda *args: 8192)
+    monkeypatch.setattr(
+        research_runs.auth_storage, "create_api_key", lambda **kwargs: ("test", {"id": 1})
+    )
+    revoked = []
+    monkeypatch.setattr(research_runs.auth_storage, "revoke_internal_api_key", revoked.append)
+    run = {
+        "id": "json-fallback",
+        "ownerSubject": "test-user",
+        "config": {"model": "sf-model", "budgets": {"modelTimeoutSeconds": 10}},
+    }
+    real_client = httpx.AsyncClient
+
+    def install_transport(transport):
+        monkeypatch.setattr(
+            research_runs.httpx,
+            "AsyncClient",
+            lambda **kwargs: real_client(transport = transport, **kwargs),
+        )
+
+    def complete(**kwargs):
+        return asyncio.run(
+            supervisor._stream_completion(
+                run,
+                [{"role": "user", "content": "Return only JSON."}],
+                json_mode = kwargs.pop("json_mode", True),
+                report_progress = False,
+                **kwargs,
+            )
+        )
+
+    return SimpleNamespace(
+        supervisor = supervisor,
+        run = run,
+        install = install_transport,
+        complete = complete,
+        revoked = revoked,
+    )
+
+
+@pytest.mark.parametrize("is_mlx", [True, False], ids = ["mlx", "transformers"])
+@pytest.mark.parametrize("phase", ["planning", "decision", "synthesis_audit"])
+def test_local_json_research_recovers_through_the_real_route(
+    monkeypatch, research_call, is_mlx, phase
+):
+    backend = _ScriptedBackend(_fixed('{"ok": true}'))
+    backend.models[backend.active_model_name]["is_mlx"] = is_mlx
+    _install(monkeypatch, backend, supports_tools = False)
+    app = FastAPI()
+    app.include_router(inference_route.router, prefix = "/v1")
+    install_api_error_handlers(app)
+    app.dependency_overrides[get_current_subject] = lambda: "test-user"
+    sent = []
+    statuses = []
+
+    class RecordingTransport(httpx.ASGITransport):
+        async def handle_async_request(self, request):
+            sent.append(json.loads(request.content))
+            response = await super().handle_async_request(request)
+            statuses.append(response.status_code)
+            return response
+
+    research_call.install(RecordingTransport(app = app))
+    report, _, finish, _ = research_call.complete(phase = phase, max_tokens = 32)
+    assert json.loads(report) == {"ok": True}
+    assert finish == "stop"
+    assert statuses == [400, 200]
+    assert len(backend.calls) == 1
+    first, second = sent
+    assert first.pop("response_format") == {"type": "json_object"}
+    assert first == second
+    assert second["tool_choice"] == "none"
+    assert second["enabled_tools"] == []
+    assert research_call.revoked == [1]
+
+
+def _completion():
+    chunk = {"choices": [{"delta": {"content": '{"ok": true}'}, "finish_reason": "stop"}]}
+    return httpx.Response(200, text = f"data: {json.dumps(chunk)}\n\ndata: [DONE]\n\n")
+
+
+@pytest.mark.parametrize("provider", [False, True], ids = ["local", "provider"])
+def test_supported_json_mode_keeps_the_format(research_call, provider):
+    if provider:
+        research_call.run["config"]["inferenceRequest"] = {
+            "providerType": "openai",
+            "providerId": "connection",
+            "externalModel": "model",
+        }
+    sent = []
+
+    def serve(request):
+        sent.append(json.loads(request.content))
+        return _completion()
+
+    research_call.install(httpx.MockTransport(serve))
+    assert json.loads(research_call.complete()[0]) == {"ok": True}
+    assert len(sent) == 1
+    assert sent[0]["response_format"] == {"type": "json_object"}
+
+
+@pytest.mark.parametrize(
+    "status,body,provider,json_mode",
+    [
+        (400, {"error": {"code": "unsupported_parameter", "param": "temperature"}}, False, True),
+        (
+            400,
+            {"error": {"code": "context_length_exceeded", "param": "response_format"}},
+            False,
+            True,
+        ),
+        (400, {"error": "response_format unsupported"}, False, True),
+        (400, [], False, True),
+        (400, "not JSON", False, True),
+        (422, _REFUSAL, False, True),
+        (400, _REFUSAL, True, True),
+        (400, _REFUSAL, False, False),
+    ],
+)
+def test_unrelated_errors_and_provider_contracts_are_not_retried(
+    research_call, status, body, provider, json_mode
+):
+    if provider:
+        research_call.run["config"]["inferenceRequest"] = {
+            "providerType": "openai",
+            "providerId": "connection",
+            "externalModel": "model",
+        }
+    sent = []
+
+    def serve(request):
+        sent.append(request)
+        return httpx.Response(status, content = body if isinstance(body, str) else json.dumps(body))
+
+    research_call.install(httpx.MockTransport(serve))
+    with pytest.raises(httpx.HTTPStatusError) as caught:
+        research_call.complete(json_mode = json_mode)
+    assert caught.value.response.status_code == status
+    assert len(sent) == 1
+    assert research_call.revoked == [1]
+
+
+def test_format_fallback_is_attempted_only_once(research_call):
+    sent = []
+
+    def serve(request):
+        sent.append(json.loads(request.content))
+        return httpx.Response(400, json = _REFUSAL)
+
+    research_call.install(httpx.MockTransport(serve))
+    with pytest.raises(httpx.HTTPStatusError):
+        research_call.complete()
+    assert len(sent) == 2
+    assert "response_format" in sent[0]
+    assert "response_format" not in sent[1]
+
+
+def test_cancellation_before_fallback_releases_response_and_key(monkeypatch, research_call):
+    responses = []
+
+    def serve(request):
+        response = httpx.Response(400, json = _REFUSAL)
+        responses.append(response)
+        return response
+
+    async def cancelled(*args):
+        raise research_runs.RunCancelled()
+
+    monkeypatch.setattr(research_call.supervisor, "_check_active", cancelled)
+    research_call.install(httpx.MockTransport(serve))
+    with pytest.raises(research_runs.RunCancelled):
+        research_call.complete()
+    assert len(responses) == 1
+    assert responses[0].is_closed
+    assert research_call.revoked == [1]
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        '{"title": "Plan", "steps": [{"title": "Check docs", "query": "MLX JSON support"}]}',
+        "not JSON",
+        '{"title": "Plan", "steps": []}',
+    ],
+)
+def test_planning_after_fallback_still_validates_before_saving(monkeypatch, research_call, output):
+    run = research_call.run
+    run.update(threadId = "thread", userMessageId = "message")
+    run["config"]["budgets"]["maxSteps"] = 3
+    monkeypatch.setattr(
+        research_runs, "_research_question_context", lambda *args: ("Research MLX JSON", "[]")
+    )
+    saved = []
+
+    def save_plan(run_id, plan, *args):
+        saved.append(plan)
+        return {"plan": plan}
+
+    monkeypatch.setattr(research_runs.db, "set_plan", save_plan)
+    monkeypatch.setattr(research_runs.db, "append_worker_event", lambda *args: 1)
+    sent = []
+
+    def serve(request):
+        payload = json.loads(request.content)
+        sent.append(payload)
+        if len(sent) == 1:
+            return httpx.Response(400, json = _REFUSAL)
+        chunk = {"choices": [{"delta": {"content": output}, "finish_reason": "stop"}]}
+        return httpx.Response(200, text = f"data: {json.dumps(chunk)}\n\ndata: [DONE]\n\n")
+
+    research_call.install(httpx.MockTransport(serve))
+    if "Check docs" in output:
+        asyncio.run(research_call.supervisor._plan(run))
+        assert saved == [json.loads(output)]
+    else:
+        with pytest.raises(ValueError, match = "Planner"):
+            asyncio.run(research_call.supervisor._plan(run))
+        assert saved == []
+    assert len(sent) == 2
+    assert "Return only strict JSON" in sent[1]["messages"][0]["content"]
+    assert "response_format" not in sent[1]


### PR DESCRIPTION
## Problem

Deep Research sends `response_format: {"type": "json_object"}` for planning, decisions and synthesis audits. Studio's MLX and Transformers routes reject this guided-decoding parameter, so research fails before generation with “Local model request failed with HTTP 400.”

## Change

Retry a local Research call once without `response_format` only when the API returns HTTP 400 with `code=unsupported_parameter` and `param=response_format`. Keep the JSON prompts and existing output validation. Recheck cancellation and lease ownership before retrying within the original timeout and transport retry budget.

Supported local backends and external providers retain their format contract. Direct API requests still receive the unsupported-format error; unrelated errors and repeated refusals propagate. Tool opt-outs remain intact, including when server tools are forced on.

## Validation

- The integration regression fails on unchanged baseline `4b6bc280a9` and passes with the fix.
- 892 surrounding Research and chat API tests passed.
- Final focused run: 37 passed, including 30 fallback regressions and 7 existing Research tool-gate checks. These overlap the broader suite.
- Six live application scenarios passed using real Uvicorn/TCP, authentication, SQLite, worker leases, plan approval, event streaming and persisted assistant messages. The unchanged baseline reproduces the original 400; the fix completes a cited report. Additional cases cover invalid plans, invented fetch URLs, invalid audits and cancellation. All internal workflow keys were revoked.
- Repository formatter and Ruff checks passed.
- [Earlier Linux/macOS ARM64 runner reproduction](https://github.com/Imagineer99/unsloth/actions/runs/34161867727) confirms the original bug; it does not validate this fix.

## Limitations

The live validation scripts model generation and search responses. Actual MLX weights, Apple Silicon inference and the exact reported desktop build have not been tested. The fallback adds one refused HTTP request per JSON phase. JSON quality remains model-dependent: existing validation rejects invalid plans, can fall back to an approved search for invalid decisions, and can proceed without an invalid audit.
