### PR TITLE
feat(studio): consistent SSH restrictions with approved-server allowlist

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -31911,7 +31911,18 @@ class LlamaCppBackend:
                             if decision_slot is not None
                             else None
                         )
-                        if _decision is not None and _decision != "deny":
+                        if _decision == "allow":
+                            from core.inference.ssh_policy import collect_ssh_hosts_for_approval
+                            from state.ssh_approvals import approve_hosts
+
+                            approve_hosts(
+                                session_id,
+                                collect_ssh_hosts_for_approval(
+                                    decision.tool_name, decision.arguments
+                                ),
+                            )
+                            yield {"type": "status", "text": decision.status_text}
+                        elif _decision is not None and _decision != "deny":
                             # Approved: now it really is running.
                             yield {"type": "status", "text": decision.status_text}
                         if _decision == "deny":

--- a/studio/backend/core/inference/safetensors_agentic.py
+++ b/studio/backend/core/inference/safetensors_agentic.py
@@ -1312,7 +1312,16 @@ def run_safetensors_tool_loop(
                     if decision_slot is not None
                     else None
                 )
-                if _decision is not None and _decision != "deny":
+                if _decision == "allow":
+                    from core.inference.ssh_policy import collect_ssh_hosts_for_approval
+                    from state.ssh_approvals import approve_hosts
+
+                    approve_hosts(
+                        session_id,
+                        collect_ssh_hosts_for_approval(decision.tool_name, decision.arguments),
+                    )
+                    yield {"type": "status", "text": decision.status_text}
+                elif _decision is not None and _decision != "deny":
                     # Approved: now it really is running.
                     yield {"type": "status", "text": decision.status_text}
                 if _decision == "deny":

--- a/studio/backend/core/inference/ssh_policy.py
+++ b/studio/backend/core/inference/ssh_policy.py
@@ -162,9 +162,7 @@ def _parse_ssh_option_token(tok: str) -> tuple[Optional[str], Optional[str]]:
     return tok.strip().lower(), None
 
 
-def _consume_ssh_flag(
-    flag: str, tokens: list[str], index: int
-) -> tuple[int, set[str], bool]:
+def _consume_ssh_flag(flag: str, tokens: list[str], index: int) -> tuple[int, set[str], bool]:
     """Advance past one ssh flag and return any hosts it names."""
     hosts: set[str] = set()
     dynamic = False
@@ -411,13 +409,23 @@ def _resolve_ssh_call(
 
     if isinstance(func.value, ast.Call):
         inner = func.value.func
-        if isinstance(inner, ast.Attribute) and inner.attr in {"SSHClient", "Transport", "Connection"}:
-            receiver_root = _fq_name(inner.value).split(".", 1)[0] if isinstance(inner.value, ast.AST) else ""
+        if isinstance(inner, ast.Attribute) and inner.attr in {
+            "SSHClient",
+            "Transport",
+            "Connection",
+        }:
+            receiver_root = (
+                _fq_name(inner.value).split(".", 1)[0] if isinstance(inner.value, ast.AST) else ""
+            )
             if receiver_root in _SSH_PY_ROOT_MODULES or receiver_root in bindings:
                 return f"{receiver_root}.{func.attr}"
         if isinstance(inner, ast.Name):
             root = bindings.get(inner.id, inner.id).split(".", 1)[0]
-            if root in _SSH_PY_ROOT_MODULES and inner.id in {"SSHClient", "Transport", "Connection"}:
+            if root in _SSH_PY_ROOT_MODULES and inner.id in {
+                "SSHClient",
+                "Transport",
+                "Connection",
+            }:
                 return f"{root}.{func.attr}"
 
     if isinstance(func.value, ast.Attribute) and func.value.attr in {
@@ -609,9 +617,7 @@ def check_ssh_python_access(code: str, session_id: Optional[str]) -> Optional[st
             "the target server first."
         )
     if uses_ssh and not hosts and not dynamic:
-        return (
-            "Blocked: SSH usage detected without a literal, approved target server."
-        )
+        return "Blocked: SSH usage detected without a literal, approved target server."
     unapproved = _unapproved(hosts, session_id)
     if unapproved:
         listed = ", ".join(sorted(unapproved))
@@ -653,9 +659,6 @@ def filter_ssh_approved_network_blocks(
     filtered["network_calls"] = [
         item
         for item in analysis_info.get("network_calls", [])
-        if not (
-            item.get("type") == "untrusted_host_blocked"
-            and item.get("line") in approved_lines
-        )
+        if not (item.get("type") == "untrusted_host_blocked" and item.get("line") in approved_lines)
     ]
     return filtered

--- a/studio/backend/core/inference/ssh_policy.py
+++ b/studio/backend/core/inference/ssh_policy.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import ast
 import re
-import shlex
 from typing import Iterable, Optional
 
 from state.ssh_approvals import approved_hosts, is_host_approved, normalize_host
@@ -33,21 +32,6 @@ _SSH_PY_CONNECT_FQ = (
     "fabric.connection.Connection",
 )
 
-_SSH_SEGMENT_RE = re.compile(
-    r"(?:^|[;&|\n(]|&&|\|\|)\s*(?:[A-Za-z_]\w*=\S*\s+)*"
-    r"(?P<cmd>(?:\S*/)?(?P<name>ssh|slogin|scp|sftp))\b(?P<rest>[^\n;&|()]*)",
-    re.IGNORECASE,
-)
-
-_USER_AT_HOST_RE = re.compile(
-    r"(?:^|[\s'\"])"
-    r"(?:(?P<user>[^@\s/\\:]+)@)?"
-    r"(?P<host>[^@\s/\\:]+)"
-    r"(?::(?P<path>[^\s'\"]+))?"
-    r"(?:[\s'\"]|$)"
-)
-
-
 def _parse_host_token(token: str) -> Optional[str]:
     token = token.strip().strip("'\"")
     if not token or token.startswith("-") or token.startswith("$") or token.startswith("${"):
@@ -66,14 +50,10 @@ def _parse_host_token(token: str) -> Optional[str]:
     return host
 
 
-def _hosts_from_ssh_segment(name: str, rest: str) -> tuple[set[str], bool]:
+def _hosts_from_ssh_segment(name: str, tokens: list[str]) -> tuple[set[str], bool]:
     """Extract literal hosts from one ssh/scp/sftp command segment."""
     literal_hosts: set[str] = set()
     dynamic = False
-    try:
-        tokens = shlex.split(rest, posix = True)
-    except ValueError:
-        tokens = rest.split()
     skip_next = False
     host_tokens: list[str] = []
     for tok in tokens:
@@ -120,13 +100,15 @@ def extract_ssh_hosts_from_command(command: str) -> tuple[set[str], bool]:
     """Return literal SSH hosts and whether a dynamic/unparsed target exists."""
     if not command or not command.strip():
         return set(), False
+    # Lazy import: tools imports ssh_policy at module load.
+    from core.inference.tools import _find_ssh_command_segments
+
     hosts: set[str] = set()
     dynamic = False
-    for match in _SSH_SEGMENT_RE.finditer(command):
-        name = match.group("name").lower()
+    for name, arg_tokens in _find_ssh_command_segments(command):
         if name not in _SSH_COMMANDS:
             continue
-        segment_hosts, segment_dynamic = _hosts_from_ssh_segment(name, match.group("rest") or "")
+        segment_hosts, segment_dynamic = _hosts_from_ssh_segment(name, arg_tokens)
         hosts.update(segment_hosts)
         dynamic = dynamic or segment_dynamic
     return hosts, dynamic

--- a/studio/backend/core/inference/ssh_policy.py
+++ b/studio/backend/core/inference/ssh_policy.py
@@ -32,63 +32,259 @@ _SSH_PY_CONNECT_FQ = (
     "fabric.connection.Connection",
 )
 
-def _parse_host_token(token: str) -> Optional[str]:
+# OpenSSH boolean flags (do not consume the next token).
+_SSH_NO_ARG_FLAGS = frozenset(
+    {
+        "4",
+        "6",
+        "A",
+        "a",
+        "C",
+        "f",
+        "G",
+        "g",
+        "K",
+        "k",
+        "M",
+        "N",
+        "n",
+        "q",
+        "s",
+        "T",
+        "t",
+        "V",
+        "v",
+        "X",
+        "x",
+        "Y",
+        "y",
+    }
+)
+
+# OpenSSH options that take a separate value token.
+_SSH_VALUE_FLAGS = frozenset(
+    {
+        "b",
+        "c",
+        "D",
+        "E",
+        "e",
+        "F",
+        "I",
+        "i",
+        "J",
+        "L",
+        "l",
+        "m",
+        "O",
+        "o",
+        "p",
+        "Q",
+        "R",
+        "S",
+        "W",
+        "w",
+    }
+)
+
+_SSH_REDIRECT_OPTIONS = frozenset({"hostname", "proxyjump"})
+_SSH_DYNAMIC_OPTIONS = frozenset({"proxycommand"})
+
+_SHELL_EXEC_FUNCS = frozenset(
+    {
+        "os.system",
+        "os.popen",
+        "os.popen2",
+        "os.popen3",
+        "os.popen4",
+        "subprocess.run",
+        "subprocess.call",
+        "subprocess.check_call",
+        "subprocess.check_output",
+        "subprocess.Popen",
+        "subprocess.getoutput",
+        "subprocess.getstatusoutput",
+    }
+)
+
+_CMD_KWARGS = frozenset({"args", "command", "executable", "path", "file"})
+
+
+def _extract_host_from_endpoint(token: str) -> Optional[str]:
+    """Parse a user@host, host:port, host:path, or bracketed IPv6 operand."""
     token = token.strip().strip("'\"")
     if not token or token.startswith("-") or token.startswith("$") or token.startswith("${"):
         return None
-    if "/" in token and "@" not in token:
+    if "/" in token and "@" not in token and ":" not in token:
         return None
-    if "@" in token:
-        _, host_part = token.split("@", 1)
-        if ":" in host_part:
-            host_part = host_part.split(":", 1)[0]
-        host = normalize_host(host_part)
+
+    host_part = token.split("@", 1)[-1]
+
+    if host_part.startswith("[") and "]" in host_part:
+        host = host_part[1 : host_part.index("]")]
+        host = normalize_host(host)
         return host or None
-    host = normalize_host(token)
+
+    if ":" in host_part:
+        left, right = host_part.split(":", 1)
+        if right.isdigit() and "/" not in left:
+            host_part = left
+        elif "/" not in left:
+            host_part = left
+
+    host = normalize_host(host_part)
     if not host or host in {"localhost", "127.0.0.1", "::1"}:
         return None
     return host
+
+
+def _host_from_ssh_option(key: str, value: Optional[str]) -> tuple[set[str], bool]:
+    """Extract hosts from one ``-o`` key/value pair."""
+    hosts: set[str] = set()
+    dynamic = False
+    key = (key or "").strip().lower()
+    value = (value or "").strip()
+    if key in _SSH_DYNAMIC_OPTIONS:
+        return hosts, True
+    if key in _SSH_REDIRECT_OPTIONS and value:
+        host = _extract_host_from_endpoint(value)
+        if host:
+            hosts.add(host)
+        else:
+            dynamic = True
+    return hosts, dynamic
+
+
+def _parse_ssh_option_token(tok: str) -> tuple[Optional[str], Optional[str]]:
+    if "=" in tok:
+        key, value = tok.split("=", 1)
+        return key.strip().lower(), value.strip()
+    return tok.strip().lower(), None
+
+
+def _consume_ssh_flag(
+    flag: str, tokens: list[str], index: int
+) -> tuple[int, set[str], bool]:
+    """Advance past one ssh flag and return any hosts it names."""
+    hosts: set[str] = set()
+    dynamic = False
+    flag_body = flag[1:]
+    if not flag_body:
+        return index, hosts, dynamic
+
+    if flag_body[0] in _SSH_NO_ARG_FLAGS and all(ch in _SSH_NO_ARG_FLAGS for ch in flag_body):
+        return index, hosts, dynamic
+
+    if flag_body[0] in _SSH_VALUE_FLAGS:
+        opt = flag_body[0]
+        attached = flag_body[1:]
+        if opt == "o":
+            if attached:
+                key, value = _parse_ssh_option_token(attached)
+                opt_hosts, opt_dynamic = _host_from_ssh_option(key, value)
+                hosts.update(opt_hosts)
+                dynamic = dynamic or opt_dynamic
+            elif index < len(tokens):
+                key, value = _parse_ssh_option_token(tokens[index])
+                if value is None and index + 1 < len(tokens):
+                    value = tokens[index + 1]
+                    index += 2
+                else:
+                    index += 1
+                opt_hosts, opt_dynamic = _host_from_ssh_option(key, value)
+                hosts.update(opt_hosts)
+                dynamic = dynamic or opt_dynamic
+            return index, hosts, dynamic
+        if attached:
+            if opt == "J":
+                host = _extract_host_from_endpoint(attached)
+                if host:
+                    hosts.add(host)
+                else:
+                    dynamic = True
+            return index, hosts, dynamic
+        if index < len(tokens):
+            value = tokens[index]
+            index += 1
+            if opt == "J":
+                host = _extract_host_from_endpoint(value)
+                if host:
+                    hosts.add(host)
+                else:
+                    dynamic = True
+            elif opt == "o":
+                key, opt_value = _parse_ssh_option_token(value)
+                if opt_value is None and index < len(tokens):
+                    opt_value = tokens[index]
+                    index += 1
+                opt_hosts, opt_dynamic = _host_from_ssh_option(key, opt_value)
+                hosts.update(opt_hosts)
+                dynamic = dynamic or opt_dynamic
+        return index, hosts, dynamic
+
+    return index, hosts, dynamic
+
+
+def _parse_ssh_cli_options(tokens: list[str]) -> tuple[list[str], set[str], bool]:
+    """Return positional tokens plus hosts named by ssh options."""
+    positional: list[str] = []
+    hosts: set[str] = set()
+    dynamic = False
+    index = 0
+    while index < len(tokens):
+        tok = tokens[index]
+        if tok == "--":
+            positional.extend(tokens[index + 1 :])
+            break
+        if tok.startswith("-") and tok != "-":
+            index += 1
+            index, opt_hosts, opt_dynamic = _consume_ssh_flag(tok, tokens, index)
+            hosts.update(opt_hosts)
+            dynamic = dynamic or opt_dynamic
+            continue
+        positional.append(tok)
+        index += 1
+    return positional, hosts, dynamic
+
+
+def _scp_remote_candidates(tokens: list[str]) -> list[str]:
+    """Return scp/sftp operands that name a remote host."""
+    candidates: list[str] = []
+    for tok in tokens:
+        if "@" in tok:
+            candidates.append(tok)
+            continue
+        if ":" in tok:
+            left, right = tok.split(":", 1)
+            if left and "/" not in left and not re.fullmatch(r"[A-Za-z]:", left):
+                candidates.append(tok)
+    return candidates
 
 
 def _hosts_from_ssh_segment(name: str, tokens: list[str]) -> tuple[set[str], bool]:
     """Extract literal hosts from one ssh/scp/sftp command segment."""
     literal_hosts: set[str] = set()
     dynamic = False
-    skip_next = False
-    host_tokens: list[str] = []
-    for tok in tokens:
-        if skip_next:
-            skip_next = False
-            continue
-        if tok in {"-p", "-i", "-F", "-l", "-o", "-b", "-c", "-J", "-L", "-R", "-D", "-W"}:
-            skip_next = True
-            continue
-        if tok.startswith("-"):
-            if "=" in tok:
-                continue
-            skip_next = True
-            continue
-        host_tokens.append(tok)
-    if name.lower() in {"ssh", "slogin"}:
-        # ssh [-options] [user@]host [command] -- host is the first target token
-        candidates = []
-        for tok in host_tokens:
-            if _parse_host_token(tok):
+    cmd = name.lower()
+    if cmd in {"ssh", "slogin"}:
+        positional, opt_hosts, opt_dynamic = _parse_ssh_cli_options(tokens)
+        literal_hosts.update(opt_hosts)
+        dynamic = dynamic or opt_dynamic
+        candidates: list[str] = []
+        for tok in positional:
+            if _extract_host_from_endpoint(tok):
                 candidates = [tok]
                 break
-        if not candidates and host_tokens:
-            candidates = [host_tokens[0]]
+        if not candidates and positional:
+            candidates = [positional[0]]
     else:
-        # scp/sftp: remote target is usually the last user@host[:path] token
-        candidates = [
-            t for t in host_tokens if "@" in t or (":" in t and "@" in t.split(":", 1)[0])
-        ]
-        if not candidates and host_tokens:
-            candidates = [host_tokens[-1]]
+        candidates = _scp_remote_candidates(tokens)
+        if not candidates and tokens:
+            candidates = [tokens[-1]]
     if not candidates:
         return literal_hosts, True
     for cand in candidates:
-        host = _parse_host_token(cand)
+        host = _extract_host_from_endpoint(cand)
         if host:
             literal_hosts.add(host)
         else:
@@ -125,101 +321,252 @@ def _module_is_ssh_root(module: Optional[str]) -> bool:
     return bool(module and module.split(".", 1)[0] in _SSH_PY_ROOT_MODULES)
 
 
-def _ssh_imports_in_tree(tree: ast.AST) -> set[str]:
-    roots: set[str] = set()
+def _ssh_import_bindings(tree: ast.AST) -> dict[str, str]:
+    """Map local names to fully-qualified SSH symbols."""
+    bindings: dict[str, str] = {}
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
                 root = alias.name.split(".", 1)[0]
                 if root in _SSH_PY_ROOT_MODULES:
-                    roots.add(root)
+                    local = alias.asname or root
+                    bindings[local] = alias.name
         elif isinstance(node, ast.ImportFrom) and _module_is_ssh_root(node.module):
-            roots.add((node.module or "").split(".", 1)[0])
-    return roots
+            module = node.module or ""
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                local = alias.asname or alias.name
+                bindings[local] = f"{module}.{alias.name}"
+    return bindings
 
 
-def _call_is_ssh_client_connect(func: ast.AST, ssh_imports: set[str]) -> bool:
-    if not isinstance(func, ast.Attribute) or func.attr not in _SSH_PY_CONNECT_ATTRS:
-        return False
-    if not ssh_imports:
-        return False
-    receiver = func.value
-    if isinstance(receiver, ast.Call):
-        inner = receiver.func
-        if isinstance(inner, ast.Attribute) and inner.attr in {"SSHClient", "Transport"}:
-            return True
-        if isinstance(inner, ast.Name) and inner.id in {"SSHClient", "Transport", "Connection"}:
-            return True
-    if isinstance(receiver, ast.Name):
-        return True
-    if isinstance(receiver, ast.Attribute) and receiver.attr in {
-        "SSHClient",
-        "Transport",
-        "Connection",
-    }:
-        return True
-    return bool(ssh_imports)
+def _ssh_client_bindings(tree: ast.AST) -> dict[str, str]:
+    """Map variables assigned from SSH client factories."""
+    clients: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name) or not isinstance(node.value, ast.Call):
+            continue
+        fq = _fq_name(node.value.func)
+        if fq.endswith(".SSHClient") or fq.endswith(".Transport") or fq.endswith(".Connection"):
+            clients[target.id] = fq
+    return clients
 
 
-def _call_is_ssh_factory(func: ast.AST, ssh_imports: set[str]) -> bool:
+def _fq_name(node: ast.AST) -> str:
     parts: list[str] = []
-    cur = func
+    cur = node
     while isinstance(cur, ast.Attribute):
         parts.insert(0, cur.attr)
         cur = cur.value
     if isinstance(cur, ast.Name):
         parts.insert(0, cur.id)
-    fq = ".".join(parts)
+    return ".".join(parts)
+
+
+def _resolve_ssh_call(
+    func: ast.AST, bindings: dict[str, str], clients: dict[str, str]
+) -> Optional[str]:
+    """Return a canonical SSH call name when ``func`` is an SSH connect/factory."""
+    if isinstance(func, ast.Name):
+        bound = bindings.get(func.id, func.id)
+        if bound in _SSH_PY_CONNECT_FQ:
+            return bound
+        if bound.endswith(".connect") and bound.split(".", 1)[0] in _SSH_PY_ROOT_MODULES:
+            return bound
+        if bound.endswith(".Connection"):
+            return bound
+        if func.id == "Connection" and any(v.endswith(".Connection") for v in bindings.values()):
+            return "fabric.Connection"
+        return None
+
+    if not isinstance(func, ast.Attribute):
+        return None
+
+    fq = _fq_name(func)
     if fq in _SSH_PY_CONNECT_FQ or fq.endswith(".Connection"):
-        return bool(ssh_imports)
-    if isinstance(func, ast.Attribute) and func.attr == "Connection":
-        return bool(ssh_imports)
-    if isinstance(func, ast.Name) and func.id == "Connection":
-        return "fabric" in ssh_imports
-    if fq.endswith(".connect") and fq.split(".", 1)[0] in ssh_imports:
-        return True
-    return False
+        root = fq.split(".", 1)[0]
+        if root in bindings or root in _SSH_PY_ROOT_MODULES:
+            return fq
+        return None
+
+    if func.attr not in _SSH_PY_CONNECT_ATTRS and func.attr != "Connection":
+        return None
+
+    if isinstance(func.value, ast.Name):
+        client_fq = clients.get(func.value.id)
+        if client_fq:
+            root = client_fq.split(".", 1)[0]
+            if root in _SSH_PY_ROOT_MODULES:
+                return f"{root}.{func.attr}"
+        root = bindings.get(func.value.id, func.value.id).split(".", 1)[0]
+        if root in _SSH_PY_ROOT_MODULES:
+            if func.attr == "Connection":
+                return f"{root}.Connection"
+            return f"{root}.{func.attr}"
+        return None
+
+    if isinstance(func.value, ast.Call):
+        inner = func.value.func
+        if isinstance(inner, ast.Attribute) and inner.attr in {"SSHClient", "Transport", "Connection"}:
+            receiver_root = _fq_name(inner.value).split(".", 1)[0] if isinstance(inner.value, ast.AST) else ""
+            if receiver_root in _SSH_PY_ROOT_MODULES or receiver_root in bindings:
+                return f"{receiver_root}.{func.attr}"
+        if isinstance(inner, ast.Name):
+            root = bindings.get(inner.id, inner.id).split(".", 1)[0]
+            if root in _SSH_PY_ROOT_MODULES and inner.id in {"SSHClient", "Transport", "Connection"}:
+                return f"{root}.{func.attr}"
+
+    if isinstance(func.value, ast.Attribute) and func.value.attr in {
+        "SSHClient",
+        "Transport",
+        "Connection",
+    }:
+        root = _fq_name(func.value).split(".", 1)[0]
+        if root in _SSH_PY_ROOT_MODULES or root in bindings:
+            return f"{root}.{func.attr}"
+
+    return None
 
 
-def extract_ssh_hosts_from_python(code: str) -> tuple[set[str], bool, bool]:
-    """Return (literal_hosts, dynamic_target, uses_ssh_library)."""
+def _literal_strings_from_node(node: ast.AST) -> list[str]:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return [node.value]
+    if isinstance(node, (ast.List, ast.Tuple)):
+        out: list[str] = []
+        for elt in node.elts:
+            out.extend(_literal_strings_from_node(elt))
+        return out
+    return []
+
+
+def _ssh_from_argv_literals(strings: list[str]) -> tuple[set[str], bool]:
+    if not strings:
+        return set(), False
+    cmd = strings[0].rsplit("/", 1)[-1].lower()
+    if cmd not in _SSH_COMMANDS:
+        return set(), False
+    return _hosts_from_ssh_segment(cmd, strings[1:])
+
+
+def _extract_ssh_from_shell_literal(literal: str) -> tuple[set[str], bool]:
+    hosts, dynamic = extract_ssh_hosts_from_command(literal)
+    return hosts, dynamic
+
+
+def _shell_exec_aliases(tree: ast.AST) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "os":
+                    aliases[alias.asname or "os"] = "os"
+                elif alias.name == "subprocess":
+                    aliases[alias.asname or "subprocess"] = "subprocess"
+        elif isinstance(node, ast.ImportFrom) and node.module in {"os", "subprocess"}:
+            module = node.module
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                aliases[alias.asname or alias.name] = f"{module}.{alias.name}"
+    return aliases
+
+
+def _scan_ssh_python_usage(code: str) -> tuple[set[str], bool, bool, set[int]]:
+    """Return (literal_hosts, dynamic_target, uses_ssh_connect, connect_line_numbers)."""
     if not code or not code.strip():
-        return set(), False, False
+        return set(), False, False, set()
     try:
         tree = ast.parse(code)
     except SyntaxError:
-        return set(), True, bool(re.search(r"\b(?:paramiko|asyncssh|fabric)\b", code))
-    ssh_imports = _ssh_imports_in_tree(tree)
+        return set(), True, bool(re.search(r"\b(?:paramiko|asyncssh|fabric)\b", code)), set()
+    bindings = _ssh_import_bindings(tree)
+    clients = _ssh_client_bindings(tree)
+    shell_aliases = _shell_exec_aliases(tree)
     hosts: set[str] = set()
     dynamic = False
-    uses_ssh = bool(ssh_imports)
+    uses_ssh = False
+    connect_lines: set[int] = set()
 
     class _Visitor(ast.NodeVisitor):
         def visit_Call(self, node: ast.Call) -> None:
             nonlocal dynamic, uses_ssh
-            is_ssh = _call_is_ssh_client_connect(node.func, ssh_imports) or _call_is_ssh_factory(
-                node.func, ssh_imports
-            )
-            if not is_ssh:
+            ssh_call = _resolve_ssh_call(node.func, bindings, clients)
+            if ssh_call:
+                uses_ssh = True
+                connect_lines.add(getattr(node, "lineno", -1))
+                host_lit: Optional[str] = None
+                if node.args:
+                    host_lit = _literal_host_from_ast(node.args[0])
+                if host_lit is None:
+                    for kw in node.keywords or []:
+                        if kw.arg in {"hostname", "host"}:
+                            host_lit = _literal_host_from_ast(kw.value)
+                            break
+                if host_lit:
+                    hosts.add(host_lit)
+                else:
+                    dynamic = True
                 self.generic_visit(node)
                 return
-            uses_ssh = True
-            host_lit: Optional[str] = None
-            if node.args:
-                host_lit = _literal_host_from_ast(node.args[0])
-            if host_lit is None:
+
+            shell_func: Optional[str] = None
+            if isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name):
+                module = shell_aliases.get(node.func.value.id)
+                if module in {"os", "subprocess"}:
+                    shell_func = f"{module}.{node.func.attr}"
+            elif isinstance(node.func, ast.Name):
+                shell_func = shell_aliases.get(node.func.id)
+
+            if shell_func and shell_func in _SHELL_EXEC_FUNCS:
+                expanded_kwargs: dict[str, ast.AST] = {}
                 for kw in node.keywords or []:
-                    if kw.arg in {"hostname", "host"}:
-                        host_lit = _literal_host_from_ast(kw.value)
-                        break
-            if host_lit:
-                hosts.add(host_lit)
-            else:
-                dynamic = True
+                    if kw.arg is not None:
+                        expanded_kwargs[kw.arg] = kw.value
+                cmd_args = list(node.args) + [
+                    expanded_kwargs[k] for k in _CMD_KWARGS if k in expanded_kwargs
+                ]
+                for arg in cmd_args:
+                    argv = _literal_strings_from_node(arg)
+                    if isinstance(arg, (ast.List, ast.Tuple)) and argv:
+                        seg_hosts, seg_dynamic = _ssh_from_argv_literals(argv)
+                        if seg_hosts or seg_dynamic:
+                            uses_ssh = True
+                            connect_lines.add(getattr(node, "lineno", -1))
+                            hosts.update(seg_hosts)
+                            dynamic = dynamic or seg_dynamic
+                        continue
+                    for literal in argv:
+                        seg_hosts, seg_dynamic = _extract_ssh_from_shell_literal(literal)
+                        if seg_hosts or seg_dynamic:
+                            uses_ssh = True
+                            connect_lines.add(getattr(node, "lineno", -1))
+                            hosts.update(seg_hosts)
+                            dynamic = dynamic or seg_dynamic
+
             self.generic_visit(node)
 
     _Visitor().visit(tree)
+    return hosts, dynamic, uses_ssh, connect_lines
+
+
+def extract_ssh_hosts_from_python(code: str) -> tuple[set[str], bool, bool]:
+    """Return (literal_hosts, dynamic_target, uses_ssh_connect)."""
+    hosts, dynamic, uses_ssh, _lines = _scan_ssh_python_usage(code)
     return hosts, dynamic, uses_ssh
+
+
+def _approved_ssh_connect_lines(code: str, session_id: Optional[str]) -> set[int]:
+    """Lines with approved SSH connect calls, for network-block filtering."""
+    hosts, dynamic, uses_ssh, connect_lines = _scan_ssh_python_usage(code)
+    if not uses_ssh or dynamic or not hosts:
+        return set()
+    if not all(is_host_approved(session_id, host) for host in hosts):
+        return set()
+    return connect_lines
 
 
 def _unapproved(hosts: Iterable[str], session_id: Optional[str]) -> set[str]:
@@ -243,21 +590,18 @@ def check_ssh_command_access(command: str, session_id: Optional[str]) -> Optiona
             f"Blocked: SSH access to unapproved server(s): {listed}. "
             "Approve the server when prompted to allow deployment workflows."
         )
-    if dynamic and unapproved:
-        return (
-            "Blocked: SSH command includes a non-literal host that is not approved. "
-            "Use a literal hostname for an approved server."
-        )
     if dynamic:
-        # Literal host approved, but other parts are dynamic: allow.
-        return None
+        return (
+            "Blocked: SSH command includes a non-literal or redirected target that "
+            "is not approved. Use a literal hostname for an approved server."
+        )
     return None
 
 
 def check_ssh_python_access(code: str, session_id: Optional[str]) -> Optional[str]:
     """Return an error message when python SSH usage is not allowed, else None."""
     hosts, dynamic, uses_ssh = extract_ssh_hosts_from_python(code)
-    if not uses_ssh and not hosts and not dynamic:
+    if not uses_ssh:
         return None
     if uses_ssh and not hosts and dynamic:
         return (
@@ -265,7 +609,9 @@ def check_ssh_python_access(code: str, session_id: Optional[str]) -> Optional[st
             "the target server first."
         )
     if uses_ssh and not hosts and not dynamic:
-        return None
+        return (
+            "Blocked: SSH usage detected without a literal, approved target server."
+        )
     unapproved = _unapproved(hosts, session_id)
     if unapproved:
         listed = ", ".join(sorted(unapproved))
@@ -299,16 +645,17 @@ def list_approved_ssh_hosts(session_id: Optional[str]) -> list[str]:
 def filter_ssh_approved_network_blocks(
     code: str, session_id: Optional[str], analysis_info: dict
 ) -> dict:
-    """Drop informational-host blocks for SSH targets the session already approved."""
-    hosts, dynamic, uses_ssh = extract_ssh_hosts_from_python(code)
-    if not uses_ssh or dynamic or not hosts:
-        return analysis_info
-    if not all(is_host_approved(session_id, host) for host in hosts):
+    """Drop host blocks only on lines with already-approved SSH connect calls."""
+    approved_lines = _approved_ssh_connect_lines(code, session_id)
+    if not approved_lines:
         return analysis_info
     filtered = dict(analysis_info)
     filtered["network_calls"] = [
         item
         for item in analysis_info.get("network_calls", [])
-        if item.get("type") != "untrusted_host_blocked"
+        if not (
+            item.get("type") == "untrusted_host_blocked"
+            and item.get("line") in approved_lines
+        )
     ]
     return filtered

--- a/studio/backend/core/inference/ssh_policy.py
+++ b/studio/backend/core/inference/ssh_policy.py
@@ -1,0 +1,330 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Consistent SSH restrictions for sandboxed terminal and python tools."""
+
+from __future__ import annotations
+
+import ast
+import re
+import shlex
+from typing import Iterable, Optional
+
+from state.ssh_approvals import approved_hosts, is_host_approved, normalize_host
+
+_SSH_COMMANDS = frozenset({"ssh", "slogin", "scp", "sftp"})
+
+_SSH_PY_ROOT_MODULES = frozenset(
+    {
+        "paramiko",
+        "asyncssh",
+        "fabric",
+    }
+)
+
+_SSH_PY_CONNECT_ATTRS = frozenset({"connect", "connect_ssh"})
+
+_SSH_PY_CONNECT_FQ = (
+    "paramiko.SSHClient.connect",
+    "paramiko.Transport.connect",
+    "asyncssh.connect",
+    "asyncssh.SSHClient.connect",
+    "fabric.Connection",
+    "fabric.connection.Connection",
+)
+
+_SSH_SEGMENT_RE = re.compile(
+    r"(?:^|[;&|\n(]|&&|\|\|)\s*(?:[A-Za-z_]\w*=\S*\s+)*"
+    r"(?P<cmd>(?:\S*/)?(?P<name>ssh|slogin|scp|sftp))\b(?P<rest>[^\n;&|()]*)",
+    re.IGNORECASE,
+)
+
+_USER_AT_HOST_RE = re.compile(
+    r"(?:^|[\s'\"])"
+    r"(?:(?P<user>[^@\s/\\:]+)@)?"
+    r"(?P<host>[^@\s/\\:]+)"
+    r"(?::(?P<path>[^\s'\"]+))?"
+    r"(?:[\s'\"]|$)"
+)
+
+
+def _parse_host_token(token: str) -> Optional[str]:
+    token = token.strip().strip("'\"")
+    if not token or token.startswith("-") or token.startswith("$") or token.startswith("${"):
+        return None
+    if "/" in token and "@" not in token:
+        return None
+    if "@" in token:
+        _, host_part = token.split("@", 1)
+        if ":" in host_part:
+            host_part = host_part.split(":", 1)[0]
+        host = normalize_host(host_part)
+        return host or None
+    host = normalize_host(token)
+    if not host or host in {"localhost", "127.0.0.1", "::1"}:
+        return None
+    return host
+
+
+def _hosts_from_ssh_segment(name: str, rest: str) -> tuple[set[str], bool]:
+    """Extract literal hosts from one ssh/scp/sftp command segment."""
+    literal_hosts: set[str] = set()
+    dynamic = False
+    try:
+        tokens = shlex.split(rest, posix = True)
+    except ValueError:
+        tokens = rest.split()
+    skip_next = False
+    host_tokens: list[str] = []
+    for tok in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if tok in {"-p", "-i", "-F", "-l", "-o", "-b", "-c", "-J", "-L", "-R", "-D", "-W"}:
+            skip_next = True
+            continue
+        if tok.startswith("-"):
+            if "=" in tok:
+                continue
+            skip_next = True
+            continue
+        host_tokens.append(tok)
+    if name.lower() in {"ssh", "slogin"}:
+        # ssh [-options] [user@]host [command] -- host is the first target token
+        candidates = []
+        for tok in host_tokens:
+            if _parse_host_token(tok):
+                candidates = [tok]
+                break
+        if not candidates and host_tokens:
+            candidates = [host_tokens[0]]
+    else:
+        # scp/sftp: remote target is usually the last user@host[:path] token
+        candidates = [t for t in host_tokens if "@" in t or (":" in t and "@" in t.split(":", 1)[0])]
+        if not candidates and host_tokens:
+            candidates = [host_tokens[-1]]
+    if not candidates:
+        return literal_hosts, True
+    for cand in candidates:
+        host = _parse_host_token(cand)
+        if host:
+            literal_hosts.add(host)
+        else:
+            dynamic = True
+    return literal_hosts, dynamic
+
+
+def extract_ssh_hosts_from_command(command: str) -> tuple[set[str], bool]:
+    """Return literal SSH hosts and whether a dynamic/unparsed target exists."""
+    if not command or not command.strip():
+        return set(), False
+    hosts: set[str] = set()
+    dynamic = False
+    for match in _SSH_SEGMENT_RE.finditer(command):
+        name = match.group("name").lower()
+        if name not in _SSH_COMMANDS:
+            continue
+        segment_hosts, segment_dynamic = _hosts_from_ssh_segment(name, match.group("rest") or "")
+        hosts.update(segment_hosts)
+        dynamic = dynamic or segment_dynamic
+    return hosts, dynamic
+
+
+def _literal_host_from_ast(node: ast.AST) -> Optional[str]:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        host = normalize_host(node.value)
+        return host or None
+    return None
+
+
+def _module_is_ssh_root(module: Optional[str]) -> bool:
+    return bool(module and module.split(".", 1)[0] in _SSH_PY_ROOT_MODULES)
+
+
+def _ssh_imports_in_tree(tree: ast.AST) -> set[str]:
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".", 1)[0]
+                if root in _SSH_PY_ROOT_MODULES:
+                    roots.add(root)
+        elif isinstance(node, ast.ImportFrom) and _module_is_ssh_root(node.module):
+            roots.add((node.module or "").split(".", 1)[0])
+    return roots
+
+
+def _call_is_ssh_client_connect(func: ast.AST, ssh_imports: set[str]) -> bool:
+    if not isinstance(func, ast.Attribute) or func.attr not in _SSH_PY_CONNECT_ATTRS:
+        return False
+    if not ssh_imports:
+        return False
+    receiver = func.value
+    if isinstance(receiver, ast.Call):
+        inner = receiver.func
+        if isinstance(inner, ast.Attribute) and inner.attr in {"SSHClient", "Transport"}:
+            return True
+        if isinstance(inner, ast.Name) and inner.id in {"SSHClient", "Transport", "Connection"}:
+            return True
+    if isinstance(receiver, ast.Name):
+        return True
+    if isinstance(receiver, ast.Attribute) and receiver.attr in {
+        "SSHClient",
+        "Transport",
+        "Connection",
+    }:
+        return True
+    return bool(ssh_imports)
+
+
+def _call_is_ssh_factory(func: ast.AST, ssh_imports: set[str]) -> bool:
+    parts: list[str] = []
+    cur = func
+    while isinstance(cur, ast.Attribute):
+        parts.insert(0, cur.attr)
+        cur = cur.value
+    if isinstance(cur, ast.Name):
+        parts.insert(0, cur.id)
+    fq = ".".join(parts)
+    if fq in _SSH_PY_CONNECT_FQ or fq.endswith(".Connection"):
+        return bool(ssh_imports)
+    if isinstance(func, ast.Attribute) and func.attr == "Connection":
+        return bool(ssh_imports)
+    if isinstance(func, ast.Name) and func.id == "Connection":
+        return "fabric" in ssh_imports
+    if fq.endswith(".connect") and fq.split(".", 1)[0] in ssh_imports:
+        return True
+    return False
+
+
+def extract_ssh_hosts_from_python(code: str) -> tuple[set[str], bool, bool]:
+    """Return (literal_hosts, dynamic_target, uses_ssh_library)."""
+    if not code or not code.strip():
+        return set(), False, False
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return set(), True, bool(re.search(r"\b(?:paramiko|asyncssh|fabric)\b", code))
+    ssh_imports = _ssh_imports_in_tree(tree)
+    hosts: set[str] = set()
+    dynamic = False
+    uses_ssh = bool(ssh_imports)
+
+    class _Visitor(ast.NodeVisitor):
+        def visit_Call(self, node: ast.Call) -> None:
+            nonlocal dynamic, uses_ssh
+            is_ssh = _call_is_ssh_client_connect(node.func, ssh_imports) or _call_is_ssh_factory(
+                node.func, ssh_imports
+            )
+            if not is_ssh:
+                self.generic_visit(node)
+                return
+            uses_ssh = True
+            host_lit: Optional[str] = None
+            if node.args:
+                host_lit = _literal_host_from_ast(node.args[0])
+            if host_lit is None:
+                for kw in node.keywords or []:
+                    if kw.arg in {"hostname", "host"}:
+                        host_lit = _literal_host_from_ast(kw.value)
+                        break
+            if host_lit:
+                hosts.add(host_lit)
+            else:
+                dynamic = True
+            self.generic_visit(node)
+
+    _Visitor().visit(tree)
+    return hosts, dynamic, uses_ssh
+
+
+def _unapproved(hosts: Iterable[str], session_id: Optional[str]) -> set[str]:
+    return {h for h in hosts if h and not is_host_approved(session_id, h)}
+
+
+def check_ssh_command_access(command: str, session_id: Optional[str]) -> Optional[str]:
+    """Return an error message when SSH is not allowed, else None."""
+    hosts, dynamic = extract_ssh_hosts_from_command(command)
+    if not hosts and not dynamic:
+        return None
+    unapproved = _unapproved(hosts, session_id)
+    if dynamic and not hosts:
+        return (
+            "Blocked: SSH command requires a literal, approved target server. "
+            "Approve the server when prompted before connecting."
+        )
+    if unapproved:
+        listed = ", ".join(sorted(unapproved))
+        return (
+            f"Blocked: SSH access to unapproved server(s): {listed}. "
+            "Approve the server when prompted to allow deployment workflows."
+        )
+    if dynamic and unapproved:
+        return (
+            "Blocked: SSH command includes a non-literal host that is not approved. "
+            "Use a literal hostname for an approved server."
+        )
+    if dynamic:
+        # Literal host approved, but other parts are dynamic: allow.
+        return None
+    return None
+
+
+def check_ssh_python_access(code: str, session_id: Optional[str]) -> Optional[str]:
+    """Return an error message when python SSH usage is not allowed, else None."""
+    hosts, dynamic, uses_ssh = extract_ssh_hosts_from_python(code)
+    if not uses_ssh and not hosts and not dynamic:
+        return None
+    if uses_ssh and not hosts and dynamic:
+        return (
+            "Blocked: SSH library usage with a non-literal host requires approving "
+            "the target server first."
+        )
+    if uses_ssh and not hosts and not dynamic:
+        return None
+    unapproved = _unapproved(hosts, session_id)
+    if unapproved:
+        listed = ", ".join(sorted(unapproved))
+        return (
+            f"Blocked: SSH library access to unapproved server(s): {listed}. "
+            "Approve the server when prompted to allow deployment workflows."
+        )
+    if dynamic:
+        return (
+            "Blocked: SSH library usage with a non-literal host requires approving "
+            "the target server first."
+        )
+    return None
+
+
+def collect_ssh_hosts_for_approval(name: str, arguments: dict) -> set[str]:
+    """Hosts to auto-approve when the user allows a gated tool call."""
+    if name == "terminal":
+        hosts, _dynamic = extract_ssh_hosts_from_command(str(arguments.get("command", "")))
+        return hosts
+    if name == "python":
+        hosts, _dynamic, _uses = extract_ssh_hosts_from_python(str(arguments.get("code", "")))
+        return hosts
+    return set()
+
+
+def list_approved_ssh_hosts(session_id: Optional[str]) -> list[str]:
+    return sorted(approved_hosts(session_id))
+
+
+def filter_ssh_approved_network_blocks(
+    code: str, session_id: Optional[str], analysis_info: dict
+) -> dict:
+    """Drop informational-host blocks for SSH targets the session already approved."""
+    hosts, dynamic, uses_ssh = extract_ssh_hosts_from_python(code)
+    if not uses_ssh or dynamic or not hosts:
+        return analysis_info
+    if not all(is_host_approved(session_id, host) for host in hosts):
+        return analysis_info
+    filtered = dict(analysis_info)
+    filtered["network_calls"] = [
+        item
+        for item in analysis_info.get("network_calls", [])
+        if item.get("type") != "untrusted_host_blocked"
+    ]
+    return filtered

--- a/studio/backend/core/inference/ssh_policy.py
+++ b/studio/backend/core/inference/ssh_policy.py
@@ -100,7 +100,9 @@ def _hosts_from_ssh_segment(name: str, rest: str) -> tuple[set[str], bool]:
             candidates = [host_tokens[0]]
     else:
         # scp/sftp: remote target is usually the last user@host[:path] token
-        candidates = [t for t in host_tokens if "@" in t or (":" in t and "@" in t.split(":", 1)[0])]
+        candidates = [
+            t for t in host_tokens if "@" in t or (":" in t and "@" in t.split(":", 1)[0])
+        ]
         if not candidates and host_tokens:
             candidates = [host_tokens[-1]]
     if not candidates:

--- a/studio/backend/core/inference/studio_tool_loop.py
+++ b/studio/backend/core/inference/studio_tool_loop.py
@@ -78,7 +78,9 @@ from core.inference.tool_stream_exec import (
     search_images_kwargs,
     stream_tool_execution,
 )
+from core.inference.ssh_policy import collect_ssh_hosts_for_approval
 from core.inference.tools import build_rag_autoinject, execute_tool, is_high_risk_tool_call
+from state.ssh_approvals import approve_hosts
 from state.tool_approvals import (
     TOOL_REJECTED_MESSAGE,
     abort_tool_decision,
@@ -1723,6 +1725,9 @@ async def stream_with_studio_tools(
                 if verdict == "deny":
                     decision_slot = None
                     denied = True
+                elif verdict == "allow":
+                    approve_hosts(session_id, collect_ssh_hosts_for_approval(name, arguments))
+                    yield _status_sse(decision.status_text)
                 elif verdict is not None:
                     yield _status_sse(decision.status_text)
                 if not denied:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -63,6 +63,11 @@ import time
 import urllib.parse
 import urllib.request
 
+from core.inference.ssh_policy import (
+    check_ssh_command_access,
+    check_ssh_python_access,
+    filter_ssh_approved_network_blocks,
+)
 from core.inference.mcp_client import (
     MCP_TOOL_PREFIX,
     TOOL_CACHE_INVALIDATING_FIELDS,
@@ -170,10 +175,8 @@ _BLOCKED_COMMANDS_COMMON = frozenset(
         "ncat",
         "netcat",
         "socat",
-        "ssh",
-        "slogin",
-        "scp",
-        "sftp",
+        # ssh/slogin/scp/sftp are gated by ssh_policy (approved-server allowlist)
+        # instead of this unconditional blocklist so users can deploy after approval.
         "rsync",
         "eval",
         "source",
@@ -14424,12 +14427,27 @@ def _check_signal_escape_patterns(code: str):
     }
 
 
-def _check_code_safety(code: str) -> str | None:
+def _check_code_safety(code: str, session_id: str | None = None) -> str | None:
     """Validate code safety via static analysis.
 
     Returns an error message string if the code is unsafe, or None if OK.
     """
+    ssh_error = check_ssh_python_access(code, session_id)
+    if ssh_error:
+        return (
+            f"Error: unsafe code detected ({ssh_error}). "
+            "Please remove unsafe patterns from your code."
+        )
+
     safe, info = _check_signal_escape_patterns(code)
+    info = filter_ssh_approved_network_blocks(code, session_id, info)
+    safe = (
+        len(info.get("signal_tampering", [])) == 0
+        and len(info.get("exception_catching", [])) == 0
+        and len(info.get("shell_escapes", [])) == 0
+        and len(info.get("network_calls", [])) == 0
+        and len(info.get("sensitive_file_reads", [])) == 0
+    )
     if not safe:
         # Let SyntaxError from ast.parse through so the subprocess produces a
         # normal Python traceback instead of a misleading "unsafe code" message.
@@ -16156,7 +16174,7 @@ def _python_exec(
 
     # Validate imports and code safety (skipped when the sandbox is disabled)
     if not disable_sandbox:
-        error = _check_code_safety(code)
+        error = _check_code_safety(code, session_id = session_id)
         if error:
             # Capped like any other result: the analyzer names every occurrence it
             # found, so code that repeats a forbidden construct enough times reports
@@ -16335,6 +16353,9 @@ def _bash_exec(
             # Capped for the same reason the Python analyzer's error is: it lists what
             # it found in the command it was handed.
             return _truncate(f"Blocked command(s) for safety: {', '.join(sorted(blocked))}")
+        ssh_error = check_ssh_command_access(command, session_id)
+        if ssh_error:
+            return _truncate(ssh_error)
         # Stripping the child env is not enough: a same-UID child can read
         # /proc/<getppid()>/environ to recover the unfiltered secrets, so close
         # that read here too, not only in bypass mode. Best-effort: the child env

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -9113,6 +9113,9 @@ def sandbox_removal_deferred(session_id: str) -> bool:
 
 
 def _remove_session_sandbox_locked(session_id: str, delete_files: bool) -> bool:
+    from state.ssh_approvals import clear_session
+
+    clear_session(session_id)
     root = os.path.realpath(sandbox_root())
     claimed = _claimed_by_this_run(session_id, root)
     entry = os.path.join(root, _sandbox_name(session_id))

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -202,6 +202,10 @@ _BLOCKED_COMMANDS = (
     else _BLOCKED_COMMANDS_COMMON
 )
 
+# ssh/slogin/scp/sftp are gated by ssh_policy (approved-server allowlist) instead
+# of the unconditional blocklist, but still scanned at command position.
+_SSH_GATED_COMMANDS = frozenset({"ssh", "slogin", "scp", "sftp"})
+
 
 _SHELL_SEPARATORS = frozenset({";", "&&", "||", "|", "&", "\n", "(", ")", "`", "{", "}"})
 # Bash keywords starting a new command position (then $cmd, do $cmd, etc.).
@@ -1434,6 +1438,142 @@ def _is_start_title(token: str) -> bool:
         or any(char.isspace() for char in token)
         or (len(token) >= 2 and token[0] == '"' and token[-1] == '"')
     )
+
+
+def _find_ssh_command_segments(command: str, _depth: int = 0) -> "list[tuple[str, list[str]]]":
+    """Return ``(cmd_name, arg_tokens)`` for each ssh/scp/sftp/slogin at command position.
+
+    Uses the same ANSI-C decode and shlex tokenization as ``_find_blocked_commands``.
+    """
+    if not command or not command.strip() or _depth > 8:
+        return []
+    segments: "list[tuple[str, list[str]]]" = []
+
+    decoded = _decode_ansi_c(command, keep_one_word = True)
+    lexed_posix = _shell_is_posix()
+    try:
+        if not lexed_posix:
+            tokens = shlex.split(decoded, posix = False)
+        else:
+            lexer = shlex.shlex(decoded, posix = True, punctuation_chars = ";&|()`")
+            lexer.whitespace_split = True
+            tokens = list(lexer)
+    except ValueError:
+        tokens = decoded.split()
+        lexed_posix = False
+    quoted_separators = (
+        _quoted_separator_indexes(decoded, tokens, ";&|()`") if lexed_posix else frozenset()
+    )
+    quoted_redirects = (
+        _quoted_redirection_indexes(decoded, tokens, ";&|()`") if lexed_posix else frozenset()
+    )
+    _exec_flag_indexes, _invocation_stops, redirect_indexes = _exec_scan_layout(
+        tokens, quoted_separators, quoted_redirects
+    )
+
+    def _token_basename(tok: str) -> str:
+        tok = tok.strip(";&|()`{}")
+        base = os.path.basename(tok).lower()
+        stem, ext = os.path.splitext(base)
+        if ext in {".exe", ".com", ".bat", ".cmd"}:
+            base = stem
+        return base
+
+    expect_command = True
+    prefix_pending = False
+    prefix_command = ""
+    skip_operand = False
+    for token_index, token in enumerate(tokens):
+        if skip_operand:
+            skip_operand = False
+            continue
+        if expect_command and token.lower() in _WIN_CONDITIONAL_KEYWORDS:
+            skip_operand = token.lower() != "not"
+            continue
+        if prefix_pending and token == "-a":
+            skip_operand = True
+            continue
+        if token_index in redirect_indexes:
+            continue
+        if (_looks_like_separator(token) and token_index not in quoted_separators) or (
+            token in _SHELL_KEYWORDS_AS_SEP and expect_command
+        ):
+            expect_command = True
+            prefix_pending = False
+            prefix_command = ""
+            continue
+        if token.startswith("-"):
+            if prefix_pending and token in _WRAPPER_VALUE_FLAGS_BY_CMD.get(
+                prefix_command, frozenset()
+            ):
+                skip_operand = True
+                continue
+            if not prefix_pending:
+                expect_command = False
+            continue
+        if not expect_command:
+            continue
+        if _REDIR_PREFIX_RE.match(token):
+            continue
+        if _ASSIGNMENT_RE.match(token):
+            continue
+        if prefix_pending and token.lstrip("-").isdigit():
+            continue
+        base = _token_basename(token)
+        if base in _SSH_GATED_COMMANDS:
+            arg_tokens: "list[str]" = []
+            j = token_index + 1
+            while j < len(tokens):
+                if j in redirect_indexes:
+                    j += 1
+                    continue
+                nxt = tokens[j]
+                if (_looks_like_separator(nxt) and j not in quoted_separators) or (
+                    nxt in _SHELL_KEYWORDS_AS_SEP
+                ):
+                    break
+                arg_tokens.append(nxt)
+                j += 1
+            segments.append((base, arg_tokens))
+            expect_command = False
+            prefix_pending = False
+            prefix_command = ""
+            continue
+        if base in _COMMAND_PREFIXES:
+            prefix_pending = True
+            prefix_command = base
+            continue
+        expect_command = False
+        prefix_pending = False
+        prefix_command = ""
+
+    _SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "csh", "tcsh", "fish"}
+    _SHELLS_WIN = {"cmd", "cmd.exe"}
+    for i, token in enumerate(tokens):
+        tok_lower = token.lower()
+        is_unix_c = tok_lower == "-c" or (
+            tok_lower.startswith("-") and tok_lower.endswith("c") and not tok_lower.startswith("--")
+        )
+        is_win_c = _win_switch(tok_lower) in ("/c", "/k")
+        if not (is_unix_c or is_win_c) or i < 1 or i + 1 >= len(tokens):
+            continue
+        for j in range(i - 1, -1, -1):
+            prev = tokens[j]
+            if prev.startswith("-"):
+                continue
+            if is_win_c and _CMD_SWITCH_RE.fullmatch(_win_switch(prev)):
+                continue
+            prev_base = os.path.basename(prev).lower()
+            if is_unix_c and prev_base in _SHELLS:
+                segments.extend(_find_ssh_command_segments(tokens[i + 1], _depth + 1))
+            elif is_win_c and prev_base in _SHELLS_WIN:
+                payload = tokens[i + 1]
+                if len(payload) > 1 and payload[0] == '"' and payload[-1] == '"':
+                    payload = payload[1:-1]
+                segments.extend(_find_ssh_command_segments(payload, _depth + 1))
+            break
+
+    return segments
 
 
 def _find_blocked_commands(command: str) -> set[str]:

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -2745,6 +2745,15 @@ class ToolConfirmRequest(BaseModel):
     decision: Literal["allow", "deny"] = "deny"
 
 
+class SshApproveRequest(BaseModel):
+    session_id: Optional[str] = None
+    hosts: list[str] = Field(default_factory = list)
+
+
+class SshApprovedHostsResponse(BaseModel):
+    hosts: list[str] = Field(default_factory = list)
+
+
 # ── OpenAI shell-tool container management ─────────────────────
 
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -16737,7 +16737,6 @@ async def list_ssh_approved_hosts(
     session_id: str | None = None, current_subject: str = Depends(get_current_subject)
 ):
     from core.inference.ssh_policy import list_approved_ssh_hosts
-
     return SshApprovedHostsResponse(hosts = list_approved_ssh_hosts(session_id))
 
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3039,6 +3039,8 @@ from models.inference import (
     ChatCompletionChunk,
     ChatCompletion,
     ToolConfirmRequest,
+    SshApproveRequest,
+    SshApprovedHostsResponse,
     ChatMessage,
     ChunkChoice,
     ChoiceDelta,
@@ -16716,6 +16718,27 @@ async def confirm_tool_call(
     if not matched:
         raise HTTPException(status_code = 404, detail = "No pending tool call confirmation")
     return {"resolved": True}
+
+
+@studio_router.post("/ssh-approve", response_model = SshApprovedHostsResponse)
+async def approve_ssh_hosts(
+    request: SshApproveRequest, current_subject: str = Depends(get_current_subject)
+):
+    """Explicitly approve SSH deployment targets for a sandbox session."""
+    from core.inference.ssh_policy import list_approved_ssh_hosts
+    from state.ssh_approvals import approve_hosts
+
+    approve_hosts(request.session_id, request.hosts)
+    return SshApprovedHostsResponse(hosts = list_approved_ssh_hosts(request.session_id))
+
+
+@studio_router.get("/ssh-approved", response_model = SshApprovedHostsResponse)
+async def list_ssh_approved_hosts(
+    session_id: str | None = None, current_subject: str = Depends(get_current_subject)
+):
+    from core.inference.ssh_policy import list_approved_ssh_hosts
+
+    return SshApprovedHostsResponse(hosts = list_approved_ssh_hosts(session_id))
 
 
 @studio_router.get("/monitor")

--- a/studio/backend/state/ssh_approvals.py
+++ b/studio/backend/state/ssh_approvals.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Per-session approved SSH deployment targets.
+
+When a user confirms a tool call that reaches an SSH server, the target host is
+recorded here so later terminal and python invocations can connect consistently.
+"""
+
+import threading
+from typing import Iterable, Optional
+
+_lock = threading.Lock()
+# session_id -> normalized host literals approved for that sandbox session
+_approved: dict[str, set[str]] = {}
+
+
+def normalize_host(host: str) -> str:
+    """Normalize a host literal for set membership."""
+    h = (host or "").strip().lower().rstrip(".")
+    if h.startswith("[") and "]" in h:
+        h = h[1 : h.index("]")]
+    return h
+
+
+def approve_hosts(session_id: Optional[str], hosts: Iterable[str]) -> None:
+    """Record one or more approved SSH targets for a sandbox session."""
+    if not session_id:
+        return
+    normalized = {normalize_host(h) for h in hosts if h and normalize_host(h)}
+    if not normalized:
+        return
+    with _lock:
+        bucket = _approved.setdefault(session_id, set())
+        bucket.update(normalized)
+
+
+def is_host_approved(session_id: Optional[str], host: str) -> bool:
+    if not session_id:
+        return False
+    key = normalize_host(host)
+    if not key:
+        return False
+    with _lock:
+        return key in _approved.get(session_id, set())
+
+
+def approved_hosts(session_id: Optional[str]) -> frozenset[str]:
+    if not session_id:
+        return frozenset()
+    with _lock:
+        return frozenset(_approved.get(session_id, set()))
+
+
+def clear_session(session_id: Optional[str]) -> None:
+    if not session_id:
+        return
+    with _lock:
+        _approved.pop(session_id, None)
+
+
+def reset_ssh_approvals() -> None:
+    """Test helper: drop every recorded approval."""
+    with _lock:
+        _approved.clear()

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -1609,7 +1609,6 @@ class TestBashBlocklistPosition:
     # ---- ANSI-C quoting must not hide a blocked command name ----
     def test_ansi_c_quoted_command_blocked(self):
         from core.inference.ssh_policy import check_ssh_command_access
-
         assert check_ssh_command_access("$'ssh' user@host", "sess-1") is not None
         assert "source" in self._find()("$'source' ./payload")
 

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -1607,6 +1607,11 @@ class TestBashBlocklistPosition:
         assert self._find()("cd .") == set()
 
     # ---- ANSI-C quoting must not hide a blocked command name ----
+    def test_ansi_c_quoted_command_blocked(self):
+        from core.inference.ssh_policy import check_ssh_command_access
+
+        assert check_ssh_command_access("$'ssh' user@host", "sess-1") is not None
+        assert "source" in self._find()("$'source' ./payload")
 
     def test_ansi_c_data_with_newline_is_not_a_command(self):
         # $'...' expands to a single word, so a newline inside it is data for

--- a/studio/backend/tests/test_ssh_policy.py
+++ b/studio/backend/tests/test_ssh_policy.py
@@ -20,7 +20,12 @@ from core.inference.ssh_policy import (
     extract_ssh_hosts_from_python,
     filter_ssh_approved_network_blocks,
 )
-from core.inference.tools import _bash_exec, _check_code_safety, _check_signal_escape_patterns, _find_blocked_commands
+from core.inference.tools import (
+    _bash_exec,
+    _check_code_safety,
+    _check_signal_escape_patterns,
+    _find_blocked_commands,
+)
 from state.ssh_approvals import approve_hosts, approved_hosts, clear_session, reset_ssh_approvals
 
 

--- a/studio/backend/tests/test_ssh_policy.py
+++ b/studio/backend/tests/test_ssh_policy.py
@@ -18,9 +18,10 @@ from core.inference.ssh_policy import (
     collect_ssh_hosts_for_approval,
     extract_ssh_hosts_from_command,
     extract_ssh_hosts_from_python,
+    filter_ssh_approved_network_blocks,
 )
-from core.inference.tools import _bash_exec, _check_code_safety, _find_blocked_commands
-from state.ssh_approvals import approve_hosts, reset_ssh_approvals
+from core.inference.tools import _bash_exec, _check_code_safety, _check_signal_escape_patterns, _find_blocked_commands
+from state.ssh_approvals import approve_hosts, approved_hosts, clear_session, reset_ssh_approvals
 
 
 @pytest.fixture(autouse = True)
@@ -43,6 +44,11 @@ class TestSshCommandExtraction:
         assert hosts == {"prod.example.com"}
         assert dynamic is False
 
+    def test_scp_host_colon_path_without_at(self):
+        hosts, dynamic = extract_ssh_hosts_from_command("scp host.example:/tmp/file local.txt")
+        assert hosts == {"host.example"}
+        assert dynamic is False
+
     def test_dynamic_host_fails_closed(self):
         hosts, dynamic = extract_ssh_hosts_from_command("ssh $DEPLOY_HOST")
         assert hosts == set()
@@ -55,6 +61,38 @@ class TestSshCommandExtraction:
         err = check_ssh_command_access("$'ssh' deploy@prod.example.com", "sess-1")
         assert err is not None
         assert "unapproved" in err
+
+    def test_wrapped_ssh_command(self):
+        hosts, dynamic = extract_ssh_hosts_from_command("env ssh deploy@prod.example.com uptime")
+        assert hosts == {"prod.example.com"}
+        assert dynamic is False
+
+    def test_ssh_verbose_flag_keeps_hostname(self):
+        hosts, dynamic = extract_ssh_hosts_from_command("ssh -v prod.example.com uptime")
+        assert hosts == {"prod.example.com"}
+        assert dynamic is False
+
+    def test_ssh_hostname_option_redirect(self):
+        hosts, dynamic = extract_ssh_hosts_from_command(
+            "ssh -o HostName=evil.example target.example"
+        )
+        assert "evil.example" in hosts
+        assert "target.example" in hosts
+
+    def test_ssh_proxyjump_option(self):
+        hosts, dynamic = extract_ssh_hosts_from_command("ssh -J jump.example target.example")
+        assert hosts == {"jump.example", "target.example"}
+        assert dynamic is False
+
+    def test_ipv6_bracketed_host(self):
+        hosts, dynamic = extract_ssh_hosts_from_command("ssh deploy@[2001:db8::1]")
+        assert hosts == {"2001:db8::1"}
+        assert dynamic is False
+
+    def test_ipv6_hosts_stay_distinct(self):
+        hosts_a, _ = extract_ssh_hosts_from_command("ssh user@[2001:db8::1]")
+        hosts_b, _ = extract_ssh_hosts_from_command("ssh user@[2001:dead::beef]")
+        assert hosts_a != hosts_b
 
 
 class TestSshPythonExtraction:
@@ -77,6 +115,37 @@ class TestSshPythonExtraction:
         hosts, dynamic, uses = extract_ssh_hosts_from_python(code)
         assert hosts == {"prod.example.com"}
         assert dynamic is False
+        assert uses is True
+
+    def test_asyncssh_direct_import_connect(self):
+        code = "from asyncssh import connect; connect('evil.example')"
+        hosts, dynamic, uses = extract_ssh_hosts_from_python(code)
+        assert hosts == {"evil.example"}
+        assert dynamic is False
+        assert uses is True
+        err = check_ssh_python_access(code, "sess-1")
+        assert err is not None
+        assert "unapproved" in err
+
+    def test_sqlite_connect_not_treated_as_ssh(self):
+        code = "import paramiko, sqlite3; sqlite3.connect('state.db')"
+        hosts, dynamic, uses = extract_ssh_hosts_from_python(code)
+        assert hosts == set()
+        assert dynamic is False
+        assert uses is False
+        assert check_ssh_python_access(code, "sess-1") is None
+
+    def test_subprocess_run_ssh(self):
+        code = "import subprocess; subprocess.run(['ssh', 'evil.example', 'uptime'])"
+        hosts, dynamic, uses = extract_ssh_hosts_from_python(code)
+        assert hosts == {"evil.example"}
+        assert dynamic is False
+        assert uses is True
+
+    def test_os_system_ssh(self):
+        code = "import os; os.system('ssh evil.example uptime')"
+        hosts, dynamic, uses = extract_ssh_hosts_from_python(code)
+        assert hosts == {"evil.example"}
         assert uses is True
 
 
@@ -134,6 +203,12 @@ class TestExecutionIntegration:
         approve_hosts("sess-1", ["prod.example.com"])
         assert _check_code_safety(code, session_id = "sess-1") is None
 
+    def test_python_exec_blocks_subprocess_ssh(self):
+        code = "import subprocess; subprocess.run(['ssh', 'evil.example', 'uptime'])"
+        err = _check_code_safety(code, session_id = "sess-1")
+        assert err is not None
+        assert "unapproved" in err
+
 
 class TestCollectHostsForApproval:
     def test_terminal_tool(self):
@@ -149,3 +224,25 @@ class TestCollectHostsForApproval:
             {"code": "import paramiko; paramiko.SSHClient().connect('prod.example.com')"},
         )
         assert hosts == {"prod.example.com"}
+
+
+class TestNetworkBlockFiltering:
+    def test_only_ssh_line_blocks_are_removed(self):
+        code = (
+            "import paramiko, requests\n"
+            "paramiko.SSHClient().connect('approved.example')\n"
+            "requests.get('http://evil.example')\n"
+        )
+        approve_hosts("sess-1", ["approved.example"])
+        safe, info = _check_signal_escape_patterns(code)
+        assert any(item["type"] == "untrusted_host_blocked" for item in info["network_calls"])
+        filtered = filter_ssh_approved_network_blocks(code, "sess-1", info)
+        assert any(item["type"] == "untrusted_host_blocked" for item in filtered["network_calls"])
+
+
+class TestSessionCleanup:
+    def test_clear_session_drops_approvals(self):
+        approve_hosts("sess-1", ["prod.example.com"])
+        assert "prod.example.com" in approved_hosts("sess-1")
+        clear_session("sess-1")
+        assert approved_hosts("sess-1") == frozenset()

--- a/studio/backend/tests/test_ssh_policy.py
+++ b/studio/backend/tests/test_ssh_policy.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""SSH approval policy for sandboxed terminal and python tools (#10397)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+from core.inference.ssh_policy import (
+    check_ssh_command_access,
+    check_ssh_python_access,
+    collect_ssh_hosts_for_approval,
+    extract_ssh_hosts_from_command,
+    extract_ssh_hosts_from_python,
+)
+from core.inference.tools import _bash_exec, _check_code_safety, _find_blocked_commands
+from state.ssh_approvals import approve_hosts, reset_ssh_approvals
+
+
+@pytest.fixture(autouse = True)
+def _clear_ssh_approvals():
+    reset_ssh_approvals()
+    yield
+    reset_ssh_approvals()
+
+
+class TestSshCommandExtraction:
+    def test_ssh_user_at_host(self):
+        hosts, dynamic = extract_ssh_hosts_from_command("ssh deploy@prod.example.com uptime")
+        assert hosts == {"prod.example.com"}
+        assert dynamic is False
+
+    def test_scp_remote_target(self):
+        hosts, dynamic = extract_ssh_hosts_from_command(
+            "scp ./app.tar deploy@prod.example.com:/tmp/"
+        )
+        assert hosts == {"prod.example.com"}
+        assert dynamic is False
+
+    def test_dynamic_host_fails_closed(self):
+        hosts, dynamic = extract_ssh_hosts_from_command("ssh $DEPLOY_HOST")
+        assert hosts == set()
+        assert dynamic is True
+
+
+class TestSshPythonExtraction:
+    def test_paramiko_literal_host(self):
+        code = "import paramiko; c=paramiko.SSHClient(); c.connect('prod.example.com', 22)"
+        hosts, dynamic, uses = extract_ssh_hosts_from_python(code)
+        assert hosts == {"prod.example.com"}
+        assert dynamic is False
+        assert uses is True
+
+    def test_paramiko_dynamic_host(self):
+        code = "import paramiko; c=paramiko.SSHClient(); c.connect(hostname, 22)"
+        hosts, dynamic, uses = extract_ssh_hosts_from_python(code)
+        assert hosts == set()
+        assert dynamic is True
+        assert uses is True
+
+    def test_fabric_connection(self):
+        code = "from fabric import Connection; Connection('prod.example.com').run('ls')"
+        hosts, dynamic, uses = extract_ssh_hosts_from_python(code)
+        assert hosts == {"prod.example.com"}
+        assert dynamic is False
+        assert uses is True
+
+
+class TestSshAccessGating:
+    def test_ssh_command_blocked_without_approval(self):
+        err = check_ssh_command_access("ssh deploy@prod.example.com", "sess-1")
+        assert err is not None
+        assert "unapproved" in err
+
+    def test_ssh_command_allowed_after_approval(self):
+        approve_hosts("sess-1", ["prod.example.com"])
+        assert check_ssh_command_access("ssh deploy@prod.example.com", "sess-1") is None
+
+    def test_paramiko_blocked_without_approval(self):
+        code = "import paramiko; c=paramiko.SSHClient(); c.connect('prod.example.com', 22)"
+        err = check_ssh_python_access(code, "sess-1")
+        assert err is not None
+        assert "unapproved" in err
+
+    def test_paramiko_allowed_after_approval(self):
+        code = "import paramiko; c=paramiko.SSHClient(); c.connect('prod.example.com', 22)"
+        approve_hosts("sess-1", ["prod.example.com"])
+        assert check_ssh_python_access(code, "sess-1") is None
+
+    def test_dynamic_paramiko_blocked_even_after_other_approval(self):
+        approve_hosts("sess-1", ["other.example.com"])
+        code = "import paramiko; c=paramiko.SSHClient(); c.connect(hostname, 22)"
+        err = check_ssh_python_access(code, "sess-1")
+        assert err is not None
+        assert "non-literal" in err
+
+
+class TestExecutionIntegration:
+    def test_ssh_not_in_hard_blocklist(self):
+        assert "ssh" not in _find_blocked_commands("ssh user@prod.example.com")
+
+    def test_bash_exec_blocks_unapproved_ssh(self):
+        result = _bash_exec("ssh deploy@prod.example.com echo hi", session_id = "sess-1")
+        assert "unapproved" in result.lower()
+
+    def test_bash_exec_allows_approved_ssh(self):
+        approve_hosts("sess-1", ["prod.example.com"])
+        result = _bash_exec("ssh deploy@prod.example.com echo hi", session_id = "sess-1")
+        assert "Blocked command(s)" not in result
+        assert "unapproved" not in result.lower()
+
+    def test_python_exec_blocks_unapproved_paramiko(self):
+        code = "import paramiko; c=paramiko.SSHClient(); c.connect('prod.example.com', 22)"
+        err = _check_code_safety(code, session_id = "sess-1")
+        assert err is not None
+        assert "unapproved" in err
+
+    def test_python_exec_allows_approved_paramiko(self):
+        code = "import paramiko; c=paramiko.SSHClient(); c.connect('prod.example.com', 22)"
+        approve_hosts("sess-1", ["prod.example.com"])
+        assert _check_code_safety(code, session_id = "sess-1") is None
+
+
+class TestCollectHostsForApproval:
+    def test_terminal_tool(self):
+        hosts = collect_ssh_hosts_for_approval(
+            "terminal",
+            {"command": "ssh deploy@prod.example.com"},
+        )
+        assert hosts == {"prod.example.com"}
+
+    def test_python_tool(self):
+        hosts = collect_ssh_hosts_for_approval(
+            "python",
+            {"code": "import paramiko; paramiko.SSHClient().connect('prod.example.com')"},
+        )
+        assert hosts == {"prod.example.com"}

--- a/studio/backend/tests/test_ssh_policy.py
+++ b/studio/backend/tests/test_ssh_policy.py
@@ -48,6 +48,14 @@ class TestSshCommandExtraction:
         assert hosts == set()
         assert dynamic is True
 
+    def test_ansi_c_quoted_ssh_command(self):
+        hosts, dynamic = extract_ssh_hosts_from_command("$'ssh' deploy@prod.example.com")
+        assert hosts == {"prod.example.com"}
+        assert dynamic is False
+        err = check_ssh_command_access("$'ssh' deploy@prod.example.com", "sess-1")
+        assert err is not None
+        assert "unapproved" in err
+
 
 class TestSshPythonExtraction:
     def test_paramiko_literal_host(self):


### PR DESCRIPTION
## Summary

Fixes #10397 by making SSH restrictions consistent across terminal commands and Python libraries, while allowing users to explicitly approve deployment targets.

Previously, Unsloth **hard-blocked** `ssh` / `scp` / `sftp` at execution time (even after the user approved the tool call), but Python SSH libraries such as **paramiko**, **asyncssh**, and **fabric** could bypass the same policy—especially with dynamic hostnames.

This PR gates **both** paths behind a per-session **approved-server allowlist**.

## Problem

- `ssh user@host` was always rejected at runtime (`Blocked command(s) for safety: ssh`)
- `paramiko.SSHClient().connect(hostname)` with a variable host could slip through static analysis
- No way to approve a specific server for deployment workflows after reviewing the tool call

## Solution

### Consistent blocking

- Remove `ssh` / `slogin` / `scp` / `sftp` from the unconditional hard blocklist
- Apply the same approved-host policy to:
  - Terminal: `ssh`, `scp`, `sftp`
  - Python: `paramiko`, `asyncssh`, `fabric` connect/connection patterns
- Fail closed on **dynamic** hosts (`ssh $HOST`, `connect(hostname)`) until a literal host is approved

### Approved-server workflow

1. Model proposes `ssh deploy@prod.example.com ./deploy.sh` (or equivalent paramiko code)
2. User is prompted in ask/auto permission mode
3. On **Allow**, the target host is recorded for the sandbox session
4. The command runs; subsequent SSH usage to that host is allowed for the session

### API

- `POST /api/inference/ssh-approve` — explicitly approve host(s) for a session
- `GET /api/inference/ssh-approved` — list approved hosts for a session

## Key files

| File | Change |
|------|--------|
| `studio/backend/core/inference/ssh_policy.py` | Host extraction + access checks |
| `studio/backend/state/ssh_approvals.py` | Per-session approved host store |
| `studio/backend/core/inference/tools.py` | Integrate policy into `_bash_exec`, `_python_exec`, `_check_code_safety` |
| `studio/backend/core/inference/studio_tool_loop.py` | Auto-approve hosts when user allows a gated call |
| `studio/backend/tests/test_ssh_policy.py` | 18 tests covering extraction, gating, and execution |


## Follow-ups (out of scope)

- Frontend copy showing which server is being approved (e.g. "Allow SSH to prod.example.com")
- Persist approved hosts across sessions / settings UI
