### PR TITLE
fix(studio): keep distinct symlink aliases for per-model settings

### DIFF
--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -596,10 +596,7 @@ def _local_model_path_is_symlink(raw_path: str) -> bool:
         return False
 
 
-def _prefer_local_inventory_row(
-    candidate: LocalModelInfo,
-    existing: LocalModelInfo,
-) -> bool:
+def _prefer_local_inventory_row(candidate: LocalModelInfo, existing: LocalModelInfo) -> bool:
     """True when *candidate* should replace *existing* for one physical model."""
     if candidate.partial != existing.partial:
         return not candidate.partial
@@ -617,9 +614,7 @@ def _prefer_local_inventory_row(
     )
 
 
-def _dedupe_custom_local_models(
-    custom_models: List[LocalModelInfo],
-) -> list[LocalModelInfo]:
+def _dedupe_custom_local_models(custom_models: List[LocalModelInfo]) -> list[LocalModelInfo]:
     """Collapse scanner overlap without folding distinct symlink aliases.
 
     Multiple symlinks to the same on-disk model each appear as their own Hub row so
@@ -960,9 +955,7 @@ def _dedupe_local_models(local_models: List[LocalModelInfo]) -> list[LocalModelI
         if prefer_candidate:
             deduped[key] = model
 
-    deduped_values = list(deduped.values()) + _dedupe_custom_local_models(
-        custom_models
-    )
+    deduped_values = list(deduped.values()) + _dedupe_custom_local_models(custom_models)
     custom_values = [model for model in deduped_values if model.source == "custom"]
     return sorted(
         [model for model in deduped_values if model.source != "custom"]

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -589,6 +589,63 @@ def _inventory_physical_identity(raw_path: str) -> str:
     return gguf.local_path_physical_identity(raw_path)
 
 
+def _local_model_path_is_symlink(raw_path: str) -> bool:
+    try:
+        return Path(raw_path).is_symlink()
+    except OSError:
+        return False
+
+
+def _prefer_local_inventory_row(
+    candidate: LocalModelInfo,
+    existing: LocalModelInfo,
+) -> bool:
+    """True when *candidate* should replace *existing* for one physical model."""
+    if candidate.partial != existing.partial:
+        return not candidate.partial
+    if (candidate.active_cache is True) != (existing.active_cache is True):
+        return candidate.active_cache is True
+    candidate_link = _local_model_path_is_symlink(candidate.path)
+    existing_link = _local_model_path_is_symlink(existing.path)
+    if candidate_link != existing_link:
+        return not candidate_link
+    return _prefer_complete_larger(
+        candidate.partial,
+        candidate.size_bytes,
+        existing.partial,
+        existing.size_bytes,
+    )
+
+
+def _dedupe_custom_local_models(
+    custom_models: List[LocalModelInfo],
+) -> list[LocalModelInfo]:
+    """Collapse scanner overlap without folding distinct symlink aliases.
+
+    Multiple symlinks to the same on-disk model each appear as their own Hub row so
+    per-model settings can be remembered independently. A symlink plus the canonical
+    on-disk path still collapse to one row.
+    """
+    by_physical: dict[tuple[str, str], list[LocalModelInfo]] = {}
+    for model in custom_models:
+        physical = _inventory_physical_identity(model.path)
+        by_physical.setdefault((physical, model.model_format), []).append(model)
+
+    kept: list[LocalModelInfo] = []
+    for group in by_physical.values():
+        symlinks = [m for m in group if _local_model_path_is_symlink(m.path)]
+        non_symlinks = [m for m in group if not _local_model_path_is_symlink(m.path)]
+        if len(symlinks) >= 2 and not non_symlinks:
+            kept.extend(group)
+            continue
+        winner = group[0]
+        for candidate in group[1:]:
+            if _prefer_local_inventory_row(candidate, winner):
+                winner = candidate
+        kept.append(winner)
+    return kept
+
+
 def _coerce_scan_folder_path(raw_path: str) -> str:
     """Normalize a scan registration target; the registry stores directories, so a pasted weight-file path is reduced to its parent folder."""
     if not raw_path or not raw_path.strip():
@@ -869,7 +926,11 @@ async def _load_custom_folders() -> list[dict]:
 
 def _dedupe_local_models(local_models: List[LocalModelInfo]) -> list[LocalModelInfo]:
     deduped: dict[str, LocalModelInfo] = {}
+    custom_models: list[LocalModelInfo] = []
     for model in local_models:
+        if model.source == "custom":
+            custom_models.append(model)
+            continue
         if model.source == "hf_cache" and model.model_id:
             key = "\x00".join(
                 (
@@ -878,13 +939,6 @@ def _dedupe_local_models(local_models: List[LocalModelInfo]) -> list[LocalModelI
                     model.model_format,
                     model.format_variant or "",
                 )
-            )
-        elif model.source == "custom":
-            key = _local_inventory_id(
-                "custom",
-                model.model_format,
-                _inventory_physical_identity(model.path),
-                None,
             )
         else:
             row_key = model.inventory_id or model.id
@@ -906,7 +960,9 @@ def _dedupe_local_models(local_models: List[LocalModelInfo]) -> list[LocalModelI
         if prefer_candidate:
             deduped[key] = model
 
-    deduped_values = list(deduped.values())
+    deduped_values = list(deduped.values()) + _dedupe_custom_local_models(
+        custom_models
+    )
     custom_values = [model for model in deduped_values if model.source == "custom"]
     return sorted(
         [model for model in deduped_values if model.source != "custom"]

--- a/studio/backend/hub/tests/test_custom_gguf_discovery.py
+++ b/studio/backend/hub/tests/test_custom_gguf_discovery.py
@@ -632,6 +632,24 @@ def test_symlinked_model_directory_stays_grouped(tmp_path):
     assert [Path(row.path) for row in _custom_rows(root)] == [alias]
 
 
+def test_two_symlink_aliases_to_one_model_stay_distinct(tmp_path):
+    """Issue #10605: symlink aliases are separate Hub rows so each can remember settings."""
+    real_model = tmp_path / "outside" / "model"
+    _write_gguf(real_model / "model-Q4_K_M.gguf")
+    _write_gguf(real_model / "model-Q8_0.gguf")
+    root = tmp_path / "root"
+    root.mkdir()
+    alias_a = root / "alias-a"
+    alias_b = root / "alias-b"
+    _symlink_dir(alias_a, real_model)
+    _symlink_dir(alias_b, real_model)
+
+    rows = _custom_rows(root)
+
+    assert {Path(row.path) for row in rows} == {alias_a, alias_b}
+    assert {row.load_id for row in rows} == {str(alias_a), str(alias_b)}
+
+
 def test_physical_identity_preserves_native_posix_names(tmp_path):
     if os.sep == "\\":
         pytest.skip("names are not distinct on Windows")

--- a/studio/frontend/tests/model-identity.test.ts
+++ b/studio/frontend/tests/model-identity.test.ts
@@ -266,6 +266,26 @@ test("a POSIX path is case sensitive, so its two spellings stay separate", () =>
   );
 });
 
+test("symlink alias paths keep independent remembered settings", () => {
+  store.clear();
+  savePerModelConfig("/models/alias-a", "Q4_K_M", config(4096));
+  savePerModelConfig("/models/alias-b", "Q4_K_M", config(32768, "q8_0"));
+
+  assert.equal(storedKeys().length, 2);
+  assert.equal(
+    resolveInitialConfig("/models/alias-a", "Q4_K_M").config.maxSeqLength,
+    4096,
+  );
+  assert.equal(
+    resolveInitialConfig("/models/alias-b", "Q4_K_M").config.maxSeqLength,
+    32768,
+  );
+  assert.equal(
+    resolveInitialConfig("/models/alias-b", "Q4_K_M").config.kvCacheDtype,
+    "q8_0",
+  );
+});
+
 // Every answer below is the backend's split_quant_suffix. The backfill folds a stored key with
 // this before comparing, so a disagreement collapses two models onto one key.
 const CASES: [string, [string, string] | null][] = [


### PR DESCRIPTION
Fixes #10605

## Problem

When a local model in Unsloth Studio is reached through a symlink, per-model settings saved with "Remember for this model" did not reliably restore after reload. A common workaround — creating multiple symlinks to the same on-disk model so each Hub entry can carry its own settings — also failed because the inventory deduplicated symlink aliases by physical inode identity, leaving only one row.

## Solution

Custom-model dedup in `local_inventory.py` now keeps **one Hub row per symlink path** when several symlinks in a scan folder point at the same model. Settings stay keyed by the path shown in the UI (`load_id`), so each alias can remember independent load settings.

Existing collapse rules are preserved:

- Symlink + canonical on-disk path → one row (prefers the real path)
- Loose file + symlink to the same file → one row
- GGUF + safetensors at the same path → two rows (unchanged)
- Overlapping scan roots (symlinked folder + real folder) → one row

## Tests

- `test_two_symlink_aliases_to_one_model_stay_distinct` (backend)
- `symlink alias paths keep independent remembered settings` (frontend)