### PR TITLE
Studio: assert the argv, not the call count, in the shutdown spawn-refusal test

### DIFF
--- a/studio/backend/tests/test_llama_cpp_wait_for_health.py
+++ b/studio/backend/tests/test_llama_cpp_wait_for_health.py
@@ -249,9 +249,13 @@ class TestWaitForHealthResilience:
         b = _make_backend()
         b._shutting_down = True
         spawned = []
-        monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: spawned.append(1))
+        monkeypatch.setattr(subprocess, "Popen", lambda cmd = None, *a, **kw: spawned.append(cmd))
         assert b._start_llama_process(["llama-server"], {}, child_gpu_physical_ids = None) is False
-        assert spawned == [], "started a server after shutdown had begun"
+        # The argv, not the call count. The defensive kill at the top of
+        # _start_llama_process scans for descendants, and on macOS that scan shells out
+        # to `ps` through this same subprocess.Popen, so "nothing was spawned at all"
+        # fails there for a reason that has nothing to do with the spawn under test.
+        assert ["llama-server"] not in spawned, "started a server after shutdown had begun"
 
     def test_a_teardown_with_no_process_still_marks_shutdown(self):
         """Quitting during a download or staging has nothing to kill, so


### PR DESCRIPTION
## What this fixes

`test_a_started_shutdown_refuses_to_spawn`, added in #10592, fails on macOS. It is the test that is wrong, not the code.

The test doubles `subprocess.Popen` and then asserts nothing was spawned at all:

```python
monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: spawned.append(1))
assert b._start_llama_process([...]) is False
assert spawned == [], "started a server after shutdown had begun"
```

`_start_llama_process` opens with a defensive `_kill_process()`, which collects the child's descendants. On Linux that reads `/proc`. On macOS `_child_pid_map` shells out to `ps -A -o pid=,ppid=`, and `subprocess.run` goes through the same `subprocess.Popen` the test replaced. So the double records the `ps` call and the assertion fails, on a platform where the behaviour under test is correct: the call still returns `False`, and no llama-server is started.

## The change

Record the argv and assert that the llama-server command specifically was never spawned. That is the claim the test exists to make, and it is the same claim on every platform.

## How it was found

Replicated onto a staging repo and run on `ubuntu-latest`, `macos-15` and `windows-latest`. On macOS the failure was `AssertionError: started a server after shutdown had begun`; with this change the case passes there.

`studio/backend/tests/test_llama_cpp_wait_for_health.py`: 77 passed.
