### PR TITLE
Run explicitly reviewed project hooks around local tools

### DIFF
--- a/.github/workflows/studio-project-hooks-ci.yml
+++ b/.github/workflows/studio-project-hooks-ci.yml
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+# Qualify review/history standalone and real execution with the secure-tools prerequisite.
+# No models, credentials, or generated frontend assets are needed.
+
+name: Studio reviewed project hooks
+
+on:
+  pull_request:
+    paths:
+      - 'studio/backend/core/agent_workspace/**'
+      - 'studio/backend/core/inference/tools.py'
+      - 'studio/backend/routes/project_verification.py'
+      - 'studio/backend/routes/chat_history.py'
+      - 'studio/backend/storage/studio_db.py'
+      - 'studio/backend/tests/test_project_hook*.py'
+      - 'studio/backend/routes/project_hooks.py'
+      - 'studio/backend/storage/project_hook_trust_db.py'
+      - 'scripts/compose_project_hook_review.py'
+      - 'studio/backend/main.py'
+      - '.github/scripts/retry-with-apt-lock.sh'
+      - '.github/workflows/studio-project-hooks-ci.yml'
+  merge_group:
+  push:
+    branches: [main, 'codex/project-hooks-*']
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  focused:
+    name: verification (${{ matrix.os }}, ${{ matrix.variant }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, windows-latest, macos-15]
+        variant: [lifecycle, secure-tools]
+
+    env:
+      PYTHONIOENCODING: utf-8
+      PYTHONUTF8: '1'
+      UNSLOTH_STUDIO_DISABLE_DEVICE_PROBE: '1'
+      UNSLOTH_VERIFICATION_NATIVE_REQUIRED: ${{ matrix.variant == 'secure-tools' && matrix.os == 'ubuntu-22.04' && '1' || '0' }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Compose the verification engine and its review surfaces
+        shell: bash
+        run: |
+          git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git eff7844bf7101762554ab43d33c390ee6ab4156e
+          if ! git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' merge --no-edit --no-ff FETCH_HEAD; then
+            python scripts/compose_project_hook_review.py
+            git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' commit --no-edit
+          fi
+
+      - name: Compose project lifecycle support
+        shell: bash
+        run: |
+          git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git 31327e51f71055215b6d67fb4de9b6eb38494a73
+          git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' merge --no-edit --no-ff FETCH_HEAD
+
+      - name: Compose confined edits and supervised commands
+        if: matrix.variant == 'secure-tools'
+        shell: bash
+        run: |
+          git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git a5d144019bb585e246d0752c11d325807d0bfb19
+          git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' merge --no-edit --no-ff FETCH_HEAD
+          git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git 9d25a218f4dc335a952b8817588a0d023479c6de
+          git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' merge --no-edit --no-ff FETCH_HEAD
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install the Linux project boundary
+        if: runner.os == 'Linux' && matrix.variant == 'secure-tools'
+        shell: bash
+        timeout-minutes: 15
+        env:
+          RETRY_ATTEMPTS: '2'
+          RETRY_ATTEMPT_TIMEOUT: '360'
+        run: |
+          bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
+            'apt-get install -y --no-install-recommends bubblewrap || { apt-get update -qq && apt-get install -y --no-install-recommends bubblewrap; }'
+
+      - name: Verify the Linux namespace facility
+        if: runner.os == 'Linux' && matrix.variant == 'secure-tools'
+        shell: bash
+        run: |
+          bwrap --version
+          bwrap --unshare-all --ro-bind / / --proc /proc --dev /dev -- /bin/true
+
+      - name: Install focused backend dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install \
+            fastapi httpx typer packaging structlog huggingface-hub \
+            pyjwt cryptography python-multipart aiofiles sqlalchemy psutil pyyaml requests \
+            pytest pytest-timeout
+
+      - name: Run hook contracts
+        working-directory: studio/backend
+        run: >-
+          python -m pytest
+          tests/test_project_hooks.py
+          tests/test_project_hook_trust_db.py
+          tests/test_project_hooks_routes.py
+          tests/test_project_hook_runtime.py
+          tests/test_project_hooks_native.py
+          -q --tb=short --timeout=60 --maxfail=5

--- a/.github/workflows/studio-project-hooks-ci.yml
+++ b/.github/workflows/studio-project-hooks-ci.yml
@@ -88,9 +88,9 @@ jobs:
         if: matrix.variant == 'secure-tools'
         shell: bash
         run: |
-          git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git a5d144019bb585e246d0752c11d325807d0bfb19
+          git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git c6118ec5a653e94158bd637bc59bc18656ca6257
           git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' merge --no-edit --no-ff FETCH_HEAD
-          git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git ba95d92a7d66d45dc6902a00947a4eaccfc06759
+          git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git 9f8e3d6b23c0a8922422411442c7ee182cf65ea7
           git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' merge --no-edit --no-ff FETCH_HEAD
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0

--- a/.github/workflows/studio-project-hooks-ci.yml
+++ b/.github/workflows/studio-project-hooks-ci.yml
@@ -24,6 +24,19 @@ on:
   merge_group:
   push:
     branches: [main, 'codex/project-hooks-*']
+    paths:
+      - 'studio/backend/core/agent_workspace/**'
+      - 'studio/backend/core/inference/tools.py'
+      - 'studio/backend/routes/project_verification.py'
+      - 'studio/backend/routes/chat_history.py'
+      - 'studio/backend/storage/studio_db.py'
+      - 'studio/backend/tests/test_project_hook*.py'
+      - 'studio/backend/routes/project_hooks.py'
+      - 'studio/backend/storage/project_hook_trust_db.py'
+      - 'scripts/compose_project_hook_review.py'
+      - 'studio/backend/main.py'
+      - '.github/scripts/retry-with-apt-lock.sh'
+      - '.github/workflows/studio-project-hooks-ci.yml'
   workflow_dispatch:
 
 concurrency:
@@ -111,6 +124,14 @@ jobs:
             pyjwt cryptography python-multipart aiofiles sqlalchemy psutil pyyaml requests \
             pytest pytest-timeout
 
+      - name: Check hook source without optional verification prerequisites
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          git worktree add --detach "$RUNNER_TEMP/hook-standalone" "$GITHUB_SHA"
+          cd "$RUNNER_TEMP/hook-standalone/studio/backend"
+          python -m pytest tests/test_project_hooks.py tests/test_project_hook_payload.py tests/test_project_hook_runtime.py tests/test_project_hooks_native.py tests/test_project_hooks_routes.py tests/test_project_hook_trust_db.py -q --tb=short --timeout=60
+
       - name: Run hook contracts
         working-directory: studio/backend
         run: >-
@@ -119,5 +140,6 @@ jobs:
           tests/test_project_hook_trust_db.py
           tests/test_project_hooks_routes.py
           tests/test_project_hook_runtime.py
+          tests/test_project_hook_payload.py
           tests/test_project_hooks_native.py
           -q --tb=short --timeout=60 --maxfail=5

--- a/.github/workflows/studio-project-hooks-ci.yml
+++ b/.github/workflows/studio-project-hooks-ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Compose the verification engine and its review surfaces
         shell: bash
         run: |
-          git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git eff7844bf7101762554ab43d33c390ee6ab4156e
+          git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git 49536716a246d39f42f5336082b736f898f1acd0
           if ! git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' merge --no-edit --no-ff FETCH_HEAD; then
             python scripts/compose_project_hook_review.py
             git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' commit --no-edit
@@ -68,7 +68,7 @@ jobs:
       - name: Compose project lifecycle support
         shell: bash
         run: |
-          git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git 31327e51f71055215b6d67fb4de9b6eb38494a73
+          git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git 9ced365ad35a84f34d5cdb00f9f0cd766825fe4c
           git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' merge --no-edit --no-ff FETCH_HEAD
 
       - name: Compose confined edits and supervised commands
@@ -77,7 +77,7 @@ jobs:
         run: |
           git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git a5d144019bb585e246d0752c11d325807d0bfb19
           git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' merge --no-edit --no-ff FETCH_HEAD
-          git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git 9d25a218f4dc335a952b8817588a0d023479c6de
+          git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git ba95d92a7d66d45dc6902a00947a4eaccfc06759
           git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' merge --no-edit --no-ff FETCH_HEAD
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0

--- a/.github/workflows/studio-project-hooks-ci.yml
+++ b/.github/workflows/studio-project-hooks-ci.yml
@@ -72,8 +72,10 @@ jobs:
       - name: Compose the verification engine and its review surfaces
         shell: bash
         run: |
-          git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git 49536716a246d39f42f5336082b736f898f1acd0
-          if ! git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' merge --no-edit --no-ff FETCH_HEAD; then
+          if ! git cat-file -e "d298242c37f772cec7a05b55de02698faeb8f3c5^{commit}" 2>/dev/null; then
+            git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git d298242c37f772cec7a05b55de02698faeb8f3c5
+          fi
+          if ! git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' merge --no-edit --no-ff d298242c37f772cec7a05b55de02698faeb8f3c5; then
             python scripts/compose_project_hook_review.py
             git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' commit --no-edit
           fi
@@ -81,17 +83,23 @@ jobs:
       - name: Compose project lifecycle support
         shell: bash
         run: |
-          git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git 9ced365ad35a84f34d5cdb00f9f0cd766825fe4c
-          git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' merge --no-edit --no-ff FETCH_HEAD
+          if ! git cat-file -e "10eec87e411ee03fed1999fd3df3971bf0c8d632^{commit}" 2>/dev/null; then
+            git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git 10eec87e411ee03fed1999fd3df3971bf0c8d632
+          fi
+          git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' merge --no-edit --no-ff 10eec87e411ee03fed1999fd3df3971bf0c8d632
 
       - name: Compose confined edits and supervised commands
         if: matrix.variant == 'secure-tools'
         shell: bash
         run: |
-          git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git c6118ec5a653e94158bd637bc59bc18656ca6257
-          git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' merge --no-edit --no-ff FETCH_HEAD
-          git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git 9f8e3d6b23c0a8922422411442c7ee182cf65ea7
-          git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' merge --no-edit --no-ff FETCH_HEAD
+          if ! git cat-file -e "c6118ec5a653e94158bd637bc59bc18656ca6257^{commit}" 2>/dev/null; then
+            git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git c6118ec5a653e94158bd637bc59bc18656ca6257
+          fi
+          git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' merge --no-edit --no-ff c6118ec5a653e94158bd637bc59bc18656ca6257
+          if ! git cat-file -e "61de31296e406f1e0dc5af4ac07c96fff1343cf5^{commit}" 2>/dev/null; then
+            git fetch --no-tags https://github.com/PhilipJohnBasile/unsloth.git 61de31296e406f1e0dc5af4ac07c96fff1343cf5
+          fi
+          git -c user.name='Verification CI' -c user.email='verification-ci@users.noreply.github.com' merge --no-edit --no-ff 61de31296e406f1e0dc5af4ac07c96fff1343cf5
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:

--- a/scripts/compose_project_hook_review.py
+++ b/scripts/compose_project_hook_review.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Resolve only the known additive hook/verification review composition conflicts."""
+import re
+import subprocess
+from pathlib import Path
+
+
+def replace_once(text, before, after):
+    if text.count(before) != 1:
+        raise RuntimeError("Review composition context changed")
+    return text.replace(before, after, 1)
+
+
+def main():
+    conflicts = subprocess.check_output(["git", "diff", "--name-only", "--diff-filter=U"], text=True).splitlines()
+    allowed = {"studio/backend/main.py", "studio/frontend/src/features/chat/chat-page.tsx"}
+    if not conflicts or set(conflicts) - allowed:
+        raise RuntimeError("Unexpected review composition conflicts")
+    for name in conflicts:
+        path = Path(name)
+        if name.endswith("main.py"):
+            def combine(match):
+                left, right = match.group(1), match.group(2)
+                for line in (left + right).splitlines():
+                    if not any(router in line for router in ("project_hooks_router", "project_verification_router")):
+                        raise RuntimeError("Unexpected route-registration conflict")
+                return left + right
+            resolved = re.sub(r"^<<<<<<<[^\n]*\n(.*?)^=======\n(.*?)^>>>>>>>[^\n]*\n", combine, path.read_text(), flags=re.M | re.S)
+        else:
+            resolved = subprocess.check_output(["git", "show", ":2:" + name], text=True)
+            engine = subprocess.check_output(["git", "show", ":3:" + name], text=True)
+            a = engine.index("const ProjectChecksPanel = lazy(")
+            b = engine.index("const ProjectSourcesPanel = lazy(", a)
+            resolved = replace_once(resolved, "const ProjectHooksLandingPanel = lazy(", engine[a:b] + "const ProjectHooksLandingPanel = lazy(")
+            resolved = replace_once(resolved, '"chats" | "sources" | "hooks"', '"chats" | "sources" | "hooks" | "checks"')
+            start = '              <button\n                type="button"\n                onClick={() => setProjectTab("checks")}'
+            a = engine.index(start)
+            b = engine.index("              </button>", a) + len("              </button>\n")
+            hook_start = start.replace('"checks"', '"hooks"')
+            resolved = replace_once(resolved, hook_start, engine[a:b] + hook_start)
+            before = '            {projectTab === "hooks" ? ('
+            after = '''            {projectTab === "checks" ? (
+              <Suspense fallback={<p className="mt-8 text-sm text-muted-foreground">Loading verification…</p>}>
+                <ProjectChecksPanel key={projectId} projectId={projectId} />
+              </Suspense>
+            ) : projectTab === "hooks" ? ('''
+            resolved = replace_once(resolved, before, after)
+        if "<<<<<<<" in resolved or ">>>>>>>" in resolved:
+            raise RuntimeError("Unresolved review composition")
+        path.write_text(resolved)
+        subprocess.run(["git", "add", name], check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compose_project_hook_review.py
+++ b/scripts/compose_project_hook_review.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 """Resolve only the known additive hook/verification review composition conflicts."""
+
 import re
 import subprocess
 from pathlib import Path
@@ -12,43 +13,63 @@ def replace_once(text, before, after):
 
 
 def main():
-    conflicts = subprocess.check_output(["git", "diff", "--name-only", "--diff-filter=U"], text=True).splitlines()
+    conflicts = subprocess.check_output(
+        ["git", "diff", "--name-only", "--diff-filter=U"], text = True
+    ).splitlines()
     allowed = {"studio/backend/main.py", "studio/frontend/src/features/chat/chat-page.tsx"}
     if not conflicts or set(conflicts) - allowed:
         raise RuntimeError("Unexpected review composition conflicts")
     for name in conflicts:
         path = Path(name)
         if name.endswith("main.py"):
+
             def combine(match):
                 left, right = match.group(1), match.group(2)
                 for line in (left + right).splitlines():
-                    if not any(router in line for router in ("project_hooks_router", "project_verification_router")):
+                    if not any(
+                        router in line
+                        for router in ("project_hooks_router", "project_verification_router")
+                    ):
                         raise RuntimeError("Unexpected route-registration conflict")
                 return left + right
-            resolved = re.sub(r"^<<<<<<<[^\n]*\n(.*?)^=======\n(.*?)^>>>>>>>[^\n]*\n", combine, path.read_text(), flags=re.M | re.S)
+
+            resolved = re.sub(
+                r"^<<<<<<<[^\n]*\n(.*?)^=======\n(.*?)^>>>>>>>[^\n]*\n",
+                combine,
+                path.read_text(),
+                flags = re.M | re.S,
+            )
         else:
-            resolved = subprocess.check_output(["git", "show", ":2:" + name], text=True)
-            engine = subprocess.check_output(["git", "show", ":3:" + name], text=True)
+            resolved = subprocess.check_output(["git", "show", ":2:" + name], text = True)
+            engine = subprocess.check_output(["git", "show", ":3:" + name], text = True)
             a = engine.index("const ProjectChecksPanel = lazy(")
             b = engine.index("const ProjectSourcesPanel = lazy(", a)
-            resolved = replace_once(resolved, "const ProjectHooksLandingPanel = lazy(", engine[a:b] + "const ProjectHooksLandingPanel = lazy(")
-            resolved = replace_once(resolved, '"chats" | "sources" | "hooks"', '"chats" | "sources" | "hooks" | "checks"')
+            resolved = replace_once(
+                resolved,
+                "const ProjectHooksLandingPanel = lazy(",
+                engine[a:b] + "const ProjectHooksLandingPanel = lazy(",
+            )
+            resolved = replace_once(
+                resolved,
+                '"chats" | "sources" | "hooks"',
+                '"chats" | "sources" | "hooks" | "checks"',
+            )
             start = '              <button\n                type="button"\n                onClick={() => setProjectTab("checks")}'
             a = engine.index(start)
             b = engine.index("              </button>", a) + len("              </button>\n")
             hook_start = start.replace('"checks"', '"hooks"')
             resolved = replace_once(resolved, hook_start, engine[a:b] + hook_start)
             before = '            {projectTab === "hooks" ? ('
-            after = '''            {projectTab === "checks" ? (
+            after = """            {projectTab === "checks" ? (
               <Suspense fallback={<p className="mt-8 text-sm text-muted-foreground">Loading verification…</p>}>
                 <ProjectChecksPanel key={projectId} projectId={projectId} />
               </Suspense>
-            ) : projectTab === "hooks" ? ('''
+            ) : projectTab === "hooks" ? ("""
             resolved = replace_once(resolved, before, after)
         if "<<<<<<<" in resolved or ">>>>>>>" in resolved:
             raise RuntimeError("Unresolved review composition")
         path.write_text(resolved)
-        subprocess.run(["git", "add", name], check=True)
+        subprocess.run(["git", "add", name], check = True)
 
 
 if __name__ == "__main__":

--- a/studio/PROJECT_HOOKS_REVIEW.md
+++ b/studio/PROJECT_HOOKS_REVIEW.md
@@ -1,0 +1,25 @@
+# Reviewed project tool hooks
+
+This split adds a Hooks tab, exact-content trust and synchronous pre/post tool
+hooks. It is independent of the verification engine source diff; review/execution
+use that engine (#10585), lifecycle (#10633), edits (#10577) and commands (#10636)
+as prerequisites. Missing verification support leaves unconfigured tool calls usable
+and makes configured hook review/execution unavailable without a shell fallback.
+
+Only trusted, matching synchronous PreToolUse/PostToolUse handlers run. They cannot
+change tool arguments or permissions. Trust, workspace identity and source bytes
+are revalidated before native dispatch. A conflicting saved conversation cannot
+bypass hooks on an explicitly bound project request. Failed capability probing
+after trust is saved returns the saved trust with execution unavailable.
+
+Post-hook failure appears before bounded tool output, so truncation cannot turn a
+completed mutation plus failed validation into apparent success. With no stored
+hook trust, project calls perform a bounded trust-state lookup, then skip hook file
+discovery, extra workspace leases and process probes. No-output hooks return the
+original result without another truncation pass. This is not a claim of literally
+zero routing overhead: the project/trust lookup is additional work.
+
+Hook commands share the verification process boundary. Other lifecycle and async
+hook declarations are reviewable but remain inactive. Native fixtures execute
+reviewed hooks without models; live provider and packaged desktop behavior are
+separate gates.

--- a/studio/PROJECT_HOOKS_REVIEW.md
+++ b/studio/PROJECT_HOOKS_REVIEW.md
@@ -14,12 +14,23 @@ after trust is saved returns the saved trust with execution unavailable.
 
 Post-hook failure appears before bounded tool output, so truncation cannot turn a
 completed mutation plus failed validation into apparent success. With no stored
-hook trust, project calls perform a bounded trust-state lookup, then skip hook file
-discovery, extra workspace leases and process probes. No-output hooks return the
+hook trust, project calls perform one bounded trust-state lookup, then call the
+original executor with the original arguments. They skip extra project/thread
+routing, archived-project checks, hook file discovery, workspace leases and
+process probes. Non-project and non-hooked calls do not query hook trust. No-output hooks return the
 original result without another truncation pass. This is not a claim of literally
-zero routing overhead: the project/trust lookup is additional work.
+zero routing overhead: argument binding and the project trust lookup add work.
+The existing tool executor remains authoritative for unconfigured project routing
+and errors. Review #10577 edits and #10585 verification before this integration;
+#10633 lifecycle and #10636 commands complete its execution prerequisites.
 
 Hook commands share the verification process boundary. Other lifecycle and async
 hook declarations are reviewable but remain inactive. Native fixtures execute
 reviewed hooks without models; live provider and packaged desktop behavior are
 separate gates.
+
+A local warmed SQLite microbenchmark (Python 3.11, seven batches of 100 stub
+executor calls, no model or command execution) measured median 0.03 microseconds
+for the direct stub, 1.13 microseconds through the non-project wrapper, and
+392.91 microseconds for an unconfigured project call. This quantifies wrapper
+and trust lookup cost on that machine; it is not a production latency guarantee.

--- a/studio/backend/core/agent_workspace/__init__.py
+++ b/studio/backend/core/agent_workspace/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Project-scoped coding-agent context primitives."""

--- a/studio/backend/core/agent_workspace/hook_context.py
+++ b/studio/backend/core/agent_workspace/hook_context.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Optional verification authority for hook review and execution."""
+
+import importlib
+from contextlib import contextmanager
+
+try:
+    from .verification_context import AgentWorkspaceError
+except ModuleNotFoundError as exc:
+    if exc.name != __package__ + ".verification_context":
+        raise
+
+    class AgentWorkspaceError(RuntimeError):
+        """Hook execution prerequisites are unavailable."""
+
+
+def _required(name):
+    try:
+        return importlib.import_module(__package__ + "." + name)
+    except ModuleNotFoundError as exc:
+        if exc.name != __package__ + "." + name:
+            raise
+        raise AgentWorkspaceError(
+            "Project verification support must be installed before hooks can be reviewed or run."
+        ) from exc
+
+
+def project_workspace(project_id):
+    return _required("verification_context").project_workspace(project_id)
+
+
+@contextmanager
+def project_workspace_access(project_id):
+    with _required("verification_context").project_workspace_access(project_id) as workspace:
+        yield workspace
+
+
+def execution_status():
+    try:
+        return _required("verification").execution_status()
+    except AgentWorkspaceError as exc:
+        return {"available": False, "backend": None, "reason": str(exc)}
+
+
+class _OptionalModule:
+    def __init__(self, name):
+        self.name = name
+
+    def __getattr__(self, name):
+        return getattr(_required(self.name), name)
+
+
+processes = _OptionalModule("verification_process")
+verification_state = _OptionalModule("verification_state")

--- a/studio/backend/core/agent_workspace/hook_runtime.py
+++ b/studio/backend/core/agent_workspace/hook_runtime.py
@@ -266,12 +266,16 @@ def with_project_tool_hooks(execute):
         tools._REQUEST_RESULT_BUDGET.set(call.get("result_budget_tokens"))
         tools._REQUEST_CONTEXT_TOKENS.set(call.get("context_tokens", tools._UNSET_CONTEXT_TOKENS))
         try:
-            project_id = _project_for_tool(call.get("session_id"), call.get("thread_id"))
-            if project_id is None:
+            session_id = call.get("session_id")
+            if not isinstance(session_id, str) or not session_id.startswith("project-"):
                 return execute(*args, **kwargs)
-            if not project_hook_trust_db.get_project_hook_trust_record(project_id)[
-                "hasStoredTrust"
-            ]:
+            # Unconfigured projects keep the original executor's routing and
+            # errors. Only configured hooks need extra thread/project checks.
+            candidate = session_id[len("project-") :]
+            if not project_hook_trust_db.get_project_hook_trust_record(candidate)["hasStoredTrust"]:
+                return execute(*args, **kwargs)
+            project_id = _project_for_tool(session_id, call.get("thread_id"))
+            if project_id is None:
                 return execute(*args, **kwargs)
             arguments = call.get("arguments")
             cancel_event = call.get("cancel_event")

--- a/studio/backend/core/agent_workspace/hook_runtime.py
+++ b/studio/backend/core/agent_workspace/hook_runtime.py
@@ -76,10 +76,26 @@ def _event_payload(event, project_id, name, arguments, result):
         "tool_name": name,
         "tool_input": arguments,
     }
-    if result is not None:
-        payload["tool_response"] = result[:4096]
-        payload["tool_response_truncated"] = len(result) > 4096
     try:
+        if result is not None:
+            # Reserve the response envelope, then fit the actual JSON encoding.
+            # A Unicode character can consume up to twelve ASCII bytes here.
+            payload["tool_response"] = ""
+            payload["tool_response_truncated"] = True
+            empty = json.dumps(payload, ensure_ascii = True, separators = (",", ":"))
+            remaining = MAX_EVENT_BYTES - len(empty)
+            end = 0
+            for character in result[:4096]:
+                cost = len(json.dumps(character, ensure_ascii = True)) - 2
+                if cost > remaining:
+                    break
+                remaining -= cost
+                end += 1
+            payload["tool_response"] = result[:end]
+            # False is a byte longer than True in JSON; retain the conservative
+            # flag if it would otherwise cross the exact event limit.
+            if end == len(result) and remaining >= 1:
+                payload["tool_response_truncated"] = False
         encoded = json.dumps(payload, ensure_ascii = True, separators = (",", ":"))
     except (ValueError, TypeError, RecursionError) as exc:
         raise AgentWorkspaceError("Project hook input could not be represented safely.") from exc
@@ -276,7 +292,10 @@ def with_project_tool_hooks(execute):
                         result = result,
                         cancel_event = cancel_event,
                     )
-                except AgentWorkspaceError as exc:
+                except (
+                    AgentWorkspaceError,
+                    project_hook_trust_db.ProjectHookTrustStateError,
+                ) as exc:
                     after = f"Post-tool hook failed after the tool ran: {exc}"
                 reports = "\n".join(part for part in (after, before) if part)
                 if not reports:

--- a/studio/backend/core/agent_workspace/hook_runtime.py
+++ b/studio/backend/core/agent_workspace/hook_runtime.py
@@ -1,0 +1,294 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Reviewed, synchronous hooks around project editing and command tools.
+
+Hook commands have the same native boundary as verification. They cannot grant
+permissions, rewrite tool arguments, or recursively call tools. Other lifecycle
+and asynchronous declarations remain reviewable but inactive in this split.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import json
+import sys
+import threading
+import time
+
+from storage import project_hook_trust_db, studio_db
+
+from . import hooks, hook_context as common
+from .hook_context import AgentWorkspaceError, processes, verification_state
+
+ACTIVE_HOOK_EVENTS = frozenset({"PreToolUse", "PostToolUse"})
+HOOKED_TOOLS = frozenset({"edit_file", "python", "terminal"})
+MAX_EVENT_BYTES = 16 * 1024
+MAX_HOOK_OUTPUT_BYTES = 16 * 1024
+MAX_EVENT_SECONDS = 60.0
+
+# -I prevents a project-local json.py/subprocess.py or PYTHONPATH from replacing
+# the trusted stdin adapter. The reviewed shell command runs in the project.
+_STDIN_ADAPTER = (
+    "import subprocess,sys; "
+    "result=subprocess.run(['/bin/sh','-c',sys.argv[1]],"
+    "input=sys.argv[2].encode('utf-8')); sys.exit(result.returncode)"
+)
+
+
+def handler_is_supported(event, handler):
+    return event in ACTIVE_HOOK_EVENTS and not handler.get("async", False)
+
+
+def _identity(workspace):
+    return int(workspace.device_id), int(workspace.file_id)
+
+
+def _snapshot(project_id):
+    workspace = common.project_workspace(project_id)
+    config = hooks.discover_project_hooks(workspace.root, expected_identity = _identity(workspace))
+    trust = project_hook_trust_db.get_project_hook_trust_state(
+        project_id,
+        config.get("contentHash"),
+        workspace_identity = _identity(workspace),
+        workspace_revision = workspace.revision,
+    )
+    return workspace, config, trust
+
+
+def _same_authority(project_id, workspace, config, trust, handler_id):
+    current_workspace, current_config, current_trust = _snapshot(project_id)
+    return (
+        current_workspace == workspace
+        and current_config["contentHash"] == config["contentHash"]
+        and current_trust["revision"] == trust["revision"]
+        and current_trust["trusted"]
+        and handler_id not in current_trust["disabledHandlerIds"]
+        and verification_state.project_execution_may_start(project_id)
+    )
+
+
+def _event_payload(event, project_id, name, arguments, result):
+    payload = {
+        "hook_event_name": event,
+        "project_id": project_id,
+        "tool_name": name,
+        "tool_input": arguments,
+    }
+    if result is not None:
+        payload["tool_response"] = result[:4096]
+        payload["tool_response_truncated"] = len(result) > 4096
+    try:
+        encoded = json.dumps(payload, ensure_ascii = True, separators = (",", ":"))
+    except (ValueError, TypeError, RecursionError) as exc:
+        raise AgentWorkspaceError("Project hook input could not be represented safely.") from exc
+    if len(encoded.encode("utf-8")) > MAX_EVENT_BYTES:
+        # Do not present a truncated tool argument as the command being approved.
+        raise AgentWorkspaceError(
+            "Project hook input exceeds its review limit; split the tool call."
+        )
+    return encoded
+
+
+def _context_output(handler, output):
+    # A UTF-8 byte bound is conservative for tokenizers with byte fallback;
+    # it also honors a zero additional-context allowance without hiding denial.
+    budget = min(2048, handler.get("additionalContextLimit", 2500))
+    return output.encode("utf-8")[:budget].decode("utf-8", errors = "ignore")
+
+
+def _blocks_tool(output):
+    try:
+        value = json.loads(output)
+    except (ValueError, RecursionError):
+        return False
+    if not isinstance(value, dict):
+        return False
+    specific = value.get("hookSpecificOutput")
+    return (
+        value.get("decision") == "block"
+        or value.get("continue") is False
+        or (isinstance(specific, dict) and specific.get("permissionDecision") == "deny")
+    )
+
+
+def run_tool_hooks(
+    project_id,
+    event,
+    name,
+    arguments,
+    *,
+    result = None,
+    cancel_event = None,
+):
+    if event not in ACTIVE_HOOK_EVENTS or name not in HOOKED_TOOLS:
+        return ""
+    if not project_hook_trust_db.get_project_hook_trust_record(project_id)["hasStoredTrust"]:
+        return ""
+    with common.project_workspace_access(project_id):
+        workspace, config, trust = _snapshot(project_id)
+        if not trust["trusted"]:
+            return ""
+        handlers = [
+            handler
+            for handler in hooks.matching_project_hooks(config, event, {"tool_name": name})
+            if handler_is_supported(event, handler)
+            and handler["id"] not in trust["disabledHandlerIds"]
+        ]
+        if not handlers:
+            return ""
+        payload = _event_payload(event, project_id, name, arguments, result)
+        event_deadline = time.monotonic() + MAX_EVENT_SECONDS
+        reports = []
+        for handler in handlers:
+            cancelled = threading.Event()
+            stopped = threading.Event()
+
+            def authority_current(handler_id = handler["id"]):
+                return _same_authority(project_id, workspace, config, trust, handler_id)
+
+            def monitor(
+                stop_signal = stopped,
+                cancel_signal = cancelled,
+                check = authority_current,
+            ):
+                while not stop_signal.wait(0.1):
+                    try:
+                        valid = check()
+                    except Exception:
+                        valid = False
+                    if (
+                        not valid
+                        or time.monotonic() >= event_deadline
+                        or (cancel_event is not None and cancel_event.is_set())
+                    ):
+                        cancel_signal.set()
+                        return
+
+            def before_start(opened_workspace, _argv):
+                if (
+                    opened_workspace.root != workspace.root
+                    or _identity(opened_workspace) != _identity(workspace)
+                    or not authority_current()
+                    or time.monotonic() >= event_deadline
+                    or (cancel_event is not None and cancel_event.is_set())
+                ):
+                    raise AgentWorkspaceError("Project hook authority changed before execution.")
+
+            remaining = event_deadline - time.monotonic()
+            if remaining <= 0:
+                raise AgentWorkspaceError("Project hooks exceeded their combined 60 second limit.")
+            watcher = threading.Thread(target = monitor, name = "project-hook-authority", daemon = True)
+            watcher.start()
+            try:
+                process = processes.run_project_process(
+                    project_id,
+                    [sys.executable, "-I", "-c", _STDIN_ADAPTER, handler["command"], payload],
+                    timeout_seconds = min(handler["timeout"], remaining),
+                    output_limit_bytes = MAX_HOOK_OUTPUT_BYTES,
+                    cancel_event = cancelled,
+                    before_start = before_start,
+                )
+            finally:
+                stopped.set()
+                watcher.join(timeout = 1)
+            context_output = _context_output(handler, process.output)
+            if process.status != "passed" or process.output_truncated:
+                raise AgentWorkspaceError(
+                    f"Project {event} hook {handler['id']} did not complete successfully "
+                    f"({process.status}). {context_output}"
+                )
+            if event == "PreToolUse" and _blocks_tool(process.output):
+                raise AgentWorkspaceError(f"Project hook blocked this tool call. {context_output}")
+            if context_output.strip():
+                reports.append(context_output)
+        return (
+            "\n".join(reports)
+            .encode("utf-8")[:MAX_HOOK_OUTPUT_BYTES]
+            .decode("utf-8", errors = "ignore")
+        )
+
+
+def _project_for_tool(session_id, thread_id):
+    from core.inference import tools  # noqa: PLC0415
+
+    if not isinstance(session_id, str) or not session_id.startswith("project-"):
+        return None
+    project_id = session_id[len("project-") :]
+    if thread_id:
+        thread = studio_db.get_chat_thread(thread_id)
+        if thread is None or thread.get("projectId") != project_id:
+            raise AgentWorkspaceError("The tool's project does not match its saved conversation.")
+        if tools._thread_exists(session_id):
+            raise AgentWorkspaceError(
+                "The project session conflicts with a saved conversation; the tool did not run."
+            )
+    elif tools._thread_exists(session_id):
+        return None
+    project = studio_db.get_chat_project(project_id)
+    if project is None:
+        return None
+    if project.get("archived"):
+        raise AgentWorkspaceError("Archived projects cannot run project hooks or tools.")
+    return project_id
+
+
+def with_project_tool_hooks(execute):
+    signature = inspect.signature(execute)
+
+    @functools.wraps(execute)
+    def wrapped(*args, **kwargs):
+        call = signature.bind(*args, **kwargs).arguments
+        name = call.get("name")
+        if name not in HOOKED_TOOLS:
+            return execute(*args, **kwargs)
+        from core.inference import tools  # noqa: PLC0415
+
+        # The core function normally seeds these before execution. Pre-hook
+        # refusal must not inherit a previous request's result/context budget.
+        tools._REQUEST_RESULT_BUDGET.set(call.get("result_budget_tokens"))
+        tools._REQUEST_CONTEXT_TOKENS.set(call.get("context_tokens", tools._UNSET_CONTEXT_TOKENS))
+        try:
+            project_id = _project_for_tool(call.get("session_id"), call.get("thread_id"))
+            if project_id is None:
+                return execute(*args, **kwargs)
+            if not project_hook_trust_db.get_project_hook_trust_record(project_id)[
+                "hasStoredTrust"
+            ]:
+                return execute(*args, **kwargs)
+            arguments = call.get("arguments")
+            cancel_event = call.get("cancel_event")
+            with common.project_workspace_access(project_id):
+                before = run_tool_hooks(
+                    project_id, "PreToolUse", name, arguments, cancel_event = cancel_event
+                )
+                if cancel_event is not None and cancel_event.is_set():
+                    return "Error: Tool call cancelled before execution."
+                # The tool always receives its original arguments and permission mode.
+                result = execute(*args, **kwargs)
+                try:
+                    after = run_tool_hooks(
+                        project_id,
+                        "PostToolUse",
+                        name,
+                        arguments,
+                        result = result,
+                        cancel_event = cancel_event,
+                    )
+                except AgentWorkspaceError as exc:
+                    after = f"Post-tool hook failed after the tool ran: {exc}"
+                reports = "\n".join(part for part in (after, before) if part)
+                if not reports:
+                    return result
+                return tools._fit_result_to_room(
+                    "Project hook output (untrusted data):\n"
+                    + reports
+                    + "\n\nTool result:\n"
+                    + result,
+                    name,
+                )
+        except (AgentWorkspaceError, project_hook_trust_db.ProjectHookTrustStateError) as exc:
+            return tools._fit_result_to_room(f"Error: {exc}", name)
+
+    return wrapped

--- a/studio/backend/core/agent_workspace/hooks.py
+++ b/studio/backend/core/agent_workspace/hooks.py
@@ -1,0 +1,601 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Trusted, project-local Codex lifecycle hooks.
+
+The module deliberately owns no persistence. Callers discover and validate an
+exact ``.codex/hooks.json`` file and persist its ``contentHash`` after review.
+Runtime execution and lifecycle authority are deliberately outside this module.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import time
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from .hook_context import AgentWorkspaceError
+
+
+HOOK_EVENTS = (
+    "SessionStart",
+    "SessionEnd",
+    "UserPromptSubmit",
+    "PreToolUse",
+    "PermissionRequest",
+    "PostToolUse",
+    "PreCompact",
+    "PostCompact",
+    "SubagentStart",
+    "SubagentStop",
+    "Stop",
+)
+MAX_HOOK_CONFIG_BYTES = 256 * 1024
+MAX_HOOK_GROUPS = 128
+MAX_HOOK_HANDLERS = 256
+MAX_HOOK_COMMAND_BYTES = 8 * 1024
+MAX_HOOK_MATCHER_CHARACTERS = 256
+MAX_HOOK_TIMEOUT_SECONDS = 600
+MAX_ADDITIONAL_CONTEXT_TOKENS = 100_000
+_HOOK_PATH = ".codex/hooks.json"
+_TOP_LEVEL_FIELDS = frozenset({"description", "hooks"})
+_GROUP_FIELDS = frozenset({"matcher", "hooks"})
+_COMMAND_FIELDS = frozenset(
+    {
+        "type",
+        "command",
+        "commandWindows",
+        "timeout",
+        "statusMessage",
+        "additionalContextLimit",
+        "async",
+    }
+)
+_MATCH_FIELD = {
+    "SessionStart": "source",
+    "SessionEnd": "reason",
+    "PreToolUse": "tool_name",
+    "PermissionRequest": "tool_name",
+    "PostToolUse": "tool_name",
+    "PreCompact": "trigger",
+    "PostCompact": "trigger",
+    "SubagentStart": "agent_type",
+    "SubagentStop": "agent_type",
+    "UserPromptSubmit": None,
+    "Stop": None,
+}
+_MATCH_LITERAL = "literal"
+_MATCH_ONE = "one"
+_MATCH_MANY = "many"
+_UNSUPPORTED_MATCHER_CHARACTERS = frozenset("()[]+?{}")
+
+
+def project_hooks_content_hash(raw: bytes | str) -> str:
+    """Hash the exact source bytes reviewed by the user."""
+    encoded = raw.encode("utf-8") if isinstance(raw, str) else bytes(raw)
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _reject_duplicate_fields(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise AgentWorkspaceError(f"Project hooks contain duplicate field {key!r}.")
+        result[key] = value
+    return result
+
+
+def _parse_json(raw: bytes) -> dict[str, Any]:
+    if len(raw) > MAX_HOOK_CONFIG_BYTES:
+        raise AgentWorkspaceError("Project hooks exceed the configuration size limit.")
+    try:
+        document = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook = _reject_duplicate_fields,
+        )
+    except AgentWorkspaceError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise AgentWorkspaceError("Project hooks must be a valid UTF-8 JSON object.") from exc
+    if not isinstance(document, dict):
+        raise AgentWorkspaceError("Project hooks must be a JSON object.")
+    return document
+
+
+def _unknown_fields(value: dict, allowed: frozenset[str], label: str) -> None:
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        rendered = ", ".join(repr(field) for field in unknown)
+        raise AgentWorkspaceError(f"{label} contains unsupported fields: {rendered}.")
+
+
+def _optional_text(
+    value: Any,
+    *,
+    label: str,
+    maximum: int,
+    allow_empty: bool = True,
+) -> Optional[str]:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise AgentWorkspaceError(f"{label} must be a string.")
+    if (not allow_empty and not value) or len(value.encode("utf-8")) > maximum:
+        raise AgentWorkspaceError(f"{label} is invalid or exceeds its size limit.")
+    if "\x00" in value:
+        raise AgentWorkspaceError(f"{label} cannot contain NUL characters.")
+    return value
+
+
+def _integer(value: Any, *, label: str, default: int, minimum: int, maximum: int) -> int:
+    if value is None:
+        return default
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise AgentWorkspaceError(f"{label} must be an integer.")
+    if value < minimum or value > maximum:
+        raise AgentWorkspaceError(f"{label} is outside the supported range.")
+    return value
+
+
+def _invalid_matcher(event: str) -> AgentWorkspaceError:
+    return AgentWorkspaceError(f"{event} hook matcher uses an unsupported or unsafe pattern.")
+
+
+def _split_matcher_alternatives(matcher: str, *, event: str) -> tuple[str, ...]:
+    alternatives = []
+    start = 0
+    escaped = False
+    for index, character in enumerate(matcher):
+        if escaped:
+            escaped = False
+            continue
+        if character == "\\":
+            escaped = True
+        elif character == "|":
+            alternatives.append(matcher[start:index])
+            start = index + 1
+    if escaped:
+        raise _invalid_matcher(event)
+    alternatives.append(matcher[start:])
+    if any(not alternative for alternative in alternatives):
+        raise _invalid_matcher(event)
+    return tuple(alternatives)
+
+
+def _parse_matcher_alternative(
+    alternative: str, *, event: str
+) -> tuple[bool, bool, tuple[tuple[str, Optional[str]], ...]]:
+    anchored_start = alternative.startswith("^")
+    index = 1 if anchored_start else 0
+    anchored_end = False
+    tokens: list[tuple[str, Optional[str]]] = []
+    while index < len(alternative):
+        character = alternative[index]
+        if character == "\\":
+            index += 1
+            if index >= len(alternative):
+                raise _invalid_matcher(event)
+            tokens.append((_MATCH_LITERAL, alternative[index]))
+            index += 1
+            continue
+        if character == "$":
+            if index != len(alternative) - 1:
+                raise _invalid_matcher(event)
+            anchored_end = True
+            index += 1
+            continue
+        if character == "^" or character in _UNSUPPORTED_MATCHER_CHARACTERS:
+            raise _invalid_matcher(event)
+        if character == "*":
+            raise _invalid_matcher(event)
+        if character == ".":
+            if index + 1 < len(alternative) and alternative[index + 1] == "*":
+                if not tokens or tokens[-1][0] != _MATCH_MANY:
+                    tokens.append((_MATCH_MANY, None))
+                index += 2
+            else:
+                tokens.append((_MATCH_ONE, None))
+                index += 1
+            continue
+        tokens.append((_MATCH_LITERAL, character))
+        index += 1
+    return anchored_start, anchored_end, tuple(tokens)
+
+
+def _parse_matcher(
+    matcher: str, *, event: str
+) -> tuple[tuple[bool, bool, tuple[tuple[str, Optional[str]], ...]], ...]:
+    return tuple(
+        _parse_matcher_alternative(alternative, event = event)
+        for alternative in _split_matcher_alternatives(matcher, event = event)
+    )
+
+
+def _match_tokens(
+    tokens: tuple[tuple[str, Optional[str]], ...],
+    value: str,
+    *,
+    anchored_start: bool,
+    anchored_end: bool,
+) -> bool:
+    effective_tokens = (
+        (() if anchored_start else ((_MATCH_MANY, None),))
+        + tokens
+        + (() if anchored_end else ((_MATCH_MANY, None),))
+    )
+    states = [False] * (len(value) + 1)
+    states[0] = True
+    for kind, literal in effective_tokens:
+        next_states = [False] * (len(value) + 1)
+        if kind == _MATCH_MANY:
+            next_states[0] = states[0]
+            for position in range(1, len(value) + 1):
+                next_states[position] = states[position] or next_states[position - 1]
+        else:
+            for position, character in enumerate(value):
+                if states[position] and (
+                    kind == _MATCH_ONE or (kind == _MATCH_LITERAL and character == literal)
+                ):
+                    next_states[position + 1] = True
+        states = next_states
+    return states[-1]
+
+
+def _safe_matcher_matches(matcher: str, value: str, *, event: str) -> bool:
+    return any(
+        _match_tokens(
+            tokens,
+            value,
+            anchored_start = anchored_start,
+            anchored_end = anchored_end,
+        )
+        for anchored_start, anchored_end, tokens in _parse_matcher(matcher, event = event)
+    )
+
+
+def _validate_matcher(value: Any, *, event: str) -> Optional[str]:
+    matcher = _optional_text(
+        value,
+        label = f"{event} hook matcher",
+        maximum = MAX_HOOK_MATCHER_CHARACTERS,
+    )
+    if matcher in {None, "", "*"}:
+        return None
+    _parse_matcher(matcher, event = event)
+    return matcher
+
+
+def _validate_handler(value: Any, *, event: str, handler_id: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise AgentWorkspaceError(f"{event} hook handlers must be JSON objects.")
+    if value.get("type") != "command":
+        raise AgentWorkspaceError(
+            f"{event} hook handler type must be command; MCP hooks are not available yet."
+        )
+    _unknown_fields(value, _COMMAND_FIELDS, f"{event} hook handler")
+    command = _optional_text(
+        value.get("command"),
+        label = f"{event} hook command",
+        maximum = MAX_HOOK_COMMAND_BYTES,
+        allow_empty = False,
+    )
+    command_windows = _optional_text(
+        value.get("commandWindows"),
+        label = f"{event} Windows hook command",
+        maximum = MAX_HOOK_COMMAND_BYTES,
+        allow_empty = False,
+    )
+    if command is None:
+        raise AgentWorkspaceError(f"{event} hook command is required.")
+    timeout_default = 1 if event == "SessionEnd" else MAX_HOOK_TIMEOUT_SECONDS
+    timeout_maximum = 3 if event == "SessionEnd" else MAX_HOOK_TIMEOUT_SECONDS
+    timeout = _integer(
+        value.get("timeout"),
+        label = f"{event} hook timeout",
+        default = timeout_default,
+        minimum = 1,
+        maximum = timeout_maximum,
+    )
+    status_message = _optional_text(
+        value.get("statusMessage"),
+        label = f"{event} hook status message",
+        maximum = 512,
+    )
+    additional_context_limit = _integer(
+        value.get("additionalContextLimit"),
+        label = f"{event} additional context limit",
+        default = 2_500,
+        minimum = 0,
+        maximum = MAX_ADDITIONAL_CONTEXT_TOKENS,
+    )
+    asynchronous = value.get("async", False)
+    if not isinstance(asynchronous, bool):
+        raise AgentWorkspaceError(f"{event} hook async must be a boolean.")
+    return {
+        "id": handler_id,
+        "type": "command",
+        "command": command,
+        "commandWindows": command_windows,
+        "timeout": timeout,
+        "statusMessage": status_message,
+        "additionalContextLimit": additional_context_limit,
+        # SessionEnd is always synchronous in Codex even when async is set.
+        "async": asynchronous and event != "SessionEnd",
+    }
+
+
+def validate_project_hooks(raw: bytes | str, *, source_path: str = _HOOK_PATH) -> dict[str, Any]:
+    """Validate exact ``hooks.json`` bytes and return a bounded runtime form."""
+    encoded = raw.encode("utf-8") if isinstance(raw, str) else bytes(raw)
+    document = _parse_json(encoded)
+    _unknown_fields(document, _TOP_LEVEL_FIELDS, "Project hooks")
+    description = _optional_text(
+        document.get("description"),
+        label = "Project hook description",
+        maximum = 4 * 1024,
+    )
+    hooks_document = document.get("hooks", {})
+    if not isinstance(hooks_document, dict):
+        raise AgentWorkspaceError("Project hooks.hooks must be a JSON object.")
+    unknown_events = sorted(set(hooks_document) - set(HOOK_EVENTS))
+    if unknown_events:
+        raise AgentWorkspaceError(
+            "Project hooks contain unsupported events: "
+            + ", ".join(repr(event) for event in unknown_events)
+            + "."
+        )
+
+    normalized: dict[str, list[dict[str, Any]]] = {}
+    group_count = 0
+    handler_count = 0
+    for event in HOOK_EVENTS:
+        groups = hooks_document.get(event, [])
+        if not isinstance(groups, list):
+            raise AgentWorkspaceError(f"Project hooks.{event} must be an array.")
+        rendered_groups: list[dict[str, Any]] = []
+        for group_index, group in enumerate(groups):
+            group_count += 1
+            if group_count > MAX_HOOK_GROUPS:
+                raise AgentWorkspaceError("Project hooks exceed the matcher-group limit.")
+            if not isinstance(group, dict):
+                raise AgentWorkspaceError(f"{event} hook matcher groups must be JSON objects.")
+            _unknown_fields(group, _GROUP_FIELDS, f"{event} hook matcher group")
+            matcher = _validate_matcher(group.get("matcher"), event = event)
+            handlers = group.get("hooks")
+            if not isinstance(handlers, list) or not handlers:
+                raise AgentWorkspaceError(f"{event} hook matcher groups need at least one hook.")
+            rendered_handlers = []
+            for handler_index, handler in enumerate(handlers):
+                handler_count += 1
+                if handler_count > MAX_HOOK_HANDLERS:
+                    raise AgentWorkspaceError("Project hooks exceed the handler limit.")
+                rendered_handlers.append(
+                    _validate_handler(
+                        handler,
+                        event = event,
+                        handler_id = f"{event}:{group_index}:{handler_index}",
+                    )
+                )
+            rendered_groups.append({"matcher": matcher, "hooks": rendered_handlers})
+        normalized[event] = rendered_groups
+
+    return {
+        "sourcePath": source_path,
+        "exists": True,
+        "contentHash": project_hooks_content_hash(encoded),
+        "rootIdentity": None,
+        "description": description,
+        "hooks": normalized,
+        "groupCount": group_count,
+        "handlerCount": handler_count,
+    }
+
+
+def _normalize_identity(expected_identity: Optional[tuple[int, int]]) -> Optional[tuple[int, int]]:
+    if expected_identity is None:
+        return None
+    try:
+        return int(expected_identity[0]), int(expected_identity[1])
+    except (IndexError, TypeError, ValueError) as exc:
+        raise AgentWorkspaceError("Project root identity is invalid.") from exc
+
+
+def _empty_project_hooks(root_identity: Optional[tuple[int, int]] = None) -> dict[str, Any]:
+    return {
+        "sourcePath": _HOOK_PATH,
+        "exists": False,
+        "contentHash": None,
+        "rootIdentity": root_identity,
+        "description": None,
+        "hooks": {event: [] for event in HOOK_EVENTS},
+        "groupCount": 0,
+        "handlerCount": 0,
+    }
+
+
+def _check_discovery_budget(cancel_event, deadline: Optional[float]) -> None:
+    if cancel_event is not None and cancel_event.is_set():
+        raise InterruptedError("Project hook discovery was cancelled.")
+    if deadline is not None and time.monotonic() >= deadline:
+        raise TimeoutError("Project hook discovery timed out.")
+
+
+def discover_project_hooks(
+    root: Path | str,
+    *,
+    expected_identity: Optional[tuple[int, int]] = None,
+    cancel_event = None,
+    deadline: Optional[float] = None,
+) -> dict[str, Any]:
+    """Read one identity-bound, non-symlink project ``hooks.json`` file."""
+    if (
+        os.name == "nt"
+        or os.open not in os.supports_dir_fd
+        or not hasattr(os, "O_DIRECTORY")
+        or not hasattr(os, "O_NOFOLLOW")
+        or not hasattr(os, "O_NONBLOCK")
+    ):
+        raise AgentWorkspaceError(
+            "Project hook discovery is unavailable without secure directory traversal."
+        )
+    workspace = root if hasattr(root, "device_id") and hasattr(root, "file_id") else None
+    requested_root = Path(workspace.root if workspace is not None else root)
+    if expected_identity is None and workspace is not None:
+        expected_identity = (workspace.device_id, workspace.file_id)
+    expected = _normalize_identity(expected_identity)
+    root_fd = codex_fd = hook_fd = None
+    try:
+        _check_discovery_budget(cancel_event, deadline)
+        if requested_root.is_symlink():
+            raise AgentWorkspaceError("Symbolic-link project roots are not supported.")
+        resolved = requested_root.resolve(strict = True)
+        _check_discovery_budget(cancel_event, deadline)
+        root_fd = os.open(resolved, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        root_path_metadata = resolved.stat(follow_symlinks = False)
+        root_opened_metadata = os.fstat(root_fd)
+        actual_identity = (
+            int(root_opened_metadata.st_dev),
+            int(root_opened_metadata.st_ino),
+        )
+        if (
+            not stat.S_ISDIR(root_path_metadata.st_mode)
+            or not stat.S_ISDIR(root_opened_metadata.st_mode)
+            or actual_identity != (int(root_path_metadata.st_dev), int(root_path_metadata.st_ino))
+            or (expected is not None and actual_identity != expected)
+        ):
+            raise AgentWorkspaceError("Project root identity changed.")
+        try:
+            _check_discovery_budget(cancel_event, deadline)
+            codex_fd = os.open(
+                ".codex",
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                dir_fd = root_fd,
+            )
+        except FileNotFoundError:
+            return _empty_project_hooks(actual_identity)
+        if not stat.S_ISDIR(os.fstat(codex_fd).st_mode):
+            raise AgentWorkspaceError("Project .codex is not a directory.")
+        try:
+            _check_discovery_budget(cancel_event, deadline)
+            hook_fd = os.open(
+                "hooks.json",
+                os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK,
+                dir_fd = codex_fd,
+            )
+        except FileNotFoundError:
+            return _empty_project_hooks(actual_identity)
+        before = os.fstat(hook_fd)
+        if not stat.S_ISREG(before.st_mode):
+            raise AgentWorkspaceError("Project hooks.json must be a regular file.")
+        raw = bytearray()
+        while len(raw) <= MAX_HOOK_CONFIG_BYTES:
+            _check_discovery_budget(cancel_event, deadline)
+            chunk = os.read(hook_fd, min(8192, MAX_HOOK_CONFIG_BYTES + 1 - len(raw)))
+            if not chunk:
+                break
+            raw.extend(chunk)
+        after = os.fstat(hook_fd)
+        if (
+            before.st_dev,
+            before.st_ino,
+            before.st_size,
+            before.st_mtime_ns,
+        ) != (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns):
+            raise AgentWorkspaceError("Project hooks.json changed while it was being read.")
+        discovered = validate_project_hooks(bytes(raw), source_path = _HOOK_PATH)
+        discovered["rootIdentity"] = actual_identity
+        return discovered
+    except (AgentWorkspaceError, TimeoutError, InterruptedError):
+        raise
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise AgentWorkspaceError(
+            "Project hooks are unavailable or cross an unsafe filesystem boundary."
+        ) from exc
+    finally:
+        for descriptor in (hook_fd, codex_fd, root_fd):
+            if descriptor is not None:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+
+
+def secure_project_hook_discovery_supported() -> bool:
+    return bool(
+        os.name != "nt"
+        and os.open in os.supports_dir_fd
+        and hasattr(os, "O_DIRECTORY")
+        and hasattr(os, "O_NOFOLLOW")
+        and hasattr(os, "O_NONBLOCK")
+    )
+
+
+def project_hooks_are_trusted(
+    config: dict[str, Any], trusted_hashes: Optional[str | Iterable[str]]
+) -> bool:
+    """Return whether the exact discovered source hash has been reviewed."""
+    content_hash = config.get("contentHash")
+    if not config.get("exists") or not isinstance(content_hash, str):
+        return False
+    if trusted_hashes is None:
+        return False
+    if isinstance(trusted_hashes, str):
+        return content_hash == trusted_hashes
+    return any(content_hash == value for value in trusted_hashes)
+
+
+def _matcher_values(event: str, event_input: dict[str, Any]) -> tuple[str, ...]:
+    field = _MATCH_FIELD[event]
+    if field is None:
+        return ()
+    value = event_input.get(field)
+    if not isinstance(value, str) or len(value) > 512:
+        return ()
+    aliases = [value]
+    if field == "tool_name" and value in {"apply_patch", "edit_file"}:
+        aliases.extend(("Edit", "Write"))
+    elif field == "tool_name" and value == "terminal":
+        aliases.extend(("Bash", "Terminal"))
+    elif field == "tool_name" and value == "python":
+        aliases.append("Python")
+    elif field == "tool_name" and value == "spawn_agent":
+        aliases.append("Agent")
+    return tuple(aliases)
+
+
+def matching_project_hooks(
+    config: dict[str, Any],
+    event: str,
+    event_input: Optional[dict[str, Any]] = None,
+) -> list[dict[str, Any]]:
+    """Return matching handlers in stable declaration order."""
+    if event not in HOOK_EVENTS:
+        raise AgentWorkspaceError("Project hook event is invalid.")
+    payload = event_input or {}
+    if not isinstance(payload, dict):
+        raise AgentWorkspaceError("Project hook input must be a JSON object.")
+    values = _matcher_values(event, payload)
+    handlers: list[dict[str, Any]] = []
+    for group in config.get("hooks", {}).get(event, []):
+        matcher = group.get("matcher")
+        matches = matcher is None or _MATCH_FIELD[event] is None
+        if not matches:
+            matches = any(_safe_matcher_matches(matcher, value, event = event) for value in values)
+        if matches:
+            handlers.extend(dict(handler) for handler in group["hooks"])
+    return handlers
+
+
+__all__ = [
+    "HOOK_EVENTS",
+    "MAX_HOOK_CONFIG_BYTES",
+    "discover_project_hooks",
+    "matching_project_hooks",
+    "project_hooks_are_trusted",
+    "project_hooks_content_hash",
+    "validate_project_hooks",
+]

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -10401,6 +10401,10 @@ def _render_html_result(arguments: dict) -> str:
     )
 
 
+from core.agent_workspace.hook_runtime import with_project_tool_hooks
+
+
+@with_project_tool_hooks
 def execute_tool(
     name: str,
     arguments: dict,

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -326,6 +326,7 @@ from routes import (
     video_openai_router,
     youtube_router,
 )
+from routes.project_hooks import router as project_hooks_router
 from routes.llama import router as llama_router
 from routes.llama_compat import is_engine_probe_path, router as llama_compat_router
 from routes.whisper import router as whisper_router
@@ -1476,6 +1477,7 @@ app.include_router(auth_router, prefix = "/api/auth", tags = ["auth"])
 app.include_router(training_router, prefix = "/api/train", tags = ["training"])
 app.include_router(models_router, prefix = "/api/models", tags = ["models"])
 app.include_router(chat_history_router, prefix = "/api/chat", tags = ["chat"])
+app.include_router(project_hooks_router, prefix = "/api/agent", tags = ["agent"])
 app.include_router(research_runs_router, prefix = "/api/chat/research-runs", tags = ["research-runs"])
 app.include_router(
     chat_generation_runs_router,

--- a/studio/backend/routes/project_hooks.py
+++ b/studio/backend/routes/project_hooks.py
@@ -1,0 +1,361 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Authenticated review and trust controls for project-local lifecycle hooks."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+from auth.authentication import authenticated_via_api_key, get_current_subject
+from core.agent_workspace.hook_context import AgentWorkspaceError, project_workspace_access
+from core.agent_workspace.hook_runtime import handler_is_supported
+from core.agent_workspace.hook_context import execution_status
+from core.agent_workspace.hooks import HOOK_EVENTS, discover_project_hooks
+from storage.project_hook_trust_db import (
+    ProjectHookTrustConflictError,
+    ProjectHookTrustStateError,
+    get_project_hook_trust_record,
+    get_project_hook_trust_state,
+    revoke_project_hook_trust,
+    set_project_hook_handler_enabled,
+    trust_project_hooks,
+)
+from storage.studio_db import get_chat_project
+
+
+router = APIRouter()
+_HASH_PATTERN = r"^[0-9a-f]{64}$"
+
+
+class TrustProjectHooksRequest(BaseModel):
+    model_config = ConfigDict(extra = "forbid")
+
+    contentHash: str = Field(pattern = _HASH_PATTERN)
+    workspaceRevision: int = Field(ge = 0)
+    revision: int = Field(ge = 0)
+
+
+class RevokeProjectHooksRequest(BaseModel):
+    model_config = ConfigDict(extra = "forbid")
+
+    revision: int = Field(ge = 0)
+
+
+class SetProjectHookHandlerRequest(TrustProjectHooksRequest):
+    enabled: bool
+
+
+def _project(project_id: str) -> dict:
+    project = get_chat_project(project_id)
+    if project is None or project.get("archived"):
+        raise HTTPException(status_code = 404, detail = "Project not found.")
+    return project
+
+
+def _workspace_error(exc: Exception) -> HTTPException:
+    return HTTPException(status_code = 409, detail = str(exc))
+
+
+def _require_ui_session(via_api_key: bool) -> None:
+    if via_api_key:
+        raise HTTPException(
+            status_code = 403,
+            detail = "Project hook authority can only be changed from the Unsloth UI.",
+        )
+
+
+def _workspace_identity(workspace: Any) -> tuple[int, int]:
+    return int(workspace.device_id), int(workspace.file_id)
+
+
+def _discover_workspace(workspace: Any) -> dict[str, Any]:
+    return discover_project_hooks(
+        workspace.root,
+        expected_identity = _workspace_identity(workspace),
+    )
+
+
+def _current_handler_ids(config: dict[str, Any]) -> set[str]:
+    return {
+        handler["id"]
+        for groups in config["hooks"].values()
+        for group in groups
+        for handler in group["hooks"]
+    }
+
+
+def _trust_snapshot_state(
+    project_id: str, config: dict[str, Any], workspace: Any
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    for _attempt in range(3):
+        state = get_project_hook_trust_state(
+            project_id,
+            config.get("contentHash"),
+            workspace_identity = _workspace_identity(workspace),
+            workspace_revision = int(workspace.revision),
+        )
+        record = get_project_hook_trust_record(project_id)
+        if state["revision"] == record["revision"]:
+            return state, record
+    raise ProjectHookTrustStateError("Hook trust changed while its snapshot was being read.")
+
+
+def _stored_trust(record: dict[str, Any]) -> dict[str, Any] | None:
+    if not record["hasStoredTrust"]:
+        return None
+    return {
+        "contentHash": record["storedContentHash"],
+        "revision": record["revision"],
+    }
+
+
+def _snapshot(project_id: str, config: dict[str, Any], workspace: Any) -> dict[str, Any]:
+    state, record = _trust_snapshot_state(project_id, config, workspace)
+    disabled = set(state["disabledHandlerIds"])
+    try:
+        execution = execution_status()
+    except Exception:
+        execution = {
+            "available": False,
+            "reason": "Hook execution capability could not be checked.",
+        }
+    rendered_hooks = {
+        event: [
+            {
+                "matcher": group["matcher"],
+                "hooks": [
+                    {
+                        **handler,
+                        "enabled": handler["id"] not in disabled,
+                        "active": (
+                            state["trusted"]
+                            and handler["id"] not in disabled
+                            and handler_is_supported(event, handler)
+                            and execution["available"]
+                        ),
+                    }
+                    for handler in group["hooks"]
+                ],
+            }
+            for group in groups
+        ]
+        for event, groups in config["hooks"].items()
+    }
+    return {
+        key: config[key]
+        for key in (
+            "sourcePath",
+            "exists",
+            "contentHash",
+            "description",
+            "groupCount",
+            "handlerCount",
+        )
+    } | {
+        "execution": execution,
+        "workspaceAvailable": True,
+        "workspaceRevision": int(workspace.revision),
+        "trusted": state["trusted"],
+        "revision": state["revision"],
+        "storedTrust": _stored_trust(record),
+        "hooks": rendered_hooks,
+    }
+
+
+def _unavailable_snapshot(record: dict[str, Any], *, workspace_revision: int) -> dict[str, Any]:
+    """Return no current-source claims when a workspace cannot be inspected."""
+    return {
+        "workspaceAvailable": False,
+        "workspaceRevision": workspace_revision,
+        "sourcePath": ".codex/hooks.json",
+        "exists": False,
+        "contentHash": None,
+        "description": None,
+        "groupCount": 0,
+        "handlerCount": 0,
+        "trusted": False,
+        "revision": record["revision"],
+        "storedTrust": _stored_trust(record),
+        "hooks": {event: [] for event in HOOK_EVENTS},
+    }
+
+
+def _revoked_record(project_id: str, revision: int) -> dict[str, Any]:
+    return {
+        "projectId": project_id,
+        "storedContentHash": None,
+        "hasStoredTrust": False,
+        "revision": revision,
+    }
+
+
+def _require_current_hash(config: dict[str, Any], requested_hash: str) -> None:
+    if not config.get("exists") or config.get("contentHash") != requested_hash:
+        raise HTTPException(
+            status_code = 409,
+            detail = "Project hooks changed. Refresh and review the current file.",
+        )
+
+
+def _require_workspace_revision(workspace: Any, requested_revision: int) -> None:
+    if int(workspace.revision) != requested_revision:
+        raise HTTPException(
+            status_code = 409,
+            detail = "Project workspace changed. Refresh and review the current hooks file.",
+        )
+
+
+@router.get("/projects/{project_id}/hooks")
+def project_hooks(project_id: str, _current_subject: str = Depends(get_current_subject)):
+    project = _project(project_id)
+    if project.get("workspaceAvailable") is False:
+        try:
+            return _unavailable_snapshot(
+                get_project_hook_trust_record(project_id),
+                workspace_revision = int(project.get("workspaceRevision") or 0),
+            )
+        except (ProjectHookTrustStateError, ValueError) as exc:
+            raise _workspace_error(exc) from exc
+    try:
+        with project_workspace_access(project_id) as workspace:
+            try:
+                config = _discover_workspace(workspace)
+                return _snapshot(project_id, config, workspace)
+            except (AgentWorkspaceError, ProjectHookTrustStateError, ValueError) as exc:
+                raise _workspace_error(exc) from exc
+    except HTTPException:
+        raise
+    except AgentWorkspaceError:
+        try:
+            return _unavailable_snapshot(
+                get_project_hook_trust_record(project_id),
+                workspace_revision = int(project.get("workspaceRevision") or 0),
+            )
+        except (ProjectHookTrustStateError, ValueError) as exc:
+            raise _workspace_error(exc) from exc
+
+
+@router.get("/projects/{project_id}/hooks/trust")
+def project_hooks_trust_state(
+    project_id: str, _current_subject: str = Depends(get_current_subject)
+):
+    """Read persisted trust without opening or interpreting the project workspace."""
+    _project(project_id)
+    try:
+        record = get_project_hook_trust_record(project_id)
+        return {
+            "storedTrust": _stored_trust(record),
+            "revision": record["revision"],
+        }
+    except (ProjectHookTrustStateError, ValueError) as exc:
+        raise _workspace_error(exc) from exc
+
+
+@router.post("/projects/{project_id}/hooks/trust")
+def project_hooks_trust(
+    project_id: str,
+    request: TrustProjectHooksRequest,
+    via_api_key: Annotated[bool, Depends(authenticated_via_api_key)] = False,
+    _current_subject: str = Depends(get_current_subject),
+):
+    _require_ui_session(via_api_key)
+    _project(project_id)
+    try:
+        with project_workspace_access(project_id) as workspace:
+            _require_workspace_revision(workspace, request.workspaceRevision)
+            config = _discover_workspace(workspace)
+            _require_current_hash(config, request.contentHash)
+            trust_project_hooks(
+                project_id,
+                config["contentHash"],
+                workspace_identity = _workspace_identity(workspace),
+                workspace_revision = int(workspace.revision),
+                expected_revision = request.revision,
+            )
+            return _snapshot(project_id, _discover_workspace(workspace), workspace)
+    except HTTPException:
+        raise
+    except (
+        AgentWorkspaceError,
+        ProjectHookTrustConflictError,
+        ProjectHookTrustStateError,
+        ValueError,
+    ) as exc:
+        raise _workspace_error(exc) from exc
+
+
+@router.post("/projects/{project_id}/hooks/revoke")
+def project_hooks_revoke(
+    project_id: str,
+    request: RevokeProjectHooksRequest,
+    via_api_key: Annotated[bool, Depends(authenticated_via_api_key)] = False,
+    _current_subject: str = Depends(get_current_subject),
+):
+    _require_ui_session(via_api_key)
+    project = _project(project_id)
+    try:
+        revoked = revoke_project_hook_trust(project_id, expected_revision = request.revision)
+    except (
+        ProjectHookTrustConflictError,
+        ProjectHookTrustStateError,
+        ValueError,
+    ) as exc:
+        raise _workspace_error(exc) from exc
+    if project.get("workspaceAvailable") is False:
+        return _unavailable_snapshot(
+            _revoked_record(project_id, revoked["revision"]),
+            workspace_revision = int(project.get("workspaceRevision") or 0),
+        )
+    try:
+        with project_workspace_access(project_id) as workspace:
+            return _snapshot(project_id, _discover_workspace(workspace), workspace)
+    except (AgentWorkspaceError, ProjectHookTrustStateError, ValueError):
+        return _unavailable_snapshot(
+            _revoked_record(project_id, revoked["revision"]),
+            workspace_revision = int(project.get("workspaceRevision") or 0),
+        )
+
+
+@router.post("/projects/{project_id}/hooks/handlers/{handler_id}")
+def project_hook_handler(
+    project_id: str,
+    handler_id: str,
+    request: SetProjectHookHandlerRequest,
+    via_api_key: Annotated[bool, Depends(authenticated_via_api_key)] = False,
+    _current_subject: str = Depends(get_current_subject),
+):
+    _require_ui_session(via_api_key)
+    _project(project_id)
+    try:
+        with project_workspace_access(project_id) as workspace:
+            _require_workspace_revision(workspace, request.workspaceRevision)
+            config = _discover_workspace(workspace)
+            _require_current_hash(config, request.contentHash)
+            if handler_id not in _current_handler_ids(config):
+                raise HTTPException(status_code = 404, detail = "Project hook handler not found.")
+            set_project_hook_handler_enabled(
+                project_id,
+                config["contentHash"],
+                handler_id,
+                workspace_identity = _workspace_identity(workspace),
+                workspace_revision = int(workspace.revision),
+                enabled = request.enabled,
+                expected_revision = request.revision,
+            )
+            return _snapshot(project_id, _discover_workspace(workspace), workspace)
+    except HTTPException:
+        raise
+    except (
+        AgentWorkspaceError,
+        ProjectHookTrustConflictError,
+        ProjectHookTrustStateError,
+        ValueError,
+    ) as exc:
+        raise _workspace_error(exc) from exc
+
+
+__all__ = ["router"]

--- a/studio/backend/storage/project_hook_trust_db.py
+++ b/studio/backend/storage/project_hook_trust_db.py
@@ -1,0 +1,636 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Hash-bound trust and handler preferences for project-local hooks."""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import threading
+import time
+from typing import Optional
+
+from storage import studio_db
+
+
+MAX_PROJECT_ID_BYTES = 512
+MAX_HANDLER_ID_BYTES = 256
+MAX_DISABLED_HANDLER_IDS = 256
+MAX_REVISION = (1 << 63) - 1
+
+_CONTENT_HASH = re.compile(r"[0-9a-f]{64}")
+_schema_lock = threading.Lock()
+_ready_databases: set[str] = set()
+
+
+class ProjectHookTrustConflictError(RuntimeError):
+    """A hook trust write was based on a stale revision or source hash."""
+
+
+class ProjectHookTrustStateError(RuntimeError):
+    """Persisted hook trust state is invalid and cannot be applied safely."""
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS project_hook_trust (
+            project_id TEXT NOT NULL PRIMARY KEY
+                REFERENCES chat_projects(id) ON DELETE CASCADE,
+            trusted_content_hash TEXT,
+            workspace_device_id INTEGER,
+            workspace_file_id INTEGER,
+            workspace_revision INTEGER,
+            disabled_handler_ids_json TEXT NOT NULL DEFAULT '[]',
+            revision INTEGER NOT NULL DEFAULT 0,
+            updated_at INTEGER NOT NULL,
+            CHECK (
+                trusted_content_hash IS NULL
+                OR (
+                    length(trusted_content_hash) = 64
+                    AND trusted_content_hash NOT GLOB '*[^0-9a-f]*'
+                )
+            ),
+            CHECK (
+                (
+                    trusted_content_hash IS NULL
+                    AND workspace_device_id IS NULL
+                    AND workspace_file_id IS NULL
+                    AND workspace_revision IS NULL
+                )
+                OR (
+                    trusted_content_hash IS NOT NULL
+                    AND workspace_device_id IS NOT NULL
+                    AND workspace_file_id IS NOT NULL
+                    AND workspace_revision IS NOT NULL
+                    AND workspace_device_id >= 0
+                    AND workspace_file_id >= 0
+                    AND workspace_revision >= 0
+                )
+            ),
+            CHECK (revision >= 0)
+        ) WITHOUT ROWID
+        """
+    )
+    columns = {
+        str(row[1]) for row in conn.execute("PRAGMA table_info(project_hook_trust)").fetchall()
+    }
+    for name in ("workspace_device_id", "workspace_file_id", "workspace_revision"):
+        if name not in columns:
+            conn.execute(f"ALTER TABLE project_hook_trust ADD COLUMN {name} INTEGER")
+
+
+def _database_key(conn: sqlite3.Connection) -> str:
+    row = conn.execute("PRAGMA database_list").fetchone()
+    return str(row[2])
+
+
+def _connection(busy_timeout_seconds: float = 30.0) -> sqlite3.Connection:
+    conn = studio_db.get_connection(busy_timeout_seconds)
+    key = _database_key(conn)
+    if key not in _ready_databases:
+        with _schema_lock:
+            if key not in _ready_databases:
+                try:
+                    _ensure_schema(conn)
+                    conn.commit()
+                    _ready_databases.add(key)
+                except Exception:
+                    conn.close()
+                    raise
+    return conn
+
+
+def _validate_project_id(project_id: str) -> str:
+    if not isinstance(project_id, str):
+        raise ValueError("Project id must be a string.")
+    try:
+        encoded = project_id.encode("utf-8", errors = "strict")
+    except UnicodeEncodeError as exc:
+        raise ValueError("Project id must be valid UTF-8.") from exc
+    if (
+        not encoded
+        or len(encoded) > MAX_PROJECT_ID_BYTES
+        or "\x00" in project_id
+        or any(ord(character) < 32 or ord(character) == 127 for character in project_id)
+    ):
+        raise ValueError("Project id is invalid or exceeds its size limit.")
+    return project_id
+
+
+def _validate_content_hash(content_hash: str) -> str:
+    if not isinstance(content_hash, str) or _CONTENT_HASH.fullmatch(content_hash) is None:
+        raise ValueError("Hook content hash must be a lowercase SHA-256 digest.")
+    return content_hash
+
+
+def _validate_current_hash(content_hash: Optional[str]) -> Optional[str]:
+    return None if content_hash is None else _validate_content_hash(content_hash)
+
+
+def _validate_workspace_identity(identity: tuple[int, int]) -> tuple[int, int]:
+    if (
+        not isinstance(identity, tuple)
+        or len(identity) != 2
+        or any(isinstance(value, bool) or not isinstance(value, int) for value in identity)
+    ):
+        raise ValueError("Hook workspace identity is invalid.")
+    normalized = identity
+    if min(normalized) < 0 or max(normalized) > MAX_REVISION:
+        raise ValueError("Hook workspace identity is invalid.")
+    return normalized
+
+
+def _validate_revision(revision: int) -> int:
+    if isinstance(revision, bool) or not isinstance(revision, int):
+        raise ValueError("Hook trust revision must be an integer.")
+    if revision < 0 or revision > MAX_REVISION:
+        raise ValueError("Hook trust revision is outside the supported range.")
+    return revision
+
+
+def _validate_handler_id(handler_id: str) -> str:
+    if not isinstance(handler_id, str):
+        raise ValueError("Hook handler id must be a string.")
+    try:
+        encoded = handler_id.encode("utf-8", errors = "strict")
+    except UnicodeEncodeError as exc:
+        raise ValueError("Hook handler id must be valid UTF-8.") from exc
+    if (
+        not encoded
+        or len(encoded) > MAX_HANDLER_ID_BYTES
+        or "\x00" in handler_id
+        or any(ord(character) < 32 or ord(character) == 127 for character in handler_id)
+    ):
+        raise ValueError("Hook handler id is invalid or exceeds its size limit.")
+    return handler_id
+
+
+def _decode_disabled_handler_ids(raw: str) -> list[str]:
+    try:
+        value = json.loads(raw)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise ProjectHookTrustStateError("Persisted hook handler preferences are invalid.") from exc
+    if (
+        not isinstance(value, list)
+        or len(value) > MAX_DISABLED_HANDLER_IDS
+        or any(not isinstance(item, str) for item in value)
+    ):
+        raise ProjectHookTrustStateError("Persisted hook handler preferences are invalid.")
+    try:
+        normalized = [_validate_handler_id(item) for item in value]
+    except ValueError as exc:
+        raise ProjectHookTrustStateError("Persisted hook handler preferences are invalid.") from exc
+    if len(set(normalized)) != len(normalized):
+        raise ProjectHookTrustStateError("Persisted hook handler preferences are invalid.")
+    return sorted(normalized)
+
+
+def _encode_disabled_handler_ids(handler_ids: set[str]) -> str:
+    if len(handler_ids) > MAX_DISABLED_HANDLER_IDS:
+        raise ValueError("Disabled hook handlers exceed the supported limit.")
+    return json.dumps(sorted(handler_ids), ensure_ascii = False, separators = (",", ":"))
+
+
+def _read_row(conn: sqlite3.Connection, project_id: str) -> Optional[sqlite3.Row]:
+    return conn.execute(
+        """
+        SELECT trusted_content_hash, workspace_device_id, workspace_file_id,
+               workspace_revision, disabled_handler_ids_json, revision
+        FROM project_hook_trust
+        WHERE project_id = ?
+        """,
+        (project_id,),
+    ).fetchone()
+
+
+def _row_values(
+    row: Optional[sqlite3.Row],
+) -> tuple[Optional[str], Optional[tuple[int, int]], Optional[int], list[str], int]:
+    if row is None:
+        return None, None, None, [], 0
+    content_hash = row["trusted_content_hash"]
+    if content_hash is not None:
+        try:
+            content_hash = _validate_content_hash(content_hash)
+        except ValueError as exc:
+            raise ProjectHookTrustStateError("Persisted hook trust hash is invalid.") from exc
+    try:
+        revision = _validate_revision(row["revision"])
+    except ValueError as exc:
+        raise ProjectHookTrustStateError("Persisted hook trust revision is invalid.") from exc
+    disabled = _decode_disabled_handler_ids(row["disabled_handler_ids_json"])
+    identity = None
+    workspace_revision = None
+    if content_hash is not None:
+        try:
+            identity = _validate_workspace_identity(
+                (row["workspace_device_id"], row["workspace_file_id"])
+            )
+            workspace_revision = _validate_revision(row["workspace_revision"])
+        except (TypeError, ValueError):
+            # Earlier development builds did not bind trust to a workspace.
+            # Fail those rows closed while keeping their CAS revision usable.
+            content_hash = None
+            disabled = []
+    if content_hash is None and disabled:
+        raise ProjectHookTrustStateError(
+            "Revoked hook trust cannot retain disabled handler preferences."
+        )
+    return content_hash, identity, workspace_revision, disabled, revision
+
+
+def _public_state(
+    project_id: str,
+    current_content_hash: Optional[str],
+    current_identity: Optional[tuple[int, int]],
+    current_workspace_revision: Optional[int],
+    stored_content_hash: Optional[str],
+    stored_identity: Optional[tuple[int, int]],
+    stored_workspace_revision: Optional[int],
+    disabled_handler_ids: list[str],
+    revision: int,
+) -> dict:
+    trusted = (
+        current_content_hash is not None
+        and current_content_hash == stored_content_hash
+        and current_identity is not None
+        and current_identity == stored_identity
+        and current_workspace_revision is not None
+        and current_workspace_revision == stored_workspace_revision
+    )
+    return {
+        "projectId": project_id,
+        "contentHash": current_content_hash,
+        "trusted": trusted,
+        "disabledHandlerIds": disabled_handler_ids if trusted else [],
+        "revision": revision,
+    }
+
+
+def get_project_hook_trust_state(
+    project_id: str,
+    current_content_hash: Optional[str],
+    *,
+    workspace_identity: Optional[tuple[int, int]],
+    workspace_revision: Optional[int],
+) -> dict:
+    """Read trust for the rediscovered source hash without applying stale preferences."""
+    project_id = _validate_project_id(project_id)
+    current_content_hash = _validate_current_hash(current_content_hash)
+    current_identity = (
+        _validate_workspace_identity(workspace_identity) if workspace_identity is not None else None
+    )
+    current_workspace_revision = (
+        _validate_revision(workspace_revision) if workspace_revision is not None else None
+    )
+    conn = _connection()
+    try:
+        stored_hash, stored_identity, stored_workspace_revision, disabled, revision = _row_values(
+            _read_row(conn, project_id)
+        )
+        return _public_state(
+            project_id,
+            current_content_hash,
+            current_identity,
+            current_workspace_revision,
+            stored_hash,
+            stored_identity,
+            stored_workspace_revision,
+            disabled,
+            revision,
+        )
+    finally:
+        conn.close()
+
+
+def get_project_hook_trust_record(project_id: str) -> dict:
+    """Return persisted authority state without consulting an unavailable workspace."""
+    project_id = _validate_project_id(project_id)
+    conn = _connection()
+    try:
+        row = _read_row(conn, project_id)
+        if row is None:
+            stored_hash = None
+            revision = 0
+        else:
+            try:
+                revision = _validate_revision(row["revision"])
+            except ValueError as exc:
+                raise ProjectHookTrustStateError(
+                    "Persisted hook trust revision is invalid."
+                ) from exc
+            stored_hash = row["trusted_content_hash"]
+            if stored_hash is not None:
+                try:
+                    stored_hash = _validate_content_hash(stored_hash)
+                    _validate_workspace_identity(
+                        (row["workspace_device_id"], row["workspace_file_id"])
+                    )
+                    _validate_revision(row["workspace_revision"])
+                except (TypeError, ValueError):
+                    # Unbound development rows must never be presented as authority.
+                    stored_hash = None
+        return {
+            "projectId": project_id,
+            "storedContentHash": stored_hash,
+            "hasStoredTrust": stored_hash is not None,
+            "revision": revision,
+        }
+    finally:
+        conn.close()
+
+
+def trust_project_hooks(
+    project_id: str,
+    rediscovered_content_hash: str,
+    *,
+    workspace_identity: tuple[int, int],
+    workspace_revision: int,
+    expected_revision: int,
+) -> dict:
+    """Trust exactly the source hash rediscovered by the server."""
+    project_id = _validate_project_id(project_id)
+    content_hash = _validate_content_hash(rediscovered_content_hash)
+    identity = _validate_workspace_identity(workspace_identity)
+    workspace_revision = _validate_revision(workspace_revision)
+    expected_revision = _validate_revision(expected_revision)
+    conn = _connection()
+    try:
+        conn.commit()
+        conn.execute("BEGIN IMMEDIATE")
+        stored_hash, stored_identity, stored_workspace_revision, disabled, revision = _row_values(
+            _read_row(conn, project_id)
+        )
+        if revision != expected_revision:
+            raise ProjectHookTrustConflictError(
+                f"Hook trust revision is {revision}, not {expected_revision}."
+            )
+        if (
+            stored_hash == content_hash
+            and stored_identity == identity
+            and stored_workspace_revision == workspace_revision
+        ):
+            conn.commit()
+            return _public_state(
+                project_id,
+                content_hash,
+                identity,
+                workspace_revision,
+                stored_hash,
+                stored_identity,
+                stored_workspace_revision,
+                disabled,
+                revision,
+            )
+        next_revision = _next_revision(revision)
+        encoded_disabled = _encode_disabled_handler_ids(set())
+        if revision == 0 and stored_hash is None and _read_row(conn, project_id) is None:
+            conn.execute(
+                """
+                INSERT INTO project_hook_trust (
+                    project_id, trusted_content_hash, workspace_device_id,
+                    workspace_file_id, workspace_revision,
+                    disabled_handler_ids_json, revision, updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    project_id,
+                    content_hash,
+                    identity[0],
+                    identity[1],
+                    workspace_revision,
+                    encoded_disabled,
+                    next_revision,
+                    _now_ms(),
+                ),
+            )
+        else:
+            cursor = conn.execute(
+                """
+                UPDATE project_hook_trust
+                SET trusted_content_hash = ?, workspace_device_id = ?,
+                    workspace_file_id = ?, workspace_revision = ?,
+                    disabled_handler_ids_json = ?,
+                    revision = ?, updated_at = ?
+                WHERE project_id = ? AND revision = ?
+                """,
+                (
+                    content_hash,
+                    identity[0],
+                    identity[1],
+                    workspace_revision,
+                    encoded_disabled,
+                    next_revision,
+                    _now_ms(),
+                    project_id,
+                    revision,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise ProjectHookTrustConflictError("Hook trust changed concurrently.")
+        conn.commit()
+        return _public_state(
+            project_id,
+            content_hash,
+            identity,
+            workspace_revision,
+            content_hash,
+            identity,
+            workspace_revision,
+            [],
+            next_revision,
+        )
+    except sqlite3.IntegrityError as exc:
+        conn.rollback()
+        raise ValueError("Project does not exist or hook trust state is invalid.") from exc
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def revoke_project_hook_trust(project_id: str, *, expected_revision: int) -> dict:
+    """Revoke even malformed trust state while retaining a monotonic CAS revision."""
+    project_id = _validate_project_id(project_id)
+    expected_revision = _validate_revision(expected_revision)
+    conn = _connection()
+    try:
+        conn.commit()
+        conn.execute("BEGIN IMMEDIATE")
+        row = _read_row(conn, project_id)
+        if row is None:
+            revision = 0
+            has_persisted_state = False
+        else:
+            try:
+                revision = _validate_revision(row["revision"])
+            except ValueError as exc:
+                raise ProjectHookTrustStateError(
+                    "Persisted hook trust revision is invalid."
+                ) from exc
+            has_persisted_state = (
+                row["trusted_content_hash"] is not None
+                or row["workspace_device_id"] is not None
+                or row["workspace_file_id"] is not None
+                or row["workspace_revision"] is not None
+                or row["disabled_handler_ids_json"] != "[]"
+            )
+        if revision != expected_revision:
+            raise ProjectHookTrustConflictError(
+                f"Hook trust revision is {revision}, not {expected_revision}."
+            )
+        if not has_persisted_state:
+            conn.commit()
+            return _public_state(project_id, None, None, None, None, None, None, [], revision)
+        next_revision = _next_revision(revision)
+        cursor = conn.execute(
+            """
+            UPDATE project_hook_trust
+            SET trusted_content_hash = NULL, workspace_device_id = NULL,
+                workspace_file_id = NULL, workspace_revision = NULL,
+                disabled_handler_ids_json = '[]',
+                revision = ?, updated_at = ?
+            WHERE project_id = ? AND revision = ?
+            """,
+            (next_revision, _now_ms(), project_id, revision),
+        )
+        if cursor.rowcount != 1:
+            raise ProjectHookTrustConflictError("Hook trust changed concurrently.")
+        conn.commit()
+        return _public_state(project_id, None, None, None, None, None, None, [], next_revision)
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def set_project_hook_handler_enabled(
+    project_id: str,
+    rediscovered_content_hash: str,
+    handler_id: str,
+    *,
+    workspace_identity: tuple[int, int],
+    workspace_revision: int,
+    enabled: bool,
+    expected_revision: int,
+) -> dict:
+    """Set one handler preference against the exact currently trusted source."""
+    project_id = _validate_project_id(project_id)
+    content_hash = _validate_content_hash(rediscovered_content_hash)
+    handler_id = _validate_handler_id(handler_id)
+    identity = _validate_workspace_identity(workspace_identity)
+    workspace_revision = _validate_revision(workspace_revision)
+    if not isinstance(enabled, bool):
+        raise ValueError("Hook handler enabled state must be a boolean.")
+    expected_revision = _validate_revision(expected_revision)
+    conn = _connection()
+    try:
+        conn.commit()
+        conn.execute("BEGIN IMMEDIATE")
+        stored_hash, stored_identity, stored_workspace_revision, disabled, revision = _row_values(
+            _read_row(conn, project_id)
+        )
+        if revision != expected_revision:
+            raise ProjectHookTrustConflictError(
+                f"Hook trust revision is {revision}, not {expected_revision}."
+            )
+        if (
+            stored_hash != content_hash
+            or stored_identity != identity
+            or stored_workspace_revision != workspace_revision
+        ):
+            raise ProjectHookTrustConflictError(
+                "Hook source or workspace changed, or has not been trusted."
+            )
+        disabled_set = set(disabled)
+        changed = False
+        if enabled and handler_id in disabled_set:
+            disabled_set.remove(handler_id)
+            changed = True
+        elif not enabled and handler_id not in disabled_set:
+            if len(disabled_set) >= MAX_DISABLED_HANDLER_IDS:
+                raise ValueError("Disabled hook handlers exceed the supported limit.")
+            disabled_set.add(handler_id)
+            changed = True
+        if not changed:
+            conn.commit()
+            return _public_state(
+                project_id,
+                content_hash,
+                identity,
+                workspace_revision,
+                stored_hash,
+                stored_identity,
+                stored_workspace_revision,
+                disabled,
+                revision,
+            )
+        next_revision = _next_revision(revision)
+        cursor = conn.execute(
+            """
+            UPDATE project_hook_trust
+            SET disabled_handler_ids_json = ?, revision = ?, updated_at = ?
+            WHERE project_id = ? AND trusted_content_hash = ?
+              AND workspace_device_id = ? AND workspace_file_id = ?
+              AND workspace_revision = ? AND revision = ?
+            """,
+            (
+                _encode_disabled_handler_ids(disabled_set),
+                next_revision,
+                _now_ms(),
+                project_id,
+                content_hash,
+                identity[0],
+                identity[1],
+                workspace_revision,
+                revision,
+            ),
+        )
+        if cursor.rowcount != 1:
+            raise ProjectHookTrustConflictError("Hook trust changed concurrently.")
+        conn.commit()
+        return _public_state(
+            project_id,
+            content_hash,
+            identity,
+            workspace_revision,
+            content_hash,
+            identity,
+            workspace_revision,
+            sorted(disabled_set),
+            next_revision,
+        )
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _next_revision(revision: int) -> int:
+    if revision >= MAX_REVISION:
+        raise ProjectHookTrustStateError("Hook trust revision is exhausted.")
+    return revision + 1
+
+
+def _now_ms() -> int:
+    return time.time_ns() // 1_000_000
+
+
+__all__ = [
+    "MAX_DISABLED_HANDLER_IDS",
+    "MAX_HANDLER_ID_BYTES",
+    "ProjectHookTrustConflictError",
+    "ProjectHookTrustStateError",
+    "get_project_hook_trust_record",
+    "get_project_hook_trust_state",
+    "revoke_project_hook_trust",
+    "set_project_hook_handler_enabled",
+    "trust_project_hooks",
+]

--- a/studio/backend/tests/test_project_hook_payload.py
+++ b/studio/backend/tests/test_project_hook_payload.py
@@ -50,3 +50,43 @@ def test_post_hook_trust_failure_retains_completed_tool_context(monkeypatch):
     assert "Post-tool hook failed after the tool ran" in result
     assert "Edited file.py" in result
     assert not result.startswith("Error:")
+
+
+@pytest.mark.parametrize("name", ["edit_file", "python", "terminal", "web_search"])
+@pytest.mark.parametrize("session_id", [None, "chat-session", "project-unconfigured"])
+def test_unconfigured_tools_keep_original_arguments_results_and_routing(
+    monkeypatch, name, session_id
+):
+    lookups = []
+
+    def trust(project_id):
+        lookups.append(project_id)
+        return {"hasStoredTrust": False}
+
+    monkeypatch.setattr(runtime.project_hook_trust_db, "get_project_hook_trust_record", trust)
+    monkeypatch.setattr(
+        runtime, "_project_for_tool", lambda *_args: pytest.fail("No extra project/thread routing")
+    )
+    monkeypatch.setattr(
+        runtime.common,
+        "project_workspace_access",
+        lambda *_args: pytest.fail("No extra workspace lease"),
+    )
+    monkeypatch.setattr(
+        runtime, "run_tool_hooks", lambda *_args, **_kwargs: pytest.fail("No hook execution")
+    )
+    arguments = {"code": "original"}
+    original = "  original result\r\n" * 1000
+
+    def raw(name, arguments, *, session_id):
+        assert arguments is expected_arguments
+        return original
+
+    expected_arguments = arguments
+    wrapped = runtime.with_project_tool_hooks(raw)
+    assert wrapped(name, arguments, session_id = session_id) is original
+    assert lookups == (
+        ["unconfigured"]
+        if name in runtime.HOOKED_TOOLS and session_id == "project-unconfigured"
+        else []
+    )

--- a/studio/backend/tests/test_project_hook_payload.py
+++ b/studio/backend/tests/test_project_hook_payload.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import json
+from contextlib import nullcontext
+
+import pytest
+
+from core.agent_workspace import hook_runtime as runtime
+
+
+@pytest.mark.parametrize("text", ["界", "😀", '"', "\\", "\n", "a"])
+@pytest.mark.parametrize("argument_size", [0, 15_000])
+def test_post_hook_response_fits_serialized_budget_without_changing_arguments(text, argument_size):
+    arguments = {"command": "a" * argument_size}
+    result = text * 4096
+    encoded = runtime._event_payload("PostToolUse", "p", "terminal", arguments, result)
+    assert len(encoded.encode("utf-8")) <= runtime.MAX_EVENT_BYTES
+    payload = json.loads(encoded)
+    assert payload["tool_input"] == arguments
+    assert result.startswith(payload["tool_response"])
+    assert payload["tool_response"]
+    assert payload["tool_response_truncated"] == (payload["tool_response"] != result)
+
+
+def test_post_hook_trust_failure_retains_completed_tool_context(monkeypatch):
+    monkeypatch.setattr(runtime, "_project_for_tool", lambda *_: "p")
+    monkeypatch.setattr(
+        runtime.project_hook_trust_db,
+        "get_project_hook_trust_record",
+        lambda _: {"hasStoredTrust": True},
+    )
+    monkeypatch.setattr(runtime.common, "project_workspace_access", lambda _: nullcontext())
+    calls = []
+
+    def hooks(_project, event, *_args, **_kwargs):
+        if event == "PostToolUse":
+            raise runtime.project_hook_trust_db.ProjectHookTrustStateError("trust row corrupt")
+        return ""
+
+    monkeypatch.setattr(runtime, "run_tool_hooks", hooks)
+
+    @runtime.with_project_tool_hooks
+    def execute(name, arguments, session_id):
+        calls.append(arguments)
+        return "Edited file.py"
+
+    result = execute("edit_file", {"path": "file.py"}, "project-p")
+    assert len(calls) == 1
+    assert "Post-tool hook failed after the tool ran" in result
+    assert "Edited file.py" in result
+    assert not result.startswith("Error:")

--- a/studio/backend/tests/test_project_hook_runtime.py
+++ b/studio/backend/tests/test_project_hook_runtime.py
@@ -287,10 +287,14 @@ def test_hook_output_shares_the_tools_final_result_budget(reviewed_hooks, monkey
         arguments,
         *,
         result_budget_tokens = None,
+        session_id = None,
     ):
         return "tool result"
 
-    assert execute("terminal", {}, result_budget_tokens = 256) == "bounded"
+    assert (
+        execute("terminal", {}, result_budget_tokens = 256, session_id = "project-" + project_id)
+        == "bounded"
+    )
     assert observed == [
         (
             "Project hook output (untrusted data):\nhook output\nhook output\n\nTool result:\ntool result",
@@ -356,7 +360,11 @@ def test_no_hook_output_preserves_the_original_result_without_rebudgeting(
 
 
 def test_unconfigured_project_skips_hook_discovery_leases_and_process_probes(monkeypatch):
-    monkeypatch.setattr(runtime, "_project_for_tool", lambda *args: "no-hooks")
+    monkeypatch.setattr(
+        runtime,
+        "_project_for_tool",
+        lambda *args: pytest.fail("Unconfigured calls must use original project routing"),
+    )
     monkeypatch.setattr(
         trust_db, "get_project_hook_trust_record", lambda _id: {"hasStoredTrust": False}
     )

--- a/studio/backend/tests/test_project_hook_runtime.py
+++ b/studio/backend/tests/test_project_hook_runtime.py
@@ -47,6 +47,7 @@ def reviewed_hooks(tmp_path, monkeypatch):
     }
     state = {"config": hooks.validate_project_hooks(json.dumps(document)), "workspace": workspace}
     monkeypatch.setattr(runtime.common, "project_workspace", lambda _id: state["workspace"])
+    monkeypatch.setattr(verification.common, "project_workspace", lambda _id: state["workspace"])
     monkeypatch.setattr(hooks, "discover_project_hooks", lambda *_args, **_kwargs: state["config"])
     trust_db.trust_project_hooks(
         project_id,

--- a/studio/backend/tests/test_project_hook_runtime.py
+++ b/studio/backend/tests/test_project_hook_runtime.py
@@ -10,6 +10,12 @@ from dataclasses import replace
 
 import pytest
 
+# These are integration contracts; pure discovery/payload tests run standalone.
+from importlib.util import find_spec
+
+if find_spec("core.agent_workspace.verification") is None:
+    pytest.skip("Requires the optional verification engine", allow_module_level = True)
+
 from core.agent_workspace import hook_runtime as runtime, hooks, verification, verification_state
 from core.agent_workspace.verification_context import AgentWorkspaceError, ProjectWorkspace
 from core.agent_workspace.verification_process import ProjectProcessResult

--- a/studio/backend/tests/test_project_hook_runtime.py
+++ b/studio/backend/tests/test_project_hook_runtime.py
@@ -1,0 +1,377 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Exact-trust hook execution, cancellation, and public tool integration."""
+
+import json
+import threading
+import time
+from dataclasses import replace
+
+import pytest
+
+from core.agent_workspace import hook_runtime as runtime, hooks, verification, verification_state
+from core.agent_workspace.verification_context import AgentWorkspaceError, ProjectWorkspace
+from core.agent_workspace.verification_process import ProjectProcessResult
+from storage import project_hook_trust_db as trust_db, studio_db
+
+
+@pytest.fixture
+def reviewed_hooks(tmp_path, monkeypatch):
+    project_id = "reviewed-hooks"
+    connection = studio_db.get_connection()
+    try:
+        connection.execute(
+            "INSERT INTO chat_projects (id,name,instructions,archived,created_at,updated_at) VALUES (?,?,'',0,1,1)",
+            (project_id, "Hooks"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    root = tmp_path / "project"
+    root.mkdir()
+    metadata = root.stat()
+    workspace = ProjectWorkspace(project_id, root, "managed", metadata.st_dev, metadata.st_ino)
+    document = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "terminal",
+                    "hooks": [{"type": "command", "command": "echo reviewed", "timeout": 5}],
+                }
+            ],
+            "PostToolUse": [
+                {"hooks": [{"type": "command", "command": "echo after", "timeout": 5}]}
+            ],
+        }
+    }
+    state = {"config": hooks.validate_project_hooks(json.dumps(document)), "workspace": workspace}
+    monkeypatch.setattr(runtime.common, "project_workspace", lambda _id: state["workspace"])
+    monkeypatch.setattr(hooks, "discover_project_hooks", lambda *_args, **_kwargs: state["config"])
+    trust_db.trust_project_hooks(
+        project_id,
+        state["config"]["contentHash"],
+        workspace_identity = (metadata.st_dev, metadata.st_ino),
+        workspace_revision = 0,
+        expected_revision = 0,
+    )
+    return project_id, workspace, state
+
+
+def passed(output = ""):
+    return ProjectProcessResult("passed", 0, output, len(output.encode()), False)
+
+
+def test_only_reviewed_supported_matching_handlers_run_with_exact_stdin(
+    reviewed_hooks, monkeypatch
+):
+    project_id, workspace, state = reviewed_hooks
+    observed = []
+
+    def run(requested, argv, **options):
+        options["before_start"](workspace, argv)
+        observed.append((requested, argv, options))
+        return passed('{"decision":"allow","updatedInput":{"command":"evil"}}')
+
+    monkeypatch.setattr(runtime.processes, "run_project_process", run)
+    args = {"command": "echo original"}
+    result = runtime.run_tool_hooks(project_id, "PreToolUse", "terminal", args)
+    assert "allow" in result
+    assert len(observed) == 1
+    requested, argv, options = observed[0]
+    assert requested == project_id
+    assert argv[1:3] == ["-I", "-c"]
+    assert argv[-2] == "echo reviewed"
+    assert json.loads(argv[-1])["tool_input"] == args
+    assert options["output_limit_bytes"] == runtime.MAX_HOOK_OUTPUT_BYTES
+    assert options["timeout_seconds"] <= 5
+    assert args == {"command": "echo original"}
+    assert runtime.run_tool_hooks(project_id, "PreToolUse", "python", args) == ""
+    assert runtime.run_tool_hooks(project_id, "SessionStart", "terminal", args) == ""
+    state["config"]["hooks"]["PreToolUse"][0]["hooks"][0]["async"] = True
+    assert runtime.run_tool_hooks(project_id, "PreToolUse", "terminal", args) == ""
+    assert len(observed) == 1
+
+
+@pytest.mark.parametrize("drift", ["revoke", "disable", "bytes", "workspace", "retire", "archive"])
+def test_stale_hook_authority_cannot_reach_native_release(reviewed_hooks, monkeypatch, drift):
+    project_id, workspace, state = reviewed_hooks
+
+    def run(_project, argv, **options):
+        if drift == "revoke":
+            trust_db.revoke_project_hook_trust(project_id, expected_revision = 1)
+        elif drift == "disable":
+            trust_db.set_project_hook_handler_enabled(
+                project_id,
+                state["config"]["contentHash"],
+                "PreToolUse:0:0",
+                workspace_identity = (workspace.device_id, workspace.file_id),
+                workspace_revision = 0,
+                enabled = False,
+                expected_revision = 1,
+            )
+        elif drift == "bytes":
+            state["config"] = {**state["config"], "contentHash": "f" * 64}
+        elif drift == "workspace":
+            state["workspace"] = replace(workspace, revision = 1)
+        elif drift == "retire":
+            verification_state.begin_verification_project_deletion(project_id, "test-retirement")
+        else:
+            studio_db.update_chat_project(project_id, {"archived": True})
+        options["before_start"](workspace, argv)
+        pytest.fail("stale hook authority started user code")
+
+    monkeypatch.setattr(runtime.processes, "run_project_process", run)
+    with pytest.raises(AgentWorkspaceError, match = "changed"):
+        runtime.run_tool_hooks(project_id, "PreToolUse", "terminal", {})
+
+
+def test_revocation_and_request_cancel_stop_an_already_running_hook(reviewed_hooks, monkeypatch):
+    project_id, workspace, _state = reviewed_hooks
+
+    def run(_project, argv, **options):
+        options["before_start"](workspace, argv)
+        trust_db.revoke_project_hook_trust(project_id, expected_revision = 1)
+        assert options["cancel_event"].wait(2)
+        return ProjectProcessResult("cancelled", None, "", 0, False)
+
+    monkeypatch.setattr(runtime.processes, "run_project_process", run)
+    with pytest.raises(AgentWorkspaceError, match = "cancelled"):
+        runtime.run_tool_hooks(project_id, "PreToolUse", "terminal", {})
+
+
+@pytest.mark.parametrize(
+    "output,status,truncated",
+    [
+        ('{"decision":"block"}', "passed", False),
+        ('{"continue":false}', "passed", False),
+        ('{"hookSpecificOutput":{"permissionDecision":"deny"}}', "passed", False),
+        ("timeout", "timed_out", False),
+        ("incomplete", "passed", True),
+    ],
+)
+def test_pre_tool_hook_failures_refuse_the_tool(
+    reviewed_hooks, monkeypatch, output, status, truncated
+):
+    project_id, _workspace, _state = reviewed_hooks
+    monkeypatch.setattr(
+        runtime.processes,
+        "run_project_process",
+        lambda *_a, **_k: ProjectProcessResult(status, 0, output, len(output), truncated),
+    )
+    with pytest.raises(AgentWorkspaceError):
+        runtime.run_tool_hooks(project_id, "PreToolUse", "terminal", {})
+
+
+def test_public_tool_wrapper_preserves_arguments_and_reports_post_failure(
+    reviewed_hooks, monkeypatch
+):
+    project_id, _workspace, _state = reviewed_hooks
+    order = []
+    monkeypatch.setattr(runtime, "_project_for_tool", lambda *_args: project_id)
+
+    def hook(_project, event, name, arguments, **options):
+        order.append(event)
+        if event == "PostToolUse":
+            assert options["result"] == "tool result"
+            raise AgentWorkspaceError("post check failed")
+        arguments_seen.append(arguments)
+        return "before output"
+
+    monkeypatch.setattr(runtime, "run_tool_hooks", hook)
+    arguments_seen = []
+
+    @runtime.with_project_tool_hooks
+    def execute(
+        name,
+        arguments,
+        *,
+        disable_sandbox = False,
+        session_id = None,
+    ):
+        order.append("tool")
+        assert arguments is original
+        assert disable_sandbox is False
+        return "tool result"
+
+    original = {"command": "original"}
+    result = execute("terminal", original, session_id = "project-" + project_id)
+    assert order == ["PreToolUse", "tool", "PostToolUse"]
+    assert arguments_seen == [original]
+    assert "tool result" in result
+    assert "after the tool ran" in result
+
+
+def test_untrusted_hook_file_never_runs(reviewed_hooks, monkeypatch):
+    project_id, _workspace, _state = reviewed_hooks
+    trust_db.revoke_project_hook_trust(project_id, expected_revision = 1)
+    monkeypatch.setattr(
+        runtime.processes,
+        "run_project_process",
+        lambda *_a, **_k: pytest.fail("untrusted command ran"),
+    )
+    assert runtime.run_tool_hooks(project_id, "PreToolUse", "terminal", {}) == ""
+
+
+def test_tool_project_identity_comes_from_the_saved_conversation(reviewed_hooks, monkeypatch):
+    project_id, _workspace, _state = reviewed_hooks
+    from core.inference import tools
+
+    monkeypatch.setattr(tools, "_thread_exists", lambda _id: False)
+    monkeypatch.setattr(studio_db, "get_chat_thread", lambda _id: {"projectId": "other"})
+    with pytest.raises(AgentWorkspaceError, match = "saved conversation"):
+        runtime._project_for_tool("project-" + project_id, "chat")
+    monkeypatch.setattr(studio_db, "get_chat_thread", lambda _id: {"projectId": project_id})
+    assert runtime._project_for_tool("project-" + project_id, "chat") == project_id
+    monkeypatch.setattr(tools, "_thread_exists", lambda _id: True)
+    with pytest.raises(AgentWorkspaceError, match = "conflicts with a saved conversation"):
+        runtime._project_for_tool("project-" + project_id, "chat")
+    assert runtime._project_for_tool("project-" + project_id, None) is None
+
+
+def test_hook_event_size_limit_refuses_ambiguous_truncated_arguments(reviewed_hooks, monkeypatch):
+    project_id, _workspace, _state = reviewed_hooks
+    monkeypatch.setattr(
+        runtime.processes,
+        "run_project_process",
+        lambda *_a, **_k: pytest.fail("oversize input ran"),
+    )
+    with pytest.raises(AgentWorkspaceError, match = "review limit"):
+        runtime.run_tool_hooks(
+            project_id, "PreToolUse", "terminal", {"command": "x" * runtime.MAX_EVENT_BYTES}
+        )
+
+
+def test_hook_context_limit_zero_suppresses_output_but_keeps_denial(reviewed_hooks, monkeypatch):
+    project_id, _workspace, state = reviewed_hooks
+    handler = state["config"]["hooks"]["PreToolUse"][0]["hooks"][0]
+    handler["additionalContextLimit"] = 0
+    monkeypatch.setattr(
+        runtime.processes, "run_project_process", lambda *_a, **_k: passed("private output")
+    )
+    assert runtime.run_tool_hooks(project_id, "PreToolUse", "terminal", {}) == ""
+    monkeypatch.setattr(
+        runtime.processes,
+        "run_project_process",
+        lambda *_a, **_k: passed('{"decision":"block","reason":"hidden"}'),
+    )
+    with pytest.raises(AgentWorkspaceError, match = "blocked") as blocked:
+        runtime.run_tool_hooks(project_id, "PreToolUse", "terminal", {})
+    assert "hidden" not in str(blocked.value)
+
+
+def test_hook_output_shares_the_tools_final_result_budget(reviewed_hooks, monkeypatch):
+    project_id, _workspace, _state = reviewed_hooks
+    from core.inference import tools
+
+    observed = []
+    monkeypatch.setattr(runtime, "_project_for_tool", lambda *_args: project_id)
+    monkeypatch.setattr(runtime, "run_tool_hooks", lambda *_a, **_k: "hook output")
+    monkeypatch.setattr(
+        tools,
+        "_fit_result_to_room",
+        lambda text, name: observed.append((text, name, tools._REQUEST_RESULT_BUDGET.get()))
+        or "bounded",
+    )
+
+    @runtime.with_project_tool_hooks
+    def execute(
+        name,
+        arguments,
+        *,
+        result_budget_tokens = None,
+    ):
+        return "tool result"
+
+    assert execute("terminal", {}, result_budget_tokens = 256) == "bounded"
+    assert observed == [
+        (
+            "Project hook output (untrusted data):\nhook output\nhook output\n\nTool result:\ntool result",
+            "terminal",
+            256,
+        )
+    ]
+
+
+def test_post_hook_failure_survives_a_large_tool_result(reviewed_hooks, monkeypatch):
+    from core.inference import tools
+
+    project_id, _workspace, _state = reviewed_hooks
+    monkeypatch.setattr(runtime, "_project_for_tool", lambda *args: project_id)
+    monkeypatch.setattr(tools, "_fit_result_to_room", lambda text, _name: text[:256])
+
+    def hook(_project, event, *args, **kwargs):
+        if event == "PostToolUse":
+            raise AgentWorkspaceError("validation rejected the change")
+        return "pre-hook output" * 2000
+
+    monkeypatch.setattr(runtime, "run_tool_hooks", hook)
+
+    @runtime.with_project_tool_hooks
+    def execute(
+        name,
+        arguments,
+        *,
+        session_id = None,
+    ):
+        return "large result" * 10000
+
+    result = execute("terminal", {}, session_id = "project-" + project_id)
+    assert "Post-tool hook failed after the tool ran" in result
+    assert "validation rejected" in result
+
+
+def test_no_hook_output_preserves_the_original_result_without_rebudgeting(
+    reviewed_hooks, monkeypatch
+):
+    from core.inference import tools
+
+    project_id, _workspace, _state = reviewed_hooks
+    monkeypatch.setattr(runtime, "_project_for_tool", lambda *args: project_id)
+    monkeypatch.setattr(runtime, "run_tool_hooks", lambda *args, **kwargs: "")
+    monkeypatch.setattr(
+        tools,
+        "_fit_result_to_room",
+        lambda *args: pytest.fail("No-hooks result must not be re-budgeted"),
+    )
+    original = "unchanged result " * 1000
+
+    @runtime.with_project_tool_hooks
+    def execute(
+        name,
+        arguments,
+        *,
+        session_id = None,
+    ):
+        return original
+
+    assert execute("terminal", {}, session_id = "project-" + project_id) is original
+
+
+def test_unconfigured_project_skips_hook_discovery_leases_and_process_probes(monkeypatch):
+    monkeypatch.setattr(runtime, "_project_for_tool", lambda *args: "no-hooks")
+    monkeypatch.setattr(
+        trust_db, "get_project_hook_trust_record", lambda _id: {"hasStoredTrust": False}
+    )
+    monkeypatch.setattr(
+        runtime.common,
+        "project_workspace_access",
+        lambda *args: pytest.fail("No hook workspace access"),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "run_tool_hooks",
+        lambda *args, **kwargs: pytest.fail("No hook discovery or executor"),
+    )
+    original = "  unchanged\r\n" * 10000
+
+    @runtime.with_project_tool_hooks
+    def execute(
+        name,
+        arguments,
+        *,
+        session_id = None,
+    ):
+        return original
+
+    assert execute("terminal", {}, session_id = "project-no-hooks") is original

--- a/studio/backend/tests/test_project_hook_trust_db.py
+++ b/studio/backend/tests/test_project_hook_trust_db.py
@@ -1,0 +1,458 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Focused coverage for hash-bound project hook trust persistence."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from storage import project_hook_trust_db as trust_db
+from storage import studio_db
+
+
+HASH_A = "a" * 64
+HASH_B = "b" * 64
+IDENTITY_A = (101, 202)
+IDENTITY_B = (303, 404)
+WORKSPACE_REVISION = 7
+
+
+@pytest.fixture(autouse = True)
+def _reset_hook_trust_schema():
+    trust_db._ready_databases.clear()
+    yield
+    trust_db._ready_databases.clear()
+
+
+def _create_project(project_id: str = "hooks-project") -> str:
+    conn = studio_db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO chat_projects (
+                id, name, instructions, archived, created_at, updated_at
+            )
+            VALUES (?, ?, '', 0, 1, 1)
+            """,
+            (project_id, "Hooks Project"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return project_id
+
+
+def _state(
+    project_id: str,
+    content_hash: str | None,
+    *,
+    identity: tuple[int, int] = IDENTITY_A,
+    workspace_revision: int = WORKSPACE_REVISION,
+) -> dict:
+    return trust_db.get_project_hook_trust_state(
+        project_id,
+        content_hash,
+        workspace_identity = identity,
+        workspace_revision = workspace_revision,
+    )
+
+
+def _trust(
+    project_id: str,
+    content_hash: str,
+    expected_revision: int,
+    *,
+    identity: tuple[int, int] = IDENTITY_A,
+    workspace_revision: int = WORKSPACE_REVISION,
+) -> dict:
+    return trust_db.trust_project_hooks(
+        project_id,
+        content_hash,
+        workspace_identity = identity,
+        workspace_revision = workspace_revision,
+        expected_revision = expected_revision,
+    )
+
+
+def _toggle(
+    project_id: str,
+    content_hash: str,
+    handler_id: str,
+    *,
+    enabled: bool,
+    expected_revision: int,
+    identity: tuple[int, int] = IDENTITY_A,
+    workspace_revision: int = WORKSPACE_REVISION,
+) -> dict:
+    return trust_db.set_project_hook_handler_enabled(
+        project_id,
+        content_hash,
+        handler_id,
+        workspace_identity = identity,
+        workspace_revision = workspace_revision,
+        enabled = enabled,
+        expected_revision = expected_revision,
+    )
+
+
+def test_table_is_lazy_and_has_project_cascade():
+    project_id = _create_project()
+    conn = studio_db.get_connection()
+    try:
+        before = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'project_hook_trust'"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert before is None
+
+    assert _state(project_id, HASH_A) == {
+        "projectId": project_id,
+        "contentHash": HASH_A,
+        "trusted": False,
+        "disabledHandlerIds": [],
+        "revision": 0,
+    }
+
+    conn = studio_db.get_connection()
+    try:
+        foreign_keys = conn.execute("PRAGMA foreign_key_list(project_hook_trust)").fetchall()
+    finally:
+        conn.close()
+    assert any(row[2] == "chat_projects" and row[6] == "CASCADE" for row in foreign_keys)
+
+
+def test_trusts_only_the_exact_rediscovered_hash_and_uses_cas():
+    project_id = _create_project()
+
+    trusted = _trust(project_id, HASH_A, 0)
+
+    assert trusted == {
+        "projectId": project_id,
+        "contentHash": HASH_A,
+        "trusted": True,
+        "disabledHandlerIds": [],
+        "revision": 1,
+    }
+    assert _state(project_id, HASH_A) == trusted
+    assert _state(project_id, HASH_B) == {
+        "projectId": project_id,
+        "contentHash": HASH_B,
+        "trusted": False,
+        "disabledHandlerIds": [],
+        "revision": 1,
+    }
+    assert _state(project_id, None)["trusted"] is False
+    with pytest.raises(trust_db.ProjectHookTrustConflictError, match = "revision"):
+        _trust(project_id, HASH_B, 0)
+
+
+def test_trust_is_bound_to_workspace_identity_and_revision():
+    project_id = _create_project()
+    trusted = _trust(project_id, HASH_A, 0)
+
+    identity_drift = _state(project_id, HASH_A, identity = IDENTITY_B)
+    revision_drift = _state(
+        project_id,
+        HASH_A,
+        workspace_revision = WORKSPACE_REVISION + 1,
+    )
+
+    assert identity_drift["trusted"] is False
+    assert revision_drift["trusted"] is False
+    assert identity_drift["revision"] == trusted["revision"]
+    assert revision_drift["revision"] == trusted["revision"]
+    with pytest.raises(trust_db.ProjectHookTrustConflictError, match = "workspace changed"):
+        _toggle(
+            project_id,
+            HASH_A,
+            "PreToolUse:0:0",
+            identity = IDENTITY_B,
+            enabled = False,
+            expected_revision = trusted["revision"],
+        )
+
+    rebound = _trust(
+        project_id,
+        HASH_A,
+        trusted["revision"],
+        identity = IDENTITY_B,
+        workspace_revision = WORKSPACE_REVISION + 1,
+    )
+    assert rebound["trusted"] is True
+    assert rebound["revision"] == trusted["revision"] + 1
+
+
+def test_retrusting_changed_source_resets_stale_disabled_ids():
+    project_id = _create_project()
+    trusted = _trust(project_id, HASH_A, 0)
+    disabled = _toggle(
+        project_id,
+        HASH_A,
+        "PreToolUse:0:0",
+        enabled = False,
+        expected_revision = trusted["revision"],
+    )
+    assert disabled["disabledHandlerIds"] == ["PreToolUse:0:0"]
+
+    changed = _state(project_id, HASH_B)
+    assert changed["trusted"] is False
+    assert changed["disabledHandlerIds"] == []
+    retrusted = _trust(project_id, HASH_B, changed["revision"])
+
+    assert retrusted["trusted"] is True
+    assert retrusted["disabledHandlerIds"] == []
+    assert retrusted["revision"] == disabled["revision"] + 1
+    with pytest.raises(trust_db.ProjectHookTrustConflictError, match = "changed"):
+        _toggle(
+            project_id,
+            HASH_A,
+            "PreToolUse:0:0",
+            enabled = False,
+            expected_revision = retrusted["revision"],
+        )
+
+
+def test_handler_toggle_is_hash_bound_idempotent_and_revisioned():
+    project_id = _create_project()
+    trusted = _trust(project_id, HASH_A, 0)
+
+    disabled = _toggle(
+        project_id,
+        HASH_A,
+        "PostToolUse:1:2",
+        enabled = False,
+        expected_revision = trusted["revision"],
+    )
+    assert disabled["disabledHandlerIds"] == ["PostToolUse:1:2"]
+    assert disabled["revision"] == 2
+
+    unchanged = _toggle(
+        project_id,
+        HASH_A,
+        "PostToolUse:1:2",
+        enabled = False,
+        expected_revision = disabled["revision"],
+    )
+    assert unchanged == disabled
+
+    enabled = _toggle(
+        project_id,
+        HASH_A,
+        "PostToolUse:1:2",
+        enabled = True,
+        expected_revision = unchanged["revision"],
+    )
+    assert enabled["disabledHandlerIds"] == []
+    assert enabled["revision"] == 3
+
+    with pytest.raises(trust_db.ProjectHookTrustConflictError, match = "revision"):
+        _toggle(
+            project_id,
+            HASH_A,
+            "PreToolUse:0:0",
+            enabled = False,
+            expected_revision = 2,
+        )
+
+
+def test_revoke_preserves_monotonic_revision_and_clears_preferences():
+    project_id = _create_project()
+    trusted = _trust(project_id, HASH_A, 0)
+    disabled = _toggle(
+        project_id,
+        HASH_A,
+        "Stop:0:0",
+        enabled = False,
+        expected_revision = trusted["revision"],
+    )
+
+    revoked = trust_db.revoke_project_hook_trust(
+        project_id,
+        expected_revision = disabled["revision"],
+    )
+
+    assert revoked == {
+        "projectId": project_id,
+        "contentHash": None,
+        "trusted": False,
+        "disabledHandlerIds": [],
+        "revision": 3,
+    }
+    assert _state(project_id, HASH_A) == {**revoked, "contentHash": HASH_A}
+    with pytest.raises(trust_db.ProjectHookTrustConflictError, match = "revision"):
+        _trust(project_id, HASH_A, 0)
+
+    retrusted = _trust(project_id, HASH_A, 3)
+    assert retrusted["trusted"] is True
+    assert retrusted["revision"] == 4
+
+
+def test_project_delete_cascades_hook_trust_row():
+    project_id = _create_project()
+    _trust(project_id, HASH_A, 0)
+
+    conn = studio_db.get_connection()
+    try:
+        conn.execute("DELETE FROM chat_projects WHERE id = ?", (project_id,))
+        conn.commit()
+        row = conn.execute(
+            "SELECT 1 FROM project_hook_trust WHERE project_id = ?",
+            (project_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row is None
+
+
+def test_rejects_missing_projects_invalid_hashes_and_unbounded_handler_ids():
+    with pytest.raises(ValueError, match = "Project does not exist"):
+        _trust("missing", HASH_A, 0)
+
+    project_id = _create_project()
+    with pytest.raises(ValueError, match = "lowercase SHA-256"):
+        _trust(project_id, "A" * 64, 0)
+    trusted = _trust(project_id, HASH_A, 0)
+    with pytest.raises(ValueError, match = "size limit"):
+        _toggle(
+            project_id,
+            HASH_A,
+            "x" * (trust_db.MAX_HANDLER_ID_BYTES + 1),
+            enabled = False,
+            expected_revision = trusted["revision"],
+        )
+    with pytest.raises(ValueError, match = "enabled state"):
+        _toggle(
+            project_id,
+            HASH_A,
+            "Stop:0:0",
+            enabled = 1,
+            expected_revision = trusted["revision"],
+        )
+
+
+def test_disabled_handler_count_is_bounded(tmp_path, monkeypatch):
+    _ = tmp_path
+    project_id = _create_project()
+    trusted = _trust(project_id, HASH_A, 0)
+    monkeypatch.setattr(trust_db, "MAX_DISABLED_HANDLER_IDS", 1)
+    first = _toggle(
+        project_id,
+        HASH_A,
+        "PreToolUse:0:0",
+        enabled = False,
+        expected_revision = trusted["revision"],
+    )
+
+    with pytest.raises(ValueError, match = "exceed"):
+        _toggle(
+            project_id,
+            HASH_A,
+            "PostToolUse:0:0",
+            enabled = False,
+            expected_revision = first["revision"],
+        )
+
+
+def test_corrupt_persisted_preferences_fail_closed():
+    project_id = _create_project()
+    _trust(project_id, HASH_A, 0)
+    conn = studio_db.get_connection()
+    try:
+        conn.execute(
+            "UPDATE project_hook_trust SET disabled_handler_ids_json = ? WHERE project_id = ?",
+            ('["Stop:0:0", "Stop:0:0"]', project_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(trust_db.ProjectHookTrustStateError, match = "preferences"):
+        _state(project_id, HASH_A)
+    assert trust_db.get_project_hook_trust_record(project_id) == {
+        "projectId": project_id,
+        "storedContentHash": HASH_A,
+        "hasStoredTrust": True,
+        "revision": 1,
+    }
+
+    revoked = trust_db.revoke_project_hook_trust(project_id, expected_revision = 1)
+    assert revoked["trusted"] is False
+    assert revoked["revision"] == 2
+    assert _state(project_id, HASH_A)["trusted"] is False
+
+
+def test_legacy_unbound_trust_is_untrusted_and_can_be_revoked():
+    project_id = _create_project()
+    conn = studio_db.get_connection()
+    try:
+        conn.execute(
+            """
+            CREATE TABLE project_hook_trust (
+                project_id TEXT NOT NULL PRIMARY KEY
+                    REFERENCES chat_projects(id) ON DELETE CASCADE,
+                trusted_content_hash TEXT,
+                disabled_handler_ids_json TEXT NOT NULL DEFAULT '[]',
+                revision INTEGER NOT NULL DEFAULT 0,
+                updated_at INTEGER NOT NULL
+            ) WITHOUT ROWID
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO project_hook_trust (
+                project_id, trusted_content_hash, disabled_handler_ids_json,
+                revision, updated_at
+            ) VALUES (?, ?, ?, 4, 1)
+            """,
+            (project_id, HASH_A, '["Stop:0:0"]'),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    state = _state(project_id, HASH_A)
+    assert state["trusted"] is False
+    assert state["disabledHandlerIds"] == []
+    assert state["revision"] == 4
+
+    revoked = trust_db.revoke_project_hook_trust(project_id, expected_revision = 4)
+    assert revoked["revision"] == 5
+    conn = studio_db.get_connection()
+    try:
+        row = conn.execute(
+            """
+            SELECT trusted_content_hash, workspace_device_id, workspace_file_id,
+                   workspace_revision, disabled_handler_ids_json
+            FROM project_hook_trust
+            WHERE project_id = ?
+            """,
+            (project_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert tuple(row) == (None, None, None, None, "[]")
+
+
+def test_schema_constraint_rejects_non_sha256_hashes():
+    project_id = _create_project()
+    _state(project_id, None)
+    conn = studio_db.get_connection()
+    try:
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """
+                INSERT INTO project_hook_trust (
+                    project_id, trusted_content_hash, disabled_handler_ids_json,
+                    revision, updated_at
+                ) VALUES (?, ?, '[]', 1, 1)
+                """,
+                (project_id, "not-a-hash"),
+            )
+        conn.rollback()
+    finally:
+        conn.close()

--- a/studio/backend/tests/test_project_hooks.py
+++ b/studio/backend/tests/test_project_hooks.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Focused coverage for trusted project lifecycle hooks."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from core.agent_workspace import hooks
+from core.agent_workspace.verification_context import AgentWorkspaceError
+
+
+def _document(
+    *handlers: dict,
+    event: str = "PreToolUse",
+    matcher: str = "Bash",
+) -> bytes:
+    return json.dumps(
+        {
+            "description": "repository policy",
+            "hooks": {
+                event: [
+                    {
+                        "matcher": matcher,
+                        "hooks": list(handlers),
+                    }
+                ]
+            },
+        },
+        separators = (",", ":"),
+    ).encode()
+
+
+def _command(command: str, **extra) -> dict:
+    return {"type": "command", "command": command, **extra}
+
+
+@pytest.mark.skipif(os.name == "nt", reason = "Secure hook discovery requires POSIX descriptors")
+def test_discovers_exact_file_hash_and_requires_retrust_after_change(tmp_path):
+    root = tmp_path / "repository"
+    config_path = root / ".codex" / "hooks.json"
+    config_path.parent.mkdir(parents = True)
+    first = _document(_command("printf first"))
+    config_path.write_bytes(first)
+    identity = (root.stat().st_dev, root.stat().st_ino)
+
+    discovered = hooks.discover_project_hooks(root, expected_identity = identity)
+
+    assert discovered["sourcePath"] == ".codex/hooks.json"
+    assert discovered["contentHash"] == hooks.project_hooks_content_hash(first)
+    assert discovered["handlerCount"] == 1
+    assert hooks.project_hooks_are_trusted(discovered, discovered["contentHash"])
+
+    trusted_hash = discovered["contentHash"]
+    second = _document(_command("printf second"))
+    config_path.write_bytes(second)
+    changed = hooks.discover_project_hooks(root, expected_identity = identity)
+
+    assert changed["contentHash"] != trusted_hash
+    assert not hooks.project_hooks_are_trusted(changed, trusted_hash)
+
+
+@pytest.mark.skipif(os.name == "nt", reason = "Secure hook discovery requires POSIX descriptors")
+def test_discovery_is_empty_when_file_is_absent_and_rejects_symlinks(tmp_path):
+    root = tmp_path / "repository"
+    root.mkdir()
+
+    assert hooks.discover_project_hooks(root)["exists"] is False
+
+    outside = tmp_path / "outside.json"
+    outside.write_bytes(_document(_command("true")))
+    codex = root / ".codex"
+    codex.mkdir()
+    (codex / "hooks.json").symlink_to(outside)
+
+    with pytest.raises(AgentWorkspaceError, match = "unsafe filesystem boundary"):
+        hooks.discover_project_hooks(root)
+
+
+@pytest.mark.parametrize(
+    "raw, message",
+    [
+        (b'{"hooks":{},"hooks":{}}', "duplicate field"),
+        (b'{"hooks":{"MadeUp":[]}}', "unsupported events"),
+        (
+            _document(_command("true"), matcher = "(a+)+"),
+            "unsupported or unsafe pattern",
+        ),
+        (
+            _document(_command("true"), matcher = "^" + "a*" * 20 + "b$"),
+            "unsupported or unsafe pattern",
+        ),
+        (
+            _document({"type": "mcp_tool", "server": "scanner", "tool": "scan"}),
+            "must be command",
+        ),
+        (
+            _document({"type": "command", "commandWindows": "echo windows"}),
+            "command is required",
+        ),
+        (
+            _document(_command("true", timeout = 4), event = "SessionEnd", matcher = "other"),
+            "outside the supported range",
+        ),
+    ],
+)
+def test_validation_rejects_ambiguous_or_unsupported_schema(raw, message):
+    with pytest.raises(AgentWorkspaceError, match = message):
+        hooks.validate_project_hooks(raw)
+
+
+def test_matchers_support_aliases_and_ignore_matcher_for_stop():
+    edit_config = hooks.validate_project_hooks(
+        _document(_command("true"), matcher = "^Edit$|^Write$")
+    )
+    stop_config = hooks.validate_project_hooks(
+        _document(_command("true"), event = "Stop", matcher = "will-not-match")
+    )
+
+    assert (
+        len(
+            hooks.matching_project_hooks(
+                edit_config,
+                "PreToolUse",
+                {"tool_name": "apply_patch"},
+            )
+        )
+        == 1
+    )
+    assert (
+        hooks.matching_project_hooks(
+            edit_config,
+            "PreToolUse",
+            {"tool_name": "Bash"},
+        )
+        == []
+    )
+    assert len(hooks.matching_project_hooks(stop_config, "Stop", {})) == 1
+
+
+@pytest.mark.parametrize(
+    "matcher, tool_name, matches",
+    [
+        ("Bash", "Bash", True),
+        ("Edit|Write", "Write", True),
+        ("^Bash$", "Bash", True),
+        ("^Bash$", "BashTool", False),
+        ("mcp__memory__.*", "mcp__memory__read_graph", True),
+        ("^mcp__.*__read$", "mcp__memory__read", True),
+        (r"^file\.txt$", "file.txt", True),
+        (r"^Literal\|Pipe$", "Literal|Pipe", True),
+        ("^.at$", "cat", True),
+        ("^.at$", "chat", False),
+    ],
+)
+def test_safe_matchers_support_official_style_patterns(matcher, tool_name, matches):
+    config = hooks.validate_project_hooks(_document(_command("true"), matcher = matcher))
+
+    selected = hooks.matching_project_hooks(config, "PreToolUse", {"tool_name": tool_name})
+
+    assert bool(selected) is matches
+
+
+@pytest.mark.parametrize("matcher", ["", "*"])
+def test_empty_and_star_matchers_match_every_value(matcher):
+    config = hooks.validate_project_hooks(_document(_command("true"), matcher = matcher))
+
+    assert hooks.matching_project_hooks(config, "PreToolUse", {"tool_name": "anything"})
+
+
+@pytest.mark.parametrize(
+    "matcher",
+    [
+        "^(Edit|Write)$",
+        "[A-Z]+",
+        "Bash?",
+        "Bash{1,3}",
+        "Bash*",
+        "Bash||Write",
+        "Bash\\",
+        "Ba^sh",
+        "Ba$sh",
+    ],
+)
+def test_matcher_rejects_groups_classes_quantifiers_and_ambiguous_forms(matcher):
+    with pytest.raises(AgentWorkspaceError, match = "unsupported or unsafe pattern"):
+        hooks.validate_project_hooks(_document(_command("true"), matcher = matcher))
+
+
+def test_hook_module_exposes_no_command_runner():
+    assert not hasattr(hooks, "run_project_hooks")
+    assert not hasattr(hooks, "_run_project_hooks_from_config")
+    assert not hasattr(hooks, "_run_command")
+
+
+@pytest.mark.skipif(os.name != "nt", reason = "Windows discovery refusal")
+def test_windows_hook_discovery_refuses_without_reading_commands(tmp_path):
+    from core.agent_workspace.hooks import discover_project_hooks
+    with pytest.raises(AgentWorkspaceError):
+        discover_project_hooks(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "matcher,tool_name",
+    [
+        ("Bash", "terminal"),
+        ("Terminal", "terminal"),
+        ("Edit", "edit_file"),
+        ("Write", "edit_file"),
+        ("Python", "python"),
+    ],
+)
+def test_studio_tool_names_match_reviewed_hook_aliases(matcher, tool_name):
+    config = hooks.validate_project_hooks(_document(_command("true"), matcher = matcher))
+    assert len(hooks.matching_project_hooks(config, "PreToolUse", {"tool_name": tool_name})) == 1
+    assert hooks.matching_project_hooks(config, "PreToolUse", {"tool_name": "web_search"}) == []

--- a/studio/backend/tests/test_project_hooks.py
+++ b/studio/backend/tests/test_project_hooks.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 
 from core.agent_workspace import hooks
-from core.agent_workspace.verification_context import AgentWorkspaceError
+from core.agent_workspace.hook_context import AgentWorkspaceError
 
 
 def _document(

--- a/studio/backend/tests/test_project_hooks_native.py
+++ b/studio/backend/tests/test_project_hooks_native.py
@@ -1,0 +1,72 @@
+import pytest
+from core.agent_workspace import hook_runtime
+from core.agent_workspace.hook_context import AgentWorkspaceError
+from routes import project_hooks
+from .test_project_verification_native import native_project
+
+
+def _review_hooks(
+    workspace,
+    command,
+    *,
+    event = "PreToolUse",
+):
+    import json
+
+    path = workspace.root / ".codex" / "hooks.json"
+    path.parent.mkdir(exist_ok = True)
+    path.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    event: [{"hooks": [{"type": "command", "command": command, "timeout": 10}]}]
+                }
+            }
+        )
+    )
+    snapshot = project_hooks.project_hooks(workspace.project_id, _current_subject = "ui")
+    return project_hooks.project_hooks_trust(
+        workspace.project_id,
+        project_hooks.TrustProjectHooksRequest(
+            contentHash = snapshot["contentHash"], workspaceRevision = 0, revision = 0
+        ),
+        via_api_key = False,
+        _current_subject = "ui",
+    )
+
+
+def test_native_hook_revalidates_trust_after_bind_before_user_code(native_project, monkeypatch):
+    native, workspace = native_project
+    _review_hooks(workspace, "echo must-not-run > forbidden")
+    original_bind = native._BubblewrapLifecycle.bind
+
+    def revoke_after_bind(self, *args, **kwargs):
+        bound = original_bind(self, *args, **kwargs)
+        project_hooks.project_hooks_revoke(
+            workspace.project_id,
+            project_hooks.RevokeProjectHooksRequest(revision = 1),
+            via_api_key = False,
+            _current_subject = "ui",
+        )
+        return bound
+
+    monkeypatch.setattr(native._BubblewrapLifecycle, "bind", revoke_after_bind)
+    with pytest.raises(AgentWorkspaceError, match = "changed"):
+        hook_runtime.run_tool_hooks(workspace.project_id, "PreToolUse", "terminal", {})
+    assert not (workspace.root / "forbidden").exists()
+
+
+def test_native_reviewed_pre_hook_blocks_public_edit_tool(native_project):
+    _native, workspace = native_project
+    from core.inference.tools import execute_tool, project_session_id
+
+    _review_hooks(workspace, "exit 2")
+    target = workspace.root / "source.txt"
+    target.write_text("before")
+    result = execute_tool(
+        "edit_file",
+        {"path": "source.txt", "old_string": "before", "new_string": "after"},
+        session_id = project_session_id(workspace.project_id),
+    )
+    assert "hook" in result.lower() and "failed" in result.lower(), result
+    assert target.read_text() == "before"

--- a/studio/backend/tests/test_project_hooks_native.py
+++ b/studio/backend/tests/test_project_hooks_native.py
@@ -1,4 +1,10 @@
 import pytest
+
+from importlib.util import find_spec
+
+if find_spec("core.agent_workspace.verification") is None:
+    pytest.skip("Requires the optional verification engine", allow_module_level = True)
+
 from core.agent_workspace import hook_runtime
 from core.agent_workspace.hook_context import AgentWorkspaceError
 from routes import project_hooks

--- a/studio/backend/tests/test_project_hooks_routes.py
+++ b/studio/backend/tests/test_project_hooks_routes.py
@@ -1,0 +1,689 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Authenticated transport coverage for project hook review and trust controls."""
+
+from __future__ import annotations
+
+import json
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from routes import project_hooks
+from storage import project_hook_trust_db, studio_db
+
+
+@pytest.fixture(autouse = True)
+def _supported_command_runtime(monkeypatch):
+    if os.name == "nt":
+        pytest.skip("Hook source review requires native POSIX descriptor discovery")
+    monkeypatch.setattr(
+        project_hooks,
+        "execution_status",
+        lambda: {"available": True, "backend": "test", "reason": None},
+    )
+
+
+def _create_project(project_id: str = "hooks-route-project") -> str:
+    connection = studio_db.get_connection()
+    try:
+        connection.execute(
+            """
+            INSERT INTO chat_projects (
+                id, name, instructions, archived, created_at, updated_at
+            ) VALUES (?, ?, '', 0, 1, 1)
+            """,
+            (project_id, "Hooks Route Project"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    return project_id
+
+
+def _write_hooks(root: Path, command: str = "python3 .codex/check.py") -> None:
+    path = root / ".codex" / "hooks.json"
+    path.parent.mkdir(parents = True, exist_ok = True)
+    path.write_text(
+        json.dumps(
+            {
+                "description": "Repository checks",
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": command,
+                                    "timeout": 30,
+                                }
+                            ],
+                        }
+                    ]
+                },
+            },
+            separators = (",", ":"),
+        ),
+        encoding = "utf-8",
+    )
+
+
+@contextmanager
+def _workspace(root: Path, revision: int = 7):
+    metadata = root.stat()
+    yield SimpleNamespace(
+        root = root,
+        device_id = metadata.st_dev,
+        file_id = metadata.st_ino,
+        revision = revision,
+    )
+
+
+def _bind_project(
+    monkeypatch,
+    project_id: str,
+    root: Path,
+    *,
+    revision: int = 7,
+) -> None:
+    monkeypatch.setattr(
+        project_hooks,
+        "get_chat_project",
+        lambda requested: (
+            {
+                "id": project_id,
+                "archived": False,
+                "workspaceAvailable": True,
+                "workspaceRevision": revision,
+            }
+            if requested == project_id
+            else None
+        ),
+    )
+    monkeypatch.setattr(
+        project_hooks,
+        "project_workspace_access",
+        lambda requested: (
+            _workspace(root, revision)
+            if requested == project_id
+            else pytest.fail("opened the wrong project")
+        ),
+    )
+
+
+def test_routes_require_explicit_exact_hash_trust_and_revisioned_handler_controls(
+    tmp_path, monkeypatch
+):
+    project_id = _create_project()
+    root = tmp_path / "repository"
+    root.mkdir()
+    _write_hooks(root)
+    _bind_project(monkeypatch, project_id, root)
+
+    discovered = project_hooks.project_hooks(project_id, _current_subject = "tester")
+
+    assert discovered["exists"] is True
+    assert discovered["workspaceAvailable"] is True
+    assert discovered["workspaceRevision"] == 7
+    assert discovered["storedTrust"] is None
+    assert discovered["trusted"] is False
+    assert discovered["revision"] == 0
+    assert discovered["sourcePath"] == ".codex/hooks.json"
+    handler = discovered["hooks"]["PreToolUse"][0]["hooks"][0]
+    assert handler["enabled"] is True
+    assert handler["active"] is False
+    assert handler["command"] == "python3 .codex/check.py"
+
+    trusted = project_hooks.project_hooks_trust(
+        project_id,
+        project_hooks.TrustProjectHooksRequest(
+            contentHash = discovered["contentHash"],
+            workspaceRevision = discovered["workspaceRevision"],
+            revision = discovered["revision"],
+        ),
+        _current_subject = "tester",
+    )
+
+    assert trusted["trusted"] is True
+    assert trusted["workspaceRevision"] == 7
+    assert trusted["revision"] == 1
+    assert trusted["storedTrust"] == {
+        "contentHash": trusted["contentHash"],
+        "revision": trusted["revision"],
+    }
+    assert trusted["hooks"]["PreToolUse"][0]["hooks"][0]["enabled"] is True
+    assert trusted["hooks"]["PreToolUse"][0]["hooks"][0]["active"] is True
+
+    disabled = project_hooks.project_hook_handler(
+        project_id,
+        handler["id"],
+        project_hooks.SetProjectHookHandlerRequest(
+            contentHash = trusted["contentHash"],
+            workspaceRevision = trusted["workspaceRevision"],
+            revision = trusted["revision"],
+            enabled = False,
+        ),
+        _current_subject = "tester",
+    )
+
+    assert disabled["revision"] == 2
+    assert disabled["hooks"]["PreToolUse"][0]["hooks"][0]["enabled"] is False
+    assert disabled["hooks"]["PreToolUse"][0]["hooks"][0]["active"] is False
+
+    revoked = project_hooks.project_hooks_revoke(
+        project_id,
+        project_hooks.RevokeProjectHooksRequest(revision = disabled["revision"]),
+        _current_subject = "tester",
+    )
+    assert revoked["trusted"] is False
+    assert revoked["revision"] == 3
+    assert revoked["storedTrust"] is None
+    assert revoked["hooks"]["PreToolUse"][0]["hooks"][0]["enabled"] is True
+    assert revoked["hooks"]["PreToolUse"][0]["hooks"][0]["active"] is False
+
+
+def test_api_keys_cannot_grant_or_change_hook_authority(monkeypatch):
+    monkeypatch.setattr(
+        project_hooks,
+        "get_chat_project",
+        lambda _project_id: pytest.fail("API-key mutations must fail before project access"),
+    )
+    trust_request = project_hooks.TrustProjectHooksRequest(
+        contentHash = "a" * 64,
+        workspaceRevision = 0,
+        revision = 0,
+    )
+    handler_request = project_hooks.SetProjectHookHandlerRequest(
+        contentHash = "a" * 64,
+        workspaceRevision = 0,
+        revision = 0,
+        enabled = True,
+    )
+
+    with pytest.raises(HTTPException) as trust_denied:
+        project_hooks.project_hooks_trust(
+            "project",
+            trust_request,
+            via_api_key = True,
+            _current_subject = "api-key",
+        )
+    assert trust_denied.value.status_code == 403
+
+    with pytest.raises(HTTPException) as handler_denied:
+        project_hooks.project_hook_handler(
+            "project",
+            "PreToolUse:0:0",
+            handler_request,
+            via_api_key = True,
+            _current_subject = "api-key",
+        )
+    assert handler_denied.value.status_code == 403
+
+    with pytest.raises(HTTPException) as revoke_denied:
+        project_hooks.project_hooks_revoke(
+            "project",
+            project_hooks.RevokeProjectHooksRequest(revision = 1),
+            via_api_key = True,
+            _current_subject = "api-key",
+        )
+    assert revoke_denied.value.status_code == 403
+
+
+def test_changed_file_is_untrusted_and_stale_mutations_fail(tmp_path, monkeypatch):
+    project_id = _create_project("hooks-route-drift")
+    root = tmp_path / "repository"
+    root.mkdir()
+    _write_hooks(root, "printf first")
+    _bind_project(monkeypatch, project_id, root)
+    first = project_hooks.project_hooks(project_id, _current_subject = "tester")
+    trusted = project_hooks.project_hooks_trust(
+        project_id,
+        project_hooks.TrustProjectHooksRequest(
+            contentHash = first["contentHash"],
+            workspaceRevision = first["workspaceRevision"],
+            revision = first["revision"],
+        ),
+        _current_subject = "tester",
+    )
+
+    _write_hooks(root, "printf changed")
+    changed = project_hooks.project_hooks(project_id, _current_subject = "tester")
+
+    assert changed["contentHash"] != first["contentHash"]
+    assert changed["workspaceRevision"] == 7
+    assert changed["trusted"] is False
+    assert changed["revision"] == trusted["revision"]
+    assert changed["hooks"]["PreToolUse"][0]["hooks"][0]["enabled"] is True
+    assert changed["hooks"]["PreToolUse"][0]["hooks"][0]["active"] is False
+    with pytest.raises(HTTPException) as stale:
+        project_hooks.project_hooks_trust(
+            project_id,
+            project_hooks.TrustProjectHooksRequest(
+                contentHash = first["contentHash"],
+                workspaceRevision = changed["workspaceRevision"],
+                revision = changed["revision"],
+            ),
+            _current_subject = "tester",
+        )
+    assert stale.value.status_code == 409
+    assert "changed" in stale.value.detail
+
+
+def test_unknown_handlers_and_stale_revisions_do_not_mutate_state(tmp_path, monkeypatch):
+    project_id = _create_project("hooks-route-conflict")
+    root = tmp_path / "repository"
+    root.mkdir()
+    _write_hooks(root)
+    _bind_project(monkeypatch, project_id, root)
+    current = project_hooks.project_hooks(project_id, _current_subject = "tester")
+    trusted = project_hooks.project_hooks_trust(
+        project_id,
+        project_hooks.TrustProjectHooksRequest(
+            contentHash = current["contentHash"],
+            workspaceRevision = current["workspaceRevision"],
+            revision = current["revision"],
+        ),
+        _current_subject = "tester",
+    )
+
+    with pytest.raises(HTTPException) as missing:
+        project_hooks.project_hook_handler(
+            project_id,
+            "PreToolUse:9:9",
+            project_hooks.SetProjectHookHandlerRequest(
+                contentHash = trusted["contentHash"],
+                workspaceRevision = trusted["workspaceRevision"],
+                revision = trusted["revision"],
+                enabled = False,
+            ),
+            _current_subject = "tester",
+        )
+    assert missing.value.status_code == 404
+
+    with pytest.raises(HTTPException) as conflict:
+        project_hooks.project_hooks_revoke(
+            project_id,
+            project_hooks.RevokeProjectHooksRequest(revision = 0),
+            _current_subject = "tester",
+        )
+    assert conflict.value.status_code == 409
+    state = project_hook_trust_db.get_project_hook_trust_state(
+        project_id,
+        trusted["contentHash"],
+        workspace_identity = (root.stat().st_dev, root.stat().st_ino),
+        workspace_revision = 7,
+    )
+    assert state["trusted"] is True
+    assert state["revision"] == trusted["revision"]
+
+
+def test_missing_or_archived_projects_are_hidden(monkeypatch):
+    monkeypatch.setattr(project_hooks, "get_chat_project", lambda _project_id: None)
+
+    with pytest.raises(HTTPException) as missing:
+        project_hooks.project_hooks("missing", _current_subject = "tester")
+
+    assert missing.value.status_code == 404
+
+
+def test_workspace_revision_change_invalidates_trust_without_applying_preferences(
+    tmp_path, monkeypatch
+):
+    project_id = _create_project("hooks-route-workspace-revision")
+    root = tmp_path / "repository"
+    root.mkdir()
+    _write_hooks(root)
+    _bind_project(monkeypatch, project_id, root, revision = 10)
+    current = project_hooks.project_hooks(project_id, _current_subject = "tester")
+    trusted = project_hooks.project_hooks_trust(
+        project_id,
+        project_hooks.TrustProjectHooksRequest(
+            contentHash = current["contentHash"],
+            workspaceRevision = current["workspaceRevision"],
+            revision = current["revision"],
+        ),
+        _current_subject = "tester",
+    )
+    disabled = project_hooks.project_hook_handler(
+        project_id,
+        current["hooks"]["PreToolUse"][0]["hooks"][0]["id"],
+        project_hooks.SetProjectHookHandlerRequest(
+            contentHash = trusted["contentHash"],
+            workspaceRevision = trusted["workspaceRevision"],
+            revision = trusted["revision"],
+            enabled = False,
+        ),
+        _current_subject = "tester",
+    )
+    assert disabled["hooks"]["PreToolUse"][0]["hooks"][0]["enabled"] is False
+
+    _bind_project(monkeypatch, project_id, root, revision = 11)
+    changed = project_hooks.project_hooks(project_id, _current_subject = "tester")
+    handler = changed["hooks"]["PreToolUse"][0]["hooks"][0]
+
+    assert changed["trusted"] is False
+    assert changed["workspaceRevision"] == 11
+    assert handler["enabled"] is True
+    assert handler["active"] is False
+
+    monkeypatch.setattr(
+        project_hooks,
+        "trust_project_hooks",
+        lambda *_args, **_kwargs: pytest.fail("stale workspace trust reached storage"),
+    )
+    with pytest.raises(HTTPException) as stale_trust:
+        project_hooks.project_hooks_trust(
+            project_id,
+            project_hooks.TrustProjectHooksRequest(
+                contentHash = changed["contentHash"],
+                workspaceRevision = trusted["workspaceRevision"],
+                revision = changed["revision"],
+            ),
+            _current_subject = "tester",
+        )
+    assert stale_trust.value.status_code == 409
+    assert "workspace changed" in stale_trust.value.detail.lower()
+
+    monkeypatch.setattr(
+        project_hooks,
+        "set_project_hook_handler_enabled",
+        lambda *_args, **_kwargs: pytest.fail("stale workspace toggle reached storage"),
+    )
+    with pytest.raises(HTTPException) as stale_toggle:
+        project_hooks.project_hook_handler(
+            project_id,
+            handler["id"],
+            project_hooks.SetProjectHookHandlerRequest(
+                contentHash = changed["contentHash"],
+                workspaceRevision = trusted["workspaceRevision"],
+                revision = changed["revision"],
+                enabled = True,
+            ),
+            _current_subject = "tester",
+        )
+    assert stale_toggle.value.status_code == 409
+    assert "workspace changed" in stale_toggle.value.detail.lower()
+
+
+def test_trust_rediscovers_source_before_rendering_snapshot(tmp_path, monkeypatch):
+    project_id = _create_project("hooks-route-source-race")
+    root = tmp_path / "repository"
+    root.mkdir()
+    _write_hooks(root, "printf first")
+    _bind_project(monkeypatch, project_id, root)
+    current = project_hooks.project_hooks(project_id, _current_subject = "tester")
+    original_discover = project_hooks._discover_workspace
+    calls = 0
+
+    def drifting_discover(workspace):
+        nonlocal calls
+        discovered = original_discover(workspace)
+        calls += 1
+        if calls == 1:
+            _write_hooks(root, "printf changed")
+        return discovered
+
+    monkeypatch.setattr(project_hooks, "_discover_workspace", drifting_discover)
+    raced = project_hooks.project_hooks_trust(
+        project_id,
+        project_hooks.TrustProjectHooksRequest(
+            contentHash = current["contentHash"],
+            workspaceRevision = current["workspaceRevision"],
+            revision = current["revision"],
+        ),
+        _current_subject = "tester",
+    )
+
+    assert calls == 2
+    assert raced["contentHash"] != current["contentHash"]
+    assert raced["trusted"] is False
+    assert raced["revision"] == 1
+    handler = raced["hooks"]["PreToolUse"][0]["hooks"][0]
+    assert handler["enabled"] is True
+    assert handler["active"] is False
+
+
+def test_trust_and_toggle_hold_one_workspace_access_lease(tmp_path, monkeypatch):
+    project_id = _create_project("hooks-route-lease")
+    root = tmp_path / "repository"
+    root.mkdir()
+    _write_hooks(root)
+    _bind_project(monkeypatch, project_id, root)
+    current = project_hooks.project_hooks(project_id, _current_subject = "tester")
+    metadata = root.stat()
+    lease = {"active": False, "enters": 0}
+
+    @contextmanager
+    def guarded_access(requested):
+        assert requested == project_id
+        assert lease["active"] is False
+        lease["active"] = True
+        lease["enters"] += 1
+        try:
+            yield SimpleNamespace(
+                root = root,
+                device_id = metadata.st_dev,
+                file_id = metadata.st_ino,
+                revision = 7,
+            )
+        finally:
+            lease["active"] = False
+
+    original_discover = project_hooks._discover_workspace
+
+    def guarded_discover(workspace):
+        assert lease["active"] is True
+        return original_discover(workspace)
+
+    monkeypatch.setattr(project_hooks, "project_workspace_access", guarded_access)
+    monkeypatch.setattr(project_hooks, "_discover_workspace", guarded_discover)
+    trusted = project_hooks.project_hooks_trust(
+        project_id,
+        project_hooks.TrustProjectHooksRequest(
+            contentHash = current["contentHash"],
+            workspaceRevision = current["workspaceRevision"],
+            revision = current["revision"],
+        ),
+        _current_subject = "tester",
+    )
+    assert lease == {"active": False, "enters": 1}
+
+    lease["enters"] = 0
+    project_hooks.project_hook_handler(
+        project_id,
+        current["hooks"]["PreToolUse"][0]["hooks"][0]["id"],
+        project_hooks.SetProjectHookHandlerRequest(
+            contentHash = trusted["contentHash"],
+            workspaceRevision = trusted["workspaceRevision"],
+            revision = trusted["revision"],
+            enabled = False,
+        ),
+        _current_subject = "tester",
+    )
+    assert lease == {"active": False, "enters": 1}
+
+
+def test_revoke_succeeds_when_workspace_cannot_be_discovered(tmp_path, monkeypatch):
+    project_id = _create_project("hooks-route-unavailable-revoke")
+    root = tmp_path / "repository"
+    root.mkdir()
+    _write_hooks(root)
+    _bind_project(monkeypatch, project_id, root)
+    current = project_hooks.project_hooks(project_id, _current_subject = "tester")
+    trusted = project_hooks.project_hooks_trust(
+        project_id,
+        project_hooks.TrustProjectHooksRequest(
+            contentHash = current["contentHash"],
+            workspaceRevision = current["workspaceRevision"],
+            revision = current["revision"],
+        ),
+        _current_subject = "tester",
+    )
+
+    monkeypatch.setattr(
+        project_hooks,
+        "get_chat_project",
+        lambda requested: (
+            {
+                "id": project_id,
+                "archived": False,
+                "workspaceAvailable": False,
+                "workspaceRevision": 7,
+            }
+            if requested == project_id
+            else None
+        ),
+    )
+    monkeypatch.setattr(
+        project_hooks,
+        "project_workspace_access",
+        lambda _requested: pytest.fail("offline hook snapshots must not discover the workspace"),
+    )
+    unavailable = project_hooks.project_hooks(project_id, _current_subject = "tester")
+    assert unavailable["workspaceAvailable"] is False
+    assert unavailable["workspaceRevision"] == 7
+    assert unavailable["storedTrust"] == {
+        "contentHash": trusted["contentHash"],
+        "revision": trusted["revision"],
+    }
+
+    revoked = project_hooks.project_hooks_revoke(
+        project_id,
+        project_hooks.RevokeProjectHooksRequest(revision = unavailable["storedTrust"]["revision"]),
+        _current_subject = "tester",
+    )
+
+    assert revoked["workspaceAvailable"] is False
+    assert revoked["storedTrust"] is None
+    assert revoked["trusted"] is False
+    assert revoked["revision"] == trusted["revision"] + 1
+    assert revoked["exists"] is False
+    assert revoked["contentHash"] is None
+    assert all(not groups for groups in revoked["hooks"].values())
+    state = project_hook_trust_db.get_project_hook_trust_state(
+        project_id,
+        current["contentHash"],
+        workspace_identity = (root.stat().st_dev, root.stat().st_ino),
+        workspace_revision = 7,
+    )
+    assert state["trusted"] is False
+    assert state["revision"] == revoked["revision"]
+
+
+def test_get_falls_back_only_when_workspace_access_itself_fails(tmp_path, monkeypatch):
+    project_id = _create_project("hooks-route-stale-workspace-health")
+    root = tmp_path / "repository"
+    root.mkdir()
+    _write_hooks(root)
+    _bind_project(monkeypatch, project_id, root)
+    current = project_hooks.project_hooks(project_id, _current_subject = "tester")
+    trusted = project_hooks.project_hooks_trust(
+        project_id,
+        project_hooks.TrustProjectHooksRequest(
+            contentHash = current["contentHash"],
+            workspaceRevision = current["workspaceRevision"],
+            revision = current["revision"],
+        ),
+        _current_subject = "tester",
+    )
+
+    @contextmanager
+    def unavailable_access(_requested):
+        raise project_hooks.AgentWorkspaceError("Project workspace is unavailable.")
+        yield
+
+    monkeypatch.setattr(project_hooks, "project_workspace_access", unavailable_access)
+    unavailable = project_hooks.project_hooks(project_id, _current_subject = "tester")
+    assert unavailable["workspaceAvailable"] is False
+    assert unavailable["workspaceRevision"] == 7
+    assert unavailable["storedTrust"] == {
+        "contentHash": trusted["contentHash"],
+        "revision": trusted["revision"],
+    }
+
+    _bind_project(monkeypatch, project_id, root)
+
+    def malformed_hooks(_workspace):
+        raise project_hooks.AgentWorkspaceError("Project hooks must be valid JSON.")
+
+    monkeypatch.setattr(project_hooks, "_discover_workspace", malformed_hooks)
+    with pytest.raises(HTTPException) as malformed:
+        project_hooks.project_hooks(project_id, _current_subject = "tester")
+    assert malformed.value.status_code == 409
+    assert "valid JSON" in malformed.value.detail
+
+
+def test_trust_state_read_does_not_open_or_parse_the_workspace(tmp_path, monkeypatch):
+    project_id = _create_project("hooks-route-independent-trust")
+    root = tmp_path / "repository"
+    root.mkdir()
+    _write_hooks(root)
+    _bind_project(monkeypatch, project_id, root)
+    current = project_hooks.project_hooks(project_id, _current_subject = "tester")
+    trusted = project_hooks.project_hooks_trust(
+        project_id,
+        project_hooks.TrustProjectHooksRequest(
+            contentHash = current["contentHash"],
+            workspaceRevision = current["workspaceRevision"],
+            revision = current["revision"],
+        ),
+        _current_subject = "tester",
+    )
+
+    monkeypatch.setattr(
+        project_hooks,
+        "project_workspace_access",
+        lambda _requested: pytest.fail("trust-state reads must not open the workspace"),
+    )
+    monkeypatch.setattr(
+        project_hooks,
+        "_discover_workspace",
+        lambda _workspace: pytest.fail("trust-state reads must not parse hooks.json"),
+    )
+
+    state = project_hooks.project_hooks_trust_state(
+        project_id,
+        _current_subject = "tester",
+    )
+
+    assert state == {
+        "storedTrust": {
+            "contentHash": trusted["contentHash"],
+            "revision": trusted["revision"],
+        },
+        "revision": trusted["revision"],
+    }
+
+
+def test_capability_probe_failure_after_trust_returns_saved_unavailable_state(
+    tmp_path, monkeypatch
+):
+    project_id = _create_project("probe-failure")
+    root = tmp_path / "repository"
+    root.mkdir()
+    _write_hooks(root)
+    _bind_project(monkeypatch, project_id, root)
+    current = project_hooks.project_hooks(project_id, _current_subject = "tester")
+
+    def failed_probe():
+        raise RuntimeError("native probe failed")
+
+    monkeypatch.setattr(project_hooks, "execution_status", failed_probe)
+    saved = project_hooks.project_hooks_trust(
+        project_id,
+        project_hooks.TrustProjectHooksRequest(
+            contentHash = current["contentHash"],
+            workspaceRevision = current["workspaceRevision"],
+            revision = current["revision"],
+        ),
+        _current_subject = "tester",
+    )
+    assert saved["trusted"]
+    assert saved["execution"]["available"] is False
+    assert saved["revision"] > current["revision"]

--- a/studio/frontend/src/features/chat/api/project-hooks-api.ts
+++ b/studio/frontend/src/features/chat/api/project-hooks-api.ts
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { authFetch } from "@/features/auth";
+import { formatApiErrorBody } from "@/lib/format-fastapi-error";
+
+export const PROJECT_HOOK_EVENTS = [
+  "SessionStart",
+  "SessionEnd",
+  "UserPromptSubmit",
+  "PreToolUse",
+  "PermissionRequest",
+  "PostToolUse",
+  "PreCompact",
+  "PostCompact",
+  "SubagentStart",
+  "SubagentStop",
+  "Stop",
+] as const;
+
+export type ProjectHookEvent = (typeof PROJECT_HOOK_EVENTS)[number];
+
+export interface ProjectHookHandler {
+  id: string;
+  type: "command";
+  command: string;
+  commandWindows: string | null;
+  timeout: number;
+  statusMessage: string | null;
+  additionalContextLimit: number;
+  async: boolean;
+  /** Saved user preference for this handler. */
+  enabled: boolean;
+  /** Effective state after exact-file trust and runtime policy are applied. */
+  active: boolean;
+}
+
+export interface ProjectHookGroup {
+  matcher: string | null;
+  hooks: ProjectHookHandler[];
+}
+
+export interface ProjectHooks {
+  execution?: { available: boolean; backend: string | null; reason: string | null };
+  workspaceAvailable?: boolean;
+  workspaceRevision: number | null;
+  sourcePath: string;
+  exists: boolean;
+  contentHash: string | null;
+  description: string | null;
+  groupCount: number;
+  handlerCount: number;
+  trusted: boolean;
+  revision: number;
+  storedTrust?: ProjectHooksStoredTrust | null;
+  hooks: Record<ProjectHookEvent, ProjectHookGroup[]>;
+}
+
+export interface ProjectHooksStoredTrust {
+  contentHash: string;
+  revision: number;
+}
+
+export interface ProjectHooksTrustState {
+  storedTrust: ProjectHooksStoredTrust | null;
+  revision: number;
+}
+
+export interface ProjectHooksTrustIdentity {
+  projectId: string;
+  workspaceRevision: number;
+  contentHash: string;
+  revision: number;
+}
+
+type ProjectHooksTrustRequest = {
+  workspaceRevision: number;
+  contentHash: string;
+  revision: number;
+};
+
+type ProjectHooksRevisionRequest = {
+  revision: number;
+};
+
+type ProjectHookHandlerRequest = ProjectHooksTrustRequest & {
+  enabled: boolean;
+};
+
+function projectHooksPath(projectId: string, suffix = ""): string {
+  const base = `/api/agent/projects/${encodeURIComponent(projectId)}/hooks`;
+  return suffix ? `${base}/${suffix}` : base;
+}
+
+async function request<T>(input: string, init?: RequestInit): Promise<T> {
+  const response = await authFetch(input, init);
+  const body = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new Error(
+      formatApiErrorBody(body) ??
+        `Project hooks request failed (${response.status})`,
+    );
+  }
+  return body as T;
+}
+
+function post<T>(input: string, body: unknown): Promise<T> {
+  return request<T>(input, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+export function getProjectHooks(projectId: string): Promise<ProjectHooks> {
+  return request(projectHooksPath(projectId), { cache: "no-store" });
+}
+
+export function getProjectHooksTrustState(
+  projectId: string,
+): Promise<ProjectHooksTrustState> {
+  return request(projectHooksPath(projectId, "trust"), { cache: "no-store" });
+}
+
+export function trustProjectHooks(
+  projectId: string,
+  input: ProjectHooksTrustRequest,
+): Promise<ProjectHooks> {
+  return post(projectHooksPath(projectId, "trust"), input);
+}
+
+export function revokeProjectHooks(
+  projectId: string,
+  input: ProjectHooksRevisionRequest,
+): Promise<ProjectHooks> {
+  return post(projectHooksPath(projectId, "revoke"), input);
+}
+
+export function setProjectHookHandlerEnabled(
+  projectId: string,
+  handlerId: string,
+  input: ProjectHookHandlerRequest,
+): Promise<ProjectHooks> {
+  return post(
+    projectHooksPath(projectId, `handlers/${encodeURIComponent(handlerId)}`),
+    input,
+  );
+}
+
+const FORMAT_CONTROL = /\p{Cf}/u;
+
+function visibleUnicodeEscape(codePoint: number): string {
+  const hexadecimal = codePoint.toString(16).toUpperCase();
+  return codePoint <= 0xffff
+    ? `\\u${hexadecimal.padStart(4, "0")}`
+    : `\\u{${hexadecimal}}`;
+}
+
+function visibleProjectHookCharacter(
+  codePoint: number,
+  character: string,
+): string {
+  if (codePoint === 0x5c) {
+    return "\\\\";
+  }
+  if (codePoint === 0x0d) {
+    return "\\r\n";
+  }
+  if (codePoint === 0x0a) {
+    return "\\n\n";
+  }
+  if (codePoint === 0x09) {
+    return "\\t";
+  }
+  if (
+    codePoint < 0x20 ||
+    (codePoint >= 0x7f && codePoint <= 0x9f) ||
+    (codePoint >= 0xd800 && codePoint <= 0xdfff) ||
+    FORMAT_CONTROL.test(character)
+  ) {
+    return visibleUnicodeEscape(codePoint);
+  }
+  return character;
+}
+
+/** Make untrusted hook text reviewable without invisible terminal controls. */
+export function visibleProjectHookText(value: string | null): string {
+  if (value === null) {
+    return "";
+  }
+  let visible = "";
+  for (let index = 0; index < value.length; ) {
+    const codePoint = value.codePointAt(index);
+    if (codePoint === undefined) {
+      break;
+    }
+    const character = String.fromCodePoint(codePoint);
+    index += character.length;
+
+    if (codePoint === 0x0d && value.codePointAt(index) === 0x0a) {
+      index += 1;
+      visible += "\\r\\n\n";
+      continue;
+    }
+    visible += visibleProjectHookCharacter(codePoint, character);
+  }
+  return visible;
+}
+
+export function projectHooksTrustIdentityMatches(
+  identity: ProjectHooksTrustIdentity,
+  current: {
+    projectId: string;
+    hooks: ProjectHooks | null;
+  },
+): boolean {
+  return (
+    current.hooks?.exists === true &&
+    current.projectId === identity.projectId &&
+    current.hooks.workspaceRevision === identity.workspaceRevision &&
+    current.hooks.contentHash === identity.contentHash &&
+    current.hooks.revision === identity.revision &&
+    current.hooks.trusted === false
+  );
+}
+
+/** Mount-scoped sequencing for reads and mutations that return full snapshots. */
+export class ProjectHooksRequestGuard {
+  private revision = 0;
+  private mounted = false;
+
+  activate(): void {
+    this.mounted = true;
+    this.revision += 1;
+  }
+
+  begin(): number {
+    this.revision += 1;
+    return this.revision;
+  }
+
+  accepts(revision: number): boolean {
+    return this.mounted && revision === this.revision;
+  }
+
+  retire(): void {
+    this.mounted = false;
+    this.revision += 1;
+  }
+}

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -247,6 +247,10 @@ import {
   hasProjectSourcesPending,
 } from "@/features/rag/components/project-source-dropzone";
 
+const ProjectHooksLandingPanel = lazy(() =>
+  import("./components/project-hooks-landing-panel").then((module) => ({ default: module.ProjectHooksLandingPanel })),
+);
+
 const ProjectSourcesPanel = lazy(() =>
   import("@/features/rag/components/project-sources-panel").then((module) => ({
     default: module.ProjectSourcesPanel,
@@ -1343,7 +1347,7 @@ function ProjectLanding({
     () => useChatRuntimeStore.getState().activeThreadId,
   );
   // Land on Sources when the project was just created with dropped files.
-  const [projectTab, setProjectTab] = useState<"chats" | "sources">(() =>
+  const [projectTab, setProjectTab] = useState<"chats" | "sources" | "hooks">(() =>
     hasProjectSourcesPending(projectId) ? "sources" : "chats",
   );
   // Drop the marker once committed: React may replay the initializer above.
@@ -1801,9 +1805,21 @@ function ProjectLanding({
               >
                 Sources
               </button>
+              <button
+                type="button"
+                onClick={() => setProjectTab("hooks")}
+                data-active={projectTab === "hooks"}
+                className="h-10 rounded-full px-5 text-ui-14 font-semibold transition-colors data-[active=true]:bg-muted data-[active=true]:text-foreground data-[active=false]:text-muted-foreground data-[active=false]:hover:bg-nav-surface-hover"
+              >
+                Hooks
+              </button>
             </div>
 
-            {projectTab === "sources" ? (
+            {projectTab === "hooks" ? (
+              <Suspense fallback={<p className="mt-8 text-sm text-muted-foreground">Loading hooks…</p>}>
+                <ProjectHooksLandingPanel key={projectId} projectId={projectId} />
+              </Suspense>
+            ) : projectTab === "sources" ? (
               <Suspense
                 fallback={
                   <div className="mt-8 rounded-[26px] bg-muted/30 px-6 py-10 text-center text-sm text-muted-foreground">

--- a/studio/frontend/src/features/chat/components/project-hook-handler-presentation.ts
+++ b/studio/frontend/src/features/chat/components/project-hook-handler-presentation.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+export interface ProjectHookHandlerPresentation {
+  state: string;
+  execution: string;
+  eligible: boolean;
+}
+
+export function projectHookHandlerPresentation({
+  trusted,
+  enabled,
+  active,
+  background,
+}: {
+  trusted: boolean;
+  enabled: boolean;
+  active: boolean;
+  background: boolean;
+}): ProjectHookHandlerPresentation {
+  const eligible = trusted && enabled && active;
+  return {
+    state: `${enabled ? "Enabled" : "Disabled"} preference, ${eligible ? "trusted and eligible" : "not eligible"}`,
+    execution: background
+      ? "background, inactive in this version"
+      : "foreground, may control supported pre-events",
+    eligible,
+  };
+}

--- a/studio/frontend/src/features/chat/components/project-hooks-landing-panel.tsx
+++ b/studio/frontend/src/features/chat/components/project-hooks-landing-panel.tsx
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { useChatProjects } from "../hooks/use-chat-projects";
+import { ProjectHooksPanel } from "./project-hooks-panel";
+
+export function ProjectHooksLandingPanel({ projectId }: { projectId: string }) {
+  const { projects, hasLoaded } = useChatProjects();
+  const project = projects.find((candidate) => candidate.id === projectId);
+  if (!project) {
+    return <p className="mt-8 text-sm text-muted-foreground">{hasLoaded ? "Project unavailable." : "Loading project…"}</p>;
+  }
+  return (
+    <div className="mt-8 flex flex-col gap-6">
+      <ProjectHooksPanel key={`hooks:${project.id}`} project={project} />
+    </div>
+  );
+}

--- a/studio/frontend/src/features/chat/components/project-hooks-panel.tsx
+++ b/studio/frontend/src/features/chat/components/project-hooks-panel.tsx
@@ -1,0 +1,791 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+
+import {
+  PROJECT_HOOK_EVENTS,
+  type ProjectHookEvent,
+  type ProjectHookGroup,
+  type ProjectHookHandler,
+  type ProjectHooks,
+  ProjectHooksRequestGuard,
+  type ProjectHooksStoredTrust,
+  type ProjectHooksTrustIdentity,
+  type ProjectHooksTrustState,
+  getProjectHooks,
+  getProjectHooksTrustState,
+  projectHooksTrustIdentityMatches,
+  revokeProjectHooks,
+  setProjectHookHandlerEnabled,
+  trustProjectHooks,
+  visibleProjectHookText,
+} from "../api/project-hooks-api";
+import type { ProjectRecord as StoredProjectRecord } from "../types";
+
+type ProjectRecord = StoredProjectRecord & { workspaceAvailable?: boolean };
+import { projectHookHandlerPresentation } from "./project-hook-handler-presentation";
+
+type MutationKey = "trust" | "revoke" | `handler:${string}`;
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error
+    ? error.message
+    : "Project hooks request failed.";
+}
+
+function VisibleProjectHookText({
+  value,
+  fallback,
+  className,
+}: {
+  value: string | null | undefined;
+  fallback?: string;
+  className: string;
+}) {
+  const visible = visibleProjectHookText(value ?? null);
+  return (
+    <pre
+      dir="ltr"
+      className={`whitespace-pre-wrap break-words ${className}`}
+      style={{ unicodeBidi: "isolate" }}
+    >
+      {visible || fallback || ""}
+    </pre>
+  );
+}
+
+function storedTrustFor(
+  hooks: ProjectHooks | null,
+  trustState: ProjectHooksTrustState | null,
+): ProjectHooksStoredTrust | null {
+  if (hooks && Object.prototype.hasOwnProperty.call(hooks, "storedTrust")) {
+    return hooks.storedTrust ?? null;
+  }
+  return trustState?.storedTrust ?? null;
+}
+
+function trustStateFromHooks(hooks: ProjectHooks): ProjectHooksTrustState {
+  return {
+    storedTrust: hooks.storedTrust ?? null,
+    revision: hooks.revision,
+  };
+}
+
+function validWorkspaceRevision(
+  workspaceRevision: number | null | undefined,
+): workspaceRevision is number {
+  return (
+    workspaceRevision !== null &&
+    workspaceRevision !== undefined &&
+    Number.isSafeInteger(workspaceRevision) &&
+    workspaceRevision >= 0
+  );
+}
+
+function trustIdentityFor(
+  projectId: string,
+  hooks: ProjectHooks | null,
+): ProjectHooksTrustIdentity | null {
+  const workspaceRevision = hooks?.workspaceRevision;
+  if (
+    !(hooks?.exists && hooks.contentHash) ||
+    hooks.trusted ||
+    !validWorkspaceRevision(workspaceRevision)
+  ) {
+    return null;
+  }
+  return {
+    projectId,
+    workspaceRevision,
+    contentHash: hooks.contentHash,
+    revision: hooks.revision,
+  };
+}
+
+function currentWorkspaceAvailable(
+  projectAvailable: boolean | undefined,
+  hooks: ProjectHooks | null,
+): boolean {
+  return hooks === null
+    ? projectAvailable !== false
+    : hooks.workspaceAvailable !== false;
+}
+
+export function ProjectHooksPanel({ project }: { project: ProjectRecord }) {
+  const [hooks, setHooks] = useState<ProjectHooks | null>(null);
+  const [trustState, setTrustState] = useState<ProjectHooksTrustState | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [mutation, setMutation] = useState<MutationKey | null>(null);
+  const [trustConfirmation, setTrustConfirmation] =
+    useState<ProjectHooksTrustIdentity | null>(null);
+  const requestGuard = useRef(new ProjectHooksRequestGuard());
+
+  const refresh = useCallback(async () => {
+    const requestRevision = requestGuard.current.begin();
+    setTrustConfirmation(null);
+    setMutation(null);
+    setHooks(null);
+    setTrustState(null);
+    setLoading(true);
+    setError(null);
+    const [hooksResult, trustStateResult] = await Promise.allSettled([
+      getProjectHooks(project.id),
+      getProjectHooksTrustState(project.id),
+    ]);
+    if (!requestGuard.current.accepts(requestRevision)) {
+      return;
+    }
+    if (hooksResult.status === "fulfilled") {
+      if (
+        trustStateResult.status === "fulfilled" &&
+        trustStateResult.value.revision !== hooksResult.value.revision
+      ) {
+        setHooks(null);
+        setTrustState(trustStateResult.value);
+        setError("Project hook trust changed during refresh. Refresh again.");
+      } else {
+        setHooks(hooksResult.value);
+        setTrustState(trustStateFromHooks(hooksResult.value));
+      }
+    } else {
+      setHooks(null);
+      setTrustState(
+        trustStateResult.status === "fulfilled" ? trustStateResult.value : null,
+      );
+      setError(errorMessage(hooksResult.reason));
+    }
+    setLoading(false);
+  }, [project.id]);
+
+  useEffect(() => {
+    const guard = requestGuard.current;
+    guard.activate();
+    const initialRefresh = window.setTimeout(() => {
+      refresh().catch(() => undefined);
+    }, 0);
+    return () => {
+      window.clearTimeout(initialRefresh);
+      guard.retire();
+    };
+  }, [refresh]);
+
+  async function applyMutation(
+    key: MutationKey,
+    request: () => Promise<ProjectHooks>,
+  ): Promise<void> {
+    if (mutation !== null || loading) {
+      return;
+    }
+    const requestRevision = requestGuard.current.begin();
+    setTrustConfirmation(null);
+    setHooks(null);
+    setTrustState(null);
+    setMutation(key);
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await request();
+      if (requestGuard.current.accepts(requestRevision)) {
+        setHooks(next);
+        setTrustState(trustStateFromHooks(next));
+      }
+    } catch (nextError) {
+      let fallbackTrustState: ProjectHooksTrustState | null = null;
+      try {
+        fallbackTrustState = await getProjectHooksTrustState(project.id);
+      } catch {
+        // The mutation error remains the primary actionable failure.
+      }
+      if (requestGuard.current.accepts(requestRevision)) {
+        setTrustState(fallbackTrustState);
+        setError(errorMessage(nextError));
+      }
+    } finally {
+      if (requestGuard.current.accepts(requestRevision)) {
+        setMutation(null);
+        setLoading(false);
+      }
+    }
+  }
+
+  function requestTrust(): void {
+    if (loading || mutation !== null) {
+      return;
+    }
+    const identity = trustIdentityFor(project.id, hooks);
+    if (identity === null) {
+      setError(
+        "Project workspace identity is unavailable. Refresh the project.",
+      );
+      return;
+    }
+    setTrustConfirmation(identity);
+  }
+
+  async function trustCurrentFile(): Promise<void> {
+    const identity = trustConfirmation;
+    setTrustConfirmation(null);
+    if (identity === null) {
+      return;
+    }
+    if (
+      loading ||
+      mutation !== null ||
+      !projectHooksTrustIdentityMatches(identity, {
+        projectId: project.id,
+        hooks,
+      })
+    ) {
+      setHooks(null);
+      setError("Project hooks changed. Refresh and review the current file.");
+      return;
+    }
+    await applyMutation("trust", () =>
+      trustProjectHooks(identity.projectId, {
+        workspaceRevision: identity.workspaceRevision,
+        contentHash: identity.contentHash,
+        revision: identity.revision,
+      }),
+    );
+  }
+
+  async function revokeTrust(): Promise<void> {
+    const storedTrust = storedTrustFor(hooks, trustState);
+    const revision = hooks?.trusted ? hooks.revision : storedTrust?.revision;
+    if (revision === undefined) {
+      return;
+    }
+    await applyMutation("revoke", () =>
+      revokeProjectHooks(project.id, { revision }),
+    );
+  }
+
+  async function setHandlerEnabled(
+    handler: ProjectHookHandler,
+    enabled: boolean,
+  ): Promise<void> {
+    if (!(hooks?.trusted && hooks.contentHash)) {
+      return;
+    }
+    const workspaceRevision = hooks.workspaceRevision;
+    if (!validWorkspaceRevision(workspaceRevision)) {
+      setHooks(null);
+      setError(
+        "Project workspace identity is unavailable. Refresh the project.",
+      );
+      return;
+    }
+    const contentHash = hooks.contentHash;
+    const revision = hooks.revision;
+    const projectId = project.id;
+    await applyMutation(`handler:${handler.id}`, () =>
+      setProjectHookHandlerEnabled(projectId, handler.id, {
+        workspaceRevision,
+        contentHash,
+        revision,
+        enabled,
+      }),
+    );
+  }
+
+  const busy = mutation !== null;
+  const workspaceAvailable = currentWorkspaceAvailable(
+    project.workspaceAvailable,
+    hooks,
+  );
+  const storedTrust = storedTrustFor(hooks, trustState);
+
+  return (
+    <>
+      <div className="mt-3 border-t border-border/70 pt-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold text-foreground">
+              Project hooks
+            </p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Review configured hook commands and manage exact-file trust.
+              Synchronous PreToolUse and PostToolUse hooks run around project
+              edits and commands. Other lifecycle and background hooks are inactive.
+            </p>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            disabled={loading || busy}
+            onClick={refresh}
+          >
+            {loading ? "Refreshing..." : "Refresh"}
+          </Button>
+        </div>
+
+        {hooks?.execution && !hooks.execution.available ? (
+          <p className="mt-2 text-xs text-muted-foreground" role="status">
+            {hooks.execution.reason ?? "Secure project hook execution is unavailable."}
+          </p>
+        ) : null}
+        {error ? (
+          <p className="mt-2 text-xs text-destructive" role="alert">
+            {error}
+          </p>
+        ) : null}
+
+        {loading && hooks === null ? (
+          <p className="mt-2 text-xs text-muted-foreground">
+            Loading project hooks...
+          </p>
+        ) : null}
+
+        {!loading && hooks === null ? (
+          <div className="mt-2">
+            <p className="text-xs text-muted-foreground">
+              Project hooks are unavailable.
+            </p>
+            {storedTrust ? (
+              <StoredTrustNotice
+                storedTrust={storedTrust}
+                message="The current hook file could not be inspected. Stored trust is inactive until the exact file and workspace can be verified."
+                loading={loading}
+                busy={busy}
+                mutation={mutation}
+                onRevokeTrust={revokeTrust}
+              />
+            ) : null}
+          </div>
+        ) : null}
+
+        {!loading && hooks && !workspaceAvailable ? (
+          <UnavailableWorkspaceHooks
+            storedTrust={storedTrust}
+            loading={loading}
+            busy={busy}
+            mutation={mutation}
+            onRevokeTrust={revokeTrust}
+          />
+        ) : null}
+
+        {!loading && workspaceAvailable && hooks && !hooks.exists ? (
+          <div className="mt-3 rounded-xl bg-background/70 px-3 py-2">
+            <p className="text-xs font-medium text-foreground">
+              No project hook file found
+            </p>
+            <VisibleProjectHookText
+              value={hooks.sourcePath}
+              className="mt-1 text-[11px] text-muted-foreground"
+            />
+            {storedTrust ? (
+              <StoredTrustNotice
+                storedTrust={storedTrust}
+                message="Stored trust is inactive while the project hook file is absent."
+                loading={loading}
+                busy={busy}
+                mutation={mutation}
+                onRevokeTrust={revokeTrust}
+              />
+            ) : null}
+          </div>
+        ) : null}
+
+        {workspaceAvailable && hooks?.exists ? (
+          <HooksBrowser
+            hooks={hooks}
+            storedTrust={storedTrust}
+            loading={loading}
+            busy={busy}
+            mutation={mutation}
+            onRequestTrust={requestTrust}
+            onRevokeTrust={revokeTrust}
+            onSetHandlerEnabled={setHandlerEnabled}
+          />
+        ) : null}
+      </div>
+
+      <AlertDialog
+        open={trustConfirmation !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setTrustConfirmation(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Trust project hooks?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Trust approves enabled synchronous PreToolUse and PostToolUse commands
+              for this exact file and workspace. They run around project file edits,
+              Python, and terminal tools, and pre-tool failures stop the tool.
+              Session, delegation, and background hooks stay inactive in this version.
+              Hooks cannot grant permissions or rewrite tool arguments. Trusting
+              resets handler preferences and enables all configured handlers.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {trustConfirmation ? (
+            <div className="space-y-1 rounded bg-muted px-2 py-1">
+              <p className="text-[10px] text-muted-foreground">
+                Workspace revision {trustConfirmation.workspaceRevision}
+              </p>
+              <VisibleProjectHookText
+                value={trustConfirmation.contentHash}
+                className="font-mono text-[11px] text-foreground"
+              />
+            </div>
+          ) : null}
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={loading || busy || trustConfirmation === null}
+              onClick={() => {
+                trustCurrentFile().catch(() => undefined);
+              }}
+            >
+              Trust current file
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+function StoredTrustNotice({
+  storedTrust,
+  message,
+  loading,
+  busy,
+  mutation,
+  onRevokeTrust,
+}: {
+  storedTrust: ProjectHooksStoredTrust;
+  message: string;
+  loading: boolean;
+  busy: boolean;
+  mutation: MutationKey | null;
+  onRevokeTrust: () => Promise<void>;
+}) {
+  return (
+    <div className="mt-2 rounded-lg border border-amber-500/30 px-3 py-2">
+      <p className="text-xs text-amber-600 dark:text-amber-400">{message}</p>
+      <p className="mt-1 text-[10px] text-muted-foreground">Stored SHA-256</p>
+      <VisibleProjectHookText
+        value={storedTrust.contentHash}
+        className="font-mono text-[11px] text-foreground"
+      />
+      <Button
+        className="mt-2"
+        type="button"
+        size="sm"
+        variant="outline"
+        disabled={loading || busy}
+        onClick={() => {
+          onRevokeTrust().catch(() => undefined);
+        }}
+      >
+        {mutation === "revoke" ? "Revoking..." : "Revoke trust"}
+      </Button>
+    </div>
+  );
+}
+
+function UnavailableWorkspaceHooks({
+  storedTrust,
+  loading,
+  busy,
+  mutation,
+  onRevokeTrust,
+}: {
+  storedTrust: ProjectHooksStoredTrust | null;
+  loading: boolean;
+  busy: boolean;
+  mutation: MutationKey | null;
+  onRevokeTrust: () => Promise<void>;
+}) {
+  return (
+    <div className="mt-3 rounded-xl bg-background/70 px-3 py-3">
+      <p className="text-xs text-muted-foreground">
+        Reconnect the project folder to inspect the current hook file.
+      </p>
+      {storedTrust ? (
+        <StoredTrustNotice
+          storedTrust={storedTrust}
+          message="Stored trust is inactive while the workspace is unavailable."
+          loading={loading}
+          busy={busy}
+          mutation={mutation}
+          onRevokeTrust={onRevokeTrust}
+        />
+      ) : (
+        <p className="mt-2 text-xs text-muted-foreground">
+          No stored hook trust exists for this project.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function HooksBrowser({
+  hooks,
+  storedTrust,
+  loading,
+  busy,
+  mutation,
+  onRequestTrust,
+  onRevokeTrust,
+  onSetHandlerEnabled,
+}: {
+  hooks: ProjectHooks;
+  storedTrust: ProjectHooksStoredTrust | null;
+  loading: boolean;
+  busy: boolean;
+  mutation: MutationKey | null;
+  onRequestTrust: () => void;
+  onRevokeTrust: () => Promise<void>;
+  onSetHandlerEnabled: (
+    handler: ProjectHookHandler,
+    enabled: boolean,
+  ) => Promise<void>;
+}) {
+  return (
+    <div className="mt-3 rounded-xl bg-background/70 px-3 py-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <VisibleProjectHookText
+            value={hooks.sourcePath}
+            className="font-mono text-[11px] text-foreground"
+          />
+          <p className="mt-1 text-[10px] text-muted-foreground">SHA-256</p>
+          <VisibleProjectHookText
+            value={hooks.contentHash}
+            fallback="none"
+            className="font-mono text-[11px] text-foreground"
+          />
+          <p
+            className={
+              hooks.trusted
+                ? "mt-1 text-xs text-emerald-600 dark:text-emerald-400"
+                : "mt-1 text-xs text-amber-600 dark:text-amber-400"
+            }
+          >
+            {hooks.trusted
+              ? "Trusted for this exact content hash."
+              : "This file is untrusted. No configured hook can run until this exact file and workspace are trusted."}
+          </p>
+        </div>
+        {hooks.trusted ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={loading || busy}
+            onClick={() => {
+              onRevokeTrust().catch(() => undefined);
+            }}
+          >
+            {mutation === "revoke" ? "Revoking..." : "Revoke trust"}
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={loading || busy || !hooks.contentHash}
+            onClick={onRequestTrust}
+          >
+            {mutation === "trust" ? "Trusting..." : "Trust current file"}
+          </Button>
+        )}
+      </div>
+
+      {!hooks.trusted && storedTrust ? (
+        <StoredTrustNotice
+          storedTrust={storedTrust}
+          message="Stored trust does not match the current hook file and workspace, so it is inactive."
+          loading={loading}
+          busy={busy}
+          mutation={mutation}
+          onRevokeTrust={onRevokeTrust}
+        />
+      ) : null}
+
+      {hooks.description ? (
+        <VisibleProjectHookText
+          value={hooks.description}
+          className="mt-2 font-sans text-xs text-muted-foreground"
+        />
+      ) : null}
+
+      <p className="mt-2 text-[10px] text-muted-foreground">
+        {hooks.groupCount} matcher group
+        {hooks.groupCount === 1 ? "" : "s"}, {hooks.handlerCount} handler
+        {hooks.handlerCount === 1 ? "" : "s"}
+      </p>
+
+      <div className="mt-3 space-y-2">
+        {PROJECT_HOOK_EVENTS.map((event) => (
+          <EventHooks
+            key={event}
+            event={event}
+            groups={hooks.hooks[event] ?? []}
+            trusted={hooks.trusted}
+            loading={loading}
+            busy={busy}
+            mutation={mutation}
+            onSetHandlerEnabled={onSetHandlerEnabled}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EventHooks({
+  event,
+  groups,
+  trusted,
+  loading,
+  busy,
+  mutation,
+  onSetHandlerEnabled,
+}: {
+  event: ProjectHookEvent;
+  groups: ProjectHookGroup[];
+  trusted: boolean;
+  loading: boolean;
+  busy: boolean;
+  mutation: MutationKey | null;
+  onSetHandlerEnabled: (
+    handler: ProjectHookHandler,
+    enabled: boolean,
+  ) => Promise<void>;
+}) {
+  const handlerCount = groups.reduce(
+    (count, group) => count + group.hooks.length,
+    0,
+  );
+  return (
+    <details className="rounded-lg border border-border/70 px-3 py-2">
+      <summary className="cursor-pointer text-xs font-medium text-foreground">
+        {event} ({handlerCount})
+      </summary>
+      {groups.length > 0 ? (
+        <div className="mt-2 space-y-3">
+          {groups.map((group) => (
+            <div
+              key={group.hooks.map((handler) => handler.id).join(":")}
+              className="space-y-2"
+            >
+              <p className="text-[10px] text-muted-foreground">Matcher:</p>
+              <VisibleProjectHookText
+                value={group.matcher}
+                fallback="all"
+                className="font-mono text-[10px] text-muted-foreground"
+              />
+              {group.hooks.map((handler) => (
+                <HandlerRow
+                  key={handler.id}
+                  handler={handler}
+                  trusted={trusted}
+                  disabled={loading || busy}
+                  updating={mutation === `handler:${handler.id}`}
+                  onSetEnabled={onSetHandlerEnabled}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="mt-2 text-[10px] text-muted-foreground">
+          No handlers configured.
+        </p>
+      )}
+    </details>
+  );
+}
+
+function HandlerRow({
+  handler,
+  trusted,
+  disabled,
+  updating,
+  onSetEnabled,
+}: {
+  handler: ProjectHookHandler;
+  trusted: boolean;
+  disabled: boolean;
+  updating: boolean;
+  onSetEnabled: (
+    handler: ProjectHookHandler,
+    enabled: boolean,
+  ) => Promise<void>;
+}) {
+  const presentation = projectHookHandlerPresentation({
+    trusted,
+    enabled: handler.enabled,
+    active: handler.active,
+    background: handler.async,
+  });
+  return (
+    <div className="rounded-lg bg-muted/40 px-3 py-2">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <VisibleProjectHookText
+            value={handler.command}
+            className="font-mono text-[11px] text-foreground"
+          />
+          {handler.commandWindows ? (
+            <div className="mt-1">
+              <p className="text-[10px] text-muted-foreground">Windows:</p>
+              <VisibleProjectHookText
+                value={handler.commandWindows}
+                className="font-mono text-[10px] text-muted-foreground"
+              />
+            </div>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-2 text-[10px] text-muted-foreground">
+          <Checkbox
+            aria-label={`Enable preference for ${visibleProjectHookText(handler.id)}`}
+            checked={handler.enabled}
+            disabled={!trusted || disabled}
+            onCheckedChange={(checked) => {
+              onSetEnabled(handler, checked === true).catch(() => undefined);
+            }}
+          />
+          {updating ? "Saving..." : presentation.state}
+        </div>
+      </div>
+      <p className="mt-1 text-[10px] text-muted-foreground">
+        Timeout {handler.timeout}s, {presentation.execution}, context limit{" "}
+        {handler.additionalContextLimit}
+      </p>
+      {handler.statusMessage ? (
+        <VisibleProjectHookText
+          value={handler.statusMessage}
+          className="mt-1 font-sans text-[10px] text-muted-foreground"
+        />
+      ) : null}
+      <VisibleProjectHookText
+        value={handler.id}
+        className="mt-1 font-mono text-[9px] text-muted-foreground/80"
+      />
+    </div>
+  );
+}

--- a/studio/frontend/tests/project-hooks-api.test.ts
+++ b/studio/frontend/tests/project-hooks-api.test.ts
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  ProjectHookEvent,
+  ProjectHookGroup,
+  ProjectHooks,
+  ProjectHooksTrustIdentity,
+} from "../src/features/chat/api/project-hooks-api";
+
+import { registerStoreStubResolver } from "./helpers/kit.ts";
+import { setAuthFetchHandler } from "./helpers/store-stubs/auth.ts";
+
+registerStoreStubResolver();
+
+const hooksApi = await import("../src/features/chat/api/project-hooks-api.ts");
+
+function hooksResponse(overrides: Record<string, unknown> = {}): Response {
+  return new Response(
+    JSON.stringify({
+      sourcePath: ".codex/hooks.json",
+      workspaceAvailable: true,
+      workspaceRevision: 8,
+      exists: true,
+      contentHash:
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      description: "Project checks",
+      groupCount: 0,
+      handlerCount: 0,
+      trusted: false,
+      revision: 4,
+      hooks: Object.fromEntries(
+        hooksApi.PROJECT_HOOK_EVENTS.map((event) => [event, []]),
+      ),
+      ...overrides,
+    }),
+    { headers: { "Content-Type": "application/json" } },
+  );
+}
+
+test.beforeEach(() => setAuthFetchHandler(null));
+
+test("hooks client uses scoped reads and exact optimistic-concurrency bodies", async () => {
+  const calls: Array<{
+    input: string;
+    method: string;
+    cache: RequestCache | null;
+    contentType: string | null;
+    body: unknown;
+  }> = [];
+  setAuthFetchHandler((input, init) => {
+    calls.push({
+      input,
+      method: init?.method ?? "GET",
+      cache: init?.cache ?? null,
+      contentType: new Headers(init?.headers).get("Content-Type"),
+      body: init?.body ? JSON.parse(String(init.body)) : null,
+    });
+    return hooksResponse();
+  });
+
+  await hooksApi.getProjectHooks("project one");
+  await hooksApi.getProjectHooksTrustState("project one");
+  await hooksApi.trustProjectHooks("project one", {
+    workspaceRevision: 8,
+    contentHash: "hash-one",
+    revision: 3,
+  });
+  await hooksApi.revokeProjectHooks("project one", { revision: 4 });
+  await hooksApi.setProjectHookHandlerEnabled("project one", "PreToolUse:0:0", {
+    workspaceRevision: 9,
+    contentHash: "hash-two",
+    revision: 5,
+    enabled: false,
+  });
+
+  assert.deepEqual(calls, [
+    {
+      input: "/api/agent/projects/project%20one/hooks",
+      method: "GET",
+      cache: "no-store",
+      contentType: null,
+      body: null,
+    },
+    {
+      input: "/api/agent/projects/project%20one/hooks/trust",
+      method: "GET",
+      cache: "no-store",
+      contentType: null,
+      body: null,
+    },
+    {
+      input: "/api/agent/projects/project%20one/hooks/trust",
+      method: "POST",
+      cache: null,
+      contentType: "application/json",
+      body: { workspaceRevision: 8, contentHash: "hash-one", revision: 3 },
+    },
+    {
+      input: "/api/agent/projects/project%20one/hooks/revoke",
+      method: "POST",
+      cache: null,
+      contentType: "application/json",
+      body: { revision: 4 },
+    },
+    {
+      input:
+        "/api/agent/projects/project%20one/hooks/handlers/PreToolUse%3A0%3A0",
+      method: "POST",
+      cache: null,
+      contentType: "application/json",
+      body: {
+        workspaceRevision: 9,
+        contentHash: "hash-two",
+        revision: 5,
+        enabled: false,
+      },
+    },
+  ]);
+});
+
+test("hooks client exposes all Codex hook events", () => {
+  assert.deepEqual(hooksApi.PROJECT_HOOK_EVENTS, [
+    "SessionStart",
+    "SessionEnd",
+    "UserPromptSubmit",
+    "PreToolUse",
+    "PermissionRequest",
+    "PostToolUse",
+    "PreCompact",
+    "PostCompact",
+    "SubagentStart",
+    "SubagentStop",
+    "Stop",
+  ]);
+});
+
+test("untrusted hook text visibly escapes slashes, newlines, controls, and bidi formatting", () => {
+  assert.equal(
+    hooksApi.visibleProjectHookText("literal\\n\r\nnext\t\u0001\u202Eend"),
+    "literal\\\\n\\r\\n\nnext\\t\\u0001\\u202Eend",
+  );
+  assert.equal(hooksApi.visibleProjectHookText(null), "");
+});
+
+test("trust confirmation identity matches every captured field exactly", () => {
+  const contentHash =
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  const hooks: ProjectHooks = {
+    workspaceRevision: 11,
+    sourcePath: ".codex/hooks.json",
+    exists: true,
+    contentHash,
+    description: null,
+    groupCount: 0,
+    handlerCount: 0,
+    trusted: false,
+    revision: 7,
+    hooks: Object.fromEntries(
+      hooksApi.PROJECT_HOOK_EVENTS.map((event) => [event, []]),
+    ) as unknown as Record<ProjectHookEvent, ProjectHookGroup[]>,
+  };
+  const identity: ProjectHooksTrustIdentity = {
+    projectId: "project-one",
+    workspaceRevision: 11,
+    contentHash,
+    revision: hooks.revision,
+  };
+
+  assert.equal(
+    hooksApi.projectHooksTrustIdentityMatches(identity, {
+      projectId: "project-one",
+      hooks,
+    }),
+    true,
+  );
+  for (const current of [
+    { projectId: "project-two", hooks },
+    {
+      projectId: "project-one",
+      hooks: { ...hooks, workspaceRevision: 12 },
+    },
+    {
+      projectId: "project-one",
+      hooks: { ...hooks, contentHash: "f".repeat(64) },
+    },
+    {
+      projectId: "project-one",
+      hooks: { ...hooks, revision: 8 },
+    },
+    {
+      projectId: "project-one",
+      hooks: { ...hooks, trusted: true },
+    },
+  ]) {
+    assert.equal(
+      hooksApi.projectHooksTrustIdentityMatches(identity, current),
+      false,
+    );
+  }
+});
+
+test("request guard rejects stale responses and every response after unmount", () => {
+  const guard = new hooksApi.ProjectHooksRequestGuard();
+  guard.activate();
+  const stale = guard.begin();
+  const current = guard.begin();
+
+  assert.equal(guard.accepts(stale), false);
+  assert.equal(guard.accepts(current), true);
+
+  guard.retire();
+  assert.equal(guard.accepts(current), false);
+  assert.equal(guard.accepts(guard.begin()), false);
+
+  guard.activate();
+  const remounted = guard.begin();
+  assert.equal(guard.accepts(remounted), true);
+});
+
+test("hooks client maps backend errors without returning a snapshot", async () => {
+  setAuthFetchHandler(
+    () =>
+      new Response(JSON.stringify({ detail: "Hooks revision changed." }), {
+        status: 409,
+        headers: { "Content-Type": "application/json" },
+      }),
+  );
+
+  await assert.rejects(
+    hooksApi.revokeProjectHooks("project", { revision: 2 }),
+    /Hooks revision changed/,
+  );
+});

--- a/studio/frontend/tests/project-hooks-panel.test.ts
+++ b/studio/frontend/tests/project-hooks-panel.test.ts
@@ -17,7 +17,7 @@ const panel = await readFile(
 );
 const controls = await readFile(
   new URL(
-    "../src/features/chat/components/project-checks-panel.tsx",
+    "../src/features/chat/components/project-hooks-landing-panel.tsx",
     import.meta.url,
   ),
   "utf8",
@@ -30,12 +30,11 @@ const handlerPresentation = await readFile(
   "utf8",
 );
 
-test("project checks mount verification and hook review together", () => {
+test("the hooks landing panel binds review to the saved project", () => {
   assert.match(
     controls,
     /import \{ ProjectHooksPanel \} from "\.\/project-hooks-panel";/,
   );
-  assert.match(controls, /<ProjectVerificationPanel/);
   assert.match(controls, /<ProjectHooksPanel[\s\S]*project=\{project\}/);
 });
 

--- a/studio/frontend/tests/project-hooks-panel.test.ts
+++ b/studio/frontend/tests/project-hooks-panel.test.ts
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+import { projectHookHandlerPresentation } from "../src/features/chat/components/project-hook-handler-presentation.ts";
+
+const panel = await readFile(
+  new URL(
+    "../src/features/chat/components/project-hooks-panel.tsx",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const controls = await readFile(
+  new URL(
+    "../src/features/chat/components/project-checks-panel.tsx",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const handlerPresentation = await readFile(
+  new URL(
+    "../src/features/chat/components/project-hook-handler-presentation.ts",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+test("project checks mount verification and hook review together", () => {
+  assert.match(
+    controls,
+    /import \{ ProjectHooksPanel \} from "\.\/project-hooks-panel";/,
+  );
+  assert.match(controls, /<ProjectVerificationPanel/);
+  assert.match(controls, /<ProjectHooksPanel[\s\S]*project=\{project\}/);
+});
+
+test("trust confirmation captures and revalidates the complete identity", () => {
+  const refreshStart = panel.indexOf("const refresh = useCallback");
+  const effectStart = panel.indexOf("useEffect(() =>", refreshStart);
+  const refreshSource = panel.slice(refreshStart, effectStart);
+  assert.ok(refreshStart >= 0 && effectStart > refreshStart);
+  assert.match(
+    refreshSource,
+    /Promise\.allSettled\(\[[\s\S]*getProjectHooks\(project\.id\),[\s\S]*getProjectHooksTrustState\(project\.id\)/,
+  );
+  assert.doesNotMatch(refreshSource, /trustProjectHooks\(/);
+
+  assert.match(panel, /useState<ProjectHooksTrustIdentity \| null>\(null\)/);
+  assert.match(
+    panel,
+    /function trustIdentityFor[\s\S]*return \{[\s\S]*projectId,[\s\S]*workspaceRevision,[\s\S]*contentHash: hooks\.contentHash,[\s\S]*revision: hooks\.revision/,
+  );
+  assert.match(panel, /const workspaceRevision = hooks\?\.workspaceRevision/);
+  assert.match(
+    panel,
+    /const identity = trustIdentityFor\(project\.id, hooks\)/,
+  );
+  assert.match(panel, /setTrustConfirmation\(identity\)/);
+  assert.match(
+    panel,
+    /projectHooksTrustIdentityMatches\(identity, \{[\s\S]*projectId: project\.id,[\s\S]*hooks/,
+  );
+  assert.match(
+    panel,
+    /trustProjectHooks\(identity\.projectId, \{[\s\S]*workspaceRevision: identity\.workspaceRevision,[\s\S]*contentHash: identity\.contentHash,[\s\S]*revision: identity\.revision/,
+  );
+  assert.match(
+    panel,
+    /Project hooks changed\. Refresh and review the current file\./,
+  );
+  assert.match(
+    panel,
+    /<AlertDialogTitle>Trust project hooks\?<\/AlertDialogTitle>/,
+  );
+  assert.match(panel, /value=\{trustConfirmation\.contentHash\}/);
+  assert.match(
+    panel,
+    /Workspace revision \{trustConfirmation\.workspaceRevision\}/,
+  );
+});
+
+test("panel shows the full hash and isolates visibly escaped project text", () => {
+  assert.doesNotMatch(panel, /shortProjectHooksHash/);
+  assert.match(panel, /value=\{hooks\.contentHash\}/);
+  assert.match(panel, /value=\{storedTrust\.contentHash\}/);
+  assert.match(panel, /visibleProjectHookText\(value \?\? null\)/);
+  assert.match(panel, /<pre[\s\S]*dir="ltr"/);
+  assert.match(panel, /style=\{\{ unicodeBidi: "isolate" \}\}/);
+  for (const expression of [
+    "hooks.sourcePath",
+    "hooks.description",
+    "group.matcher",
+    "handler.command",
+    "handler.commandWindows",
+    "handler.statusMessage",
+    "handler.id",
+  ]) {
+    assert.match(
+      panel,
+      new RegExp(`value=\\{${expression.replace(".", "\\.")}\\}`),
+    );
+  }
+});
+
+test("refresh and mutation clear stale snapshots and pending confirmation", () => {
+  const refreshStart = panel.indexOf("const refresh = useCallback");
+  const effectStart = panel.indexOf("useEffect(() =>", refreshStart);
+  const refreshSource = panel.slice(refreshStart, effectStart);
+  assert.match(
+    refreshSource,
+    /setTrustConfirmation\(null\);[\s\S]*setMutation\(null\);[\s\S]*setHooks\(null\);[\s\S]*setLoading\(true\)/,
+  );
+
+  const mutationStart = panel.indexOf("async function applyMutation");
+  const trustStart = panel.indexOf("function requestTrust", mutationStart);
+  const mutationSource = panel.slice(mutationStart, trustStart);
+  assert.match(
+    mutationSource,
+    /setTrustConfirmation\(null\);[\s\S]*setHooks\(null\);[\s\S]*setMutation\(key\);[\s\S]*setLoading\(true\)/,
+  );
+  assert.match(mutationSource, /setLoading\(false\)/);
+});
+
+test("refresh rejects a hooks snapshot raced by a newer trust revision", () => {
+  const refreshStart = panel.indexOf("const refresh = useCallback");
+  const effectStart = panel.indexOf("useEffect(() =>", refreshStart);
+  const refreshSource = panel.slice(refreshStart, effectStart);
+  assert.match(
+    refreshSource,
+    /trustStateResult\.status === "fulfilled"[\s\S]*trustStateResult\.value\.revision !== hooksResult\.value\.revision/,
+  );
+  assert.match(
+    refreshSource,
+    /setHooks\(null\);[\s\S]*setTrustState\(trustStateResult\.value\);[\s\S]*Project hook trust changed during refresh\. Refresh again\./,
+  );
+  assert.match(
+    refreshSource,
+    /else \{[\s\S]*setHooks\(hooksResult\.value\);[\s\S]*setTrustState\(trustStateFromHooks\(hooksResult\.value\)\)/,
+  );
+});
+
+test("loading disables refresh, trust, revoke, and handler actions", () => {
+  assert.match(panel, /disabled=\{loading \|\| busy\}/g);
+  assert.match(
+    panel,
+    /disabled=\{loading \|\| busy \|\| !hooks\.contentHash\}/,
+  );
+  assert.match(
+    panel,
+    /disabled=\{loading \|\| busy \|\| trustConfirmation === null\}/,
+  );
+  assert.match(panel, /disabled=\{loading \|\| busy\}/);
+  assert.match(panel, /disabled=\{!trusted \|\| disabled\}/);
+  assert.match(panel, /disabled=\{loading \|\| busy\}/);
+});
+
+test("unavailable workspace fallback surfaces stored trust and can revoke it", () => {
+  assert.match(
+    panel,
+    /return hooks === null[\s\S]*projectAvailable !== false[\s\S]*hooks\.workspaceAvailable !== false/,
+  );
+  assert.match(
+    panel,
+    /currentWorkspaceAvailable\([\s\S]*project\.workspaceAvailable,[\s\S]*hooks/,
+  );
+  assert.match(panel, /storedTrust=\{storedTrust\}/);
+  assert.match(
+    panel,
+    /Stored trust is inactive while the workspace is unavailable\./,
+  );
+  assert.match(panel, /Stored SHA-256/);
+  assert.match(
+    panel,
+    /const revision = hooks\?\.trusted \? hooks\.revision : storedTrust\?\.revision/,
+  );
+  assert.match(panel, /revokeProjectHooks\(project\.id, \{ revision \}\)/);
+  assert.match(
+    panel,
+    /Reconnect the project folder to inspect the current hook file/,
+  );
+});
+
+test("stored trust remains revocable across absent, changed, error, and unavailable states", () => {
+  assert.match(panel, /getProjectHooksTrustState/);
+  assert.match(
+    panel,
+    /useState<ProjectHooksTrustState \| null>\([\s\S]*null,[\s\S]*\)/,
+  );
+  assert.match(
+    panel,
+    /The current hook file could not be inspected\. Stored trust is inactive until the exact file and workspace can be verified\./,
+  );
+  assert.match(
+    panel,
+    /Stored trust is inactive while the project hook file is absent\./,
+  );
+  assert.match(
+    panel,
+    /Stored trust does not match the current hook file and workspace, so it is inactive\./,
+  );
+  assert.match(
+    panel,
+    /Stored trust is inactive while the workspace is unavailable\./,
+  );
+  assert.match(
+    panel,
+    /function StoredTrustNotice[\s\S]*onRevokeTrust\(\)\.catch/,
+  );
+});
+
+test("handler UI separates saved preference from effective active state", () => {
+  assert.match(panel, /checked=\{handler\.enabled\}/);
+  assert.match(
+    panel,
+    /projectHookHandlerPresentation\(\{[\s\S]*trusted,[\s\S]*enabled: handler\.enabled,[\s\S]*active: handler\.active,[\s\S]*background: handler\.async/,
+  );
+  assert.match(
+    panel,
+    /setProjectHookHandlerEnabled\(projectId, handler\.id, \{[\s\S]*workspaceRevision,[\s\S]*contentHash,[\s\S]*revision,[\s\S]*enabled/,
+  );
+  assert.match(handlerPresentation, /background, inactive in this version/);
+  assert.match(
+    handlerPresentation,
+    /foreground, may control supported pre-events/,
+  );
+  assert.match(handlerPresentation, /trusted && enabled && active/);
+});
+
+test("copy limits execution to reviewed synchronous tool hooks", () => {
+  assert.match(panel, /Synchronous PreToolUse and PostToolUse hooks run around project/);
+  assert.match(panel, /Other lifecycle and background hooks are inactive/);
+  assert.match(panel, /Hooks cannot grant permissions or rewrite tool arguments/);
+  assert.match(panel, /hooks\?\.execution/);
+});
+
+test("every async state update is guarded and cleanup retires the panel", () => {
+  assert.match(
+    panel,
+    /const requestGuard = useRef\(new ProjectHooksRequestGuard\(\)\)/,
+  );
+  assert.match(panel, /const guard = requestGuard\.current/);
+  assert.match(panel, /guard\.activate\(\)/);
+  assert.match(panel, /guard\.retire\(\)/);
+  assert.match(
+    panel,
+    /const requestRevision = requestGuard\.current\.begin\(\)/g,
+  );
+  assert.match(
+    panel,
+    /if \(requestGuard\.current\.accepts\(requestRevision\)\) \{\s*setHooks\(next\)/g,
+  );
+  assert.match(
+    panel,
+    /if \(requestGuard\.current\.accepts\(requestRevision\)\) \{[\s\S]*setTrustState\(fallbackTrustState\);[\s\S]*setError\(errorMessage\(nextError\)\)/,
+  );
+});
+
+test("mounted browser renders trusted enabled active foreground and background states", async (t) => {
+  const require = createRequire(import.meta.url);
+  let createElement: typeof import("react").createElement;
+  let renderToStaticMarkup: typeof import("react-dom/server").renderToStaticMarkup;
+  try {
+    ({ createElement } = require("react") as typeof import("react"));
+    ({ renderToStaticMarkup } = require("react-dom/server") as typeof import("react-dom/server"));
+  } catch {
+    t.skip("mounted frontend dependencies are unavailable on this host");
+    return;
+  }
+  const render = (
+    props: Parameters<typeof projectHookHandlerPresentation>[0],
+  ) => {
+    const presentation = projectHookHandlerPresentation(props);
+    return renderToStaticMarkup(
+      createElement(
+        "div",
+        { "data-eligible": presentation.eligible },
+        createElement("span", { className: "state" }, presentation.state),
+        createElement(
+          "span",
+          { className: "execution" },
+          presentation.execution,
+        ),
+      ),
+    );
+  };
+
+  const foreground = render({
+    trusted: true,
+    enabled: true,
+    active: true,
+    background: false,
+  });
+  assert.match(foreground, /data-eligible="true"/);
+  assert.match(foreground, /Enabled preference, trusted and eligible/);
+  assert.match(foreground, /foreground, may control supported pre-events/);
+
+  const background = render({
+    trusted: true,
+    enabled: true,
+    active: true,
+    background: true,
+  });
+  assert.match(background, /data-eligible="true"/);
+  assert.match(background, /background, inactive in this version/);
+
+  for (const state of [
+    { trusted: false, enabled: true, active: true, background: false },
+    { trusted: true, enabled: false, active: true, background: false },
+    { trusted: true, enabled: true, active: false, background: true },
+  ]) {
+    const inactive = render(state);
+    assert.match(inactive, /data-eligible="false"/);
+    assert.match(inactive, /not eligible/);
+    assert.doesNotMatch(inactive, /trusted and eligible/);
+  }
+});


### PR DESCRIPTION
Add exact-content review and trust for project hooks, with synchronous PreToolUse and PostToolUse execution around editing and command tools. The independent Hooks tab shows current source, trust, handler controls and execution availability.

This extracts hook behavior from #10585 without including the verification engine in this source diff. Review/execution requires #10585, lifecycle #10633, confined edits #10577 and command supervision #10636. Missing execution support is reported unavailable. Unconfigured tool calls remain usable.

Review fixes prevent an explicit project session from bypassing hooks through a colliding saved conversation, return saved trust with execution unavailable when capability probing fails, and place post-hook failure ahead of large bounded tool output. With no stored trust, project calls perform one bounded trust lookup and return to the original executor before any extra project/thread routing, archived-project checks, hook discovery, workspace lease or process probe. Original arguments, results and routing remain owned by the existing executor. Non-project and non-hooked calls do not query trust. No-output hooks preserve the original result without another truncation pass; no zero-overhead claim is made for the added metadata lookup.

Post-hook trust-state read failures now retain the completed tool's result and completion context. JSON event responses are bounded by serialized UTF-8 bytes, including Unicode escaping, without truncating arguments. Standalone collection skips only integration modules whose optional engine is absent; pure hook/payload tests still run.

Review order: start with #10577 confined edits and #10585 verification. #10633 lifecycle and #10636 supervision complete the prerequisites for this integration; hooks remain on their own branch.

A local warmed SQLite microbenchmark (Python 3.11, seven batches of 100 stub calls) measured 0.03 microseconds per direct call, 1.13 through the non-project wrapper and 392.91 for an unconfigured project call. This is additional wrapper/trust-lookup overhead on that machine, not a claim of identical timing or production latency.

At head `8107decc5c8d551acd6aff60daaab2e090435ecc`, the standalone backend selection passed 86 tests with three skips; the composed hook selection passed 108 with three skips. All six [native jobs](https://github.com/PhilipJohnBasile/unsloth/actions/runs/34430175549) passed against the exact updated prerequisite pins. Twelve pure no-op cases check original arguments/results and the absence of extra routing, leases and hook execution. Existing configured-hook tests retain authority, collision, cancellation and output-budget coverage. Workflow-policy regressions (119), formatter, Ruff and diff checks passed. Composition resolves only known additive route/tab conflicts and rejects unexpected conflicts. Frontend code is unchanged in this review follow-up.
Hooks cannot change arguments, grant permissions or recursively execute tools. Other lifecycle and async declarations remain inactive. Native/model-free testing does not certify live provider loops or packaged desktop behavior. See studio/PROJECT_HOOKS_REVIEW.md.
