### PR TITLE
Studio: restore the CLI help text the comment passes had trimmed

### DIFF
--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1596,6 +1596,7 @@ def studio_default(
         "process list and shell history. Rotate later with `unsloth studio reset-password`.",
     ),
 ):
+    """Launch the Unsloth Studio server."""
     # --not-secure is a deprecated alias for --no-secure.
     secure = _resolve_secure(secure, not_secure)
     _ensure_studio_env_exported()
@@ -2204,12 +2205,19 @@ def run(
 ):
     """Start Unsloth, load a model, print an API key -- one-liner server.
 
-    Unknown flags pass through to llama-server (GGUF only). Unsloth rejects managed flags with
-    HTTP 400: model identity, network, auth/TLS, single-model UI, and parallel slots (use
-    --parallel). Full denylist in studio/backend/core/inference/llama_server_args.py.
+    Unknown flags pass through to llama-server (GGUF only). Unsloth
+    rejects managed flags with HTTP 400: model identity, network
+    (--host/--port/--path/--api-prefix/--reuse-port), auth/TLS
+    (--api-key/--ssl-*), single-model UI (--ui/--models-*/--webui),
+    and parallel slots (use --parallel above). Full denylist in
+    studio/backend/core/inference/llama_server_args.py. Other knobs
+    (-c, -ngl, --jinja, --flash-attn, -t, ...) pass through and
+    last-wins-override Unsloth's auto-set value.
 
+    Example:
         unsloth studio run --model unsloth/Qwen3-1.7B-GGUF --gguf-variant UD-Q4_K_XL
-        unsloth studio run --model unsloth/Qwen3-1.7B-GGUF --temperature 0.7 --parallel 8
+        unsloth studio run --model unsloth/Qwen3-1.7B-GGUF --temperature 0.7 --seed 42 --parallel 8
+        unsloth studio run --model some-model --chat-template-file /path/to/tpl.jinja
         unsloth studio run --model unsloth/Qwen3-27B-GGUF --gguf-variant Q8_0 --tensor-parallel
     """
     # Passed via env, so an older re-exec target ignores it instead of treating it as a llama-server arg.
@@ -2769,8 +2777,10 @@ def _signal_stop(pid: int) -> "str | None":
 
 @studio_app.command()
 def stop():
-    """Stop every running Unsloth Studio server for this STUDIO_HOME. The port fallback can leave
-    more than one running."""
+    """Stop every running Unsloth Studio server for this STUDIO_HOME.
+
+    The port fallback can leave more than one running, so stop them all.
+    """
     unreadable: "list[Path]" = []
     entries = _pid_file_entries(unreadable)
     if not entries:
@@ -4189,8 +4199,14 @@ def verify_install(
         help = "Emit machine-readable JSON.",
     ),
 ):
-    """Check that the Unsloth Studio dependency install completed. Exits 0 when complete; setup.sh
-    and setup.ps1 use the code for the "already up to date" fast path. Scans installed files too."""
+    """Check that the Unsloth Studio dependency install completed.
+
+    Exits 0 when complete, 1 otherwise. setup.sh / setup.ps1 use the exit code
+    to decide whether the "already up to date" fast path may be taken.
+
+    Scans the installed files too, unlike `desktop-capabilities`: nothing times
+    this one out.
+    """
     state = _install_state(deep = True)
 
     if json_output:
@@ -4219,8 +4235,12 @@ def provision_desktop_auth():
 
 @studio_app.command("reset-password")
 def reset_password():
-    """Reset the Unsloth admin password. Rotates in place, so nothing needs restarting. Shared /p
-    preview links are not revoked; rotate those in Settings if the old password leaked."""
+    """Reset the Unsloth admin password.
+
+    Rotates the credential in place: a running Unsloth accepts the new password on
+    its next request, so there is nothing to restart. Shared /p preview links are
+    not revoked -- rotate those in Settings if the old password leaked.
+    """
     new_password = _generate_reset_password()
     try:
         conn = _connect_auth_db()


### PR DESCRIPTION
Follow-up to #10604. Two commits in that PR were meant to be comment-only passes, but in `unsloth_cli/commands/studio.py` they also rewrote docstrings of Typer-decorated functions. Typer renders those docstrings as `--help`, so the trimming was a user-visible loss.

### What was lost

`unsloth studio run --help`, before:

```
 Unknown flags pass through to llama-server (GGUF only). Unsloth
 rejects managed flags with HTTP 400: model identity, network
 (--host/--port/--path/--api-prefix/--reuse-port), auth/TLS
 (--api-key/--ssl-*), single-model UI (--ui/--models-*/--webui),
 and parallel slots (use --parallel above). Full denylist in
 studio/backend/core/inference/llama_server_args.py. Other knobs
 (-c, -ngl, --jinja, --flash-attn, -t, ...) pass through and
 last-wins-override Unsloth's auto-set value.

 Example:
     unsloth studio run --model unsloth/Qwen3-1.7B-GGUF --gguf-variant UD-Q4_K_XL
     unsloth studio run --model unsloth/Qwen3-1.7B-GGUF --temperature 0.7 --seed 42 --parallel 8
     unsloth studio run --model some-model --chat-template-file /path/to/tpl.jinja
     unsloth studio run --model unsloth/Qwen3-27B-GGUF --gguf-variant Q8_0 --tensor-parallel
```

after:

```
 Unknown flags pass through to llama-server (GGUF only). Unsloth rejects managed flags with
 HTTP 400: model identity, network, auth/TLS, single-model UI, and parallel slots (use
 --parallel). Full denylist in studio/backend/core/inference/llama_server_args.py.

     unsloth studio run --model unsloth/Qwen3-1.7B-GGUF --gguf-variant UD-Q4_K_XL
     unsloth studio run --model unsloth/Qwen3-1.7B-GGUF --temperature 0.7 --parallel 8
     unsloth studio run --model unsloth/Qwen3-27B-GGUF --gguf-variant Q8_0 --tensor-parallel
```

Users lost the concrete list of rejected flag families, the `--chat-template-file` example, the `--seed` example, the "Example:" label, and the sentence saying pass-through knobs last-wins-override the auto-set value.

A second effect: collapsing a docstring to one paragraph makes Click's short help swallow the whole paragraph, so `unsloth studio --help` listed `stop`, `verify-install` and `reset-password` with three wrapped lines each instead of one summary line.

### What is restored

Docstrings restored verbatim from the tree before the first pass (`aa83fc5f2^`), code untouched:

- `run` (`unsloth studio run`)
- `stop` (`unsloth studio stop`)
- `verify_install` (`unsloth studio verify-install`)
- `reset_password` (`unsloth studio reset-password`)
- `studio_default` (the `@studio_app.callback()`, whose docstring had been deleted outright)

Docstrings of plain internal helpers are left as main has them.

### Verification

- Dumped `unsloth studio --help` plus `--help` for all eight subcommands (`run`, `stop`, `setup`, `update`, `verify-install`, `reset-password`, `desktop-capabilities`, `provision-desktop-auth`, enumerated from the app so hidden ones are included) from this branch and from `aa83fc5f2^`. The diff is empty.
- No `help=` string on any `typer.Option` / `typer.Argument` was changed by the two passes, so none needed restoring.
- `pytest unsloth_cli/tests -q -k "not inference_chat"`: 1276 passed, 9 skipped.
- `python scripts/run_ruff_format.py unsloth_cli/commands/studio.py` clean.
