### PR TITLE
Windows: run the native-type tests on Windows, and fix the two that could not

### DIFF
--- a/.github/workflows/cross-platform-parity-ci.yml
+++ b/.github/workflows/cross-platform-parity-ci.yml
@@ -71,6 +71,7 @@ on:
       - 'tests/studio/test_native_path_resolver_degrades.ps1'
       - 'tests/python/test_windows_python_venv_hardening.py'
       - 'tests/python/test_windows_setup_output_encoding.py'
+      - 'tests/python/test_windows_installer_native_type_fallback.py'
       - 'tests/python/test_pwsh_runner_encoding.py'
       # Every PowerShell test in this job shells out through it, so a change here can break
       # all of them. It was in no path filter, so it triggered nothing.
@@ -142,6 +143,7 @@ on:
       - 'tests/studio/test_native_path_resolver_degrades.ps1'
       - 'tests/python/test_windows_python_venv_hardening.py'
       - 'tests/python/test_windows_setup_output_encoding.py'
+      - 'tests/python/test_windows_installer_native_type_fallback.py'
       - 'tests/python/test_pwsh_runner_encoding.py'
       # Every PowerShell test in this job shells out through it, so a change here can break
       # all of them. It was in no path filter, so it triggered nothing.
@@ -236,6 +238,7 @@ jobs:
           tests/python/test_cross_platform_parity.py
           tests/python/test_windows_python_venv_hardening.py
           tests/python/test_windows_setup_output_encoding.py
+          tests/python/test_windows_installer_native_type_fallback.py
           tests/python/test_pwsh_runner_encoding.py
           tests/test_installer_skip_autostart.py
           tests/test_installer_system32_guard.py

--- a/tests/python/test_windows_installer_native_type_fallback.py
+++ b/tests/python/test_windows_installer_native_type_fallback.py
@@ -1813,6 +1813,10 @@ def test_the_probe_body_carries_no_double_quote(script: str):
 # Every case here is a way a real child can answer badly: it printed the marker and then died,
 # it ran in a language mode its parent did not, it printed something that merely CONTAINS the
 # marker, or it never returned at all.
+# A #!/bin/sh host, so POSIX only: Windows CreateProcess rejects a file with no
+# executable format, every case would come back false through the catch, and the
+# accept case would fail while the deadline case passed without waiting.
+@pytest.mark.skipif(os.name == "nt", reason = "the fake host is a shell script")
 @requires_pwsh
 @pytest.mark.parametrize("script", ["install", "setup"])
 @pytest.mark.parametrize(
@@ -1890,6 +1894,13 @@ def test_only_a_probe_that_never_answered_is_retried(script: str, outcome: str, 
                 "$script:StudioCanDefineNativeTypes = $null",
                 "$script:StudioEmitProbeOutcome = $null",
                 "$script:ProbeCalls = 0",
+                # An active policy, so the gate reaches the probe on any host. Without
+                # this the real query answers 0 on a Windows runner and the gate returns
+                # before the stub below is ever called.
+                "function Get-CimInstance {",
+                "    param([string]$Namespace, [string]$ClassName, [string]$ErrorAction)",
+                "    [pscustomobject]@{ UsermodeCodeIntegrityPolicyEnforcementStatus = 1 }",
+                "}",
                 # A stub, because the gate calls the real probe through $PSHOME, which is
                 # read-only and cannot be pointed at a fake host. What is under test here is
                 # the gate's retry rule, not the child.
@@ -2034,6 +2045,10 @@ def test_the_console_helper_keeps_a_type_it_already_has(script: str):
     ], "a published console type was discarded because a child probe said no"
 
 
+# A #!/bin/sh host, so POSIX only: Windows CreateProcess rejects a file with no
+# executable format, every case would come back false through the catch, and the
+# accept case would fail while the deadline case passed without waiting.
+@pytest.mark.skipif(os.name == "nt", reason = "the fake host is a shell script")
 @requires_pwsh
 def test_a_child_that_never_returns_does_not_hang_the_installer(tmp_path: Path):
     """The deadline. A probe that exists to keep the installer alive must not be the thing


### PR DESCRIPTION
Follow-up to #10540.

## What is wrong

Two of the tests #10540 added only pass on POSIX. Nothing in CI noticed, because the Windows row of `cross-platform-parity-ci.yml` does not run `tests/python/test_windows_installer_native_type_fallback.py` at all. Run on a real `windows-latest` runner, twelve cases fail.

## The retry test never reached the code it measures

`test_only_a_probe_that_never_answered_is_retried` stubs the child probe but not the Device Guard query. On Linux that query fails, so the gate falls through to the probe and the stub is what answers. On Windows the query succeeds and reports status 0, which is the "no policy" shortcut, so the gate returns true and the stub is never called. The test then reads a true it did not ask for.

It now stubs the query as well, reporting an active policy, which is what the two active-policy tests immediately above it already do. The case under test is reached on either host.

## The fake host is a shell script

`test_the_probe_only_accepts_a_clean_exact_answer` and `test_a_child_that_never_returns_does_not_hang_the_installer` write a `#!/bin/sh` file and hand it to `Process.Start` as a stand-in for the PowerShell host, which is how the acceptance rules get exercised without a policy or a Windows box.

Windows cannot execute a file with no executable format. Every case comes back false through the catch, so the accept case fails outright, and the deadline case passes in milliseconds without ever exercising the deadline. The second of those is the worse outcome: a green result that measured nothing.

Both are marked POSIX only, with the reason in the test, since what they measure is host-independent PowerShell logic and the Windows behaviour of the same code is covered by the production path.

## So that this cannot happen again quietly

The file joins the Windows parity row. The next test in it that only works on one platform fails in CI instead of waiting to be found by hand.

## Verification

`tests/python/test_cross_platform_parity.py`, `test_windows_python_venv_hardening.py`, `test_windows_setup_output_encoding.py`, `test_windows_installer_native_type_fallback.py`, `test_pwsh_runner_encoding.py` and `tests/studio/test_workflow_guards_run_unfiltered.py`: 308 passed, 8 skipped.
