### PR TITLE
Fix missing filesystem import in continuation tests

### DIFF
--- a/studio/frontend/tests/chat-continuation.test.ts
+++ b/studio/frontend/tests/chat-continuation.test.ts
@@ -2,6 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { readSrc, registerBundlerResolver } from "./helpers/kit.ts";


### PR DESCRIPTION
Two continuation tests call readFileSync without importing it, causing ReferenceError and TypeScript failures on main. Import the existing Node filesystem function. Validation: all 93 continuation tests and the full frontend typecheck pass.