### PR TITLE
fix(Unsloth Studio/Desktop): find an MTP head cached in a different snapshot than the weights

### DIFF
--- a/studio/backend/core/inference/local_model_resolver.py
+++ b/studio/backend/core/inference/local_model_resolver.py
@@ -180,6 +180,27 @@ def local_gguf_companion_roots(load_path: str, *, repo_level: bool = False) -> t
     return (str(selected), *(str(path) for path in siblings))
 
 
+def hf_cache_snapshot_companion_roots(load_path: str) -> tuple[str, ...]:
+    """Repo-level companion roots for a GGUF pinned to one cache snapshot.
+
+    The picker hands out a snapshot path whenever ``refs/main`` stops holding a
+    complete quant, which is what fetching a companion after the weights does.
+    That revision is the cache's own bookkeeping and not a choice anyone made,
+    so the companion scan still spans the repo. A path outside a
+    ``models--*/snapshots/<sha>`` layout is left alone.
+    """
+    from pathlib import Path
+
+    if not load_path:
+        return ()
+    path = Path(load_path)
+    for candidate in (path, *path.parents):
+        snapshots = candidate.parent
+        if snapshots.name == "snapshots" and snapshots.parent.name.startswith("models--"):
+            return local_gguf_companion_roots(str(candidate), repo_level = True)
+    return ()
+
+
 def local_gguf_companion_state(roots: tuple[str, ...]) -> tuple:
     """File metadata for trusted snapshots, including newly completed companions."""
     from pathlib import Path

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -6811,6 +6811,7 @@ def _drafter_for_path(
     *,
     kind: str = "mtp",
     log_native_fallback: bool = False,
+    companion_roots: tuple[str, ...] = (),
 ) -> Optional[str]:
     """The drafter of ``kind`` that pairs with a local GGUF, or None.
 
@@ -6838,7 +6839,16 @@ def _drafter_for_path(
             rejected |= not usable
             return usable
 
-    detected = detect(gguf_path, search_root = root, accept = accept)
+    # The load resolved its companions across these roots, so the comparison has to
+    # look where the launch looked or an Apply reloads against a drafter it cannot see.
+    detected = next(
+        (
+            found
+            for candidate_root in (companion_roots or (root,))
+            if (found := detect(gguf_path, search_root = candidate_root, accept = accept))
+        ),
+        None,
+    )
     if log_native_fallback and rejected and detected:
         logger.info(
             "Using %s subdirectory drafter for native load: %s",
@@ -6882,9 +6892,13 @@ def _mtp_draft_for_path(
     native_grant_backed: bool,
     *,
     log_native_fallback: bool = False,
+    companion_roots: tuple[str, ...] = (),
 ) -> Optional[str]:
     return _drafter_for_path(
-        gguf_path, native_grant_backed, log_native_fallback = log_native_fallback
+        gguf_path,
+        native_grant_backed,
+        log_native_fallback = log_native_fallback,
+        companion_roots = companion_roots,
     )
 
 
@@ -6893,12 +6907,14 @@ def _dspark_draft_for_path(
     native_grant_backed: bool,
     *,
     log_native_fallback: bool = False,
+    companion_roots: tuple[str, ...] = (),
 ) -> Optional[str]:
     return _drafter_for_path(
         gguf_path,
         native_grant_backed,
         kind = "dspark",
         log_native_fallback = log_native_fallback,
+        companion_roots = companion_roots,
     )
 
 
@@ -6907,12 +6923,14 @@ def _dflash_draft_for_path(
     native_grant_backed: bool,
     *,
     log_native_fallback: bool = False,
+    companion_roots: tuple[str, ...] = (),
 ) -> Optional[str]:
     return _drafter_for_path(
         gguf_path,
         native_grant_backed,
         kind = "dflash",
         log_native_fallback = log_native_fallback,
+        companion_roots = companion_roots,
     )
 
 
@@ -6957,6 +6975,7 @@ def _active_gguf_intent(
     else:
         effective_extra = request.llama_extra_args
         batch_overrides_inherit = False
+    _request_roots = tuple(request._gguf_companion_roots)
     source = llama_backend.last_load_intent or GgufLoadIntent(
         model_identifier = model_identifier,
         gguf_path = None if llama_backend.hf_repo else llama_backend.gguf_path,
@@ -6984,9 +7003,15 @@ def _active_gguf_intent(
         preserve_multi_gpu_on_layer = (
             llama_backend.layer_preserves_tensor_intent and not _is_explicit_tensor_drop(request)
         ),
-        mtp_draft_path = _mtp_draft_for_path(llama_backend.gguf_path, native_grant_backed),
-        dspark_draft_path = _dspark_draft_for_path(llama_backend.gguf_path, native_grant_backed),
-        dflash_draft_path = _dflash_draft_for_path(llama_backend.gguf_path, native_grant_backed),
+        mtp_draft_path = _mtp_draft_for_path(
+            llama_backend.gguf_path, native_grant_backed, companion_roots = _request_roots
+        ),
+        dspark_draft_path = _dspark_draft_for_path(
+            llama_backend.gguf_path, native_grant_backed, companion_roots = _request_roots
+        ),
+        dflash_draft_path = _dflash_draft_for_path(
+            llama_backend.gguf_path, native_grant_backed, companion_roots = _request_roots
+        ),
         compare_mtp_draft = True,
         extra_args_inherited = inherits_extras and not batch_overrides_inherit,
     )
@@ -12977,18 +13002,21 @@ def _resolve_gguf_load_intent(
                     config.gguf_file,
                     True,
                     log_native_fallback = True,
+                    companion_roots = tuple(request._gguf_companion_roots),
                 )
             if config.gguf_dspark_file:
                 config.gguf_dspark_file = _dspark_draft_for_path(
                     config.gguf_file,
                     True,
                     log_native_fallback = True,
+                    companion_roots = tuple(request._gguf_companion_roots),
                 )
             if config.gguf_dflash_file:
                 config.gguf_dflash_file = _dflash_draft_for_path(
                     config.gguf_file,
                     True,
                     log_native_fallback = True,
+                    companion_roots = tuple(request._gguf_companion_roots),
                 )
         source = GgufLoadIntent(
             model_identifier = public_model_identifier,
@@ -14142,6 +14170,16 @@ async def _load_model_impl(
 
         # Keep the inventory ref public while loading the materialized artifact.
         public_model_identifier = _public_model_identifier(request.model_path, model_identifier)
+
+        # A row pinned to a snapshot path means refs/main stopped holding a complete
+        # quant, which is what fetching a companion after the weights does. The
+        # revision is the cache's bookkeeping, so the companion scan still spans the
+        # repo and an MTP head or mmproj one snapshot over is still found (#10599).
+        if not request._gguf_companion_roots:
+            from core.inference.local_model_resolver import hf_cache_snapshot_companion_roots
+            request._gguf_companion_roots = await asyncio.to_thread(
+                hf_cache_snapshot_companion_roots, model_identifier
+            )
         # Version switching is handled by the subprocess-based inference
         # backend -- no ensure_transformers_version() needed here.
 
@@ -14411,9 +14449,21 @@ async def _load_model_impl(
             if same_loaded_model and config.gguf_hf_repo and llama_backend.gguf_path:
                 gguf_intent = replace(
                     gguf_intent,
-                    mtp_draft_path = _mtp_draft_for_path(llama_backend.gguf_path, False),
-                    dspark_draft_path = _dspark_draft_for_path(llama_backend.gguf_path, False),
-                    dflash_draft_path = _dflash_draft_for_path(llama_backend.gguf_path, False),
+                    mtp_draft_path = _mtp_draft_for_path(
+                        llama_backend.gguf_path,
+                        False,
+                        companion_roots = tuple(request._gguf_companion_roots),
+                    ),
+                    dspark_draft_path = _dspark_draft_for_path(
+                        llama_backend.gguf_path,
+                        False,
+                        companion_roots = tuple(request._gguf_companion_roots),
+                    ),
+                    dflash_draft_path = _dflash_draft_for_path(
+                        llama_backend.gguf_path,
+                        False,
+                        companion_roots = tuple(request._gguf_companion_roots),
+                    ),
                     compare_mtp_draft = True,
                 )
             _effective_tensor = _effective_tensor_parallel(

--- a/studio/backend/tests/test_gguf_load_cache_reuse.py
+++ b/studio/backend/tests/test_gguf_load_cache_reuse.py
@@ -1254,3 +1254,91 @@ class TestLoadHubDownloadExclusion:
         assert (
             self._capture_hub_guard_require_mmproj(["--no-mmproj"], request_extra_args = []) is True
         )
+
+
+class TestCachePinnedCompanionScope:
+    """A row pinned to one snapshot still finds a companion in a sibling one (#10599)."""
+
+    REPO_ID = "unsloth/Qwen3.8-Flash-Next-GGUF"
+    WEIGHTS_REL = "UD-IQ1_S/Qwen3.8-Flash-Next-UD-IQ1_S-00001-of-00001.gguf"
+    HEAD_REL = "MTP/mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf"
+
+    def _split_repo(self, root: Path) -> tuple[Path, Path, str]:
+        """Weights in the older snapshot, MTP head alone in the newer one."""
+        weights = _build_cache(root, self.REPO_ID, {self.WEIGHTS_REL: 64}, snapshot_sha = "c" * 40)
+        head = _build_cache(root, self.REPO_ID, {self.HEAD_REL: 32}, snapshot_sha = "3" * 40)
+        return weights, head, str(weights / self.WEIGHTS_REL)
+
+    def test_roots_span_the_repo_from_a_pinned_shard(self, tmp_path):
+        from core.inference.local_model_resolver import hf_cache_snapshot_companion_roots
+        weights, head, shard = self._split_repo(tmp_path)
+
+        # Selected snapshot first, so a colocated companion still wins.
+        assert hf_cache_snapshot_companion_roots(shard) == (str(weights), str(head))
+
+    def test_a_path_outside_the_cache_layout_gains_no_siblings(self, tmp_path):
+        from core.inference.local_model_resolver import hf_cache_snapshot_companion_roots
+
+        loose = tmp_path / "my-models" / "snapshots" / "abc" / "model.gguf"
+        loose.parent.mkdir(parents = True)
+        loose.write_bytes(b"GGUF weights")
+
+        assert hf_cache_snapshot_companion_roots(str(loose)) == ()
+        assert hf_cache_snapshot_companion_roots(self.REPO_ID) == ()
+        assert hf_cache_snapshot_companion_roots("") == ()
+
+    def test_the_drafter_comparison_looks_where_the_launch_looked(self, tmp_path):
+        route = _load_route_module(
+            "inference_route_module_for_companion_scope_drafter_test",
+            "routes/inference.py",
+        )
+        weights, head, shard = self._split_repo(tmp_path)
+
+        assert route._mtp_draft_for_path(shard, False) is None
+        assert route._mtp_draft_for_path(
+            shard, False, companion_roots = (str(weights), str(head))
+        ) == str(head / self.HEAD_REL)
+
+    def test_a_pinned_load_hands_the_sibling_snapshot_to_the_resolver(self, tmp_path):
+        from models.inference import LoadRequest
+
+        route = _load_route_module(
+            "inference_route_module_for_companion_scope_load_test",
+            "routes/inference.py",
+        )
+        weights, head, shard = self._split_repo(tmp_path)
+        seen: dict = {}
+
+        class ResolverReached(BaseException):
+            pass
+
+        def _capture(**kwargs):
+            seen.update(kwargs)
+            raise ResolverReached()
+
+        backend = SimpleNamespace(
+            is_loaded = False,
+            model_identifier = None,
+            adopt_load_intent_if_matched = lambda _intent: False,
+            _audio_probed = True,
+            holds_no_vram = False,
+        )
+        with (
+            patch.object(
+                route,
+                "_resolve_model_identifier_for_request",
+                return_value = (shard, shard, False),
+            ),
+            patch.object(route, "resolve_effective_chat_template_override", return_value = None),
+            patch.object(route, "get_llama_cpp_backend", return_value = backend),
+            patch.object(
+                route,
+                "get_inference_backend",
+                return_value = SimpleNamespace(active_model_name = None),
+            ),
+            patch.object(route, "ModelConfig", SimpleNamespace(from_identifier = _capture)),
+            pytest.raises(ResolverReached),
+        ):
+            _run_route_load(route, LoadRequest(model_path = shard))
+
+        assert seen["gguf_companion_roots"] == (str(weights), str(head))

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -8704,6 +8704,28 @@ def test_the_resident_shortcut_never_answers_where_the_full_check_would_not(
     ), f"shortcut served {requested!r} against {identity!r} (quant={quant!r})"
 
 
+def test_a_cache_pinned_chat_load_leaves_the_resident_shortcut_alone(monkeypatch, tmp_path):
+    """A chat load of a snapshot path now carries repo-level companion roots (#10599).
+
+    The shortcut already refuses a bare load path that advertises nothing, so the
+    roots reach it but cannot change its answer either way.
+    """
+    repo = tmp_path / "models--unsloth--Muse-GGUF" / "snapshots"
+    weights, head = repo / ("c" * 40), repo / ("3" * 40)
+    (weights / "UD-IQ1_S").mkdir(parents = True)
+    head.mkdir(parents = True)
+    shard = weights / "UD-IQ1_S" / "Muse-UD-IQ1_S-00001-of-00001.gguf"
+    shard.write_bytes(b"GGUF weights")
+
+    backend = _FakeBackend(str(shard))
+    monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: backend)
+    for requested in ("unsloth/Muse-GGUF", str(shard)):
+        backend._openai_gguf_companion_roots = ()
+        without_roots = inference_route._loaded_identity_satisfies(requested)
+        backend._openai_gguf_companion_roots = (str(weights), str(head))
+        assert inference_route._loaded_identity_satisfies(requested) is without_roots is False
+
+
 def test_the_resident_shortcut_refuses_an_explicit_quant_mismatch(monkeypatch):
     backend = _FakeBackend("unsloth/Muse-GGUF", hf_variant = "Q4_K_M")
     monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: backend)


### PR DESCRIPTION
Fixes #10599.

Download a GGUF before its MTP head exists on the Hub, and when Studio later fetches the head it lands in a different `snapshots/<sha>/` folder than the weights. The On Device row then pins to the weights' snapshot, the chat picker sends that path, and the path route only scans that one folder. The head sits one directory over and never gets found. Every load says `MTP requested but this GGUF has no MTP head or drafter` and launches with `--spec-default`. The only way out today is deleting the repo from the cache and pulling 50 to 100 GB again.

#10210 fixed the same layout for `/v1/models` by handing every snapshot in the cache repo to the companion scan. The chat load route hands it nothing.

### The change

`_load_model_impl` in routes/inference.py: if the request has no companion roots and `model_path` is inside a `models--*/snapshots/<sha>/` layout, set `request._gguf_companion_roots` from `local_gguf_companion_roots(<snapshot dir>, repo_level = True)`. It needs the snapshot directory, not a shard path, or it returns nothing. It puts the selected snapshot first and siblings newest-first behind it, so a companion sitting next to the weights still wins. A sibling only gets read when the pinned snapshot has none. `from_identifier` already walks those roots for mmproj, MTP, DSpark and DFlash, and already flips `allow_disjoint_search_root` when roots are supplied, so nothing changes there.

`_drafter_for_path` walks the same roots instead of the single root it derives from the file. Skip that and the Apply dedup compares against a drafter it can't see, so every Apply reloads the server.

### What doesn't widen

A revision pin still drops repo scope. Only the OpenAI route can name `repo@sha`, and it isn't touched. Inside the HF cache a snapshot folder isn't something a user picked, it's how the cache stores one commit, so widening the companion scan there doesn't override anyone's choice. Anything outside a `models--*` repo gets no siblings, scanned folders and custom directories included. That guard already lives in `local_gguf_companion_roots`.

One interaction worth naming. `_load_model_impl` copies the request's roots onto the backend, and the `/v1/models` reuse check reads that tuple. A chat load now fills it where it used to be empty. That check refuses a bare load path with nothing advertised before it gets there, so the answer cannot change, and a test in `test_openai_auto_switch.py` pins that with the roots set and unset.

### Tests

- `test_gguf_load_cache_reuse.py`: #10210's fixture, a complete quant in the older snapshot and MTP alone in the newer one, loaded by the pinned path. Asserts the load hands both snapshots to the resolver and that the drafter comparison finds the head. Negative cases: a path outside the cache layout, a bare repo id and an empty string all gain no siblings.
- `test_openai_auto_switch.py`: the reuse check above.

The 21 test files that touch the changed functions give the same 7 failures on this branch as on a clean tree, all pre-existing on the machine below (GPU probes, an Ollama lease race, a Windows preview error).

### Before and after

One machine, one load, same command: the chat load route pointed at a shard in the older snapshot with MTP forced. Weights downloaded Aug 28 into `snapshots/c8b5954`, MTP head fetched later into `snapshots/38bb39e`.

Before, on main at 89976f1c25:

```
Detected local GGUF model: L:\...\snapshots\c8b5954...\UD-IQ1_S\Qwen3.8-Flash-Next-UD-IQ1_S-00001-of-00003.gguf
Detected mmproj for vision: L:\...\snapshots\c8b5954...\mmproj-F16.gguf
MTP requested but this GGUF has no MTP head or drafter; loading without speculative decoding.
Starting llama-server: ... --alias unsloth/Qwen3.8-Flash-Next-GGUF ... --spec-default ...
```

After, on this branch:

```
Detected local GGUF model: L:\...\snapshots\c8b5954...\UD-IQ1_S\Qwen3.8-Flash-Next-UD-IQ1_S-00001-of-00003.gguf
Detected mmproj for vision: L:\...\snapshots\c8b5954...\mmproj-F16.gguf
Detected MTP subdirectory drafter: L:\...\snapshots\38bb39e...\MTP\mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf
Using separate MTP drafter: L:\...\snapshots\38bb39e...\MTP\mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf
Starting llama-server: ... --model-draft L:\...\snapshots\38bb39e...\MTP\mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf --spec-type draft-mtp --spec-draft-n-max 2 ...
```

No download in the after run: the head was already on disk in the sibling snapshot, which is the whole point.

Machine: Windows 11, AMD Radeon AI PRO R9700, llama.cpp b10840-mix-d5c17a0 (ROCm gfx120X build), hub cache on a separate drive with no blob dir, which is the Windows default.

### Left out

`_companion_snapshot_sibling` still only checks the weights' snapshot on the repo-id route, so a README-only commit upstream re-downloads the 2.6 GB head. That's a different symptom and it needs a rule for whether a same-named file in a newer revision is the same file. `_cached_repo_mtp_drafter` already has the repo-wide scan to reuse. Its own PR.

#10243 fixes the download side. Independent of this one, and a cache that predates the companion needs both.
