### PR TITLE
Studio: import readFileSync in the chat continuation test

### DIFF
--- a/studio/frontend/tests/chat-continuation.test.ts
+++ b/studio/frontend/tests/chat-continuation.test.ts
@@ -2,6 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { readSrc, registerBundlerResolver } from "./helpers/kit.ts";


### PR DESCRIPTION
## Summary

`studio/frontend/tests/chat-continuation.test.ts` calls `readFileSync` at two sites but never imports it, so the file fails under `node --test` and `tsc -p tsconfig.test.json` reports two errors on main. The test came in with #10557. This adds the one missing import.

## Verification

- `node --experimental-strip-types --test tests/chat-continuation.test.ts`: 93 pass, 0 fail
- `tsc -p tsconfig.test.json`: exit 0
- Biome reports only the `noNodejsModules` notices that every file under `tests/` already carries, unchanged from main.
