### PR TITLE
Retire optional project operations before archive and deletion

### DIFF
--- a/studio/backend/core/project_retirement.py
+++ b/studio/backend/core/project_retirement.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""One lifecycle entry point for optional project features during archive/delete."""
+
+import importlib
+from dataclasses import dataclass
+from functools import partial
+from typing import Callable, Optional
+
+
+PROJECT_RETIREMENT_PROTOCOL = 1
+
+
+@dataclass
+class ProjectRetirement:
+    project_id: str
+    release: Optional[Callable[[], None]] = None
+
+
+def _feature(name: str):
+    module = "core.agent_workspace." + name
+    try:
+        return importlib.import_module(module)
+    except ModuleNotFoundError as exc:
+        if exc.name not in {module, "core.agent_workspace"}:
+            raise
+        return None
+
+
+def begin_project_retirement(project_id: str, *, deleting: bool = False) -> ProjectRetirement:
+    """Leave existing projects unchanged when no optional retirement feature exists.
+
+    Git retirement also retires verification when present; choosing it first
+    avoids nesting two owners of the same process-shared execution fence.
+    """
+    git = _feature("git_retirement")
+    if git is not None:
+        token = git.begin_git_retirement(project_id, deleting = deleting)
+        return ProjectRetirement(project_id, partial(git.finish_git_retirement, project_id, token))
+    verification = _feature("verification")
+    if verification is None:
+        return ProjectRetirement(project_id)
+    verification.begin_project_deletion(project_id)
+    try:
+        verification.cancel_project_verifications_and_wait(project_id)
+    except BaseException:
+        verification.finish_project_deletion(project_id)
+        raise
+    return ProjectRetirement(project_id, partial(verification.finish_project_deletion, project_id))
+
+
+def finish_project_retirement(project_id: str, token: ProjectRetirement) -> None:
+    if token.project_id != project_id:
+        raise RuntimeError("Project retirement ownership changed.")
+    release = token.release
+    token.release = None
+    if release is not None:
+        release()

--- a/studio/backend/core/project_retirement.py
+++ b/studio/backend/core/project_retirement.py
@@ -10,6 +10,7 @@ from typing import Callable, Optional
 
 
 PROJECT_RETIREMENT_PROTOCOL = 1
+PROJECT_TASK_RETIREMENT_PROTOCOL = 1
 
 
 @dataclass
@@ -28,7 +29,7 @@ def _feature(name: str):
         return None
 
 
-def begin_project_retirement(project_id: str, *, deleting: bool = False) -> ProjectRetirement:
+def _begin_workspace_retirement(project_id: str, *, deleting: bool = False) -> ProjectRetirement:
     """Leave existing projects unchanged when no optional retirement feature exists.
 
     Git retirement also retires verification when present; choosing it first
@@ -48,6 +49,28 @@ def begin_project_retirement(project_id: str, *, deleting: bool = False) -> Proj
         verification.finish_project_deletion(project_id)
         raise
     return ProjectRetirement(project_id, partial(verification.finish_project_deletion, project_id))
+
+
+def begin_project_retirement(project_id: str, *, deleting: bool = False) -> ProjectRetirement:
+    # Cancel/drain tasks BEFORE acquiring Git's exclusive execution fence. A
+    # running task may need that same fence to finish its current operation.
+    tasks = _feature("task_service")
+    if tasks is None:
+        return _begin_workspace_retirement(project_id, deleting = deleting)
+    task_token = tasks.begin_task_retirement(project_id)
+    try:
+        workspace = _begin_workspace_retirement(project_id, deleting = deleting)
+    except BaseException:
+        tasks.finish_task_retirement(project_id, task_token)
+        raise
+
+    def release():
+        try:
+            finish_project_retirement(project_id, workspace)
+        finally:
+            tasks.finish_task_retirement(project_id, task_token)
+
+    return ProjectRetirement(project_id, release)
 
 
 def finish_project_retirement(project_id: str, token: ProjectRetirement) -> None:

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -1094,7 +1094,10 @@ def save_project(payload: ChatProject, current_subject: str = Depends(get_curren
         # POST also updates existing rows. Fence every archived payload before
         # the upsert, including ids created concurrently with this request.
         if payload.archived:
-            fence = begin_project_retirement(payload.id)
+            try:
+                fence = begin_project_retirement(payload.id)
+            except (RuntimeError, OSError) as exc:
+                raise HTTPException(status_code = 409, detail = str(exc)) from exc
             begun = True
         return ChatProject(**upsert_chat_project(payload.model_dump()))
     except ProjectWorkspaceError as exc:
@@ -1109,8 +1112,6 @@ def save_project(payload: ChatProject, current_subject: str = Depends(get_curren
             event = "chat_history.create_project_workspace_failed",
             log = logger,
         ) from exc
-    except (RuntimeError, OSError) as exc:
-        raise HTTPException(status_code = 409, detail = str(exc)) from exc
     finally:
         if begun:
             finish_project_retirement(payload.id, fence)
@@ -1146,11 +1147,12 @@ def patch_project(
         raise HTTPException(status_code = 404, detail = "Project not found.")
     try:
         if retiring:
-            fence = begin_project_retirement(project_id)
+            try:
+                fence = begin_project_retirement(project_id)
+            except (RuntimeError, OSError) as exc:
+                raise HTTPException(status_code = 409, detail = str(exc)) from exc
             begun = True
         project = update_chat_project(project_id, patch)
-    except (RuntimeError, OSError) as exc:
-        raise HTTPException(status_code = 409, detail = str(exc)) from exc
     finally:
         if begun:
             finish_project_retirement(project_id, fence)

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -1123,7 +1123,23 @@ def patch_project(
     for field in ("name", "archived", "createdAt", "updatedAt"):
         if field in patch and patch[field] is None:
             raise HTTPException(status_code = 400, detail = f"{field} cannot be null")
-    project = update_chat_project(project_id, patch)
+    from core.project_retirement import begin_project_retirement, finish_project_retirement
+
+    fence = None
+    retiring = bool(patch.get("archived"))
+    begun = False
+    if retiring and get_chat_project(project_id) is None:
+        raise HTTPException(status_code = 404, detail = "Project not found.")
+    try:
+        if retiring:
+            fence = begin_project_retirement(project_id)
+            begun = True
+        project = update_chat_project(project_id, patch)
+    except (RuntimeError, OSError) as exc:
+        raise HTTPException(status_code = 409, detail = str(exc)) from exc
+    finally:
+        if begun:
+            finish_project_retirement(project_id, fence)
     if project is not None:
         project = ensure_chat_project_workspace(project_id)
     if project is None:
@@ -1167,6 +1183,22 @@ async def delete_project(
     delete_files: bool = Query(False),
     current_subject: str = Depends(get_current_subject),
 ):
+    from starlette.concurrency import run_in_threadpool
+    from core.project_retirement import begin_project_retirement, finish_project_retirement
+
+    if await run_in_threadpool(get_chat_project, project_id) is None:
+        raise HTTPException(status_code = 404, detail = "Project not found.")
+    try:
+        fence = await run_in_threadpool(begin_project_retirement, project_id, deleting = True)
+    except (RuntimeError, OSError) as exc:
+        raise HTTPException(status_code = 409, detail = str(exc)) from exc
+    try:
+        return await _delete_retired_project(project_id, request, delete_files, current_subject)
+    finally:
+        await run_in_threadpool(finish_project_retirement, project_id, fence)
+
+
+async def _delete_retired_project(project_id, request, delete_files, current_subject):
     from starlette.concurrency import run_in_threadpool
 
     # Rows first, files last: a member chat can still be running a tool in the

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -1086,7 +1086,16 @@ def list_projects(
 
 @router.post("/projects", response_model = ChatProject)
 def save_project(payload: ChatProject, current_subject: str = Depends(get_current_subject)):
+    from core.project_retirement import begin_project_retirement, finish_project_retirement
+
+    fence = None
+    begun = False
     try:
+        # POST also updates existing rows. Fence every archived payload before
+        # the upsert, including ids created concurrently with this request.
+        if payload.archived:
+            fence = begin_project_retirement(payload.id)
+            begun = True
         return ChatProject(**upsert_chat_project(payload.model_dump()))
     except ProjectWorkspaceError as exc:
         # A project is the only thing Unsloth writes to Documents, so only this error and only its own path: the same
@@ -1100,6 +1109,11 @@ def save_project(payload: ChatProject, current_subject: str = Depends(get_curren
             event = "chat_history.create_project_workspace_failed",
             log = logger,
         ) from exc
+    except (RuntimeError, OSError) as exc:
+        raise HTTPException(status_code = 409, detail = str(exc)) from exc
+    finally:
+        if begun:
+            finish_project_retirement(payload.id, fence)
 
 
 @router.get("/projects/{project_id}", response_model = ChatProject)

--- a/studio/backend/tests/test_chat_history_routes.py
+++ b/studio/backend/tests/test_chat_history_routes.py
@@ -332,7 +332,7 @@ def test_project_delete_cancels_research_before_workspace_cleanup(monkeypatch):
 
     with pytest.raises(OSError, match = "workspace is busy"):
         asyncio.run(
-            chat_history.delete_project(
+            chat_history._delete_retired_project(
                 "project-1",
                 SimpleNamespace(),
                 delete_files = True,

--- a/studio/backend/tests/test_project_retirement.py
+++ b/studio/backend/tests/test_project_retirement.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from auth.authentication import get_current_subject
+from core import project_retirement as lifecycle
+from routes import chat_history
+from storage import studio_db
+
+
+@pytest.fixture(autouse = True)
+def isolated_projects(monkeypatch, tmp_path):
+    monkeypatch.setenv("UNSLOTH_STUDIO_PROJECTS_HOME", str(tmp_path / "projects"))
+
+
+def _client():
+    app = FastAPI()
+    app.include_router(chat_history.router, prefix = "/history")
+    app.dependency_overrides[get_current_subject] = lambda: "test"
+    return TestClient(app)
+
+
+def _project():
+    return studio_db.upsert_chat_project(
+        {"id": "lifecycle", "name": "Lifecycle", "createdAt": 1, "updatedAt": 1}
+    )
+
+
+def test_no_feature_archive_and_delete_keep_existing_behavior():
+    _project()
+    with _client() as client:
+        archived = client.patch("/history/projects/lifecycle", json = {"archived": True})
+        assert archived.status_code == 200
+        assert archived.json()["archived"] is True
+        assert client.delete("/history/projects/lifecycle").status_code == 200
+        assert client.delete("/history/projects/lifecycle").status_code == 404
+
+
+@pytest.mark.parametrize("operation", ["archive", "delete"])
+def test_failed_retirement_preserves_project_and_its_workspace(monkeypatch, operation):
+    project = _project()
+
+    def refuse(*args, **kwargs):
+        raise RuntimeError("Recover owned state first")
+
+    monkeypatch.setattr(
+        lifecycle, "_feature", lambda _name: SimpleNamespace(begin_git_retirement = refuse)
+    )
+    with _client() as client:
+        response = (
+            client.patch("/history/projects/lifecycle", json = {"archived": True})
+            if operation == "archive"
+            else client.delete("/history/projects/lifecycle?delete_files=true")
+        )
+        assert response.status_code == 409
+    assert studio_db.get_chat_project("lifecycle")["archived"] is False
+    assert studio_db.get_chat_project("lifecycle")["sandboxPath"] == project["sandboxPath"]
+
+
+def test_combined_features_use_only_git_retirement_owner(monkeypatch):
+    events = []
+    sentinel = object()
+
+    def begin(project_id, *, deleting):
+        events.append(("begin", project_id, deleting))
+        return sentinel
+
+    def finish(project_id, token):
+        assert token is sentinel
+        events.append(("finish", project_id))
+
+    git = SimpleNamespace(begin_git_retirement = begin, finish_git_retirement = finish)
+
+    def feature(name):
+        assert name == "git_retirement", "Verification is retired by Git, never a second owner"
+        return git
+
+    monkeypatch.setattr(lifecycle, "_feature", feature)
+    token = lifecycle.begin_project_retirement("p", deleting = True)
+    lifecycle.finish_project_retirement("p", token)
+    lifecycle.finish_project_retirement("p", token)
+    assert events == [("begin", "p", True), ("finish", "p")]
+
+
+def test_verification_cancellation_failure_releases_admission(monkeypatch):
+    active = set()
+
+    def cannot_stop(project_id):
+        assert project_id in active
+        raise RuntimeError("Still running")
+
+    verification = SimpleNamespace(
+        begin_project_deletion = active.add,
+        cancel_project_verifications_and_wait = cannot_stop,
+        finish_project_deletion = active.remove,
+    )
+    monkeypatch.setattr(
+        lifecycle, "_feature", lambda name: verification if name == "verification" else None
+    )
+    with pytest.raises(RuntimeError, match = "Still running"):
+        lifecycle.begin_project_retirement("p")
+    assert not active
+
+
+def test_unexpected_feature_import_failure_is_not_treated_as_absent(monkeypatch):
+    def broken(name):
+        raise ModuleNotFoundError("broken dependency", name = "unavailable_dependency")
+
+    monkeypatch.setattr(lifecycle.importlib, "import_module", broken)
+    with pytest.raises(ModuleNotFoundError):
+        lifecycle.begin_project_retirement("p")

--- a/studio/backend/tests/test_project_retirement.py
+++ b/studio/backend/tests/test_project_retirement.py
@@ -41,7 +41,7 @@ def test_no_feature_archive_and_delete_keep_existing_behavior():
         assert client.delete("/history/projects/lifecycle").status_code == 404
 
 
-@pytest.mark.parametrize("operation", ["archive", "delete"])
+@pytest.mark.parametrize("operation", ["archive", "delete", "upsert_archive"])
 def test_failed_retirement_preserves_project_and_its_workspace(monkeypatch, operation):
     project = _project()
 
@@ -53,13 +53,83 @@ def test_failed_retirement_preserves_project_and_its_workspace(monkeypatch, oper
     )
     with _client() as client:
         response = (
-            client.patch("/history/projects/lifecycle", json = {"archived": True})
-            if operation == "archive"
-            else client.delete("/history/projects/lifecycle?delete_files=true")
+            client.post("/history/projects", json = {**project, "archived": True})
+            if operation == "upsert_archive"
+            else (
+                client.patch("/history/projects/lifecycle", json = {"archived": True})
+                if operation == "archive"
+                else client.delete("/history/projects/lifecycle?delete_files=true")
+            )
         )
         assert response.status_code == 409
     assert studio_db.get_chat_project("lifecycle")["archived"] is False
     assert studio_db.get_chat_project("lifecycle")["sandboxPath"] == project["sandboxPath"]
+
+
+@pytest.mark.parametrize("existing", [False, True])
+@pytest.mark.parametrize("fail_write", [False, True])
+def test_post_archive_holds_retirement_until_upsert_finishes(monkeypatch, existing, fail_write):
+    if existing:
+        _project()
+    events = []
+    write = chat_history.upsert_chat_project
+
+    def begin(project_id, *, deleting):
+        assert project_id == "lifecycle" and not deleting
+        events.append("begin")
+        return "token"
+
+    def finish(project_id, token):
+        assert token == "token"
+        events.append("finish")
+
+    def upsert(payload):
+        assert events == ["begin"]
+        events.append("write")
+        if fail_write:
+            raise RuntimeError("write failed")
+        return write(payload)
+
+    monkeypatch.setattr(
+        lifecycle,
+        "_feature",
+        lambda _name: SimpleNamespace(begin_git_retirement = begin, finish_git_retirement = finish),
+    )
+    monkeypatch.setattr(chat_history, "upsert_chat_project", upsert)
+    with _client() as client:
+        response = client.post(
+            "/history/projects",
+            json = {
+                "id": "lifecycle",
+                "name": "Lifecycle",
+                "createdAt": 1,
+                "updatedAt": 1,
+                "archived": True,
+            },
+        )
+    assert response.status_code == (409 if fail_write else 200)
+    assert events == ["begin", "write", "finish"]
+    if not fail_write:
+        assert studio_db.get_chat_project("lifecycle")["archived"] is True
+
+
+def test_post_active_project_does_not_retire(monkeypatch):
+    def unexpected(*args, **kwargs):
+        pytest.fail("An active project must not enter retirement")
+
+    monkeypatch.setattr(lifecycle, "begin_project_retirement", unexpected)
+    with _client() as client:
+        response = client.post(
+            "/history/projects",
+            json = {
+                "id": "active",
+                "name": "Active",
+                "createdAt": 1,
+                "updatedAt": 1,
+            },
+        )
+    assert response.status_code == 200
+    assert response.json()["archived"] is False
 
 
 def test_combined_features_use_only_git_retirement_owner(monkeypatch):

--- a/studio/backend/tests/test_project_retirement.py
+++ b/studio/backend/tests/test_project_retirement.py
@@ -49,7 +49,11 @@ def test_failed_retirement_preserves_project_and_its_workspace(monkeypatch, oper
         raise RuntimeError("Recover owned state first")
 
     monkeypatch.setattr(
-        lifecycle, "_feature", lambda _name: SimpleNamespace(begin_git_retirement = refuse)
+        lifecycle,
+        "_feature",
+        lambda name: None
+        if name == "task_service"
+        else SimpleNamespace(begin_git_retirement = refuse),
     )
     with _client() as client:
         response = (
@@ -93,7 +97,9 @@ def test_post_archive_holds_retirement_until_upsert_finishes(monkeypatch, existi
     monkeypatch.setattr(
         lifecycle,
         "_feature",
-        lambda _name: SimpleNamespace(begin_git_retirement = begin, finish_git_retirement = finish),
+        lambda name: None
+        if name == "task_service"
+        else SimpleNamespace(begin_git_retirement = begin, finish_git_retirement = finish),
     )
     monkeypatch.setattr(chat_history, "upsert_chat_project", upsert)
     with _client() as client:
@@ -147,6 +153,8 @@ def test_combined_features_use_only_git_retirement_owner(monkeypatch):
     git = SimpleNamespace(begin_git_retirement = begin, finish_git_retirement = finish)
 
     def feature(name):
+        if name == "task_service":
+            return None
         assert name == "git_retirement", "Verification is retired by Git, never a second owner"
         return git
 

--- a/studio/backend/tests/test_project_retirement.py
+++ b/studio/backend/tests/test_project_retirement.py
@@ -18,11 +18,11 @@ def isolated_projects(monkeypatch, tmp_path):
     monkeypatch.setenv("UNSLOTH_STUDIO_PROJECTS_HOME", str(tmp_path / "projects"))
 
 
-def _client():
+def _client(*, raise_server_exceptions = True):
     app = FastAPI()
     app.include_router(chat_history.router, prefix = "/history")
     app.dependency_overrides[get_current_subject] = lambda: "test"
-    return TestClient(app)
+    return TestClient(app, raise_server_exceptions = raise_server_exceptions)
 
 
 def _project():
@@ -102,7 +102,7 @@ def test_post_archive_holds_retirement_until_upsert_finishes(monkeypatch, existi
         else SimpleNamespace(begin_git_retirement = begin, finish_git_retirement = finish),
     )
     monkeypatch.setattr(chat_history, "upsert_chat_project", upsert)
-    with _client() as client:
+    with _client(raise_server_exceptions = False) as client:
         response = client.post(
             "/history/projects",
             json = {
@@ -113,7 +113,7 @@ def test_post_archive_holds_retirement_until_upsert_finishes(monkeypatch, existi
                 "archived": True,
             },
         )
-    assert response.status_code == (409 if fail_write else 200)
+    assert response.status_code == (500 if fail_write else 200)
     assert events == ["begin", "write", "finish"]
     if not fail_write:
         assert studio_db.get_chat_project("lifecycle")["archived"] is True
@@ -192,3 +192,33 @@ def test_unexpected_feature_import_failure_is_not_treated_as_absent(monkeypatch)
     monkeypatch.setattr(lifecycle.importlib, "import_module", broken)
     with pytest.raises(ModuleNotFoundError):
         lifecycle.begin_project_retirement("p")
+
+
+@pytest.mark.parametrize("operation", ["post", "patch"])
+@pytest.mark.parametrize("archived", [False, True])
+@pytest.mark.parametrize("error_type", [RuntimeError, OSError])
+def test_unrelated_project_write_errors_keep_server_error_status(
+    monkeypatch, operation, archived, error_type
+):
+    project = _project()
+    released = []
+    monkeypatch.setattr(lifecycle, "begin_project_retirement", lambda *_args, **_kwargs: "retired")
+    monkeypatch.setattr(
+        lifecycle, "finish_project_retirement", lambda *_args: released.append(True)
+    )
+
+    def fail(*_args, **_kwargs):
+        raise error_type("unrelated storage failure")
+
+    monkeypatch.setattr(
+        chat_history, "upsert_chat_project" if operation == "post" else "update_chat_project", fail
+    )
+    with _client(raise_server_exceptions = False) as client:
+        response = (
+            client.post("/history/projects", json = {**project, "archived": archived})
+            if operation == "post"
+            else client.patch("/history/projects/lifecycle", json = {"archived": archived})
+        )
+    assert response.status_code == 500
+    assert released == ([True] if archived else [])
+    assert studio_db.get_chat_project("lifecycle")["archived"] is False


### PR DESCRIPTION
Project archive and deletion must wait for optional project operations to retire before removing their workspace or database record. Add one lifecycle entry point that drains tasks first, then chooses the installed Git retirement owner or verification retirement when Git is absent, releasing admission after success or failure.

With no optional feature installed, archive/delete behavior remains available. Retirement refusal alone maps to HTTP 409 and preserves the project. POST/PATCH storage failures retain their existing server-error behavior; unrelated RuntimeError/OSError exceptions from upsert/update are not converted to conflicts. The existing project-folder error handling is preserved. POST archive acquires retirement before its upsert, including newly created IDs, and holds it through the write.

This extracts the shared chat-history integration requested in #10594 and #10585. It adds no Git, task or verification execution. Optional task draining precedes Git's exclusive fence so active tasks can finish their current Git operations.

At head `10eec87e411ee03fed1999fd3df3971bf0c8d632`, 63 standalone lifecycle/chat-route tests passed, including POST/PATCH storage failures for active and archived projects and fence release after failed writes. The updated head is also pinned in the full task/command native compositions (#10658 and #10672), which exercise active task/worktree retirement. Formatting and diff checks passed.
