### PR TITLE
Keep recovery breadcrumbs when shutdown leaves child processes

### DIFF
--- a/.github/workflows/studio-shutdown-recovery-ci.yml
+++ b/.github/workflows/studio-shutdown-recovery-ci.yml
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+# Native process-lifetime and shutdown recovery coverage.
+# This lane does not download a model or depend on a model choosing a tool.
+
+name: Studio shutdown recovery
+
+on:
+  pull_request:
+    paths:
+      - 'studio/backend/run.py'
+      - 'studio/backend/utils/process_lifetime.py'
+      - 'studio/backend/tests/test_studio_pid_files.py'
+      - 'studio/backend/tests/test_process_lifetime.py'
+      - '.github/workflows/studio-shutdown-recovery-ci.yml'
+  merge_group:
+  push:
+    # Let the source split qualify on its author's fork before upstream
+    # maintainers approve the pull_request runs.
+    branches: [main, 'codex/project-shutdown-cleanup-*']
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  focused:
+    name: shutdown recovery (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, windows-latest, macos-15]
+
+    env:
+      PYTHONIOENCODING: utf-8
+      PYTHONUTF8: '1'
+      UNSLOTH_STUDIO_DISABLE_DEVICE_PROBE: '1'
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install focused backend dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install \
+            fastapi httpx typer packaging structlog huggingface-hub \
+            pyjwt cryptography python-multipart aiofiles sqlalchemy psutil pyyaml requests \
+            pytest pytest-timeout
+
+      - name: Run shutdown recovery tests
+        working-directory: studio/backend
+        run: >-
+          python -m pytest
+          tests/test_studio_pid_files.py
+          tests/test_process_lifetime.py
+          -q --tb=short --timeout=60 --maxfail=5

--- a/.github/workflows/studio-shutdown-recovery-ci.yml
+++ b/.github/workflows/studio-shutdown-recovery-ci.yml
@@ -19,6 +19,12 @@ on:
     # Let the source split qualify on its author's fork before upstream
     # maintainers approve the pull_request runs.
     branches: [main, 'codex/project-shutdown-cleanup-*']
+    paths:
+      - 'studio/backend/run.py'
+      - 'studio/backend/utils/process_lifetime.py'
+      - 'studio/backend/tests/test_studio_pid_files.py'
+      - 'studio/backend/tests/test_process_lifetime.py'
+      - '.github/workflows/studio-shutdown-recovery-ci.yml'
   workflow_dispatch:
 
 concurrency:

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -1591,6 +1591,20 @@ def _install_windows_console_handler(shutdown) -> bool:
         return False
 
 
+def _retry_project_process_quarantine():
+    """No work when the optional supervisor is absent; broken imports still fail."""
+    import importlib
+
+    module_name = "core.agent_workspace.supervisor"
+    try:
+        supervisor = importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        if exc.name not in {module_name, "core.agent_workspace"}:
+            raise
+        return 0
+    return supervisor.retry_quarantined_project_processes()
+
+
 def _graceful_shutdown(server = None):
     """Shut down all subprocess backends and the uvicorn server.
 
@@ -1672,13 +1686,51 @@ def _graceful_shutdown(server = None):
     except Exception as e:
         logger.warning("Error stopping Cloudflare tunnel: %s", e)
 
-    # 7. Backstop sweep for any adopted child the steps above missed.
+    # 7. Retry fail-closed cleanup for project processes whose exact namespace
+    # lifecycle could not be proven earlier. Their workspace lease and mutation
+    # slot stay held unless this pidfd-backed retry succeeds.
+    try:
+        retained = _retry_project_process_quarantine()
+        if retained:
+            logger.warning(
+                "%s supervised project process(es) remain quarantined; "
+                "workspace locks will stay held until process exit",
+                retained,
+            )
+    except Exception as e:
+        logger.warning("Error retrying quarantined project processes: %s", e)
+
+    # 8. Backstop sweep for any adopted child the steps above missed.
+    survivors = None
     try:
         from utils.process_lifetime import clear_breadcrumb, terminate_all
-        terminate_all()
-        clear_breadcrumb()  # nothing left for the next startup to sweep
+        survivors = terminate_all()
     except Exception as e:
         logger.warning("Error in process-lifetime sweep: %s", e)
+
+    # 9. The generic sweep may have made an earlier pidfd cleanup provable.
+    retained_after_sweep = None
+    try:
+        retained_after_sweep = _retry_project_process_quarantine()
+        if retained_after_sweep:
+            logger.warning(
+                "%s supervised project process(es) remain quarantined after the "
+                "generic process sweep",
+                retained_after_sweep,
+            )
+    except Exception as e:
+        logger.warning("Error retrying project quarantine after process sweep: %s", e)
+
+    if survivors is not None and retained_after_sweep is not None:
+        if not survivors and not retained_after_sweep:
+            clear_breadcrumb()
+        else:
+            logger.warning(
+                "Keeping the child-process recovery record for %s survivor(s) and "
+                "%s quarantined project process(es)",
+                len(survivors),
+                retained_after_sweep,
+            )
 
     # Last: while cleanup runs the server is still alive, and dropping the record
     # early leaves a retried `stop` or a new launch unable to find it.

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -1591,20 +1591,6 @@ def _install_windows_console_handler(shutdown) -> bool:
         return False
 
 
-def _retry_project_process_quarantine():
-    """No work when the optional supervisor is absent; broken imports still fail."""
-    import importlib
-
-    module_name = "core.agent_workspace.supervisor"
-    try:
-        supervisor = importlib.import_module(module_name)
-    except ModuleNotFoundError as exc:
-        if exc.name not in {module_name, "core.agent_workspace"}:
-            raise
-        return 0
-    return supervisor.retry_quarantined_project_processes()
-
-
 def _graceful_shutdown(server = None):
     """Shut down all subprocess backends and the uvicorn server.
 
@@ -1686,51 +1672,19 @@ def _graceful_shutdown(server = None):
     except Exception as e:
         logger.warning("Error stopping Cloudflare tunnel: %s", e)
 
-    # 7. Retry fail-closed cleanup for project processes whose exact namespace
-    # lifecycle could not be proven earlier. Their workspace lease and mutation
-    # slot stay held unless this pidfd-backed retry succeeds.
-    try:
-        retained = _retry_project_process_quarantine()
-        if retained:
-            logger.warning(
-                "%s supervised project process(es) remain quarantined; "
-                "workspace locks will stay held until process exit",
-                retained,
-            )
-    except Exception as e:
-        logger.warning("Error retrying quarantined project processes: %s", e)
-
-    # 8. Backstop sweep for any adopted child the steps above missed.
-    survivors = None
+    # 7. Backstop sweep for any adopted child the steps above missed.
     try:
         from utils.process_lifetime import clear_breadcrumb, terminate_all
         survivors = terminate_all()
+        if survivors:
+            logger.warning(
+                "Keeping the child-process recovery record for %s survivor(s)",
+                len(survivors),
+            )
+        else:
+            clear_breadcrumb()  # nothing left for the next startup to sweep
     except Exception as e:
         logger.warning("Error in process-lifetime sweep: %s", e)
-
-    # 9. The generic sweep may have made an earlier pidfd cleanup provable.
-    retained_after_sweep = None
-    try:
-        retained_after_sweep = _retry_project_process_quarantine()
-        if retained_after_sweep:
-            logger.warning(
-                "%s supervised project process(es) remain quarantined after the "
-                "generic process sweep",
-                retained_after_sweep,
-            )
-    except Exception as e:
-        logger.warning("Error retrying project quarantine after process sweep: %s", e)
-
-    if survivors is not None and retained_after_sweep is not None:
-        if not survivors and not retained_after_sweep:
-            clear_breadcrumb()
-        else:
-            logger.warning(
-                "Keeping the child-process recovery record for %s survivor(s) and "
-                "%s quarantined project process(es)",
-                len(survivors),
-                retained_after_sweep,
-            )
 
     # Last: while cleanup runs the server is still alive, and dropping the record
     # early leaves a retried `stop` or a new launch unable to find it.

--- a/studio/backend/tests/test_studio_pid_files.py
+++ b/studio/backend/tests/test_studio_pid_files.py
@@ -215,6 +215,103 @@ def test_graceful_shutdown_drops_the_record_last(monkeypatch):
     assert order == ["release_socket", "remove_record"]
 
 
+def test_graceful_shutdown_retries_project_quarantine_before_generic_sweep(monkeypatch):
+    from utils import process_lifetime
+
+    order = []
+    retry_count = {"value": 0}
+
+    def retry_quarantine():
+        retry_count["value"] += 1
+        order.append(f"project_quarantine_{retry_count['value']}")
+        return 0
+
+    monkeypatch.setattr(run, "_retry_project_process_quarantine", retry_quarantine)
+    monkeypatch.setattr(
+        process_lifetime,
+        "terminate_all",
+        lambda: order.append("generic_sweep") or [],
+    )
+    monkeypatch.setattr(process_lifetime, "clear_breadcrumb", lambda: None)
+    monkeypatch.setattr(run, "_remove_pid_file", lambda: None)
+
+    run._graceful_shutdown()
+
+    assert order == ["project_quarantine_1", "generic_sweep", "project_quarantine_2"]
+
+
+def test_graceful_shutdown_retries_quarantine_even_when_generic_sweep_fails(monkeypatch):
+    from utils import process_lifetime
+
+    order = []
+
+    def retry_quarantine():
+        order.append("project_quarantine")
+        return 1
+
+    def failed_sweep():
+        order.append("generic_sweep")
+        raise RuntimeError("sweep failed")
+
+    monkeypatch.setattr(run, "_retry_project_process_quarantine", retry_quarantine)
+    monkeypatch.setattr(process_lifetime, "terminate_all", failed_sweep)
+    monkeypatch.setattr(
+        process_lifetime,
+        "clear_breadcrumb",
+        lambda: pytest.fail("cleared recovery state after a failed sweep"),
+    )
+    monkeypatch.setattr(run, "_remove_pid_file", lambda: None)
+
+    run._graceful_shutdown()
+
+    assert order == ["project_quarantine", "generic_sweep", "project_quarantine"]
+
+
+@pytest.mark.parametrize("missing", ["core.agent_workspace", "core.agent_workspace.supervisor"])
+def test_shutdown_without_optional_supervisor_has_no_quarantine(monkeypatch, missing):
+    import importlib
+
+    def absent(name):
+        assert name == "core.agent_workspace.supervisor"
+        raise ModuleNotFoundError("optional feature absent", name = missing)
+
+    monkeypatch.setattr(importlib, "import_module", absent)
+    assert run._retry_project_process_quarantine() == 0
+
+
+def test_shutdown_broken_supervisor_import_cannot_claim_no_quarantine(monkeypatch):
+    import importlib
+
+    def broken(name):
+        raise ModuleNotFoundError("broken dependency", name = "supervisor_dependency")
+
+    monkeypatch.setattr(importlib, "import_module", broken)
+    with pytest.raises(ModuleNotFoundError):
+        run._retry_project_process_quarantine()
+
+
+@pytest.mark.parametrize("survivors", [[], [123]])
+@pytest.mark.parametrize("retained", [0, 1, None])
+def test_shutdown_keeps_recovery_record_until_both_sweeps_are_proven(
+    monkeypatch, survivors, retained
+):
+    from utils import process_lifetime
+
+    cleared = []
+
+    def retry():
+        if retained is None:
+            raise RuntimeError("cleanup could not be proven")
+        return retained
+
+    monkeypatch.setattr(run, "_retry_project_process_quarantine", retry)
+    monkeypatch.setattr(process_lifetime, "terminate_all", lambda: survivors)
+    monkeypatch.setattr(process_lifetime, "clear_breadcrumb", lambda: cleared.append(True))
+    monkeypatch.setattr(run, "_remove_pid_file", lambda: None)
+    run._graceful_shutdown()
+    assert bool(cleared) == (not survivors and retained == 0)
+
+
 def test_own_studio_on_port_is_found_without_psutil(tmp_path, monkeypatch):
     # psutil is optional; a listener scan finds nothing without it, so detection
     # must come from our own records or we silently start a duplicate.

--- a/studio/backend/tests/test_studio_pid_files.py
+++ b/studio/backend/tests/test_studio_pid_files.py
@@ -215,101 +215,25 @@ def test_graceful_shutdown_drops_the_record_last(monkeypatch):
     assert order == ["release_socket", "remove_record"]
 
 
-def test_graceful_shutdown_retries_project_quarantine_before_generic_sweep(monkeypatch):
-    from utils import process_lifetime
-
-    order = []
-    retry_count = {"value": 0}
-
-    def retry_quarantine():
-        retry_count["value"] += 1
-        order.append(f"project_quarantine_{retry_count['value']}")
-        return 0
-
-    monkeypatch.setattr(run, "_retry_project_process_quarantine", retry_quarantine)
-    monkeypatch.setattr(
-        process_lifetime,
-        "terminate_all",
-        lambda: order.append("generic_sweep") or [],
-    )
-    monkeypatch.setattr(process_lifetime, "clear_breadcrumb", lambda: None)
-    monkeypatch.setattr(run, "_remove_pid_file", lambda: None)
-
-    run._graceful_shutdown()
-
-    assert order == ["project_quarantine_1", "generic_sweep", "project_quarantine_2"]
-
-
-def test_graceful_shutdown_retries_quarantine_even_when_generic_sweep_fails(monkeypatch):
+@pytest.mark.parametrize("outcome", ["stopped", "survivors", "failed"])
+def test_shutdown_preserves_recovery_until_generic_sweep_is_proven(monkeypatch, outcome):
     from utils import process_lifetime
 
     order = []
 
-    def retry_quarantine():
-        order.append("project_quarantine")
-        return 1
+    def sweep():
+        order.append("sweep")
+        if outcome == "failed":
+            raise RuntimeError("could not prove process exit")
+        return [123] if outcome == "survivors" else []
 
-    def failed_sweep():
-        order.append("generic_sweep")
-        raise RuntimeError("sweep failed")
-
-    monkeypatch.setattr(run, "_retry_project_process_quarantine", retry_quarantine)
-    monkeypatch.setattr(process_lifetime, "terminate_all", failed_sweep)
-    monkeypatch.setattr(
-        process_lifetime,
-        "clear_breadcrumb",
-        lambda: pytest.fail("cleared recovery state after a failed sweep"),
+    monkeypatch.setattr(process_lifetime, "terminate_all", sweep)
+    monkeypatch.setattr(process_lifetime, "clear_breadcrumb", lambda: order.append("clear"))
+    monkeypatch.setattr(run, "_remove_pid_file", lambda: order.append("remove_pid"))
+    run._graceful_shutdown()
+    assert order == (
+        ["sweep", "clear", "remove_pid"] if outcome == "stopped" else ["sweep", "remove_pid"]
     )
-    monkeypatch.setattr(run, "_remove_pid_file", lambda: None)
-
-    run._graceful_shutdown()
-
-    assert order == ["project_quarantine", "generic_sweep", "project_quarantine"]
-
-
-@pytest.mark.parametrize("missing", ["core.agent_workspace", "core.agent_workspace.supervisor"])
-def test_shutdown_without_optional_supervisor_has_no_quarantine(monkeypatch, missing):
-    import importlib
-
-    def absent(name):
-        assert name == "core.agent_workspace.supervisor"
-        raise ModuleNotFoundError("optional feature absent", name = missing)
-
-    monkeypatch.setattr(importlib, "import_module", absent)
-    assert run._retry_project_process_quarantine() == 0
-
-
-def test_shutdown_broken_supervisor_import_cannot_claim_no_quarantine(monkeypatch):
-    import importlib
-
-    def broken(name):
-        raise ModuleNotFoundError("broken dependency", name = "supervisor_dependency")
-
-    monkeypatch.setattr(importlib, "import_module", broken)
-    with pytest.raises(ModuleNotFoundError):
-        run._retry_project_process_quarantine()
-
-
-@pytest.mark.parametrize("survivors", [[], [123]])
-@pytest.mark.parametrize("retained", [0, 1, None])
-def test_shutdown_keeps_recovery_record_until_both_sweeps_are_proven(
-    monkeypatch, survivors, retained
-):
-    from utils import process_lifetime
-
-    cleared = []
-
-    def retry():
-        if retained is None:
-            raise RuntimeError("cleanup could not be proven")
-        return retained
-
-    monkeypatch.setattr(run, "_retry_project_process_quarantine", retry)
-    monkeypatch.setattr(process_lifetime, "terminate_all", lambda: survivors)
-    monkeypatch.setattr(process_lifetime, "clear_breadcrumb", lambda: cleared.append(True))
-    monkeypatch.setattr(run, "_remove_pid_file", lambda: None)
-    run._graceful_shutdown()
-    assert bool(cleared) == (not survivors and retained == 0)
 
 
 def test_own_studio_on_port_is_found_without_psutil(tmp_path, monkeypatch):

--- a/studio/backend/tests/test_studio_pid_files.py
+++ b/studio/backend/tests/test_studio_pid_files.py
@@ -1034,6 +1034,7 @@ def test_a_zombie_backend_is_not_a_live_sibling(tmp_path, monkeypatch):
     assert run.live_sibling_backend() is None
 
 
+@pytest.mark.skipif(os.name != "posix", reason = "unreaped zombie processes are POSIX-only")
 def test_a_real_unreaped_child_is_not_a_live_sibling(tmp_path):
     # The same thing without a patch: a killed but unwaited child.
     import subprocess


### PR DESCRIPTION
When Studio shuts down, `terminate_all()` can report surviving child processes. The existing shutdown path cleared their recovery breadcrumb anyway, leaving the next startup with no record to sweep. Keep that breadcrumb whenever the generic sweep reports survivors or raises; clear it only after the sweep confirms no survivors.

This PR is limited to that existing shutdown path and its regression coverage. It does not import or depend on `core.agent_workspace.supervisor`. Supervisor-specific quarantine retries now live with #10636.

At head `32505cedc245b80e6cb7015cc9781a0bb3e2ef35`, local shutdown/process-lifetime tests passed (129 passed, four platform skips), and all three [native Linux/macOS/Windows jobs](https://github.com/PhilipJohnBasile/unsloth/actions/runs/34429671490) passed. Tests cover successful cleanup, surviving processes and sweep failure, while preserving final PID-record removal. Formatting and diff checks passed.
