### PR TITLE
Studio: document the intentional torch and torchcodec floor gap

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3275,6 +3275,7 @@ _TORCH_CEILING="2.12.0"
 _TORCHVISION_CEILING="0.27.0"
 _TORCHAUDIO_CEILING="2.12.0"
 # Default torch constraint; tightened for Python 3.13+ on arm64 macOS (no cp313 wheels below 2.6).
+# Torch 2.4 remains supported without automatic torchcodec installation; Studio's table starts at 2.5.
 TORCH_CONSTRAINT="torch>=2.4,<${_TORCH_CEILING}"
 if [ "$SKIP_TORCH" = false ] && [ "$OS" = "macos" ] && [ "$_ARCH" = "arm64" ]; then
     _PY_MINOR=$("$VENV_DIR/bin/python" -c \
@@ -5073,6 +5074,7 @@ case "$_torch_index_leaf" in
             done
             TORCH_INDEX_URL="${_amd_gfx906_base}/rocm6.3"
             # Cap below <2.12: a rocm7.2 pick floors at 2.11, which rocm6.3 (<= 2.9.x) cannot meet.
+            # Keep the default 2.4 floor, including its lack of automatic torchcodec installation.
             TORCH_CONSTRAINT="torch>=2.4,<2.11.0"
             TORCHVISION_CONSTRAINT="torchvision>=0.19,<0.26.0"
             TORCHAUDIO_CONSTRAINT="torchaudio>=2.4,<2.11.0"

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -371,6 +371,7 @@ def _select_torchao_spec(torch_version: str | None) -> str:
 # >=2.11, hence the open floor. Mirrors pyproject's audio-torch2xx and import_fixes.
 _TORCHCODEC_DEFAULT_SPEC = "torchcodec>=0.10.0,<0.11.0"
 _TORCHCODEC_ABI_STABLE_SPEC = "torchcodec>=0.12.0"
+# install.sh also supports torch 2.4; leave torchcodec alone there rather than pinning its untested 0.0.3 line.
 _TORCHCODEC_TORCH_SPECS: dict[int, str] = {
     12: _TORCHCODEC_ABI_STABLE_SPEC,
     11: "torchcodec>=0.11.0,<0.12.0",

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -274,6 +274,18 @@ def test_select_torchcodec_spec_falls_back_on_unknown_torch():
         assert ips._select_torchcodec_spec(value) == ips._TORCHCODEC_DEFAULT_SPEC
 
 
+def test_shell_torch_floor_intentionally_precedes_torchcodec():
+    ips = _load_install_python_stack()
+    source = (REPO_ROOT / "install.sh").read_text(encoding = "utf-8")
+    floors = re.findall(r'TORCH_CONSTRAINT="torch>=2\.(\d+),', source)
+    assert floors, "install.sh torch constraints were not found"
+    shell_floor = min(map(int, floors))
+    codec_floor = min(ips._TORCHCODEC_TORCH_SPECS)
+    assert (shell_floor, codec_floor) == (4, 5), "revisit the documented torchcodec opt-out"
+    assert ips._select_torchcodec_spec(f"2.{shell_floor}.0") is None
+    assert ips._select_torchcodec_spec(f"2.{codec_floor}.0") is not None
+
+
 def test_select_torchcodec_spec_skips_older_torch():
     ips = _load_install_python_stack()
     for minor in range(min(ips._TORCHCODEC_TORCH_SPECS)):

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -277,8 +277,9 @@ def test_select_torchcodec_spec_falls_back_on_unknown_torch():
 def test_shell_torch_floor_intentionally_precedes_torchcodec():
     ips = _load_install_python_stack()
     source = (REPO_ROOT / "install.sh").read_text(encoding = "utf-8")
-    floors = re.findall(r'TORCH_CONSTRAINT="torch>=2\.(\d+),', source)
+    floors = re.findall(r'^\s*TORCH_CONSTRAINT="torch>=2\.(\d+)(?:\.\d+)?,', source, re.M)
     assert floors, "install.sh torch constraints were not found"
+    assert floors.count("4") == 2, "both default and gfx906 floors must retain the opt-out"
     shell_floor = min(map(int, floors))
     codec_floor = min(ips._TORCHCODEC_TORCH_SPECS)
     assert (shell_floor, codec_floor) == (4, 5), "revisit the documented torchcodec opt-out"


### PR DESCRIPTION
Fixes #10598.

This takes option 2: keep PyTorch 2.4 supported and document that Studio does not automatically install torchcodec for it. Both shell constraints now explain the exception, and the codec table records why its first supported minor remains 2.5. No version constraints or runtime behavior change.

The new test reads the shell constraints and the codec table together. It checks that both 2.4 constraints remain intentional, that the codec floor is 2.5, and that the selector skips 2.4 while selecting a spec for 2.5.

Tested on macOS with Python 3.12:

- 320 tests passed across `test_torchcodec_torch_compat.py`, `test_install_python_stack.py` and `test_flash_attn_install_python_stack.py`.
- Five deliberate changes to the shell or codec floors were caught by the new test, including changing either shell constraint alone.
- The repository's pinned formatter, Ruff, `bash -n install.sh` and `git diff --check` passed.

This preserves current support while making the difference explicit. Raising the installer floor would be a separate release decision.
