### PR TITLE
Studio: rebuild only the transformers sidecar that is actually stale

### DIFF
--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -1,0 +1,101 @@
+# Unsloth Zoo - Utilities for Unsloth
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""The runtime's idea of a complete sidecar matches setup's.
+
+setup.sh and setup.ps1 install tiktoken best-effort and record a sidecar without it as
+complete; the runtime validator used to require it, delete the sidecar and retry the
+install that had just failed.
+"""
+
+
+
+import sys
+import types as _types
+from pathlib import Path
+
+# The backend uses "from utils..." imports; ensure the backend dir is on sys.path.
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+# Stub the custom logger before importing the module under test, as the sibling tests do.
+_loggers_stub = _types.ModuleType("loggers")
+_loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
+sys.modules.setdefault("loggers", _loggers_stub)
+
+import utils.transformers_version as tv
+
+
+def _sidecar(root, *names, versions = None):
+    versions = versions or {}
+    for name in names:
+        (root / name).mkdir(parents = True)
+        version = versions.get(name)
+        if version:
+            info = root / f"{name}-{version}.dist-info"
+            info.mkdir()
+            (info / "METADATA").write_text(f"Name: {name}\nVersion: {version}\n", encoding = "utf-8")
+    (root / tv._STUDIO_OWNED_MARKER).touch()
+
+
+def test_a_sidecar_without_tiktoken_is_still_valid(tmp_path):
+    root = tmp_path / ".venv_t5_550"
+    _sidecar(
+        root,
+        "transformers",
+        "huggingface_hub",
+        "hf_xet",
+        versions = {
+            "transformers": tv.TRANSFORMERS_550_VERSION,
+            "huggingface_hub": "1.8.0",
+            "hf_xet": "1.4.2",
+        },
+    )
+    assert tv._venv_dir_is_valid(str(root), tv._VENV_T5_550_PACKAGES) is True
+    assert tv._venv_dir_is_valid(str(root), tv._venv_t5_latest_packages(tv.TRANSFORMERS_550_VERSION)) is True
+
+
+def test_a_sidecar_without_a_required_package_is_still_invalid(tmp_path):
+    root = tmp_path / ".venv_t5_550"
+    _sidecar(
+        root,
+        "transformers",
+        "huggingface_hub",
+        "tiktoken",
+        versions = {"transformers": tv.TRANSFORMERS_550_VERSION, "huggingface_hub": "1.8.0"},
+    )
+    assert tv._venv_dir_is_valid(str(root), tv._VENV_T5_550_PACKAGES) is False
+
+
+def test_a_runtime_repair_survives_a_tiktoken_that_will_not_install(tmp_path, monkeypatch):
+    root = tmp_path / ".venv_t5_550"
+    installed = []
+
+    def fake_install(pkg, target_dir):
+        installed.append(pkg)
+        return not pkg.startswith("tiktoken")
+
+    monkeypatch.setattr(tv, "_install_to_dir", fake_install)
+    monkeypatch.setattr(tv, "_venv_dir_is_valid_and_undamaged", lambda *a, **k: False)
+    assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is True
+    assert installed == list(tv._VENV_T5_550_PACKAGES)
+
+    def fake_install_failing_required(pkg, target_dir):
+        return not pkg.startswith("hf_xet")
+
+    monkeypatch.setattr(tv, "_install_to_dir", fake_install_failing_required)
+    assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is False

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -339,3 +339,27 @@ def test_the_top_up_removes_the_recordless_dist_info_an_interrupted_install_left
     assert not stale.exists()
     assert (root / "tiktoken-0.9.0.dist-info" / "marker").is_file()
     assert (other / "RECORD").is_file()
+
+
+def test_a_recordless_record_beside_a_complete_install_is_removed_without_a_top_up(
+    tmp_path, monkeypatch
+):
+    """A retry that succeeded after an interrupted install leaves both; the package is
+    present, so no top-up runs, and the stale metadata must still go."""
+    root = tmp_path / ".venv_t5_550"
+    (root / "tiktoken").mkdir(parents = True)
+    (root / "tiktoken" / "__init__.py").write_text("", encoding = "utf-8")
+    good = root / "tiktoken-0.9.0.dist-info"
+    good.mkdir()
+    (good / "RECORD").write_text("", encoding = "utf-8")
+    stale = root / "tiktoken-0.7.0.dist-info"
+    stale.mkdir()
+    (stale / "METADATA").write_text("Name: tiktoken\nVersion: 0.7.0\n", encoding = "utf-8")
+    monkeypatch.setattr(tv, "_env_offline", lambda: False)
+    monkeypatch.delenv("UV_OFFLINE", raising = False)
+    monkeypatch.setattr(tv, "_install_to_dir", lambda *a, **k: pytest.fail("installed over a present package"))
+    tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
+    tv._top_up_optional_packages(str(root), ("tiktoken",))
+    assert not stale.exists()
+    assert (good / "RECORD").is_file()
+

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -69,6 +69,8 @@ def test_a_failed_optional_install_leaves_no_partial_payload(tmp_path, monkeypat
         if pkg.startswith("tiktoken"):
             (Path(target) / "tiktoken").mkdir()
             (Path(target) / "tiktoken" / "__init__.py").write_text("", encoding = "utf-8")
+            (Path(target) / "tiktoken_ext").mkdir()
+            (Path(target) / "tiktoken_ext" / "openai_public.py").write_text("", encoding = "utf-8")
             (Path(target) / "tiktoken-0.9.0.dist-info").mkdir()
             (Path(target) / "tiktoken-0.9.0.dist-info" / "METADATA").write_text(
                 "", encoding = "utf-8"
@@ -79,7 +81,45 @@ def test_a_failed_optional_install_leaves_no_partial_payload(tmp_path, monkeypat
     monkeypatch.setattr(tv, "_install_to_dir", fake_install)
     assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is True
     assert not (root / "tiktoken").exists()
+    # The plugin namespace too: a partial tiktoken_ext ahead of site-packages shadows
+    # the ambient one's openai_public module by itself.
+    assert not (root / "tiktoken_ext").exists()
     assert not list(root.glob("tiktoken-*.dist-info"))
+    assert tv._optional_package_absent(str(root), "tiktoken") is True
+
+
+def test_a_staging_move_that_fails_part_way_rolls_the_moved_entries_back(tmp_path, monkeypatch):
+    """os.replace failing on the second entry used to leave the first one in the sidecar
+    with no dist-info for the whole retry backoff; the package must read as absent."""
+    root = tmp_path / ".venv_t5_550"
+    root.mkdir()
+
+    def fake_install(pkg, target):
+        (Path(target) / "tiktoken").mkdir()
+        (Path(target) / "tiktoken" / "__init__.py").write_text("", encoding = "utf-8")
+        (Path(target) / "tiktoken_ext").mkdir()
+        (Path(target) / "tiktoken_ext" / "openai_public.py").write_text("", encoding = "utf-8")
+        (Path(target) / "tiktoken-0.9.0.dist-info").mkdir()
+        (Path(target) / "tiktoken-0.9.0.dist-info" / "RECORD").write_text("", encoding = "utf-8")
+        return True
+
+    monkeypatch.setattr(tv, "_install_to_dir", fake_install)
+    real_replace = tv.os.replace
+    moved = []
+
+    def flaky_replace(source, target):
+        if ".top-up-staging" in str(source) and len(moved) == 1:
+            raise OSError("disk full")
+        moved.append(target)
+        return real_replace(source, target)
+
+    monkeypatch.setattr(tv.os, "replace", flaky_replace)
+    assert tv._stage_optional_package("tiktoken", str(root)) is False
+    assert len(moved) == 1
+    assert not (root / "tiktoken").exists()
+    assert not (root / "tiktoken_ext").exists()
+    assert not list(root.glob("tiktoken-*.dist-info"))
+    assert not (root / ".top-up-staging").exists()
     assert tv._optional_package_absent(str(root), "tiktoken") is True
 
 

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -357,9 +357,10 @@ def test_a_recordless_record_beside_a_complete_install_is_removed_without_a_top_
     (stale / "METADATA").write_text("Name: tiktoken\nVersion: 0.7.0\n", encoding = "utf-8")
     monkeypatch.setattr(tv, "_env_offline", lambda: False)
     monkeypatch.delenv("UV_OFFLINE", raising = False)
-    monkeypatch.setattr(tv, "_install_to_dir", lambda *a, **k: pytest.fail("installed over a present package"))
+    monkeypatch.setattr(
+        tv, "_install_to_dir", lambda *a, **k: pytest.fail("installed over a present package")
+    )
     tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
     tv._top_up_optional_packages(str(root), ("tiktoken",))
     assert not stale.exists()
     assert (good / "RECORD").is_file()
-

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -180,3 +180,32 @@ def test_latest_sidecar_activation_tops_up_a_missing_tiktoken(tmp_path, monkeypa
     tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
     assert tv._ensure_venv_t5_latest_exists() is True
     assert installed == [("tiktoken", str(latest))]
+
+
+def test_the_top_up_stays_home_offline_and_yields_to_another_process(tmp_path, monkeypatch):
+    """Workers activate tiers on their own: offline, none of them should sit through
+    network retries for a best-effort package, and two finding it absent at once must
+    not both write into the shared sidecar."""
+    root = tmp_path / ".venv_t5_550"
+    root.mkdir()
+    packages = tv._VENV_T5_550_PACKAGES
+    installed = []
+    monkeypatch.setattr(tv, "_install_to_dir", lambda pkg, target: installed.append(pkg) or True)
+    tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    tv._top_up_optional_packages(str(root), packages)
+    assert installed == []
+    monkeypatch.delenv("HF_HUB_OFFLINE")
+    monkeypatch.setenv("UV_OFFLINE", "1")
+    tv._top_up_optional_packages(str(root), packages)
+    assert installed == []
+    monkeypatch.delenv("UV_OFFLINE")
+    # Another process holds the sidecar's top-up lock: this one leaves it to them.
+    with tv._optional_top_up_lock(str(root)) as held:
+        assert held is True
+        tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
+        tv._top_up_optional_packages(str(root), packages)
+        assert installed == []
+    tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
+    tv._top_up_optional_packages(str(root), packages)
+    assert installed == ["tiktoken"]

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -1,3 +1,4 @@
+import pathlib
 # Unsloth Zoo - Utilities for Unsloth
 # Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
 #
@@ -155,7 +156,7 @@ def test_a_valid_sidecar_missing_tiktoken_is_topped_up_once(tmp_path, monkeypatc
     )
     tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
     assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is True
-    assert installed == [("tiktoken", str(root))]
+    assert installed == [("tiktoken", str(root / ".top-up-staging"))]
     assert root.is_dir(), "the top-up must not wipe the sidecar"
     assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is True
     assert len(installed) == 1, "an unavailable wheel is asked for once per process"
@@ -183,7 +184,7 @@ def test_latest_sidecar_activation_tops_up_a_missing_tiktoken(tmp_path, monkeypa
     )
     tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
     assert tv._ensure_venv_t5_latest_exists() is True
-    assert installed == [("tiktoken", str(latest))]
+    assert installed == [("tiktoken", str(latest / ".top-up-staging"))]
 
 
 def test_the_top_up_stays_home_offline_and_yields_to_another_process(tmp_path, monkeypatch):
@@ -204,7 +205,9 @@ def test_the_top_up_stays_home_offline_and_yields_to_another_process(tmp_path, m
     tv._top_up_optional_packages(str(root), packages)
     assert installed == []
     monkeypatch.delenv("UV_OFFLINE")
-    # Another process holds the sidecar's top-up lock: this one leaves it to them.
+    # Another process holds the sidecar's top-up lock: this one waits for it, up to the
+    # bound, and leaves the package to the holder when the bound passes.
+    monkeypatch.setattr(tv, "_OPTIONAL_TOP_UP_WAIT_SECONDS", 0.5)
     with tv._optional_top_up_lock(str(root)) as held:
         assert held is True
         tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
@@ -213,3 +216,31 @@ def test_the_top_up_stays_home_offline_and_yields_to_another_process(tmp_path, m
     tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
     tv._top_up_optional_packages(str(root), packages)
     assert installed == ["tiktoken"]
+
+
+def test_the_top_up_is_staged_and_lands_dist_info_last(tmp_path, monkeypatch):
+    """A scan by another worker must never meet a RECORD whose files have not landed:
+    the package is built beside the sidecar and moved in, payload first, dist-info last."""
+    root = tmp_path / ".venv_t5_550"
+    root.mkdir()
+    order = []
+
+    def fake_install(pkg, target):
+        assert target != str(root), "installed straight into the shared sidecar"
+        for d in ("tiktoken", "tiktoken_ext", "tiktoken-0.9.0.dist-info"):
+            (pathlib.Path(target) / d).mkdir()
+            (pathlib.Path(target) / d / "marker").write_text(d, encoding = "utf-8")
+        return True
+
+    real_replace = tv.os.replace
+
+    def replacing(src, dst):
+        order.append(pathlib.Path(dst).name)
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(tv, "_install_to_dir", fake_install)
+    monkeypatch.setattr(tv.os, "replace", replacing)
+    assert tv._stage_optional_package("tiktoken", str(root)) is True
+    assert order[-1] == "tiktoken-0.9.0.dist-info"
+    assert set(order) == {"tiktoken", "tiktoken_ext", "tiktoken-0.9.0.dist-info"}
+    assert (root / "tiktoken" / "marker").is_file() and not (root / ".top-up-staging").exists()

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -310,3 +310,32 @@ def test_the_top_up_is_staged_and_lands_dist_info_last(tmp_path, monkeypatch):
     assert order[-1] == "tiktoken-0.9.0.dist-info"
     assert set(order) == {"tiktoken", "tiktoken_ext", "tiktoken-0.9.0.dist-info"}
     assert (root / "tiktoken" / "marker").is_file() and not (root / ".top-up-staging").exists()
+
+
+def test_the_top_up_removes_the_recordless_dist_info_an_interrupted_install_left(
+    tmp_path, monkeypatch
+):
+    """uv cannot uninstall a dist-info with no RECORD and lands the new version beside
+    it; both validators skip the recordless one, but importlib.metadata would keep
+    answering its version. Every other dist-info of the project goes before the new
+    metadata lands, and a dist-info of another project stays."""
+    root = tmp_path / ".venv_t5_550"
+    root.mkdir()
+    stale = root / "tiktoken-0.7.0.dist-info"
+    stale.mkdir()
+    (stale / "METADATA").write_text("Name: tiktoken\nVersion: 0.7.0\n", encoding = "utf-8")
+    other = root / "regex-2024.11.6.dist-info"
+    other.mkdir()
+    (other / "RECORD").write_text("", encoding = "utf-8")
+
+    def fake_install(pkg, target):
+        for d in ("tiktoken", "tiktoken-0.9.0.dist-info"):
+            (pathlib.Path(target) / d).mkdir()
+            (pathlib.Path(target) / d / "marker").write_text(d, encoding = "utf-8")
+        return True
+
+    monkeypatch.setattr(tv, "_install_to_dir", fake_install)
+    assert tv._stage_optional_package("tiktoken", str(root)) is True
+    assert not stale.exists()
+    assert (root / "tiktoken-0.9.0.dist-info" / "marker").is_file()
+    assert (other / "RECORD").is_file()

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -321,6 +321,61 @@ def test_a_partial_live_tree_goes_when_the_top_up_install_itself_fails(tmp_path,
     assert not (root / ".top-up-staging").exists()
 
 
+def _partial_tiktoken(root):
+    (root / "tiktoken").mkdir(parents = True, exist_ok = True)
+    (root / "tiktoken" / "__init__.py").write_text("", encoding = "utf-8")
+    (root / "tiktoken_ext").mkdir(exist_ok = True)
+    (root / "tiktoken_ext" / "openai_public.py").write_text("", encoding = "utf-8")
+
+
+def test_offline_still_clears_a_partial_optional_payload(tmp_path, monkeypatch):
+    """A worker killed after the payload moved in and before its dist-info left tiktoken/
+    ahead of site-packages. Offline there is no install, but the partial tree still goes,
+    or the otherwise valid sidecar would be activated with it shadowing the ambient copy."""
+    root = tmp_path / ".venv_t5_550"
+    _partial_tiktoken(root)
+    monkeypatch.setenv("UV_OFFLINE", "1")
+    installs = []
+    monkeypatch.setattr(tv, "_install_to_dir", lambda pkg, target_dir: installs.append(pkg) or False)
+    assert tv._top_up_optional_packages(str(root), tv._VENV_T5_550_PACKAGES) is True
+    assert installs == []
+    assert not (root / "tiktoken").exists() and not (root / "tiktoken_ext").exists()
+    # And through the sidecar check that activation runs.
+    _partial_tiktoken(root)
+    monkeypatch.setattr(tv, "_venv_dir_is_valid_and_undamaged", lambda *a, **k: True)
+    assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is True
+    assert not (root / "tiktoken").exists()
+
+
+def test_a_sidecar_whose_top_up_remnants_will_not_go_is_not_activated(tmp_path, monkeypatch):
+    """The top-up failed and the cleanup could not remove the partial tree (a locked
+    file, a permission): the sidecar the cleanup itself calls unusable is not activated."""
+    root = tmp_path / ".venv_t5_550"
+    root.mkdir()
+    _partial_tiktoken(root)
+    monkeypatch.delenv("UV_OFFLINE", raising = False)
+    monkeypatch.setattr(tv, "_env_offline", lambda: False)
+    monkeypatch.setattr(tv, "_install_to_dir", lambda pkg, target_dir: False)
+    monkeypatch.setattr(tv, "_venv_dir_is_valid_and_undamaged", lambda *a, **k: True)
+    real_rmtree = tv.shutil.rmtree
+
+    def stuck_rmtree(path, *a, **k):
+        if Path(path).name in ("tiktoken", "tiktoken_ext"):
+            return None
+        return real_rmtree(path, *a, **k)
+
+    monkeypatch.setattr(tv.shutil, "rmtree", stuck_rmtree)
+    tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
+    assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is False
+    assert (root / "tiktoken").is_dir()
+    # Once the remnants can go, the same failed top-up leaves a usable sidecar.
+    monkeypatch.setattr(tv.shutil, "rmtree", real_rmtree)
+    tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
+    (root / tv._OPTIONAL_TOP_UP_FAILED).unlink(missing_ok = True)
+    assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is True
+    assert not (root / "tiktoken").exists()
+
+
 def test_an_interrupted_top_up_is_finished_by_the_next_one(tmp_path, monkeypatch):
     """A process killed between moving tiktoken/ in and its dist-info left a payload no
     scan could judge and no activation would complete: a package counts as present only

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -163,3 +163,20 @@ def test_a_valid_sidecar_missing_tiktoken_is_topped_up_once(tmp_path, monkeypatc
     (root / "tiktoken" / "__init__.py").write_text("", encoding = "utf-8")
     assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is True
     assert len(installed) == 1
+
+
+def test_latest_sidecar_activation_tops_up_a_missing_tiktoken(tmp_path, monkeypatch):
+    """Model activation goes through _ensure_venv_t5_latest_exists, not the provisioning
+    path; a healthy latest sidecar without tiktoken has to get its top-up there too, or a
+    latest-tier Qwen model keeps failing to tokenize after a transient install failure."""
+    latest = tmp_path / ".venv_t5_latest"
+    latest.mkdir()
+    packages = ("transformers==9.9.9", "huggingface_hub==1.8.0", "hf_xet==1.4.2", "tiktoken")
+    monkeypatch.setattr(tv, "_VENV_T5_LATEST_DIR", str(latest))
+    monkeypatch.setattr(tv, "_latest_pin_data", lambda: {"version": "9.9.9", "packages": packages})
+    monkeypatch.setattr(tv, "_venv_dir_health", lambda *a, **k: (True, True))
+    installed = []
+    monkeypatch.setattr(tv, "_install_to_dir", lambda pkg, target: installed.append((pkg, target)) or True)
+    tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
+    assert tv._ensure_venv_t5_latest_exists() is True
+    assert installed == [("tiktoken", str(latest))]

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -70,7 +70,9 @@ def test_a_failed_optional_install_leaves_no_partial_payload(tmp_path, monkeypat
             (Path(target) / "tiktoken").mkdir()
             (Path(target) / "tiktoken" / "__init__.py").write_text("", encoding = "utf-8")
             (Path(target) / "tiktoken-0.9.0.dist-info").mkdir()
-            (Path(target) / "tiktoken-0.9.0.dist-info" / "METADATA").write_text("", encoding = "utf-8")
+            (Path(target) / "tiktoken-0.9.0.dist-info" / "METADATA").write_text(
+                "", encoding = "utf-8"
+            )
             return False
         return True
 

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -175,6 +175,38 @@ def test_a_runtime_repair_survives_a_tiktoken_that_will_not_install(tmp_path, mo
     assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is False
 
 
+def test_a_remnant_that_will_not_go_fails_the_build_instead_of_shadowing(tmp_path, monkeypatch):
+    """The optional install failed part-way and left tiktoken/ behind, and the cleanup
+    cannot remove it (a file another process holds open on Windows, a permission). That
+    directory sits ahead of site-packages, so the build is a failure to be redone, not a
+    sidecar without the package."""
+    root = tmp_path / ".venv_t5_550"
+
+    def fake_install(pkg, target_dir):
+        if pkg.startswith("tiktoken"):
+            (Path(target_dir) / "tiktoken").mkdir(parents = True, exist_ok = True)
+            (Path(target_dir) / "tiktoken" / "__init__.py").write_text("", encoding = "utf-8")
+            return False
+        return True
+
+    monkeypatch.setattr(tv, "_install_to_dir", fake_install)
+    monkeypatch.setattr(tv, "_venv_dir_is_valid_and_undamaged", lambda *a, **k: False)
+    real_rmtree = tv.shutil.rmtree
+
+    def stuck_rmtree(path, *a, **k):
+        if Path(path).name == "tiktoken":
+            return None
+        return real_rmtree(path, *a, **k)
+
+    monkeypatch.setattr(tv.shutil, "rmtree", stuck_rmtree)
+    assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is False
+    assert (root / "tiktoken").is_dir()
+    monkeypatch.setattr(tv.shutil, "rmtree", real_rmtree)
+    assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is True
+    assert not (root / "tiktoken").exists()
+    assert tv._remove_optional_remnants(str(root), "tiktoken==0.12.0") is True
+
+
 def test_a_present_tiktoken_is_held_to_its_record_like_any_other(tmp_path, monkeypatch):
     """Absence is what is optional. A tiktoken that is present but whose RECORD names a
     file that is not there (an interrupted install, a native extension left from an

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -106,10 +106,10 @@ def test_a_runtime_repair_survives_a_tiktoken_that_will_not_install(tmp_path, mo
     assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is False
 
 
-def test_a_tiktoken_dist_info_without_its_payload_is_not_damage(tmp_path, monkeypatch):
-    """An interrupted tiktoken install leaves a dist-info whose RECORD names files that
-    never landed. The whole-tree scan used to read that as damage and wipe the sidecar
-    on every check; the optional package's leftovers are the top-up's business."""
+def test_a_present_tiktoken_is_held_to_its_record_like_any_other(tmp_path, monkeypatch):
+    """Absence is what is optional. A tiktoken that is present but whose RECORD names a
+    file that is not there (an interrupted install, a native extension left from an
+    older interpreter) is a tokenizer that fails at import, and the scan says so."""
     root = tmp_path / ".venv_t5_550"
     _sidecar(
         root,
@@ -128,9 +128,38 @@ def test_a_tiktoken_dist_info_without_its_payload_is_not_damage(tmp_path, monkey
     (info / "METADATA").write_text("Name: tiktoken\nVersion: 0.9.0\n", encoding = "utf-8")
     (info / "RECORD").write_text("tiktoken/__init__.py,sha256=abc,1234\n", encoding = "utf-8")
     monkeypatch.delenv(tv._SIDECAR_FILE_CHECK_ENV, raising = False)
+    assert tv._sidecar_damaged_files(str(root)) != []
+    assert tv._venv_dir_is_valid_and_undamaged(str(root), tv._VENV_T5_550_PACKAGES) is False
+    # With the payload the RECORD names in place, the sidecar is whole.
+    (root / "tiktoken").mkdir()
+    (root / "tiktoken" / "__init__.py").write_bytes(b"x" * 1234)
     assert tv._sidecar_damaged_files(str(root)) == []
     assert tv._venv_dir_is_valid_and_undamaged(str(root), tv._VENV_T5_550_PACKAGES) is True
-    # A required package's RECORD is still held to the disk.
+    # A required package's RECORD is held to the disk too.
     hub = root / "huggingface_hub-1.8.0.dist-info"
     (hub / "RECORD").write_text("huggingface_hub/gone.py,sha256=abc,12\n", encoding = "utf-8")
     assert tv._sidecar_damaged_files(str(root)) != []
+
+
+def test_a_valid_sidecar_missing_tiktoken_is_topped_up_once(tmp_path, monkeypatch):
+    """A transient failure while a sidecar was built (the latest sidecar in particular,
+    which no setup top-up visits) left tiktoken out for good: every later check accepted
+    the sidecar and returned before another install. The top-up adds it without touching
+    the rest, and asks once per process when the wheel is unavailable."""
+    root = tmp_path / ".venv_t5_550"
+    root.mkdir()
+    monkeypatch.setattr(tv, "_venv_dir_is_valid_and_undamaged", lambda *a, **k: True)
+    installed: list[tuple[str, str]] = []
+    monkeypatch.setattr(tv, "_install_to_dir", lambda pkg, target: installed.append((pkg, target)) or False)
+    tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
+    assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is True
+    assert installed == [("tiktoken", str(root))]
+    assert root.is_dir(), "the top-up must not wipe the sidecar"
+    assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is True
+    assert len(installed) == 1, "an unavailable wheel is asked for once per process"
+    # A tiktoken that is there is left alone.
+    tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
+    (root / "tiktoken").mkdir()
+    (root / "tiktoken" / "__init__.py").write_text("", encoding = "utf-8")
+    assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is True
+    assert len(installed) == 1

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -1,4 +1,3 @@
-import pathlib
 # Unsloth Zoo - Utilities for Unsloth
 # Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
 #
@@ -22,6 +21,7 @@ complete; the runtime validator used to require it, delete the sidecar and retry
 install that had just failed.
 """
 
+import pathlib
 import sys
 import types as _types
 from pathlib import Path

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -21,8 +21,6 @@ complete; the runtime validator used to require it, delete the sidecar and retry
 install that had just failed.
 """
 
-
-
 import sys
 import types as _types
 from pathlib import Path
@@ -40,7 +38,11 @@ sys.modules.setdefault("loggers", _loggers_stub)
 import utils.transformers_version as tv
 
 
-def _sidecar(root, *names, versions = None):
+def _sidecar(
+    root,
+    *names,
+    versions = None,
+):
     versions = versions or {}
     for name in names:
         (root / name).mkdir(parents = True)
@@ -66,7 +68,10 @@ def test_a_sidecar_without_tiktoken_is_still_valid(tmp_path):
         },
     )
     assert tv._venv_dir_is_valid(str(root), tv._VENV_T5_550_PACKAGES) is True
-    assert tv._venv_dir_is_valid(str(root), tv._venv_t5_latest_packages(tv.TRANSFORMERS_550_VERSION)) is True
+    assert (
+        tv._venv_dir_is_valid(str(root), tv._venv_t5_latest_packages(tv.TRANSFORMERS_550_VERSION))
+        is True
+    )
 
 
 def test_a_sidecar_without_a_required_package_is_still_invalid(tmp_path):

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -22,6 +22,7 @@ install that had just failed.
 """
 
 import pathlib
+import shutil
 import sys
 import types as _types
 from pathlib import Path
@@ -162,10 +163,75 @@ def test_a_valid_sidecar_missing_tiktoken_is_topped_up_once(tmp_path, monkeypatc
     assert len(installed) == 1, "an unavailable wheel is asked for once per process"
     # A tiktoken that is there is left alone.
     tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
+    (root / tv._OPTIONAL_TOP_UP_FAILED).unlink()
     (root / "tiktoken").mkdir()
     (root / "tiktoken" / "__init__.py").write_text("", encoding = "utf-8")
+    (root / "tiktoken-0.9.0.dist-info").mkdir()
+    (root / "tiktoken-0.9.0.dist-info" / "RECORD").write_text("", encoding = "utf-8")
     assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is True
     assert len(installed) == 1
+
+
+def test_a_failed_top_up_is_remembered_across_processes_and_retried_later(tmp_path, monkeypatch):
+    """Each job spawns its own workers, and every one of them used to run the same
+    doomed install: the failure is written beside the sidecar, read by the next process,
+    and forgotten after a while in case it was the network."""
+    root = tmp_path / ".venv_t5_550"
+    root.mkdir()
+    packages = tv._VENV_T5_550_PACKAGES
+    installed = []
+    monkeypatch.setattr(tv, "_install_to_dir", lambda pkg, target: installed.append(pkg) or False)
+    tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
+    tv._top_up_optional_packages(str(root), packages)
+    assert installed == ["tiktoken"]
+    # A fresh process: the in-memory set is empty, the file is not.
+    tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
+    tv._top_up_optional_packages(str(root), packages)
+    assert installed == ["tiktoken"]
+    # Old enough to try again.
+    failures = tv._read_top_up_failures(str(root))
+    failures["tiktoken"] -= tv._OPTIONAL_TOP_UP_RETRY_SECONDS + 1
+    tv._write_top_up_failures(str(root), failures)
+    tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
+    tv._top_up_optional_packages(str(root), packages)
+    assert installed == ["tiktoken", "tiktoken"]
+    # A success clears the record.
+    monkeypatch.setattr(tv, "_install_to_dir", lambda pkg, target: installed.append(pkg) or True)
+    failures = tv._read_top_up_failures(str(root))
+    failures["tiktoken"] -= tv._OPTIONAL_TOP_UP_RETRY_SECONDS + 1
+    tv._write_top_up_failures(str(root), failures)
+    tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
+    tv._top_up_optional_packages(str(root), packages)
+    assert not (root / tv._OPTIONAL_TOP_UP_FAILED).exists()
+
+
+def test_an_interrupted_top_up_is_finished_by_the_next_one(tmp_path, monkeypatch):
+    """A process killed between moving tiktoken/ in and its dist-info left a payload no
+    scan could judge and no activation would complete: a package counts as present only
+    once its dist-info has landed, and the next top-up replaces the partial entries."""
+    root = tmp_path / ".venv_t5_550"
+    root.mkdir()
+    (root / "tiktoken").mkdir()
+    (root / "tiktoken" / "__init__.py").write_text("", encoding = "utf-8")
+    assert tv._optional_package_absent(str(root), "tiktoken") is True
+    (root / "tiktoken-0.9.0.dist-info").mkdir()
+    assert tv._optional_package_absent(str(root), "tiktoken") is True
+    (root / "tiktoken-0.9.0.dist-info" / "RECORD").write_text("", encoding = "utf-8")
+    assert tv._optional_package_absent(str(root), "tiktoken") is False
+    shutil.rmtree(root / "tiktoken-0.9.0.dist-info")
+
+    def fake_install(pkg, target):
+        for d in ("tiktoken", "tiktoken_ext", "tiktoken-0.9.0.dist-info"):
+            (pathlib.Path(target) / d).mkdir()
+            (pathlib.Path(target) / d / "RECORD").write_text(d, encoding = "utf-8")
+        (pathlib.Path(target) / "tiktoken" / "__init__.py").write_text("", encoding = "utf-8")
+        return True
+
+    monkeypatch.setattr(tv, "_install_to_dir", fake_install)
+    tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
+    tv._top_up_optional_packages(str(root), tv._VENV_T5_550_PACKAGES)
+    assert tv._optional_package_absent(str(root), "tiktoken") is False
+    assert (root / "tiktoken_ext" / "RECORD").is_file()
 
 
 def test_latest_sidecar_activation_tops_up_a_missing_tiktoken(tmp_path, monkeypatch):

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -56,6 +56,31 @@ def _sidecar(
     (root / tv._STUDIO_OWNED_MARKER).touch()
 
 
+def test_a_failed_optional_install_leaves_no_partial_payload(tmp_path, monkeypatch):
+    """pip or uv exiting nonzero after copying part of tiktoken: the sidecar is still
+    accepted (the package is optional), but nothing of the package may stay, or the
+    half-copied tree ahead of site-packages shadows the ambient one at tokenization."""
+    root = tmp_path / ".venv_t5_550"
+    monkeypatch.setattr(tv, "_venv_dir_is_valid_and_undamaged", lambda *a, **k: False)
+    optional = [p for p in tv._VENV_T5_550_PACKAGES if p.startswith("tiktoken")]
+    assert optional and tv._sidecar_package_is_optional(optional[0])
+
+    def fake_install(pkg, target):
+        if pkg.startswith("tiktoken"):
+            (Path(target) / "tiktoken").mkdir()
+            (Path(target) / "tiktoken" / "__init__.py").write_text("", encoding = "utf-8")
+            (Path(target) / "tiktoken-0.9.0.dist-info").mkdir()
+            (Path(target) / "tiktoken-0.9.0.dist-info" / "METADATA").write_text("", encoding = "utf-8")
+            return False
+        return True
+
+    monkeypatch.setattr(tv, "_install_to_dir", fake_install)
+    assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is True
+    assert not (root / "tiktoken").exists()
+    assert not list(root.glob("tiktoken-*.dist-info"))
+    assert tv._optional_package_absent(str(root), "tiktoken") is True
+
+
 def test_a_sidecar_without_tiktoken_is_still_valid(tmp_path):
     root = tmp_path / ".venv_t5_550"
     _sidecar(

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -150,7 +150,9 @@ def test_a_valid_sidecar_missing_tiktoken_is_topped_up_once(tmp_path, monkeypatc
     root.mkdir()
     monkeypatch.setattr(tv, "_venv_dir_is_valid_and_undamaged", lambda *a, **k: True)
     installed: list[tuple[str, str]] = []
-    monkeypatch.setattr(tv, "_install_to_dir", lambda pkg, target: installed.append((pkg, target)) or False)
+    monkeypatch.setattr(
+        tv, "_install_to_dir", lambda pkg, target: installed.append((pkg, target)) or False
+    )
     tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
     assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is True
     assert installed == [("tiktoken", str(root))]
@@ -176,7 +178,9 @@ def test_latest_sidecar_activation_tops_up_a_missing_tiktoken(tmp_path, monkeypa
     monkeypatch.setattr(tv, "_latest_pin_data", lambda: {"version": "9.9.9", "packages": packages})
     monkeypatch.setattr(tv, "_venv_dir_health", lambda *a, **k: (True, True))
     installed = []
-    monkeypatch.setattr(tv, "_install_to_dir", lambda pkg, target: installed.append((pkg, target)) or True)
+    monkeypatch.setattr(
+        tv, "_install_to_dir", lambda pkg, target: installed.append((pkg, target)) or True
+    )
     tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
     assert tv._ensure_venv_t5_latest_exists() is True
     assert installed == [("tiktoken", str(latest))]

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -304,6 +304,23 @@ def test_a_failed_top_up_is_remembered_across_processes_and_retried_later(tmp_pa
     assert not (root / tv._OPTIONAL_TOP_UP_FAILED).exists()
 
 
+def test_a_partial_live_tree_goes_when_the_top_up_install_itself_fails(tmp_path, monkeypatch):
+    """An earlier top-up moved tiktoken/ in and was interrupted before its dist-info; the
+    next one finds the package "absent", and its install fails (no network). The partial
+    payload must not stay ahead of site-packages for the six-hour backoff."""
+    root = tmp_path / ".venv_t5_550"
+    (root / "tiktoken").mkdir(parents = True)
+    (root / "tiktoken" / "__init__.py").write_text("", encoding = "utf-8")
+    (root / "tiktoken_ext").mkdir()
+    (root / "tiktoken_ext" / "openai_public.py").write_text("", encoding = "utf-8")
+    assert tv._optional_package_absent(str(root), "tiktoken==0.12.0") is True
+    monkeypatch.setattr(tv, "_install_to_dir", lambda pkg, target_dir: False)
+    assert tv._stage_optional_package("tiktoken==0.12.0", str(root)) is False
+    assert not (root / "tiktoken").exists()
+    assert not (root / "tiktoken_ext").exists()
+    assert not (root / ".top-up-staging").exists()
+
+
 def test_an_interrupted_top_up_is_finished_by_the_next_one(tmp_path, monkeypatch):
     """A process killed between moving tiktoken/ in and its dist-info left a payload no
     scan could judge and no activation would complete: a package counts as present only

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -81,8 +81,7 @@ def test_a_failed_optional_install_leaves_no_partial_payload(tmp_path, monkeypat
     monkeypatch.setattr(tv, "_install_to_dir", fake_install)
     assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is True
     assert not (root / "tiktoken").exists()
-    # The plugin namespace too: a partial tiktoken_ext ahead of site-packages shadows
-    # the ambient one's openai_public module by itself.
+    # The plugin namespace too: a partial tiktoken_ext shadows the ambient openai_public module.
     assert not (root / "tiktoken_ext").exists()
     assert not list(root.glob("tiktoken-*.dist-info"))
     assert tv._optional_package_absent(str(root), "tiktoken") is True
@@ -473,8 +472,7 @@ def test_the_top_up_stays_home_offline_and_yields_to_another_process(tmp_path, m
     tv._top_up_optional_packages(str(root), packages)
     assert installed == []
     monkeypatch.delenv("UV_OFFLINE")
-    # Another process holds the sidecar's top-up lock: this one waits for it, up to the
-    # bound, and leaves the package to the holder when the bound passes.
+    # Another process holds the top-up lock: wait up to the bound, then leave the package to it.
     monkeypatch.setattr(tv, "_OPTIONAL_TOP_UP_WAIT_SECONDS", 0.5)
     with tv._optional_top_up_lock(str(root)) as held:
         assert held is True

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -104,3 +104,33 @@ def test_a_runtime_repair_survives_a_tiktoken_that_will_not_install(tmp_path, mo
 
     monkeypatch.setattr(tv, "_install_to_dir", fake_install_failing_required)
     assert tv._ensure_venv_dir(str(root), tv._VENV_T5_550_PACKAGES, "test sidecar") is False
+
+
+def test_a_tiktoken_dist_info_without_its_payload_is_not_damage(tmp_path, monkeypatch):
+    """An interrupted tiktoken install leaves a dist-info whose RECORD names files that
+    never landed. The whole-tree scan used to read that as damage and wipe the sidecar
+    on every check; the optional package's leftovers are the top-up's business."""
+    root = tmp_path / ".venv_t5_550"
+    _sidecar(
+        root,
+        "transformers",
+        "huggingface_hub",
+        "hf_xet",
+        versions = {
+            "transformers": tv.TRANSFORMERS_550_VERSION,
+            "huggingface_hub": "1.8.0",
+            "hf_xet": "1.4.2",
+        },
+    )
+    (root / "transformers" / "__init__.py").write_text("", encoding = "utf-8")
+    info = root / "tiktoken-0.9.0.dist-info"
+    info.mkdir()
+    (info / "METADATA").write_text("Name: tiktoken\nVersion: 0.9.0\n", encoding = "utf-8")
+    (info / "RECORD").write_text("tiktoken/__init__.py,sha256=abc,1234\n", encoding = "utf-8")
+    monkeypatch.delenv(tv._SIDECAR_FILE_CHECK_ENV, raising = False)
+    assert tv._sidecar_damaged_files(str(root)) == []
+    assert tv._venv_dir_is_valid_and_undamaged(str(root), tv._VENV_T5_550_PACKAGES) is True
+    # A required package's RECORD is still held to the disk.
+    hub = root / "huggingface_hub-1.8.0.dist-info"
+    (hub / "RECORD").write_text("huggingface_hub/gone.py,sha256=abc,12\n", encoding = "utf-8")
+    assert tv._sidecar_damaged_files(str(root)) != []

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -347,6 +347,34 @@ def test_offline_still_clears_a_partial_optional_payload(tmp_path, monkeypatch):
     assert not (root / "tiktoken").exists()
 
 
+def test_a_partial_payload_behind_an_unobtainable_lock_withholds_the_sidecar(tmp_path, monkeypatch):
+    """The lock could not be taken (held too long, or the file cannot be opened) and a
+    payload without its RECORD is there: nothing is touched, and the sidecar is not
+    activated with that payload shadowing the ambient copy. Nothing there: usable."""
+    import contextlib
+
+    root = tmp_path / ".venv_t5_550"
+    root.mkdir()
+    _partial_tiktoken(root)
+    monkeypatch.delenv("UV_OFFLINE", raising = False)
+    monkeypatch.setattr(tv, "_env_offline", lambda: False)
+    monkeypatch.setattr(tv, "_install_to_dir", lambda pkg, target_dir: False)
+
+    @contextlib.contextmanager
+    def not_held(venv_dir):
+        yield False
+
+    monkeypatch.setattr(tv, "_optional_top_up_lock", not_held)
+    tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
+    assert tv._top_up_optional_packages(str(root), tv._VENV_T5_550_PACKAGES) is False
+    assert (root / "tiktoken").is_dir()
+    import shutil as _shutil
+    _shutil.rmtree(root / "tiktoken")
+    _shutil.rmtree(root / "tiktoken_ext")
+    tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()
+    assert tv._top_up_optional_packages(str(root), tv._VENV_T5_550_PACKAGES) is True
+
+
 def test_a_sidecar_whose_top_up_remnants_will_not_go_is_not_activated(tmp_path, monkeypatch):
     """The top-up failed and the cleanup could not remove the partial tree (a locked
     file, a permission): the sidecar the cleanup itself calls unusable is not activated."""

--- a/studio/backend/tests/test_transformers_version_optional_tiktoken.py
+++ b/studio/backend/tests/test_transformers_version_optional_tiktoken.py
@@ -336,7 +336,9 @@ def test_offline_still_clears_a_partial_optional_payload(tmp_path, monkeypatch):
     _partial_tiktoken(root)
     monkeypatch.setenv("UV_OFFLINE", "1")
     installs = []
-    monkeypatch.setattr(tv, "_install_to_dir", lambda pkg, target_dir: installs.append(pkg) or False)
+    monkeypatch.setattr(
+        tv, "_install_to_dir", lambda pkg, target_dir: installs.append(pkg) or False
+    )
     assert tv._top_up_optional_packages(str(root), tv._VENV_T5_550_PACKAGES) is True
     assert installs == []
     assert not (root / "tiktoken").exists() and not (root / "tiktoken_ext").exists()
@@ -369,6 +371,7 @@ def test_a_partial_payload_behind_an_unobtainable_lock_withholds_the_sidecar(tmp
     assert tv._top_up_optional_packages(str(root), tv._VENV_T5_550_PACKAGES) is False
     assert (root / "tiktoken").is_dir()
     import shutil as _shutil
+
     _shutil.rmtree(root / "tiktoken")
     _shutil.rmtree(root / "tiktoken_ext")
     tv._OPTIONAL_TOP_UP_ATTEMPTED.clear()

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2026,6 +2026,17 @@ _VENV_T5_550_PACKAGES = (
 # Backwards-compat alias
 _VENV_T5_PACKAGES = _VENV_T5_550_PACKAGES
 
+# Packages a sidecar is complete without. setup.sh and setup.ps1 install tiktoken into
+# every sidecar on a best-effort basis (a Python with no compatible wheel gets the
+# sidecar without it, and only Qwen tokenizers notice), and record that sidecar as
+# complete. The runtime has to agree, or the first model on that tier would find the
+# sidecar "incomplete", delete it, and retry the same install that could not be done.
+_OPTIONAL_SIDECAR_PACKAGES = frozenset({"tiktoken"})
+
+
+def _sidecar_package_is_optional(pkg_spec: str) -> bool:
+    return pkg_spec.split("==", 1)[0].strip().lower().replace("_", "-") in _OPTIONAL_SIDECAR_PACKAGES
+
 
 _SIDECAR_FILE_CHECK_ENV = "UNSLOTH_SKIP_SIDECAR_FILE_CHECK"
 
@@ -2268,6 +2279,8 @@ def _venv_dir_is_valid(venv_dir: str, packages: tuple[str, ...]) -> bool:
         if not any(
             (Path(venv_dir) / d).is_dir() for d in (pkg_name_norm, pkg_name_norm.replace("_", "-"))
         ):
+            if _sidecar_package_is_optional(pkg_spec):
+                continue
             return False
         # Unpinned packages: existence is enough.
         if pkg_version is None:
@@ -2424,6 +2437,13 @@ def _ensure_venv_dir(venv_dir: str, packages: tuple[str, ...], label: str) -> bo
     for idx, pkg in enumerate(packages, start = 1):
         logger.info("Installing %s (%d/%d) into %s ...", pkg, idx, total, venv_dir)
         if not _install_to_dir(pkg, venv_dir):
+            if _sidecar_package_is_optional(pkg):
+                logger.warning(
+                    "%s could not be installed into %s; continuing without it (Qwen tokenizers may fail)",
+                    pkg,
+                    venv_dir,
+                )
+                continue
             return False
     logger.info("Installed %s to %s", label, venv_dir)
     return True

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2450,9 +2450,15 @@ def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> None:
     the sidecar was built (the latest sidecar in particular, which no setup top-up
     visits) left Qwen tokenizers broken until the user deleted the directory. Best
     effort and non-destructive: a failure is logged and not retried in this process,
-    nothing is attempted while the session is offline (a worker would otherwise sit
-    through network retries for a model that may not even need the package), and one
-    process at a time writes into a sidecar every worker shares.
+    and nothing is attempted while the session is offline (a worker would otherwise
+    sit through network retries for a model that may not even need the package).
+
+    Workers activate tiers independently and share the sidecar, so the add is staged:
+    the package is installed into a scratch directory beside the sidecar and its
+    entries are renamed in, payload first and dist-info last, so a scan by another
+    worker never meets a RECORD whose files have not landed and reads the sidecar as
+    damaged. One process at a time does this; another that finds the lock held waits
+    for it, then finds the package there.
     """
     if _env_offline() or os.environ.get("UV_OFFLINE", "").strip().lower() in _OFFLINE_TRUE_VALUES:
         return
@@ -2465,12 +2471,12 @@ def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> None:
         _OPTIONAL_TOP_UP_ATTEMPTED.add(key)
         with _optional_top_up_lock(venv_dir) as held:
             if not held:
-                # Another process is adding it now; this one uses whatever it leaves.
+                logger.warning("%s: another process held the top-up lock too long; left as is", venv_dir)
                 continue
             if not _optional_package_absent(venv_dir, pkg):
                 continue
             logger.info("Adding %s to %s (optional package missing) ...", pkg, venv_dir)
-            if not _install_to_dir(pkg, venv_dir):
+            if not _stage_optional_package(pkg, venv_dir):
                 logger.warning(
                     "%s could not be added to %s; continuing without it (Qwen tokenizers may fail)",
                     pkg,
@@ -2478,28 +2484,69 @@ def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> None:
                 )
 
 
+def _stage_optional_package(pkg: str, venv_dir: str) -> bool:
+    """Install *pkg* beside the sidecar, then move its entries in, dist-info last."""
+    staging = os.path.join(venv_dir, ".top-up-staging")
+    shutil.rmtree(staging, ignore_errors = True)
+    try:
+        os.makedirs(staging, exist_ok = True)
+        if not _install_to_dir(pkg, staging):
+            return False
+        entries = sorted(os.listdir(staging), key = lambda name: name.endswith(".dist-info"))
+        for name in entries:
+            source = os.path.join(staging, name)
+            target = os.path.join(venv_dir, name)
+            if os.path.isdir(target) and not os.path.islink(target):
+                shutil.rmtree(target, ignore_errors = True)
+            elif os.path.lexists(target):
+                os.unlink(target)
+            os.replace(source, target)
+        return True
+    except OSError as exc:
+        logger.warning("staging %s into %s failed: %s", pkg, venv_dir, exc)
+        return False
+    finally:
+        shutil.rmtree(staging, ignore_errors = True)
+
+
 _OPTIONAL_TOP_UP_LOCK = ".optional-top-up.lock"
+
+
+# How long a worker waits for another process's top-up before giving up on it.
+_OPTIONAL_TOP_UP_WAIT_SECONDS = 120.0
 
 
 @contextlib.contextmanager
 def _optional_top_up_lock(venv_dir: str):
-    """A non-blocking cross-process lock on a sidecar's optional top-up.
+    """A cross-process lock on a sidecar's optional top-up, waited for up to a bound.
 
     Workers activate tiers independently, so two can find the package absent at once;
-    two installers writing one --target tree leave it half-written. Yields True when
-    this process holds the lock, False when another does (or the lock cannot be taken,
-    which is read as "someone else's turn" rather than a reason to write unguarded).
+    two installers writing one --target tree leave it half-written, and a worker that
+    went on without waiting would activate with the package still absent. Yields True
+    when this process holds the lock, False when another kept it past the bound (or
+    the lock cannot be taken at all, read as "someone else's turn" rather than a
+    reason to write unguarded).
     """
     handle = None
     try:
         handle = open(os.path.join(venv_dir, _OPTIONAL_TOP_UP_LOCK), "a+b")
-        if sys.platform == "win32":
-            import msvcrt
-            handle.seek(0)
-            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
-        else:
-            import fcntl
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        deadline = time.monotonic() + _OPTIONAL_TOP_UP_WAIT_SECONDS
+        while True:
+            try:
+                if sys.platform == "win32":
+                    import msvcrt
+
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError:
+                if time.monotonic() >= deadline:
+                    raise
+                time.sleep(0.25)
     except OSError:
         if handle is not None:
             handle.close()

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2581,6 +2581,18 @@ def _stage_optional_package(pkg: str, venv_dir: str) -> bool:
         if not _install_to_dir(pkg, staging):
             return False
         entries = sorted(os.listdir(staging), key = lambda name: name.endswith(".dist-info"))
+        # An interrupted install can have left `<pkg>-<old>.dist-info` with no RECORD.
+        # uv cannot uninstall one (it warns and installs the new version beside it), the
+        # two validators skip a recordless dist-info, and importlib.metadata would keep
+        # answering whichever it meets first; every other dist-info of the project goes
+        # before the new metadata lands, under the lock the caller holds.
+        for name in entries:
+            if not name.endswith(".dist-info"):
+                continue
+            project = name[: -len(".dist-info")].rsplit("-", 1)[0]
+            for stale in _dist_info_entries(venv_dir, project):
+                if stale != name:
+                    shutil.rmtree(os.path.join(venv_dir, stale), ignore_errors = True)
         for name in entries:
             source = os.path.join(staging, name)
             target = os.path.join(venv_dir, name)

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -34,6 +34,7 @@ import importlib.util
 import json
 import structlog
 from loggers import get_logger
+import contextlib
 import os
 import re
 import shutil

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2163,13 +2163,10 @@ def _sidecar_scan_impl(venv_dir: str, limit: int = 3) -> tuple[list[str], bool]:
         return [], True
     for di in dist_infos:
         name = di.name.split("-")[0]
-        # An optional package's leftovers are not damage to the sidecar: an interrupted
-        # tiktoken install leaves a dist-info whose RECORD names files that never landed,
-        # and reading that as damage wiped and rebuilt the whole sidecar on every check,
-        # for a package the rebuild is allowed to fail to add again. The top-up in setup
-        # (and the optional rule in _ensure_venv_dir) is what repairs it.
-        if _sidecar_package_is_optional(name):
-            continue
+        # An optional package (tiktoken) may be absent, and _venv_dir_is_valid accepts
+        # that; present, its RECORD is held to the same standard as every other. A
+        # native extension left over from an older interpreter, or a file an interrupted
+        # install never landed, is a tokenizer that fails at import, not a spare part.
         try:
             record = (di / "RECORD").read_text(encoding = "utf-8", errors = "replace")
         except FileNotFoundError:
@@ -2433,9 +2430,46 @@ def _mark_studio_owned(venv_dir: str) -> None:
         pass
 
 
+# (venv_dir, package) pairs this process already tried to top up, so a package whose
+# wheel is unavailable is asked for once per session, not on every tier activation.
+_OPTIONAL_TOP_UP_ATTEMPTED: set[tuple[str, str]] = set()
+
+
+def _optional_package_absent(venv_dir: str, pkg_spec: str) -> bool:
+    name = pkg_spec.split("==")[0].replace("-", "_")
+    return not any(
+        (Path(venv_dir) / d / "__init__.py").is_file() for d in (name, name.replace("_", "-"))
+    )
+
+
+def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> None:
+    """Add an optional package a valid sidecar is missing, without touching the rest.
+
+    _venv_dir_is_valid accepts a sidecar without tiktoken, so a transient failure while
+    the sidecar was built (the latest sidecar in particular, which no setup top-up
+    visits) left Qwen tokenizers broken until the user deleted the directory. Best
+    effort and non-destructive: a failure is logged and not retried in this process.
+    """
+    for pkg in packages:
+        if not _sidecar_package_is_optional(pkg) or not _optional_package_absent(venv_dir, pkg):
+            continue
+        key = (os.path.normcase(os.path.abspath(venv_dir)), pkg)
+        if key in _OPTIONAL_TOP_UP_ATTEMPTED:
+            continue
+        _OPTIONAL_TOP_UP_ATTEMPTED.add(key)
+        logger.info("Adding %s to %s (optional package missing) ...", pkg, venv_dir)
+        if not _install_to_dir(pkg, venv_dir):
+            logger.warning(
+                "%s could not be added to %s; continuing without it (Qwen tokenizers may fail)",
+                pkg,
+                venv_dir,
+            )
+
+
 def _ensure_venv_dir(venv_dir: str, packages: tuple[str, ...], label: str) -> bool:
     """Ensure *venv_dir* exists with all *packages*. Install if missing."""
     if _venv_dir_is_valid_and_undamaged(venv_dir, packages):
+        _top_up_optional_packages(venv_dir, packages)
         return True
 
     logger.warning("%s not found or incomplete at %s -- installing at runtime", label, venv_dir)
@@ -2951,6 +2985,7 @@ def ensure_latest_transformers_venv(
         and tuple(pin["packages"]) == packages
         and _venv_dir_is_valid_and_undamaged(_VENV_T5_LATEST_DIR, packages)
     ):
+        _top_up_optional_packages(_VENV_T5_LATEST_DIR, packages)
         return True
     return _stage_and_swap_latest_venv(version, packages, before_swap = before_swap)
 

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2027,11 +2027,9 @@ _VENV_T5_550_PACKAGES = (
 # Backwards-compat alias
 _VENV_T5_PACKAGES = _VENV_T5_550_PACKAGES
 
-# Packages a sidecar is complete without. setup.sh and setup.ps1 install tiktoken into
-# every sidecar on a best-effort basis (a Python with no compatible wheel gets the
-# sidecar without it, and only Qwen tokenizers notice), and record that sidecar as
-# complete. The runtime has to agree, or the first model on that tier would find the
-# sidecar "incomplete", delete it, and retry the same install that could not be done.
+# Packages a sidecar is complete without: setup installs tiktoken best-effort (no wheel for the
+# interpreter is fine, only Qwen tokenizers notice), and the runtime has to agree or it would delete
+# the sidecar and retry the same impossible install.
 _OPTIONAL_SIDECAR_PACKAGES = frozenset({"tiktoken"})
 
 
@@ -2164,10 +2162,8 @@ def _sidecar_scan_impl(venv_dir: str, limit: int = 3) -> tuple[list[str], bool]:
         return [], True
     for di in dist_infos:
         name = di.name.split("-")[0]
-        # An optional package (tiktoken) may be absent, and _venv_dir_is_valid accepts
-        # that; present, its RECORD is held to the same standard as every other. A
-        # native extension left over from an older interpreter, or a file an interrupted
-        # install never landed, is a tokenizer that fails at import, not a spare part.
+        # An optional package may be absent; present, its RECORD is held to the same standard, since
+        # a stale extension or a missing file is a tokenizer that fails at import.
         try:
             record = (di / "RECORD").read_text(encoding = "utf-8", errors = "replace")
         except FileNotFoundError:
@@ -2431,8 +2427,8 @@ def _mark_studio_owned(venv_dir: str) -> None:
         pass
 
 
-# (venv_dir, package) pairs this process already tried to top up, so a package whose
-# wheel is unavailable is asked for once per session, not on every tier activation.
+# (venv_dir, package) pairs already tried this process: an unavailable wheel is asked for once per
+# session.
 _OPTIONAL_TOP_UP_ATTEMPTED: set[tuple[str, str]] = set()
 
 
@@ -2488,11 +2484,9 @@ def _remove_optional_remnants(venv_dir: str, pkg_spec: str) -> bool:
     site-packages, and the caller has to treat the directory as not usable rather than
     report a sidecar that will fail at tokenization.
     """
-    # Every top-level entry the wheel owns, not only the import package: tiktoken ships
-    # tiktoken/, tiktoken_ext/ (the plugin namespace, whose openai_public module would
-    # shadow the ambient one on its own) and tiktoken-<v>.dist-info; a .libs directory
-    # would follow the same naming. The prefix is the project name followed by the end,
-    # an underscore, a dot or a hyphen, which no other package in these sidecars shares.
+    # Every top-level entry the wheel owns: tiktoken/, tiktoken_ext/ (whose openai_public would
+    # shadow the ambient one alone), tiktoken-<v>.dist-info, a .libs directory. The prefix is the
+    # project name then end, underscore, dot or hyphen, which no other sidecar package shares.
     root = Path(venv_dir)
 
     def _owned() -> list[str]:
@@ -2541,9 +2535,8 @@ def _dist_info_entries(venv_dir: str, name: str) -> list[str]:
     ]
 
 
-# Failed top-ups, recorded beside the sidecar so every worker process sees them: each
-# job spawns its own workers, and a wheel that is not there for one of them is not
-# there for the next either. Retried after a while, in case it was the network.
+# Failed top-ups, recorded beside the sidecar so every worker process sees them; retried after a
+# while in case it was the network.
 _OPTIONAL_TOP_UP_FAILED = ".optional-top-up-failed.json"
 _OPTIONAL_TOP_UP_RETRY_SECONDS = 6 * 60 * 60.0
 
@@ -2622,10 +2615,9 @@ def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> bool:
         if not _sidecar_package_is_optional(pkg):
             continue
         if offline:
-            # No install offline, but a payload an interrupted top-up left without its
-            # dist-info is still cleared: it counts as absent to the validators and would
-            # otherwise be activated ahead of a working ambient copy. Under the lock, so
-            # a top-up another process is finishing right now is not swept from under it.
+            # No install offline, but a payload left without its dist-info is still cleared: it
+            # counts as absent yet would be activated ahead of a working ambient copy. Under the
+            # lock.
             if _optional_package_partly_there(venv_dir, pkg):
                 with _optional_top_up_lock(venv_dir) as held:
                     if held and _optional_package_partly_there(venv_dir, pkg):
@@ -2637,9 +2629,8 @@ def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> bool:
                     elif not held:
                         usable = False
             continue
-        # A recordless dist-info beside a complete install (a retry that succeeded after
-        # an interrupted one) is never reached by the staging path's cleanup, since the
-        # package reads as present; importlib.metadata could keep answering its version.
+        # A recordless dist-info beside a complete install is never reached by the staging cleanup,
+        # and importlib.metadata could keep answering its version.
         _remove_recordless_dist_infos(venv_dir, pkg)
         if not _optional_package_absent(venv_dir, pkg):
             continue
@@ -2652,8 +2643,7 @@ def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> bool:
                 logger.warning(
                     "%s: another process held the top-up lock too long; left as is", venv_dir
                 )
-                # Left as is, but not activated with a partial payload ahead of
-                # site-packages: the same rule as the offline branch above.
+                # Left as is, but not activated with a partial payload ahead of site-packages.
                 if _optional_package_partly_there(venv_dir, pkg):
                     usable = False
                 continue
@@ -2673,9 +2663,7 @@ def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> bool:
                     pkg,
                     venv_dir,
                 )
-                # ...only if nothing of it is left behind. A remnant the cleanup could
-                # not remove sits ahead of site-packages, and the sidecar is not one to
-                # activate until it is gone.
+                # ...only if nothing of it is left behind ahead of site-packages.
                 if _optional_package_partly_there(venv_dir, pkg):
                     usable = False
     return usable
@@ -2688,19 +2676,14 @@ def _stage_optional_package(pkg: str, venv_dir: str) -> bool:
     try:
         os.makedirs(staging, exist_ok = True)
         if not _install_to_dir(pkg, staging):
-            # The caller came here because the package is absent or only partly there
-            # (a payload directory an interrupted top-up moved in without its
-            # dist-info). Left as it is, that partial tree would sit ahead of
-            # site-packages for the whole retry backoff and shadow a working ambient
-            # copy; absent is the only safe shape until the next attempt.
+            # A partial payload (moved in without its dist-info) would shadow a working ambient copy
+            # for the whole retry backoff; absent is the only safe shape.
             _remove_optional_remnants(venv_dir, pkg)
             return False
         entries = sorted(os.listdir(staging), key = lambda name: name.endswith(".dist-info"))
-        # An interrupted install can have left `<pkg>-<old>.dist-info` with no RECORD.
-        # uv cannot uninstall one (it warns and installs the new version beside it), the
-        # two validators skip a recordless dist-info, and importlib.metadata would keep
-        # answering whichever it meets first; every other dist-info of the project goes
-        # before the new metadata lands, under the lock the caller holds.
+        # A recordless `<pkg>-<old>.dist-info`: uv cannot uninstall it, the validators skip it, and
+        # importlib.metadata answers whichever it meets first. Every other dist-info of the project
+        # goes before the new metadata lands.
         for name in entries:
             if not name.endswith(".dist-info"):
                 continue
@@ -2719,8 +2702,7 @@ def _stage_optional_package(pkg: str, venv_dir: str) -> bool:
         return True
     except OSError as exc:
         logger.warning("staging %s into %s failed: %s", pkg, venv_dir, exc)
-        # Entries moved before the failure would sit ahead of site-packages without
-        # their dist-info for the whole retry backoff; absent is the only safe shape.
+        # Entries moved before the failure would shadow site-packages for the whole backoff.
         _remove_optional_remnants(venv_dir, pkg)
         return False
     finally:
@@ -2803,11 +2785,9 @@ def _ensure_venv_dir(venv_dir: str, packages: tuple[str, ...], label: str) -> bo
                     pkg,
                     venv_dir,
                 )
-                # Only an absent optional package is safe to continue without: this
-                # directory goes ahead of site-packages, and a half-copied payload
-                # would shadow the ambient one and fail at tokenization. A remnant
-                # that would not go makes this a failed build, not a sidecar without
-                # the package; the next run rebuilds it.
+                # Only an absent optional package is safe: a half-copied payload ahead of
+                # site-packages fails at tokenization. A remnant that would not go is a failed
+                # build.
                 if _remove_optional_remnants(venv_dir, pkg):
                     continue
             return False
@@ -3231,9 +3211,8 @@ def _ensure_venv_t5_latest_exists() -> bool:
         # Only a scan that actually read the files may retire it; one that hit EIO has not.
         if conclusive:
             _clear_latest_repair_request()
-        # Healthy without an optional package is healthy; activation is where the latest
-        # tier is asked for, so it is where a missing tiktoken gets its top-up. A partial
-        # one that would not go withholds the sidecar for this activation.
+        # Healthy without an optional package is healthy; activation is where a missing tiktoken
+        # gets its top-up, and a partial one that would not go withholds the sidecar.
         return _top_up_optional_packages(_VENV_T5_LATEST_DIR, packages)
     # Broken, and every path below can still fail to fix it (offline, a child, a swap already
     # running, pip). Flag it here rather than per bailout, so the routing predicate withholds

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2452,6 +2452,15 @@ def _optional_package_absent(venv_dir: str, pkg_spec: str) -> bool:
     )
 
 
+def _remove_recordless_dist_infos(venv_dir: str, pkg_spec: str) -> None:
+    """Drop every `<pkg>-*.dist-info` with no RECORD: metadata uv cannot uninstall."""
+    name = pkg_spec.split("==")[0]
+    root = Path(venv_dir)
+    for entry in _dist_info_entries(venv_dir, name):
+        if not (root / entry / "RECORD").is_file():
+            shutil.rmtree(root / entry, ignore_errors = True)
+
+
 def _dist_info_entries(venv_dir: str, name: str) -> list[str]:
     wanted = name.lower().replace("-", "_")
     try:
@@ -2542,7 +2551,13 @@ def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> None:
     if _env_offline() or os.environ.get("UV_OFFLINE", "").strip().lower() in _OFFLINE_TRUE_VALUES:
         return
     for pkg in packages:
-        if not _sidecar_package_is_optional(pkg) or not _optional_package_absent(venv_dir, pkg):
+        if not _sidecar_package_is_optional(pkg):
+            continue
+        # A recordless dist-info beside a complete install (a retry that succeeded after
+        # an interrupted one) is never reached by the staging path's cleanup, since the
+        # package reads as present; importlib.metadata could keep answering its version.
+        _remove_recordless_dist_infos(venv_dir, pkg)
+        if not _optional_package_absent(venv_dir, pkg):
             continue
         key = (os.path.normcase(os.path.abspath(venv_dir)), pkg)
         if key in _OPTIONAL_TOP_UP_ATTEMPTED:

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2650,6 +2650,10 @@ def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> bool:
                 logger.warning(
                     "%s: another process held the top-up lock too long; left as is", venv_dir
                 )
+                # Left as is, but not activated with a partial payload ahead of
+                # site-packages: the same rule as the offline branch above.
+                if _optional_package_partly_there(venv_dir, pkg):
+                    usable = False
                 continue
             if not _optional_package_absent(venv_dir, pkg):
                 continue

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2035,7 +2035,9 @@ _OPTIONAL_SIDECAR_PACKAGES = frozenset({"tiktoken"})
 
 
 def _sidecar_package_is_optional(pkg_spec: str) -> bool:
-    return pkg_spec.split("==", 1)[0].strip().lower().replace("_", "-") in _OPTIONAL_SIDECAR_PACKAGES
+    return (
+        pkg_spec.split("==", 1)[0].strip().lower().replace("_", "-") in _OPTIONAL_SIDECAR_PACKAGES
+    )
 
 
 _SIDECAR_FILE_CHECK_ENV = "UNSLOTH_SKIP_SIDECAR_FILE_CHECK"

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2647,6 +2647,12 @@ def _stage_optional_package(pkg: str, venv_dir: str) -> bool:
     try:
         os.makedirs(staging, exist_ok = True)
         if not _install_to_dir(pkg, staging):
+            # The caller came here because the package is absent or only partly there
+            # (a payload directory an interrupted top-up moved in without its
+            # dist-info). Left as it is, that partial tree would sit ahead of
+            # site-packages for the whole retry backoff and shadow a working ambient
+            # copy; absent is the only safe shape until the next attempt.
+            _remove_optional_remnants(venv_dir, pkg)
             return False
         entries = sorted(os.listdir(staging), key = lambda name: name.endswith(".dist-info"))
         # An interrupted install can have left `<pkg>-<old>.dist-info` with no RECORD.

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2471,7 +2471,9 @@ def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> None:
         _OPTIONAL_TOP_UP_ATTEMPTED.add(key)
         with _optional_top_up_lock(venv_dir) as held:
             if not held:
-                logger.warning("%s: another process held the top-up lock too long; left as is", venv_dir)
+                logger.warning(
+                    "%s: another process held the top-up lock too long; left as is", venv_dir
+                )
                 continue
             if not _optional_package_absent(venv_dir, pkg):
                 continue
@@ -2535,12 +2537,10 @@ def _optional_top_up_lock(venv_dir: str):
             try:
                 if sys.platform == "win32":
                     import msvcrt
-
                     handle.seek(0)
                     msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
                 else:
                     import fcntl
-
                     fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
                 break
             except OSError:

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2448,8 +2448,13 @@ def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> None:
     _venv_dir_is_valid accepts a sidecar without tiktoken, so a transient failure while
     the sidecar was built (the latest sidecar in particular, which no setup top-up
     visits) left Qwen tokenizers broken until the user deleted the directory. Best
-    effort and non-destructive: a failure is logged and not retried in this process.
+    effort and non-destructive: a failure is logged and not retried in this process,
+    nothing is attempted while the session is offline (a worker would otherwise sit
+    through network retries for a model that may not even need the package), and one
+    process at a time writes into a sidecar every worker shares.
     """
+    if _env_offline() or os.environ.get("UV_OFFLINE", "").strip().lower() in _OFFLINE_TRUE_VALUES:
+        return
     for pkg in packages:
         if not _sidecar_package_is_optional(pkg) or not _optional_package_absent(venv_dir, pkg):
             continue
@@ -2457,13 +2462,66 @@ def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> None:
         if key in _OPTIONAL_TOP_UP_ATTEMPTED:
             continue
         _OPTIONAL_TOP_UP_ATTEMPTED.add(key)
-        logger.info("Adding %s to %s (optional package missing) ...", pkg, venv_dir)
-        if not _install_to_dir(pkg, venv_dir):
-            logger.warning(
-                "%s could not be added to %s; continuing without it (Qwen tokenizers may fail)",
-                pkg,
-                venv_dir,
-            )
+        with _optional_top_up_lock(venv_dir) as held:
+            if not held:
+                # Another process is adding it now; this one uses whatever it leaves.
+                continue
+            if not _optional_package_absent(venv_dir, pkg):
+                continue
+            logger.info("Adding %s to %s (optional package missing) ...", pkg, venv_dir)
+            if not _install_to_dir(pkg, venv_dir):
+                logger.warning(
+                    "%s could not be added to %s; continuing without it (Qwen tokenizers may fail)",
+                    pkg,
+                    venv_dir,
+                )
+
+
+_OPTIONAL_TOP_UP_LOCK = ".optional-top-up.lock"
+
+
+@contextlib.contextmanager
+def _optional_top_up_lock(venv_dir: str):
+    """A non-blocking cross-process lock on a sidecar's optional top-up.
+
+    Workers activate tiers independently, so two can find the package absent at once;
+    two installers writing one --target tree leave it half-written. Yields True when
+    this process holds the lock, False when another does (or the lock cannot be taken,
+    which is read as "someone else's turn" rather than a reason to write unguarded).
+    """
+    handle = None
+    try:
+        handle = open(os.path.join(venv_dir, _OPTIONAL_TOP_UP_LOCK), "a+b")
+        if sys.platform == "win32":
+            import msvcrt
+
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        if handle is not None:
+            handle.close()
+        yield False
+        return
+    try:
+        yield True
+    finally:
+        try:
+            if sys.platform == "win32":
+                import msvcrt
+
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            pass
+        handle.close()
 
 
 def _ensure_venv_dir(venv_dir: str, packages: tuple[str, ...], label: str) -> bool:

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2452,6 +2452,29 @@ def _optional_package_absent(venv_dir: str, pkg_spec: str) -> bool:
     )
 
 
+def _optional_package_entries(venv_dir: str, pkg_spec: str) -> list[str]:
+    """Every top-level entry of the sidecar the optional package's wheel owns."""
+    stem = pkg_spec.split("==")[0].lower().replace("-", "_")
+    try:
+        entries = os.listdir(venv_dir)
+    except OSError:
+        return []
+    return [
+        entry
+        for entry in entries
+        if entry.lower().replace("-", "_") == stem
+        or entry.lower().replace("-", "_").startswith((stem + "_", stem + "."))
+    ]
+
+
+def _optional_package_partly_there(venv_dir: str, pkg_spec: str) -> bool:
+    """A payload without the dist-info that would make it count: an interrupted top-up
+    (or a failed install) left it, and it sits ahead of site-packages."""
+    return _optional_package_absent(venv_dir, pkg_spec) and bool(
+        _optional_package_entries(venv_dir, pkg_spec)
+    )
+
+
 def _remove_optional_remnants(venv_dir: str, pkg_spec: str) -> bool:
     """Drop what a failed optional install left: the payload directory and every dist-info.
 
@@ -2470,20 +2493,10 @@ def _remove_optional_remnants(venv_dir: str, pkg_spec: str) -> bool:
     # shadow the ambient one on its own) and tiktoken-<v>.dist-info; a .libs directory
     # would follow the same naming. The prefix is the project name followed by the end,
     # an underscore, a dot or a hyphen, which no other package in these sidecars shares.
-    stem = pkg_spec.split("==")[0].lower().replace("-", "_")
     root = Path(venv_dir)
 
     def _owned() -> list[str]:
-        try:
-            entries = os.listdir(venv_dir)
-        except OSError:
-            return []
-        return [
-            entry
-            for entry in entries
-            if entry.lower().replace("-", "_") == stem
-            or entry.lower().replace("-", "_").startswith((stem + "_", stem + "."))
-        ]
+        return _optional_package_entries(venv_dir, pkg_spec)
 
     for entry in _owned():
         path = root / entry
@@ -2582,7 +2595,7 @@ def _record_top_up_outcome(venv_dir: str, pkg: str, ok: bool) -> None:
     _write_top_up_failures(venv_dir, failures)
 
 
-def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> None:
+def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> bool:
     """Add an optional package a valid sidecar is missing, without touching the rest.
 
     _venv_dir_is_valid accepts a sidecar without tiktoken, so a transient failure while
@@ -2601,10 +2614,26 @@ def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> None:
     damaged. One process at a time does this; another that finds the lock held waits
     for it, then finds the package there.
     """
-    if _env_offline() or os.environ.get("UV_OFFLINE", "").strip().lower() in _OFFLINE_TRUE_VALUES:
-        return
+    usable = True
+    offline = _env_offline() or os.environ.get("UV_OFFLINE", "").strip().lower() in _OFFLINE_TRUE_VALUES
     for pkg in packages:
         if not _sidecar_package_is_optional(pkg):
+            continue
+        if offline:
+            # No install offline, but a payload an interrupted top-up left without its
+            # dist-info is still cleared: it counts as absent to the validators and would
+            # otherwise be activated ahead of a working ambient copy. Under the lock, so
+            # a top-up another process is finishing right now is not swept from under it.
+            if _optional_package_partly_there(venv_dir, pkg):
+                with _optional_top_up_lock(venv_dir) as held:
+                    if held and _optional_package_partly_there(venv_dir, pkg):
+                        logger.warning(
+                            "%s: removing the partial %s an interrupted add left", venv_dir, pkg
+                        )
+                        if not _remove_optional_remnants(venv_dir, pkg):
+                            usable = False
+                    elif not held:
+                        usable = False
             continue
         # A recordless dist-info beside a complete install (a retry that succeeded after
         # an interrupted one) is never reached by the staging path's cleanup, since the
@@ -2638,6 +2667,12 @@ def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> None:
                     pkg,
                     venv_dir,
                 )
+                # ...only if nothing of it is left behind. A remnant the cleanup could
+                # not remove sits ahead of site-packages, and the sidecar is not one to
+                # activate until it is gone.
+                if _optional_package_partly_there(venv_dir, pkg):
+                    usable = False
+    return usable
 
 
 def _stage_optional_package(pkg: str, venv_dir: str) -> bool:
@@ -2746,8 +2781,7 @@ def _optional_top_up_lock(venv_dir: str):
 def _ensure_venv_dir(venv_dir: str, packages: tuple[str, ...], label: str) -> bool:
     """Ensure *venv_dir* exists with all *packages*. Install if missing."""
     if _venv_dir_is_valid_and_undamaged(venv_dir, packages):
-        _top_up_optional_packages(venv_dir, packages)
-        return True
+        return _top_up_optional_packages(venv_dir, packages)
 
     logger.warning("%s not found or incomplete at %s -- installing at runtime", label, venv_dir)
     shutil.rmtree(venv_dir, ignore_errors = True)
@@ -3192,9 +3226,9 @@ def _ensure_venv_t5_latest_exists() -> bool:
         if conclusive:
             _clear_latest_repair_request()
         # Healthy without an optional package is healthy; activation is where the latest
-        # tier is asked for, so it is where a missing tiktoken gets its top-up.
-        _top_up_optional_packages(_VENV_T5_LATEST_DIR, packages)
-        return True
+        # tier is asked for, so it is where a missing tiktoken gets its top-up. A partial
+        # one that would not go withholds the sidecar for this activation.
+        return _top_up_optional_packages(_VENV_T5_LATEST_DIR, packages)
     # Broken, and every path below can still fail to fix it (offline, a child, a swap already
     # running, pip). Flag it here rather than per bailout, so the routing predicate withholds
     # the sidecar whichever we take: it cannot see sub-file damage itself, and a mapping
@@ -3271,8 +3305,7 @@ def ensure_latest_transformers_venv(
         and tuple(pin["packages"]) == packages
         and _venv_dir_is_valid_and_undamaged(_VENV_T5_LATEST_DIR, packages)
     ):
-        _top_up_optional_packages(_VENV_T5_LATEST_DIR, packages)
-        return True
+        return _top_up_optional_packages(_VENV_T5_LATEST_DIR, packages)
     return _stage_and_swap_latest_venv(version, packages, before_swap = before_swap)
 
 

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2437,10 +2437,88 @@ _OPTIONAL_TOP_UP_ATTEMPTED: set[tuple[str, str]] = set()
 
 
 def _optional_package_absent(venv_dir: str, pkg_spec: str) -> bool:
+    """Whether *pkg_spec* is missing from the sidecar, or only partly there.
+
+    The top-up moves a package in entry by entry with its dist-info last, so a package
+    counts as present only when its dist-info has landed: a payload directory on its
+    own is an interrupted top-up, which nothing else would ever finish.
+    """
     name = pkg_spec.split("==")[0].replace("-", "_")
+    root = Path(venv_dir)
+    if not any((root / d / "__init__.py").is_file() for d in (name, name.replace("_", "-"))):
+        return True
     return not any(
-        (Path(venv_dir) / d / "__init__.py").is_file() for d in (name, name.replace("_", "-"))
+        (root / entry / "RECORD").is_file()
+        for entry in _dist_info_entries(venv_dir, name)
     )
+
+
+def _dist_info_entries(venv_dir: str, name: str) -> list[str]:
+    wanted = name.lower().replace("-", "_")
+    try:
+        entries = os.listdir(venv_dir)
+    except OSError:
+        return []
+    return [
+        entry
+        for entry in entries
+        if entry.endswith(".dist-info")
+        and entry[: -len(".dist-info")].rsplit("-", 1)[0].lower().replace("-", "_") == wanted
+    ]
+
+
+# Failed top-ups, recorded beside the sidecar so every worker process sees them: each
+# job spawns its own workers, and a wheel that is not there for one of them is not
+# there for the next either. Retried after a while, in case it was the network.
+_OPTIONAL_TOP_UP_FAILED = ".optional-top-up-failed.json"
+_OPTIONAL_TOP_UP_RETRY_SECONDS = 6 * 60 * 60.0
+
+
+def _top_up_failure_path(venv_dir: str) -> str:
+    return os.path.join(venv_dir, _OPTIONAL_TOP_UP_FAILED)
+
+
+def _read_top_up_failures(venv_dir: str) -> dict:
+    try:
+        with open(_top_up_failure_path(venv_dir), encoding = "utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_top_up_failures(venv_dir: str, failures: dict) -> None:
+    path = _top_up_failure_path(venv_dir)
+    try:
+        if not failures:
+            if os.path.exists(path):
+                os.unlink(path)
+            return
+        tmp = path + ".tmp"
+        with open(tmp, "w", encoding = "utf-8") as fh:
+            json.dump(failures, fh)
+        os.replace(tmp, path)
+    except OSError:
+        pass
+
+
+def _top_up_failed_recently(venv_dir: str, pkg: str) -> bool:
+    when = _read_top_up_failures(venv_dir).get(pkg)
+    if not isinstance(when, (int, float)):
+        return False
+    age = time.time() - when
+    return 0 <= age < _OPTIONAL_TOP_UP_RETRY_SECONDS
+
+
+def _record_top_up_outcome(venv_dir: str, pkg: str, ok: bool) -> None:
+    failures = _read_top_up_failures(venv_dir)
+    if ok:
+        if pkg not in failures:
+            return
+        failures.pop(pkg, None)
+    else:
+        failures[pkg] = time.time()
+    _write_top_up_failures(venv_dir, failures)
 
 
 def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> None:
@@ -2449,9 +2527,11 @@ def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> None:
     _venv_dir_is_valid accepts a sidecar without tiktoken, so a transient failure while
     the sidecar was built (the latest sidecar in particular, which no setup top-up
     visits) left Qwen tokenizers broken until the user deleted the directory. Best
-    effort and non-destructive: a failure is logged and not retried in this process,
-    and nothing is attempted while the session is offline (a worker would otherwise
-    sit through network retries for a model that may not even need the package).
+    effort and non-destructive: a failure is logged, recorded beside the sidecar and
+    not retried by any worker process for a while (each job spawns its own workers,
+    which would otherwise each sit through the same doomed install), and nothing is
+    attempted while the session is offline (a worker would otherwise sit through
+    network retries for a model that may not even need the package).
 
     Workers activate tiers independently and share the sidecar, so the add is staged:
     the package is installed into a scratch directory beside the sidecar and its
@@ -2477,8 +2557,15 @@ def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> None:
                 continue
             if not _optional_package_absent(venv_dir, pkg):
                 continue
+            if _top_up_failed_recently(venv_dir, pkg):
+                logger.info(
+                    "%s: a recent attempt to add %s failed; not retrying yet", venv_dir, pkg
+                )
+                continue
             logger.info("Adding %s to %s (optional package missing) ...", pkg, venv_dir)
-            if not _stage_optional_package(pkg, venv_dir):
+            ok = _stage_optional_package(pkg, venv_dir)
+            _record_top_up_outcome(venv_dir, pkg, ok)
+            if not ok:
                 logger.warning(
                     "%s could not be added to %s; continuing without it (Qwen tokenizers may fail)",
                     pkg,

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2615,7 +2615,9 @@ def _top_up_optional_packages(venv_dir: str, packages: tuple[str, ...]) -> bool:
     for it, then finds the package there.
     """
     usable = True
-    offline = _env_offline() or os.environ.get("UV_OFFLINE", "").strip().lower() in _OFFLINE_TRUE_VALUES
+    offline = (
+        _env_offline() or os.environ.get("UV_OFFLINE", "").strip().lower() in _OFFLINE_TRUE_VALUES
+    )
     for pkg in packages:
         if not _sidecar_package_is_optional(pkg):
             continue

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2452,13 +2452,18 @@ def _optional_package_absent(venv_dir: str, pkg_spec: str) -> bool:
     )
 
 
-def _remove_optional_remnants(venv_dir: str, pkg_spec: str) -> None:
+def _remove_optional_remnants(venv_dir: str, pkg_spec: str) -> bool:
     """Drop what a failed optional install left: the payload directory and every dist-info.
 
     An installer that exits nonzero part-way (a full disk, an interrupted copy) can leave
     the package directory without its native extension, or metadata without the package;
     with both gone, _optional_package_absent reads the package as absent and the next
     top-up tries again instead of the sidecar shadowing a working ambient copy.
+
+    Answers whether nothing of the package is left. A remnant that would not go (a file
+    another process holds open on Windows, a permission) still sits ahead of
+    site-packages, and the caller has to treat the directory as not usable rather than
+    report a sidecar that will fail at tokenization.
     """
     # Every top-level entry the wheel owns, not only the import package: tiktoken ships
     # tiktoken/, tiktoken_ext/ (the plugin namespace, whose openai_public module would
@@ -2467,14 +2472,20 @@ def _remove_optional_remnants(venv_dir: str, pkg_spec: str) -> None:
     # an underscore, a dot or a hyphen, which no other package in these sidecars shares.
     stem = pkg_spec.split("==")[0].lower().replace("-", "_")
     root = Path(venv_dir)
-    try:
-        entries = os.listdir(venv_dir)
-    except OSError:
-        return
-    for entry in entries:
-        lowered = entry.lower().replace("-", "_")
-        if lowered != stem and not lowered.startswith((stem + "_", stem + ".")):
-            continue
+
+    def _owned() -> list[str]:
+        try:
+            entries = os.listdir(venv_dir)
+        except OSError:
+            return []
+        return [
+            entry
+            for entry in entries
+            if entry.lower().replace("-", "_") == stem
+            or entry.lower().replace("-", "_").startswith((stem + "_", stem + "."))
+        ]
+
+    for entry in _owned():
         path = root / entry
         if path.is_dir() and not path.is_symlink():
             shutil.rmtree(path, ignore_errors = True)
@@ -2483,6 +2494,15 @@ def _remove_optional_remnants(venv_dir: str, pkg_spec: str) -> None:
                 path.unlink()
             except OSError:
                 pass
+    left = _owned()
+    if left:
+        logger.warning(
+            "%s could not be removed from %s after a failed install of %s; the directory is not usable",
+            ", ".join(sorted(left)[:5]),
+            venv_dir,
+            pkg_spec,
+        )
+    return not left
 
 
 def _remove_recordless_dist_infos(venv_dir: str, pkg_spec: str) -> None:
@@ -2739,9 +2759,11 @@ def _ensure_venv_dir(venv_dir: str, packages: tuple[str, ...], label: str) -> bo
                 )
                 # Only an absent optional package is safe to continue without: this
                 # directory goes ahead of site-packages, and a half-copied payload
-                # would shadow the ambient one and fail at tokenization.
-                _remove_optional_remnants(venv_dir, pkg)
-                continue
+                # would shadow the ambient one and fail at tokenization. A remnant
+                # that would not go makes this a failed build, not a sidecar without
+                # the package; the next run rebuilds it.
+                if _remove_optional_remnants(venv_dir, pkg):
+                    continue
             return False
     logger.info("Installed %s to %s", label, venv_dir)
     return True

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2495,12 +2495,10 @@ def _optional_top_up_lock(venv_dir: str):
         handle = open(os.path.join(venv_dir, _OPTIONAL_TOP_UP_LOCK), "a+b")
         if sys.platform == "win32":
             import msvcrt
-
             handle.seek(0)
             msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
         else:
             import fcntl
-
             fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
     except OSError:
         if handle is not None:
@@ -2513,12 +2511,10 @@ def _optional_top_up_lock(venv_dir: str):
         try:
             if sys.platform == "win32":
                 import msvcrt
-
                 handle.seek(0)
                 msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
             else:
                 import fcntl
-
                 fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
         except OSError:
             pass

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2448,8 +2448,7 @@ def _optional_package_absent(venv_dir: str, pkg_spec: str) -> bool:
     if not any((root / d / "__init__.py").is_file() for d in (name, name.replace("_", "-"))):
         return True
     return not any(
-        (root / entry / "RECORD").is_file()
-        for entry in _dist_info_entries(venv_dir, name)
+        (root / entry / "RECORD").is_file() for entry in _dist_info_entries(venv_dir, name)
     )
 
 

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2908,6 +2908,9 @@ def _ensure_venv_t5_latest_exists() -> bool:
         # Only a scan that actually read the files may retire it; one that hit EIO has not.
         if conclusive:
             _clear_latest_repair_request()
+        # Healthy without an optional package is healthy; activation is where the latest
+        # tier is asked for, so it is where a missing tiktoken gets its top-up.
+        _top_up_optional_packages(_VENV_T5_LATEST_DIR, packages)
         return True
     # Broken, and every path below can still fail to fix it (offline, a child, a swap already
     # running, pip). Flag it here rather than per bailout, so the routing predicate withholds

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2460,14 +2460,29 @@ def _remove_optional_remnants(venv_dir: str, pkg_spec: str) -> None:
     with both gone, _optional_package_absent reads the package as absent and the next
     top-up tries again instead of the sidecar shadowing a working ambient copy.
     """
-    name = pkg_spec.split("==")[0]
+    # Every top-level entry the wheel owns, not only the import package: tiktoken ships
+    # tiktoken/, tiktoken_ext/ (the plugin namespace, whose openai_public module would
+    # shadow the ambient one on its own) and tiktoken-<v>.dist-info; a .libs directory
+    # would follow the same naming. The prefix is the project name followed by the end,
+    # an underscore, a dot or a hyphen, which no other package in these sidecars shares.
+    stem = pkg_spec.split("==")[0].lower().replace("-", "_")
     root = Path(venv_dir)
-    for candidate in {name, name.replace("-", "_"), name.replace("_", "-")}:
-        payload = root / candidate
-        if payload.is_dir() and not payload.is_symlink():
-            shutil.rmtree(payload, ignore_errors = True)
-    for entry in _dist_info_entries(venv_dir, name):
-        shutil.rmtree(root / entry, ignore_errors = True)
+    try:
+        entries = os.listdir(venv_dir)
+    except OSError:
+        return
+    for entry in entries:
+        lowered = entry.lower().replace("-", "_")
+        if lowered != stem and not lowered.startswith((stem + "_", stem + ".")):
+            continue
+        path = root / entry
+        if path.is_dir() and not path.is_symlink():
+            shutil.rmtree(path, ignore_errors = True)
+        elif path.exists() or path.is_symlink():
+            try:
+                path.unlink()
+            except OSError:
+                pass
 
 
 def _remove_recordless_dist_infos(venv_dir: str, pkg_spec: str) -> None:
@@ -2637,6 +2652,9 @@ def _stage_optional_package(pkg: str, venv_dir: str) -> bool:
         return True
     except OSError as exc:
         logger.warning("staging %s into %s failed: %s", pkg, venv_dir, exc)
+        # Entries moved before the failure would sit ahead of site-packages without
+        # their dist-info for the whole retry backoff; absent is the only safe shape.
+        _remove_optional_remnants(venv_dir, pkg)
         return False
     finally:
         shutil.rmtree(staging, ignore_errors = True)

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2163,6 +2163,13 @@ def _sidecar_scan_impl(venv_dir: str, limit: int = 3) -> tuple[list[str], bool]:
         return [], True
     for di in dist_infos:
         name = di.name.split("-")[0]
+        # An optional package's leftovers are not damage to the sidecar: an interrupted
+        # tiktoken install leaves a dist-info whose RECORD names files that never landed,
+        # and reading that as damage wiped and rebuilt the whole sidecar on every check,
+        # for a package the rebuild is allowed to fail to add again. The top-up in setup
+        # (and the optional rule in _ensure_venv_dir) is what repairs it.
+        if _sidecar_package_is_optional(name):
+            continue
         try:
             record = (di / "RECORD").read_text(encoding = "utf-8", errors = "replace")
         except FileNotFoundError:

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2452,6 +2452,24 @@ def _optional_package_absent(venv_dir: str, pkg_spec: str) -> bool:
     )
 
 
+def _remove_optional_remnants(venv_dir: str, pkg_spec: str) -> None:
+    """Drop what a failed optional install left: the payload directory and every dist-info.
+
+    An installer that exits nonzero part-way (a full disk, an interrupted copy) can leave
+    the package directory without its native extension, or metadata without the package;
+    with both gone, _optional_package_absent reads the package as absent and the next
+    top-up tries again instead of the sidecar shadowing a working ambient copy.
+    """
+    name = pkg_spec.split("==")[0]
+    root = Path(venv_dir)
+    for candidate in {name, name.replace("-", "_"), name.replace("_", "-")}:
+        payload = root / candidate
+        if payload.is_dir() and not payload.is_symlink():
+            shutil.rmtree(payload, ignore_errors = True)
+    for entry in _dist_info_entries(venv_dir, name):
+        shutil.rmtree(root / entry, ignore_errors = True)
+
+
 def _remove_recordless_dist_infos(venv_dir: str, pkg_spec: str) -> None:
     """Drop every `<pkg>-*.dist-info` with no RECORD: metadata uv cannot uninstall."""
     name = pkg_spec.split("==")[0]
@@ -2701,6 +2719,10 @@ def _ensure_venv_dir(venv_dir: str, packages: tuple[str, ...], label: str) -> bo
                     pkg,
                     venv_dir,
                 )
+                # Only an absent optional package is safe to continue without: this
+                # directory goes ahead of site-packages, and a half-copied payload
+                # would shadow the ambient one and fail at tokenization.
+                _remove_optional_remnants(venv_dir, pkg)
                 continue
             return False
     logger.info("Installed %s to %s", label, venv_dir)

--- a/studio/install_manifest.py
+++ b/studio/install_manifest.py
@@ -1427,6 +1427,17 @@ def _sidecar_damaged_files(
     return found
 
 
+# Mirror of transformers_version._sidecar_file_check_disabled: same variable, same
+# values. The runtime's file scan has this escape hatch because a false positive costs a
+# several-hundred-MB reinstall, and the setup-side predicate must not be the one path
+# that still wipes the sidecar while the hatch is set. Package and version checks stay.
+SIDECAR_FILE_CHECK_ENV = "UNSLOTH_SKIP_SIDECAR_FILE_CHECK"
+
+
+def _sidecar_file_check_disabled() -> bool:
+    return os.environ.get(SIDECAR_FILE_CHECK_ENV, "").strip().lower() in ("1", "true", "yes", "on")
+
+
 def sidecar_is_current(
     venv_dir,
     pins: Sequence[str],
@@ -1456,6 +1467,8 @@ def sidecar_is_current(
         problem = _sidecar_pin_ok(root, spec)
         if problem is not None:
             return False, problem
+    if _sidecar_file_check_disabled():
+        return True, ""
     damaged = _sidecar_damaged_files(root, budget_seconds = budget_seconds)
     if damaged:
         return False, "; ".join(damaged)

--- a/studio/install_manifest.py
+++ b/studio/install_manifest.py
@@ -1357,12 +1357,9 @@ def _sidecar_damaged_files(
         return []
     for dist_info in dist_infos:
         name = dist_info.name.split("-")[0]
-        # An optional package's leftovers are not damage: an interrupted tiktoken install
-        # leaves a dist-info whose RECORD names files that never landed, and setup's
-        # top-up is what repairs it. Mirrors _sidecar_package_is_optional in
-        # studio/backend/utils/transformers_version.py.
-        if name.strip().lower().replace("_", "-") in OPTIONAL_SIDECAR_PACKAGES:
-            continue
+        # An optional package (tiktoken) may be absent; present, its RECORD is held to
+        # the same standard as every other, as the runtime scan does. Mirrors
+        # _sidecar_scan_impl in studio/backend/utils/transformers_version.py.
         try:
             record = (dist_info / "RECORD").read_text(encoding = "utf-8", errors = "replace")
         except OSError:

--- a/studio/install_manifest.py
+++ b/studio/install_manifest.py
@@ -1314,6 +1314,13 @@ def _sidecar_pin_ok(root: Path, spec: str) -> Optional[str]:
                 payload_present = _sidecar_payload_present(root, dist)
     except Exception:
         return f"{name} metadata unreadable"
+    # An optional package (tiktoken) is one the sidecar is complete without: absent, or
+    # left as a dist-info by an interrupted install, it is setup's top-up's business, not
+    # a reason to rebuild the sidecar. Present, it is held to its pin like any other.
+    if canonical in OPTIONAL_SIDECAR_PACKAGES and (
+        not found or (not directory_present and not payload_present)
+    ):
+        return None
     if not found:
         return f"{name} not installed"
     if not directory_present and not payload_present:
@@ -1350,6 +1357,12 @@ def _sidecar_damaged_files(
         return []
     for dist_info in dist_infos:
         name = dist_info.name.split("-")[0]
+        # An optional package's leftovers are not damage: an interrupted tiktoken install
+        # leaves a dist-info whose RECORD names files that never landed, and setup's
+        # top-up is what repairs it. Mirrors _sidecar_package_is_optional in
+        # studio/backend/utils/transformers_version.py.
+        if name.strip().lower().replace("_", "-") in OPTIONAL_SIDECAR_PACKAGES:
+            continue
         try:
             record = (dist_info / "RECORD").read_text(encoding = "utf-8", errors = "replace")
         except OSError:
@@ -1431,6 +1444,9 @@ def _sidecar_damaged_files(
 # values. The runtime's file scan has this escape hatch because a false positive costs a
 # several-hundred-MB reinstall, and the setup-side predicate must not be the one path
 # that still wipes the sidecar while the hatch is set. Package and version checks stay.
+# Packages a sidecar is complete without; setup installs them best-effort and the
+# runtime (transformers_version._OPTIONAL_SIDECAR_PACKAGES) treats them the same way.
+OPTIONAL_SIDECAR_PACKAGES = frozenset({"tiktoken"})
 SIDECAR_FILE_CHECK_ENV = "UNSLOTH_SKIP_SIDECAR_FILE_CHECK"
 
 

--- a/studio/install_manifest.py
+++ b/studio/install_manifest.py
@@ -1336,6 +1336,7 @@ def _sidecar_damaged_files(
     root: Path,
     limit: int = 3,
     budget_seconds: float = SIDECAR_SCAN_BUDGET_SECONDS,
+    required: Sequence[str] = (),
 ) -> List[str]:
     """RECORD rows under a sidecar that are gone, truncated, or built for another CPython.
 
@@ -1351,6 +1352,8 @@ def _sidecar_damaged_files(
     ext_tag = _current_ext_tag()
     entries: List[Tuple[str, str, Optional[int], Path, str]] = []
     owners: Dict[str, int] = {}
+    required_names = {_canonical(name) for name in required if name}
+    recordless: List[str] = []
     try:
         dist_infos = sorted(root.glob("*.dist-info"))
     except OSError:
@@ -1362,8 +1365,16 @@ def _sidecar_damaged_files(
         # _sidecar_scan_impl in studio/backend/utils/transformers_version.py.
         try:
             record = (dist_info / "RECORD").read_text(encoding = "utf-8", errors = "replace")
+        except FileNotFoundError:
+            # No RECORD under a pinned package's dist-info is an interrupted install
+            # (pip and uv write it last), and every truncation of that payload is then
+            # invisible to the size check below; an optional package's is cleared by
+            # its top-up instead, so only the pins are held to it.
+            if _canonical(name) in required_names:
+                recordless.append(f"{name}: RECORD is missing")
+            continue
         except OSError:
-            # Absent or unreadable RECORD says nothing about damage.
+            # Unreadable RECORD says nothing about damage.
             continue
         try:
             rows = list(csv.reader(io.StringIO(record)))
@@ -1399,7 +1410,9 @@ def _sidecar_damaged_files(
                     recorded = None
             entries.append((name, rel, recorded, target, key))
 
-    found: List[str] = []
+    found: List[str] = list(recordless[:limit])
+    if len(found) >= limit:
+        return found
     for name, rel, recorded, target, key in entries:
         # Every row: a batched deadline let one slow mount overrun it by a minute.
         if deadline is not None and time.monotonic() > deadline:
@@ -1482,7 +1495,11 @@ def sidecar_is_current(
             return False, problem
     if _sidecar_file_check_disabled():
         return True, ""
-    damaged = _sidecar_damaged_files(root, budget_seconds = budget_seconds)
+    damaged = _sidecar_damaged_files(
+        root,
+        budget_seconds = budget_seconds,
+        required = [spec.split("==")[0] for spec in pins if "==" in spec],
+    )
     if damaged:
         return False, "; ".join(damaged)
     return True, ""

--- a/studio/install_manifest.py
+++ b/studio/install_manifest.py
@@ -1314,9 +1314,8 @@ def _sidecar_pin_ok(root: Path, spec: str) -> Optional[str]:
                 payload_present = _sidecar_payload_present(root, dist)
     except Exception:
         return f"{name} metadata unreadable"
-    # An optional package (tiktoken) is one the sidecar is complete without: absent, or
-    # left as a dist-info by an interrupted install, it is setup's top-up's business, not
-    # a reason to rebuild the sidecar. Present, it is held to its pin like any other.
+    # An optional package (tiktoken) absent or left as a bare dist-info is the top-up's business,
+    # not a reason to rebuild; present, it is held to its pin.
     if canonical in OPTIONAL_SIDECAR_PACKAGES and (
         not found or (not directory_present and not payload_present)
     ):
@@ -1360,16 +1359,13 @@ def _sidecar_damaged_files(
         return []
     for dist_info in dist_infos:
         name = dist_info.name.split("-")[0]
-        # An optional package (tiktoken) may be absent; present, its RECORD is held to
-        # the same standard as every other, as the runtime scan does. Mirrors
-        # _sidecar_scan_impl in studio/backend/utils/transformers_version.py.
+        # An optional package may be absent; present, its RECORD is held to the same standard
+        # (mirrors _sidecar_scan_impl in transformers_version.py).
         try:
             record = (dist_info / "RECORD").read_text(encoding = "utf-8", errors = "replace")
         except FileNotFoundError:
-            # No RECORD under a pinned package's dist-info is an interrupted install
-            # (pip and uv write it last), and every truncation of that payload is then
-            # invisible to the size check below; an optional package's is cleared by
-            # its top-up instead, so only the pins are held to it.
+            # No RECORD under a pinned dist-info is an interrupted install (written last) whose
+            # truncations the size check cannot see; an optional package's top-up clears its own.
             if _canonical(name) in required_names:
                 recordless.append(f"{name}: RECORD is missing")
             continue
@@ -1450,12 +1446,9 @@ def _sidecar_damaged_files(
     return found
 
 
-# Mirror of transformers_version._sidecar_file_check_disabled: same variable, same
-# values. The runtime's file scan has this escape hatch because a false positive costs a
-# several-hundred-MB reinstall, and the setup-side predicate must not be the one path
-# that still wipes the sidecar while the hatch is set. Package and version checks stay.
-# Packages a sidecar is complete without; setup installs them best-effort and the
-# runtime (transformers_version._OPTIONAL_SIDECAR_PACKAGES) treats them the same way.
+# Mirror of transformers_version._sidecar_file_check_disabled: the escape hatch for a false positive
+# (a several-hundred-MB reinstall) must hold on the setup side too. Then the packages a sidecar is
+# complete without (transformers_version._OPTIONAL_SIDECAR_PACKAGES).
 OPTIONAL_SIDECAR_PACKAGES = frozenset({"tiktoken"})
 SIDECAR_FILE_CHECK_ENV = "UNSLOTH_SKIP_SIDECAR_FILE_CHECK"
 

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -5899,10 +5899,25 @@ function Test-SidecarCurrent {
     }
     $pins = @("transformers==$Version") + $SidecarCommonPins
     $out = ""
+    # The shim answers "stale" with exit 1. Under PowerShell 7 with
+    # $PSNativeCommandUseErrorActionPreference set and ErrorActionPreference "Stop", that
+    # exit is a terminating error, the catch below discarded the answer, and the
+    # fallback grep then accepted a sidecar the shim had just rejected.
+    $previousNativeErrorPreference = $null
+    $restoreNativeErrorPreference = $false
+    if ($PSVersionTable.PSVersion.Major -ge 7) {
+        $previousNativeErrorPreference = $PSNativeCommandUseErrorActionPreference
+        $PSNativeCommandUseErrorActionPreference = $false
+        $restoreNativeErrorPreference = $true
+    }
     try {
         $out = (& python $shim sidecar $TargetDir @pins 2>$null | Out-String).Trim()
     } catch {
         $out = ""
+    } finally {
+        if ($restoreNativeErrorPreference) {
+            $PSNativeCommandUseErrorActionPreference = $previousNativeErrorPreference
+        }
     }
     # The marker, not the exit code alone. An install_manifest.py predating the shim has
     # no __main__ block at all, so running it exits 0 with no output -- and reading that

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -5869,6 +5869,21 @@ function Test-TargetPackageVersion {
 # retries it alone instead. Mirrors _SIDECAR_COMMON_PINS in setup.sh.
 $SidecarCommonPins = @("huggingface_hub==1.8.0", "hf_xet==1.4.2")
 
+# Mirror of setup.sh's fast_install_sidecar: an inherited UV_OVERRIDE replaces a
+# requirement outright (uv's override semantics), so one naming huggingface_hub or hf_xet
+# would install another version than the exact pin, the sidecar audit would reject it, and
+# the next setup would rebuild the sidecar to the same wrong answer.
+function Fast-Install-Sidecar {
+    param([Parameter(ValueFromRemainingArguments=$true)]$Args_)
+    $savedOverride = $env:UV_OVERRIDE
+    try {
+        Remove-Item Env:UV_OVERRIDE -ErrorAction SilentlyContinue
+        Fast-Install @Args_
+    } finally {
+        if ($null -ne $savedOverride) { $env:UV_OVERRIDE = $savedOverride }
+    }
+}
+
 function Repair-SidecarTiktoken {
     param(
         [Parameter(Mandatory = $true)][string]$TargetDir,
@@ -5884,7 +5899,7 @@ function Repair-SidecarTiktoken {
     # --upgrade: a --target install without it does not replace existing files, so a
     # damaged tiktoken\ directory an interrupted install left would be kept under fresh
     # metadata and read as present on the next run.
-    $output = Fast-Install --target $TargetDir --no-deps --upgrade tiktoken 2>&1 | Out-String
+    $output = Fast-Install-Sidecar --target $TargetDir --no-deps --upgrade tiktoken 2>&1 | Out-String
     if ($LASTEXITCODE -ne 0) {
         substep "Could not install tiktoken into $DirName/ -- Qwen tokenizers may fail" "Yellow"
     }
@@ -5907,26 +5922,24 @@ function Test-SidecarCurrent {
     }
     $pins = @("transformers==$Version") + $SidecarCommonPins
     $out = ""
-    # The shim answers "stale" with exit 1. Under PowerShell 7 with
-    # $PSNativeCommandUseErrorActionPreference set and ErrorActionPreference "Stop", that
-    # exit is a terminating error, the catch below discarded the answer, and the
-    # fallback grep then accepted a sidecar the shim had just rejected.
-    $previousNativeErrorPreference = $null
-    $restoreNativeErrorPreference = $false
-    # The variable exists from PowerShell 7.3; under Set-StrictMode a read of an absent
-    # variable is a terminating error, so its existence is what is tested, not the version.
-    if (Get-Variable -Name PSNativeCommandUseErrorActionPreference -ErrorAction SilentlyContinue) {
-        $previousNativeErrorPreference = $PSNativeCommandUseErrorActionPreference
-        $PSNativeCommandUseErrorActionPreference = $false
-        $restoreNativeErrorPreference = $true
-    }
-    try {
-        $out = (& python $shim sidecar $TargetDir @pins 2>$null | Out-String).Trim()
-    } catch {
-        $out = ""
-    } finally {
-        if ($restoreNativeErrorPreference) {
-            $PSNativeCommandUseErrorActionPreference = $previousNativeErrorPreference
+    # Run as a bounded process, not as a native command: the shim's own scan budget
+    # starts after it has read every RECORD and cannot interrupt a stalled read, so a
+    # Studio home on a wedged mount would hold setup here forever, and a native command's
+    # nonzero exit ("stale") is a terminating error under
+    # $PSNativeCommandUseErrorActionPreference. The argv travels base64-encoded, so a path
+    # with quotes or backslashes cannot break the -c string. A timeout reads as stale, and
+    # the rebuild that follows is the installer's own fallback.
+    $pythonExe = $null
+    try { $pythonExe = (Get-Command python -ErrorAction Stop).Source } catch { $pythonExe = $null }
+    if ($pythonExe) {
+        $argv = (@($shim, "sidecar", $TargetDir) + $pins) -join [char]0
+        $encoded = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($argv))
+        $code = "import sys, runpy, base64; sys.argv = base64.b64decode('$encoded').decode('utf-8').split(chr(0)); runpy.run_path(sys.argv[0], run_name='__main__')"
+        $probe = Invoke-BoundedPythonProbe -PythonExe $pythonExe -Code $code -TimeoutSec 60
+        if ($probe.TimedOut) {
+            $out = "sidecar: audit did not answer within 60 seconds"
+        } else {
+            $out = ([string]$probe.Output).Trim()
         }
     }
     # The marker, not the exit code alone. An install_manifest.py predating the shim has
@@ -5956,11 +5969,11 @@ function Install-T5Sidecar {
     Mark-StudioOwned -Path $TargetDir
     foreach ($pkg in @("transformers==$Version", "huggingface_hub==1.8.0", "hf_xet==1.4.2")) {
         if ($script:UnslothVerbose) {
-            Fast-Install --target $TargetDir --no-deps $pkg
+            Fast-Install-Sidecar --target $TargetDir --no-deps $pkg
             $t5PkgExit = $LASTEXITCODE
             $output = ""
         } else {
-            $output = Fast-Install --target $TargetDir --no-deps $pkg | Out-String
+            $output = Fast-Install-Sidecar --target $TargetDir --no-deps $pkg | Out-String
             $t5PkgExit = $LASTEXITCODE
         }
         if ($t5PkgExit -ne 0) {
@@ -5971,11 +5984,11 @@ function Install-T5Sidecar {
         }
     }
     if ($script:UnslothVerbose) {
-        Fast-Install --target $TargetDir --no-deps tiktoken
+        Fast-Install-Sidecar --target $TargetDir --no-deps tiktoken
         $tiktokenInstallExit = $LASTEXITCODE
         $output = ""
     } else {
-        $output = Fast-Install --target $TargetDir --no-deps tiktoken | Out-String
+        $output = Fast-Install-Sidecar --target $TargetDir --no-deps tiktoken | Out-String
         $tiktokenInstallExit = $LASTEXITCODE
     }
     if ($tiktokenInstallExit -ne 0) {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -5855,6 +5855,13 @@ function Test-TargetPackageVersion {
 # The pins, once. install_manifest.sidecar_is_current audits these exact strings and
 # Install-T5Sidecar installs them, so the check and the install can never disagree about
 # what a current sidecar holds. Mirrors _SIDECAR_COMMON_PINS in setup.sh.
+#
+# Every name here has to be one that audit can actually reach. It proves a distribution
+# arrived by looking for its package directory, and falls back to the top-level names in
+# that distribution's own RECORD only when neither spelling of the project name is a
+# directory (six.py has no directory at all; pillow's is PIL). A pin whose payload is
+# neither -- nothing recorded either -- reads as stale forever, and then every update
+# deletes and refetches a healthy several-hundred-MB sidecar.
 $SidecarCommonPins = @("huggingface_hub==1.8.0", "hf_xet==1.4.2", "tiktoken")
 
 function Test-SidecarCurrent {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -5881,7 +5881,10 @@ function Repair-SidecarTiktoken {
     $present = @(Get-ChildItem -LiteralPath $TargetDir -Directory -Filter "tiktoken-*.dist-info" -ErrorAction SilentlyContinue)
     $payload = Join-Path $TargetDir "tiktoken"
     if ($present.Count -gt 0 -and (Test-Path -LiteralPath (Join-Path $payload "__init__.py") -PathType Leaf)) { return }
-    $output = Fast-Install --target $TargetDir --no-deps tiktoken 2>&1 | Out-String
+    # --upgrade: a --target install without it does not replace existing files, so a
+    # damaged tiktoken\ directory an interrupted install left would be kept under fresh
+    # metadata and read as present on the next run.
+    $output = Fast-Install --target $TargetDir --no-deps --upgrade tiktoken 2>&1 | Out-String
     if ($LASTEXITCODE -ne 0) {
         substep "Could not install tiktoken into $DirName/ -- Qwen tokenizers may fail" "Yellow"
     }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -5895,16 +5895,17 @@ function Repair-SidecarTiktoken {
     # and the package without the native extension and RECORD; the sidecar predicate
     # accepts the sidecar either way (tiktoken is unpinned and optional), and a weaker
     # check would skip this top-up forever while Qwen tokenizers keep failing.
+    # A dist-info with no RECORD is one uv cannot uninstall: --upgrade warns and lands
+    # the new version beside it, and importlib.metadata may keep answering the stale
+    # one. It goes before the package is declared present, so a complete install that
+    # a retry put beside an older recordless record does not keep the record forever.
+    Get-ChildItem -LiteralPath $TargetDir -Directory -Filter "tiktoken-*.dist-info" -ErrorAction SilentlyContinue |
+        Where-Object { -not (Test-Path -LiteralPath (Join-Path $_.FullName "RECORD") -PathType Leaf) } |
+        ForEach-Object { Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue }
     $present = @(Get-ChildItem -LiteralPath $TargetDir -Directory -Filter "tiktoken-*.dist-info" -ErrorAction SilentlyContinue |
         Where-Object { Test-Path -LiteralPath (Join-Path $_.FullName "RECORD") -PathType Leaf })
     $payload = Join-Path $TargetDir "tiktoken"
     if ($present.Count -gt 0 -and (Test-Path -LiteralPath (Join-Path $payload "__init__.py") -PathType Leaf)) { return }
-    # A dist-info with no RECORD is one uv cannot uninstall: --upgrade warns and lands
-    # the new version beside it, and importlib.metadata may keep answering the stale
-    # one. The recordless metadata goes first.
-    Get-ChildItem -LiteralPath $TargetDir -Directory -Filter "tiktoken-*.dist-info" -ErrorAction SilentlyContinue |
-        Where-Object { -not (Test-Path -LiteralPath (Join-Path $_.FullName "RECORD") -PathType Leaf) } |
-        ForEach-Object { Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue }
     # --upgrade: a --target install without it does not replace existing files, so a
     # damaged tiktoken\ directory an interrupted install left would be kept under fresh
     # metadata and read as present on the next run.

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -5906,6 +5906,12 @@ function Repair-SidecarTiktoken {
         Where-Object { Test-Path -LiteralPath (Join-Path $_.FullName "RECORD") -PathType Leaf })
     $payload = Join-Path $TargetDir "tiktoken"
     if ($present.Count -gt 0 -and (Test-Path -LiteralPath (Join-Path $payload "__init__.py") -PathType Leaf)) { return }
+    # Not present, so every tiktoken dist-info still here describes a payload that is
+    # missing or damaged. It goes before the install: --upgrade replaces the package but
+    # lands the new version's dist-info under its own name beside the old one, and
+    # importlib.metadata may keep answering the stale version.
+    Get-ChildItem -LiteralPath $TargetDir -Directory -Filter "tiktoken-*.dist-info" -ErrorAction SilentlyContinue |
+        ForEach-Object { Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue }
     # --upgrade: a --target install without it does not replace existing files, so a
     # damaged tiktoken\ directory an interrupted install left would be kept under fresh
     # metadata and read as present on the next run.

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -5874,8 +5874,13 @@ function Repair-SidecarTiktoken {
         [Parameter(Mandatory = $true)][string]$TargetDir,
         [Parameter(Mandatory = $true)][string]$DirName
     )
+    # The payload, not the dist-info alone: an interrupted install can leave the
+    # dist-info directory with no package beside it, the sidecar predicate accepts the
+    # sidecar (tiktoken is unpinned and optional), and a dist-info-only check would then
+    # skip this top-up forever while Qwen tokenizers keep failing.
     $present = @(Get-ChildItem -LiteralPath $TargetDir -Directory -Filter "tiktoken-*.dist-info" -ErrorAction SilentlyContinue)
-    if ($present.Count -gt 0) { return }
+    $payload = Join-Path $TargetDir "tiktoken"
+    if ($present.Count -gt 0 -and (Test-Path -LiteralPath (Join-Path $payload "__init__.py") -PathType Leaf)) { return }
     $output = Fast-Install --target $TargetDir --no-deps tiktoken 2>&1 | Out-String
     if ($LASTEXITCODE -ne 0) {
         substep "Could not install tiktoken into $DirName/ -- Qwen tokenizers may fail" "Yellow"
@@ -5905,7 +5910,9 @@ function Test-SidecarCurrent {
     # fallback grep then accepted a sidecar the shim had just rejected.
     $previousNativeErrorPreference = $null
     $restoreNativeErrorPreference = $false
-    if ($PSVersionTable.PSVersion.Major -ge 7) {
+    # The variable exists from PowerShell 7.3; under Set-StrictMode a read of an absent
+    # variable is a terminating error, so its existence is what is tested, not the version.
+    if (Get-Variable -Name PSNativeCommandUseErrorActionPreference -ErrorAction SilentlyContinue) {
         $previousNativeErrorPreference = $PSNativeCommandUseErrorActionPreference
         $PSNativeCommandUseErrorActionPreference = $false
         $restoreNativeErrorPreference = $true

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -5884,6 +5884,20 @@ function Fast-Install-Sidecar {
     }
 }
 
+function Remove-SidecarTiktoken {
+    # What a failed tiktoken install leaves must go: the sidecar sits ahead of
+    # site-packages, so a partial tiktoken\ or tiktoken_ext\ shadows a working ambient
+    # copy, and tiktoken is unpinned, so nothing else would ever clear it. Every entry
+    # the wheel owns, as the runtime's _remove_optional_remnants removes them.
+    param([Parameter(Mandatory = $true)][string]$TargetDir)
+    foreach ($name in @("tiktoken", "tiktoken_ext", "tiktoken.libs")) {
+        $entry = Join-Path $TargetDir $name
+        if (Test-Path -LiteralPath $entry) { Remove-Item -LiteralPath $entry -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+    Get-ChildItem -LiteralPath $TargetDir -Directory -Filter "tiktoken-*.dist-info" -ErrorAction SilentlyContinue |
+        ForEach-Object { Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue }
+}
+
 function Repair-SidecarTiktoken {
     param(
         [Parameter(Mandatory = $true)][string]$TargetDir,
@@ -5917,6 +5931,7 @@ function Repair-SidecarTiktoken {
     # metadata and read as present on the next run.
     $output = Fast-Install-Sidecar --target $TargetDir --no-deps --upgrade tiktoken 2>&1 | Out-String
     if ($LASTEXITCODE -ne 0) {
+        Remove-SidecarTiktoken -TargetDir $TargetDir
         substep "Could not install tiktoken into $DirName/ -- Qwen tokenizers may fail" "Yellow"
     }
 }
@@ -6017,6 +6032,7 @@ function Install-T5Sidecar {
         $tiktokenInstallExit = $LASTEXITCODE
     }
     if ($tiktokenInstallExit -ne 0) {
+        Remove-SidecarTiktoken -TargetDir $TargetDir
         substep "Could not install tiktoken into $DirName/ -- Qwen tokenizers may fail" "Yellow"
     }
     step "transformers" "$Version pre-installed"

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -5862,7 +5862,25 @@ function Test-TargetPackageVersion {
 # directory (six.py has no directory at all; pillow's is PIL). A pin whose payload is
 # neither -- nothing recorded either -- reads as stale forever, and then every update
 # deletes and refetches a healthy several-hundred-MB sidecar.
-$SidecarCommonPins = @("huggingface_hub==1.8.0", "hf_xet==1.4.2", "tiktoken")
+# tiktoken is deliberately not a pin. Install-T5Sidecar treats its install as optional (no
+# wheel for the interpreter is a warning, not a failure), so a sidecar without it is a
+# finished sidecar; as a pin it would read stale on every update and be wiped and refetched
+# three times over, for a package the rebuild would fail to add again. Repair-SidecarTiktoken
+# retries it alone instead. Mirrors _SIDECAR_COMMON_PINS in setup.sh.
+$SidecarCommonPins = @("huggingface_hub==1.8.0", "hf_xet==1.4.2")
+
+function Repair-SidecarTiktoken {
+    param(
+        [Parameter(Mandatory = $true)][string]$TargetDir,
+        [Parameter(Mandatory = $true)][string]$DirName
+    )
+    $present = @(Get-ChildItem -LiteralPath $TargetDir -Directory -Filter "tiktoken-*.dist-info" -ErrorAction SilentlyContinue)
+    if ($present.Count -gt 0) { return }
+    $output = Fast-Install --target $TargetDir --no-deps tiktoken 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) {
+        substep "Could not install tiktoken into $DirName/ -- Qwen tokenizers may fail" "Yellow"
+    }
+}
 
 function Test-SidecarCurrent {
     # One predicate for both shells: install_manifest.py answers, setup.sh asks the same
@@ -5976,16 +5994,19 @@ if ($_NeedT5_530) {
     Install-T5Sidecar -TargetDir $VenvT5_530Dir -Version "5.3.0" -Label "5.3" -DirName ".venv_t5_530" -Reason "for newer model support"
 } else {
     step "transformers" "5.3.0 sidecar current"
+    Repair-SidecarTiktoken -TargetDir $VenvT5_530Dir -DirName ".venv_t5_530"
 }
 if ($_NeedT5_550) {
     Install-T5Sidecar -TargetDir $VenvT5_550Dir -Version "5.5.0" -Label "5.5" -DirName ".venv_t5_550" -Reason "for Gemma 4 support"
 } else {
     step "transformers" "5.5.0 sidecar current"
+    Repair-SidecarTiktoken -TargetDir $VenvT5_550Dir -DirName ".venv_t5_550"
 }
 if ($_NeedT5_510) {
     Install-T5Sidecar -TargetDir $VenvT5_510Dir -Version "5.10.2" -Label "5.10" -DirName ".venv_t5_510" -Reason "for Gemma 4 Unified support"
 } else {
     step "transformers" "5.10.2 sidecar current"
+    Repair-SidecarTiktoken -TargetDir $VenvT5_510Dir -DirName ".venv_t5_510"
 }
 $ErrorActionPreference = $script:PrevEAP_T5
 

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -5889,11 +5889,14 @@ function Repair-SidecarTiktoken {
         [Parameter(Mandatory = $true)][string]$TargetDir,
         [Parameter(Mandatory = $true)][string]$DirName
     )
-    # The payload, not the dist-info alone: an interrupted install can leave the
-    # dist-info directory with no package beside it, the sidecar predicate accepts the
-    # sidecar (tiktoken is unpinned and optional), and a dist-info-only check would then
-    # skip this top-up forever while Qwen tokenizers keep failing.
-    $present = @(Get-ChildItem -LiteralPath $TargetDir -Directory -Filter "tiktoken-*.dist-info" -ErrorAction SilentlyContinue)
+    # The payload AND a complete dist-info (RECORD is written last), as
+    # _sidecar_top_up_tiktoken and the runtime's _optional_package_absent check: an
+    # interrupted install can leave the dist-info with no package beside it, or METADATA
+    # and the package without the native extension and RECORD; the sidecar predicate
+    # accepts the sidecar either way (tiktoken is unpinned and optional), and a weaker
+    # check would skip this top-up forever while Qwen tokenizers keep failing.
+    $present = @(Get-ChildItem -LiteralPath $TargetDir -Directory -Filter "tiktoken-*.dist-info" -ErrorAction SilentlyContinue |
+        Where-Object { Test-Path -LiteralPath (Join-Path $_.FullName "RECORD") -PathType Leaf })
     $payload = Join-Path $TargetDir "tiktoken"
     if ($present.Count -gt 0 -and (Test-Path -LiteralPath (Join-Path $payload "__init__.py") -PathType Leaf)) { return }
     # --upgrade: a --target install without it does not replace existing files, so a
@@ -5930,6 +5933,7 @@ function Test-SidecarCurrent {
     # with quotes or backslashes cannot break the -c string. A timeout reads as stale, and
     # the rebuild that follows is the installer's own fallback.
     $pythonExe = $null
+    $probe = $null
     try { $pythonExe = (Get-Command python -ErrorAction Stop).Source } catch { $pythonExe = $null }
     if ($pythonExe) {
         $argv = (@($shim, "sidecar", $TargetDir) + $pins) -join [char]0
@@ -5950,7 +5954,15 @@ function Test-SidecarCurrent {
         if ($script:UnslothVerbose) { substep "sidecar $TargetDir`: $($out.Substring(9))" }
         return $false
     }
-    # An old or unusable tree: fall back to the version grep this replaced.
+    # No marker and a failure: the audit started and died (an exception in the shim, an
+    # interpreter that cannot run it). That is not the legacy silent exit 0 the version
+    # grep below stands in for, and reading it as current would retire the audit for
+    # exactly the trees it could not read. Stale, and the rebuild follows.
+    if ($null -ne $probe -and -not $probe.Ok) {
+        if ($script:UnslothVerbose) { substep "sidecar $TargetDir`: audit failed" }
+        return $false
+    }
+    # An old shim (clean, silent exit 0): fall back to the version grep this replaced.
     return (Test-TargetPackageVersion -TargetDir $TargetDir -PackageName "transformers" -ExpectedVersion $Version)
 }
 

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -5852,27 +5852,15 @@ function Test-TargetPackageVersion {
     return $false
 }
 
-# The pins, once. install_manifest.sidecar_is_current audits these exact strings and
-# Install-T5Sidecar installs them, so the check and the install can never disagree about
-# what a current sidecar holds. Mirrors _SIDECAR_COMMON_PINS in setup.sh.
-#
-# Every name here has to be one that audit can actually reach. It proves a distribution
-# arrived by looking for its package directory, and falls back to the top-level names in
-# that distribution's own RECORD only when neither spelling of the project name is a
-# directory (six.py has no directory at all; pillow's is PIL). A pin whose payload is
-# neither -- nothing recorded either -- reads as stale forever, and then every update
-# deletes and refetches a healthy several-hundred-MB sidecar.
-# tiktoken is deliberately not a pin. Install-T5Sidecar treats its install as optional (no
-# wheel for the interpreter is a warning, not a failure), so a sidecar without it is a
-# finished sidecar; as a pin it would read stale on every update and be wiped and refetched
-# three times over, for a package the rebuild would fail to add again. Repair-SidecarTiktoken
-# retries it alone instead. Mirrors _SIDECAR_COMMON_PINS in setup.sh.
+# The pins, once, audited by install_manifest.sidecar_is_current and installed by Install-T5Sidecar;
+# mirrors _SIDECAR_COMMON_PINS in setup.sh. Every name must be one the audit can reach (a package
+# directory, or the RECORD's top-level names: six.py, PIL), or it reads stale forever and every
+# update refetches the sidecar. tiktoken is not a pin: its install is optional, so a sidecar without
+# it is finished; Repair-SidecarTiktoken retries it alone.
 $SidecarCommonPins = @("huggingface_hub==1.8.0", "hf_xet==1.4.2")
 
-# Mirror of setup.sh's fast_install_sidecar: an inherited UV_OVERRIDE replaces a
-# requirement outright (uv's override semantics), so one naming huggingface_hub or hf_xet
-# would install another version than the exact pin, the sidecar audit would reject it, and
-# the next setup would rebuild the sidecar to the same wrong answer.
+# Mirror of setup.sh's fast_install_sidecar: an inherited UV_OVERRIDE naming huggingface_hub would
+# replace the exact pin, the audit would reject it, and every setup would rebuild.
 function Fast-Install-Sidecar {
     param([Parameter(ValueFromRemainingArguments=$true)]$Args_)
     $savedOverride = $env:UV_OVERRIDE
@@ -5885,14 +5873,10 @@ function Fast-Install-Sidecar {
 }
 
 function Remove-SidecarTiktoken {
-    # What a failed tiktoken install leaves must go: the sidecar sits ahead of
-    # site-packages, so a partial tiktoken\ or tiktoken_ext\ shadows a working ambient
-    # copy, and tiktoken is unpinned, so nothing else would ever clear it. Every entry
-    # the wheel owns, as the runtime's _remove_optional_remnants removes them.
-    # Returns $true when nothing of tiktoken is left, $false when an entry would not go
-    # (a file another process holds open, an ACL): the caller then retires the whole
-    # sidecar, since a partial tiktoken ahead of site-packages shadows a working ambient
-    # copy and the sidecar predicate (tiktoken optional) would still call it current.
+    # A failed tiktoken install's remnants shadow a working ambient copy from ahead of
+    # site-packages, and being unpinned nothing else clears them. Every entry the wheel owns, as the
+    # runtime's _remove_optional_remnants. $false when one would not go (held open, an ACL): the
+    # caller then retires the whole sidecar, which the predicate would still call current.
     param([Parameter(Mandatory = $true)][string]$TargetDir)
     foreach ($name in @("tiktoken", "tiktoken_ext", "tiktoken.libs")) {
         $entry = Join-Path $TargetDir $name
@@ -5908,9 +5892,7 @@ function Remove-SidecarTiktoken {
 }
 
 function Retire-SidecarAfterFailedTiktoken {
-    # The cleanup left part of tiktoken behind: the sidecar is not one to keep. Best
-    # effort, as the cleanup was; what this cannot remove the runtime withholds at
-    # activation, and the next update rebuilds it.
+    # Part of tiktoken remains: the sidecar goes, best effort; the runtime withholds the rest.
     param(
         [Parameter(Mandatory = $true)][string]$TargetDir,
         [Parameter(Mandatory = $true)][string]$DirName
@@ -5924,16 +5906,11 @@ function Repair-SidecarTiktoken {
         [Parameter(Mandatory = $true)][string]$TargetDir,
         [Parameter(Mandatory = $true)][string]$DirName
     )
-    # The payload AND a complete dist-info (RECORD is written last), as
-    # _sidecar_top_up_tiktoken and the runtime's _optional_package_absent check: an
-    # interrupted install can leave the dist-info with no package beside it, or METADATA
-    # and the package without the native extension and RECORD; the sidecar predicate
-    # accepts the sidecar either way (tiktoken is unpinned and optional), and a weaker
-    # check would skip this top-up forever while Qwen tokenizers keep failing.
-    # A dist-info with no RECORD is one uv cannot uninstall: --upgrade warns and lands
-    # the new version beside it, and importlib.metadata may keep answering the stale
-    # one. It goes before the package is declared present, so a complete install that
-    # a retry put beside an older recordless record does not keep the record forever.
+    # The payload AND a complete dist-info (RECORD is written last), as _sidecar_top_up_tiktoken and
+    # the runtime check: an interrupted install leaves either without the other, the predicate
+    # accepts both, and a weaker check would skip this top-up while Qwen tokenizers fail. A
+    # recordless dist-info goes first: uv cannot uninstall it and importlib.metadata may keep
+    # answering it.
     Get-ChildItem -LiteralPath $TargetDir -Directory -Filter "tiktoken-*.dist-info" -ErrorAction SilentlyContinue |
         Where-Object { -not (Test-Path -LiteralPath (Join-Path $_.FullName "RECORD") -PathType Leaf) } |
         ForEach-Object { Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue }
@@ -5941,15 +5918,11 @@ function Repair-SidecarTiktoken {
         Where-Object { Test-Path -LiteralPath (Join-Path $_.FullName "RECORD") -PathType Leaf })
     $payload = Join-Path $TargetDir "tiktoken"
     if ($present.Count -gt 0 -and (Test-Path -LiteralPath (Join-Path $payload "__init__.py") -PathType Leaf)) { return }
-    # Not present, so every tiktoken dist-info still here describes a payload that is
-    # missing or damaged. It goes before the install: --upgrade replaces the package but
-    # lands the new version's dist-info under its own name beside the old one, and
-    # importlib.metadata may keep answering the stale version.
+    # Not present, so every tiktoken dist-info here describes a missing or damaged payload and goes
+    # before the install: --upgrade lands the new dist-info beside the old one.
     Get-ChildItem -LiteralPath $TargetDir -Directory -Filter "tiktoken-*.dist-info" -ErrorAction SilentlyContinue |
         ForEach-Object { Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue }
-    # --upgrade: a --target install without it does not replace existing files, so a
-    # damaged tiktoken\ directory an interrupted install left would be kept under fresh
-    # metadata and read as present on the next run.
+    # --upgrade: a --target install without it keeps a damaged tiktoken\ under fresh metadata.
     $output = Fast-Install-Sidecar --target $TargetDir --no-deps --upgrade tiktoken 2>&1 | Out-String
     if ($LASTEXITCODE -ne 0) {
         if (Remove-SidecarTiktoken -TargetDir $TargetDir) {
@@ -5961,11 +5934,8 @@ function Repair-SidecarTiktoken {
 }
 
 function Test-SidecarCurrent {
-    # One predicate for both shells: install_manifest.py answers, setup.sh asks the same
-    # way. A shell reimplementation is what let the two drift -- Test-TargetPackageVersion
-    # sees a transformers 5.3.0 METADATA and calls a sidecar whose package tree an
-    # interrupted pip left half-written "current", and the training worker then dies on
-    # `import transformers` with the setup log reporting success.
+    # One predicate for both shells (install_manifest.py): the shell reimplementation called a
+    # half-written sidecar with a transformers 5.3.0 METADATA "current".
     param(
         [Parameter(Mandatory = $true)][string]$TargetDir,
         [Parameter(Mandatory = $true)][string]$Version
@@ -5977,13 +5947,10 @@ function Test-SidecarCurrent {
     }
     $pins = @("transformers==$Version") + $SidecarCommonPins
     $out = ""
-    # Run as a bounded process, not as a native command: the shim's own scan budget
-    # starts after it has read every RECORD and cannot interrupt a stalled read, so a
-    # Studio home on a wedged mount would hold setup here forever, and a native command's
-    # nonzero exit ("stale") is a terminating error under
-    # $PSNativeCommandUseErrorActionPreference. The argv travels base64-encoded, so a path
-    # with quotes or backslashes cannot break the -c string. A timeout reads as stale, and
-    # the rebuild that follows is the installer's own fallback.
+    # A bounded process, not a native command: the shim cannot interrupt a stalled RECORD read (a
+    # wedged mount), and a native nonzero exit ("stale") terminates under
+    # $PSNativeCommandUseErrorActionPreference. The argv travels base64-encoded so quotes and
+    # backslashes cannot break -c. A timeout reads as stale, and the rebuild follows.
     $pythonExe = $null
     $probe = $null
     try { $pythonExe = (Get-Command python -ErrorAction Stop).Source } catch { $pythonExe = $null }
@@ -5998,18 +5965,14 @@ function Test-SidecarCurrent {
             $out = ([string]$probe.Output).Trim()
         }
     }
-    # The marker, not the exit code alone. An install_manifest.py predating the shim has
-    # no __main__ block at all, so running it exits 0 with no output -- and reading that
-    # silence as "current" would retire the sidecar rebuild entirely.
+    # The marker, not the exit code alone: an install_manifest.py predating the shim exits 0
+    # silently.
     if ($out -eq "sidecar: current") { return $true }
     if ($out -like "sidecar:*") {
         if ($script:UnslothVerbose) { substep "sidecar $TargetDir`: $($out.Substring(9))" }
         return $false
     }
-    # No marker and a failure: the audit started and died (an exception in the shim, an
-    # interpreter that cannot run it). That is not the legacy silent exit 0 the version
-    # grep below stands in for, and reading it as current would retire the audit for
-    # exactly the trees it could not read. Stale, and the rebuild follows.
+    # No marker and a failure: the audit died, which is not the legacy silent exit 0. Stale.
     if ($null -ne $probe -and -not $probe.Ok) {
         if ($script:UnslothVerbose) { substep "sidecar $TargetDir`: audit failed" }
         return $false
@@ -6065,18 +6028,14 @@ function Install-T5Sidecar {
     step "transformers" "$Version pre-installed"
 }
 
-# Per tier, not one flag for all three. The old single flag rebuilt every sidecar
-# whenever any one of them was stale, and -- through the `-not $SkipPythonDeps` clause
-# that used to sit at the end of this list -- on every update that touched the dependency
-# pass at all, whether or not a sidecar had moved. That is three wipes and twelve
-# `--target` installs, measured at 60-90 s on Windows, for work already done.
+# Per tier: the old single flag (with its `-not $SkipPythonDeps` clause) rebuilt all three sidecars
+# on every update that touched the dependency pass, 60-90 s on Windows for nothing.
 $_NeedT5_530 = $false
 $_NeedT5_550 = $false
 $_NeedT5_510 = $false
 if (Test-Path -LiteralPath $VenvT5Legacy) {
-    # Legacy layout -- migrate. The tiered venvs a staged run builds land under the
-    # stage root and may never be activated, so removing the live legacy one here
-    # would strip the running install of its only sidecar. The live update does it.
+    # Legacy layout, migrate. A staged run's tiered venvs may never be activated, so the live legacy
+    # one is removed by the live update, not here.
     if (-not $StageRoot) {
         Assert-StudioOwnedOrAbsent -Path $VenvT5Legacy -Label "legacy transformers sidecar venv"
         Remove-Item -LiteralPath $VenvT5Legacy -Recurse -Force

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -5899,6 +5899,12 @@ function Repair-SidecarTiktoken {
         Where-Object { Test-Path -LiteralPath (Join-Path $_.FullName "RECORD") -PathType Leaf })
     $payload = Join-Path $TargetDir "tiktoken"
     if ($present.Count -gt 0 -and (Test-Path -LiteralPath (Join-Path $payload "__init__.py") -PathType Leaf)) { return }
+    # A dist-info with no RECORD is one uv cannot uninstall: --upgrade warns and lands
+    # the new version beside it, and importlib.metadata may keep answering the stale
+    # one. The recordless metadata goes first.
+    Get-ChildItem -LiteralPath $TargetDir -Directory -Filter "tiktoken-*.dist-info" -ErrorAction SilentlyContinue |
+        Where-Object { -not (Test-Path -LiteralPath (Join-Path $_.FullName "RECORD") -PathType Leaf) } |
+        ForEach-Object { Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue }
     # --upgrade: a --target install without it does not replace existing files, so a
     # damaged tiktoken\ directory an interrupted install left would be kept under fresh
     # metadata and read as present on the next run.

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -5852,7 +5852,96 @@ function Test-TargetPackageVersion {
     return $false
 }
 
-$_NeedT5Install = $false
+# The pins, once. install_manifest.sidecar_is_current audits these exact strings and
+# Install-T5Sidecar installs them, so the check and the install can never disagree about
+# what a current sidecar holds. Mirrors _SIDECAR_COMMON_PINS in setup.sh.
+$SidecarCommonPins = @("huggingface_hub==1.8.0", "hf_xet==1.4.2", "tiktoken")
+
+function Test-SidecarCurrent {
+    # One predicate for both shells: install_manifest.py answers, setup.sh asks the same
+    # way. A shell reimplementation is what let the two drift -- Test-TargetPackageVersion
+    # sees a transformers 5.3.0 METADATA and calls a sidecar whose package tree an
+    # interrupted pip left half-written "current", and the training worker then dies on
+    # `import transformers` with the setup log reporting success.
+    param(
+        [Parameter(Mandatory = $true)][string]$TargetDir,
+        [Parameter(Mandatory = $true)][string]$Version
+    )
+    if (-not (Test-Path -LiteralPath $TargetDir -PathType Container)) { return $false }
+    $shim = Join-Path $PSScriptRoot "install_manifest.py"
+    if (-not (Test-Path -LiteralPath $shim -PathType Leaf)) {
+        return (Test-TargetPackageVersion -TargetDir $TargetDir -PackageName "transformers" -ExpectedVersion $Version)
+    }
+    $pins = @("transformers==$Version") + $SidecarCommonPins
+    $out = ""
+    try {
+        $out = (& python $shim sidecar $TargetDir @pins 2>$null | Out-String).Trim()
+    } catch {
+        $out = ""
+    }
+    # The marker, not the exit code alone. An install_manifest.py predating the shim has
+    # no __main__ block at all, so running it exits 0 with no output -- and reading that
+    # silence as "current" would retire the sidecar rebuild entirely.
+    if ($out -eq "sidecar: current") { return $true }
+    if ($out -like "sidecar:*") {
+        if ($script:UnslothVerbose) { substep "sidecar $TargetDir`: $($out.Substring(9))" }
+        return $false
+    }
+    # An old or unusable tree: fall back to the version grep this replaced.
+    return (Test-TargetPackageVersion -TargetDir $TargetDir -PackageName "transformers" -ExpectedVersion $Version)
+}
+
+function Install-T5Sidecar {
+    param(
+        [Parameter(Mandatory = $true)][string]$TargetDir,
+        [Parameter(Mandatory = $true)][string]$Version,
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$DirName,
+        [Parameter(Mandatory = $true)][string]$Reason
+    )
+    substep "pre-installing transformers $Version $Reason..."
+    Assert-StudioOwnedOrAbsent -Path $TargetDir -Label "transformers $Label sidecar venv"
+    if (Test-Path -LiteralPath $TargetDir) { Remove-Item -LiteralPath $TargetDir -Recurse -Force }
+    [System.IO.Directory]::CreateDirectory($TargetDir) | Out-Null
+    Mark-StudioOwned -Path $TargetDir
+    foreach ($pkg in @("transformers==$Version", "huggingface_hub==1.8.0", "hf_xet==1.4.2")) {
+        if ($script:UnslothVerbose) {
+            Fast-Install --target $TargetDir --no-deps $pkg
+            $t5PkgExit = $LASTEXITCODE
+            $output = ""
+        } else {
+            $output = Fast-Install --target $TargetDir --no-deps $pkg | Out-String
+            $t5PkgExit = $LASTEXITCODE
+        }
+        if ($t5PkgExit -ne 0) {
+            Write-StudioLine "[FAIL] Could not install $pkg into $DirName/" -ForegroundColor Red
+            Write-StudioLine (Redact-InstallOutput $output) -ForegroundColor Red
+            $ErrorActionPreference = $script:PrevEAP_T5
+            Exit-SetupFailure "Could not install $pkg into $DirName"
+        }
+    }
+    if ($script:UnslothVerbose) {
+        Fast-Install --target $TargetDir --no-deps tiktoken
+        $tiktokenInstallExit = $LASTEXITCODE
+        $output = ""
+    } else {
+        $output = Fast-Install --target $TargetDir --no-deps tiktoken | Out-String
+        $tiktokenInstallExit = $LASTEXITCODE
+    }
+    if ($tiktokenInstallExit -ne 0) {
+        substep "Could not install tiktoken into $DirName/ -- Qwen tokenizers may fail" "Yellow"
+    }
+    step "transformers" "$Version pre-installed"
+}
+
+# Per tier, not one flag for all three. The old single flag rebuilt every sidecar
+# whenever any one of them was stale, and -- through the `-not $SkipPythonDeps` clause
+# that used to sit at the end of this list -- on every update that touched the dependency
+# pass at all, whether or not a sidecar had moved. That is three wipes and twelve
+# `--target` installs, measured at 60-90 s on Windows, for work already done.
+$_NeedT5_530 = $false
+$_NeedT5_550 = $false
+$_NeedT5_510 = $false
 if (Test-Path -LiteralPath $VenvT5Legacy) {
     # Legacy layout -- migrate. The tiered venvs a staged run builds land under the
     # stage root and may never be activated, so removing the live legacy one here
@@ -5861,130 +5950,37 @@ if (Test-Path -LiteralPath $VenvT5Legacy) {
         Assert-StudioOwnedOrAbsent -Path $VenvT5Legacy -Label "legacy transformers sidecar venv"
         Remove-Item -LiteralPath $VenvT5Legacy -Recurse -Force
     }
-    $_NeedT5Install = $true
+    $_NeedT5_530 = $true
+    $_NeedT5_550 = $true
+    $_NeedT5_510 = $true
 }
-if (-not (Test-Path -LiteralPath $VenvT5_530Dir)) { $_NeedT5Install = $true }
-if (-not (Test-Path -LiteralPath $VenvT5_550Dir)) { $_NeedT5Install = $true }
-if (-not (Test-Path -LiteralPath $VenvT5_510Dir)) { $_NeedT5Install = $true }
-if (-not (Test-TargetPackageVersion -TargetDir $VenvT5_530Dir -PackageName "transformers" -ExpectedVersion "5.3.0")) { $_NeedT5Install = $true }
-if (-not (Test-TargetPackageVersion -TargetDir $VenvT5_550Dir -PackageName "transformers" -ExpectedVersion "5.5.0")) { $_NeedT5Install = $true }
-if (-not (Test-TargetPackageVersion -TargetDir $VenvT5_510Dir -PackageName "transformers" -ExpectedVersion "5.10.2")) { $_NeedT5Install = $true }
-# Also reinstall when python deps were updated
-if (-not $SkipPythonDeps) { $_NeedT5Install = $true }
+if (-not (Test-SidecarCurrent -TargetDir $VenvT5_530Dir -Version "5.3.0")) { $_NeedT5_530 = $true }
+if (-not (Test-SidecarCurrent -TargetDir $VenvT5_550Dir -Version "5.5.0")) { $_NeedT5_550 = $true }
+if (-not (Test-SidecarCurrent -TargetDir $VenvT5_510Dir -Version "5.10.2")) { $_NeedT5_510 = $true }
 
-if ($_NeedT5Install) {
+if ($_NeedT5_530 -or $_NeedT5_550 -or $_NeedT5_510) {
 Write-StudioLine ""
+}
 
-$prevEAP_t5 = $ErrorActionPreference
+$script:PrevEAP_T5 = $ErrorActionPreference
 $ErrorActionPreference = "Continue"
 
-# --- .venv_t5_530 (transformers 5.3.0) ---
-substep "pre-installing transformers 5.3.0 for newer model support..."
-Assert-StudioOwnedOrAbsent -Path $VenvT5_530Dir -Label "transformers 5.3 sidecar venv"
-if (Test-Path -LiteralPath $VenvT5_530Dir) { Remove-Item -LiteralPath $VenvT5_530Dir -Recurse -Force }
-[System.IO.Directory]::CreateDirectory($VenvT5_530Dir) | Out-Null
-Mark-StudioOwned -Path $VenvT5_530Dir
-foreach ($pkg in @("transformers==5.3.0", "huggingface_hub==1.8.0", "hf_xet==1.4.2")) {
-    if ($script:UnslothVerbose) {
-        Fast-Install --target $VenvT5_530Dir --no-deps $pkg
-        $t5PkgExit = $LASTEXITCODE
-        $output = ""
-    } else {
-        $output = Fast-Install --target $VenvT5_530Dir --no-deps $pkg | Out-String
-        $t5PkgExit = $LASTEXITCODE
-    }
-    if ($t5PkgExit -ne 0) {
-        Write-StudioLine "[FAIL] Could not install $pkg into .venv_t5_530/" -ForegroundColor Red
-        Write-StudioLine (Redact-InstallOutput $output) -ForegroundColor Red
-        $ErrorActionPreference = $prevEAP_t5
-        Exit-SetupFailure "Could not install $pkg into .venv_t5_530"
-    }
-}
-if ($script:UnslothVerbose) {
-    Fast-Install --target $VenvT5_530Dir --no-deps tiktoken
-    $tiktokenInstallExit = $LASTEXITCODE
-    $output = ""
+if ($_NeedT5_530) {
+    Install-T5Sidecar -TargetDir $VenvT5_530Dir -Version "5.3.0" -Label "5.3" -DirName ".venv_t5_530" -Reason "for newer model support"
 } else {
-    $output = Fast-Install --target $VenvT5_530Dir --no-deps tiktoken | Out-String
-    $tiktokenInstallExit = $LASTEXITCODE
+    step "transformers" "5.3.0 sidecar current"
 }
-if ($tiktokenInstallExit -ne 0) {
-    substep "Could not install tiktoken into .venv_t5_530/ -- Qwen tokenizers may fail" "Yellow"
-}
-step "transformers" "5.3.0 pre-installed"
-
-# --- .venv_t5_550 (transformers 5.5.0) ---
-substep "pre-installing transformers 5.5.0 for Gemma 4 support..."
-Assert-StudioOwnedOrAbsent -Path $VenvT5_550Dir -Label "transformers 5.5 sidecar venv"
-if (Test-Path -LiteralPath $VenvT5_550Dir) { Remove-Item -LiteralPath $VenvT5_550Dir -Recurse -Force }
-[System.IO.Directory]::CreateDirectory($VenvT5_550Dir) | Out-Null
-Mark-StudioOwned -Path $VenvT5_550Dir
-foreach ($pkg in @("transformers==5.5.0", "huggingface_hub==1.8.0", "hf_xet==1.4.2")) {
-    if ($script:UnslothVerbose) {
-        Fast-Install --target $VenvT5_550Dir --no-deps $pkg
-        $t5PkgExit = $LASTEXITCODE
-        $output = ""
-    } else {
-        $output = Fast-Install --target $VenvT5_550Dir --no-deps $pkg | Out-String
-        $t5PkgExit = $LASTEXITCODE
-    }
-    if ($t5PkgExit -ne 0) {
-        Write-StudioLine "[FAIL] Could not install $pkg into .venv_t5_550/" -ForegroundColor Red
-        Write-StudioLine (Redact-InstallOutput $output) -ForegroundColor Red
-        $ErrorActionPreference = $prevEAP_t5
-        Exit-SetupFailure "Could not install $pkg into .venv_t5_550"
-    }
-}
-if ($script:UnslothVerbose) {
-    Fast-Install --target $VenvT5_550Dir --no-deps tiktoken
-    $tiktokenInstallExit = $LASTEXITCODE
-    $output = ""
+if ($_NeedT5_550) {
+    Install-T5Sidecar -TargetDir $VenvT5_550Dir -Version "5.5.0" -Label "5.5" -DirName ".venv_t5_550" -Reason "for Gemma 4 support"
 } else {
-    $output = Fast-Install --target $VenvT5_550Dir --no-deps tiktoken | Out-String
-    $tiktokenInstallExit = $LASTEXITCODE
+    step "transformers" "5.5.0 sidecar current"
 }
-if ($tiktokenInstallExit -ne 0) {
-    substep "Could not install tiktoken into .venv_t5_550/ -- Qwen tokenizers may fail" "Yellow"
-}
-step "transformers" "5.5.0 pre-installed"
-
-# --- .venv_t5_510 (transformers 5.10.2) ---
-substep "pre-installing transformers 5.10.2 for Gemma 4 Unified support..."
-Assert-StudioOwnedOrAbsent -Path $VenvT5_510Dir -Label "transformers 5.10 sidecar venv"
-if (Test-Path -LiteralPath $VenvT5_510Dir) { Remove-Item -LiteralPath $VenvT5_510Dir -Recurse -Force }
-[System.IO.Directory]::CreateDirectory($VenvT5_510Dir) | Out-Null
-Mark-StudioOwned -Path $VenvT5_510Dir
-foreach ($pkg in @("transformers==5.10.2", "huggingface_hub==1.8.0", "hf_xet==1.4.2")) {
-    if ($script:UnslothVerbose) {
-        Fast-Install --target $VenvT5_510Dir --no-deps $pkg
-        $t5PkgExit = $LASTEXITCODE
-        $output = ""
-    } else {
-        $output = Fast-Install --target $VenvT5_510Dir --no-deps $pkg | Out-String
-        $t5PkgExit = $LASTEXITCODE
-    }
-    if ($t5PkgExit -ne 0) {
-        Write-StudioLine "[FAIL] Could not install $pkg into .venv_t5_510/" -ForegroundColor Red
-        Write-StudioLine (Redact-InstallOutput $output) -ForegroundColor Red
-        $ErrorActionPreference = $prevEAP_t5
-        Exit-SetupFailure "Could not install $pkg into .venv_t5_510"
-    }
-}
-if ($script:UnslothVerbose) {
-    Fast-Install --target $VenvT5_510Dir --no-deps tiktoken
-    $tiktokenInstallExit = $LASTEXITCODE
-    $output = ""
+if ($_NeedT5_510) {
+    Install-T5Sidecar -TargetDir $VenvT5_510Dir -Version "5.10.2" -Label "5.10" -DirName ".venv_t5_510" -Reason "for Gemma 4 Unified support"
 } else {
-    $output = Fast-Install --target $VenvT5_510Dir --no-deps tiktoken | Out-String
-    $tiktokenInstallExit = $LASTEXITCODE
+    step "transformers" "5.10.2 sidecar current"
 }
-if ($tiktokenInstallExit -ne 0) {
-    substep "Could not install tiktoken into .venv_t5_510/ -- Qwen tokenizers may fail" "Yellow"
-}
-$ErrorActionPreference = $prevEAP_t5
-step "transformers" "5.10.2 pre-installed"
-
-} # end $_NeedT5Install
+$ErrorActionPreference = $script:PrevEAP_T5
 
 # ==========================================================================
 #  PHASE 3.4: Prefer prebuilt llama.cpp bundles before source build

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -5889,6 +5889,10 @@ function Remove-SidecarTiktoken {
     # site-packages, so a partial tiktoken\ or tiktoken_ext\ shadows a working ambient
     # copy, and tiktoken is unpinned, so nothing else would ever clear it. Every entry
     # the wheel owns, as the runtime's _remove_optional_remnants removes them.
+    # Returns $true when nothing of tiktoken is left, $false when an entry would not go
+    # (a file another process holds open, an ACL): the caller then retires the whole
+    # sidecar, since a partial tiktoken ahead of site-packages shadows a working ambient
+    # copy and the sidecar predicate (tiktoken optional) would still call it current.
     param([Parameter(Mandatory = $true)][string]$TargetDir)
     foreach ($name in @("tiktoken", "tiktoken_ext", "tiktoken.libs")) {
         $entry = Join-Path $TargetDir $name
@@ -5896,6 +5900,23 @@ function Remove-SidecarTiktoken {
     }
     Get-ChildItem -LiteralPath $TargetDir -Directory -Filter "tiktoken-*.dist-info" -ErrorAction SilentlyContinue |
         ForEach-Object { Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue }
+    foreach ($name in @("tiktoken", "tiktoken_ext", "tiktoken.libs")) {
+        if (Test-Path -LiteralPath (Join-Path $TargetDir $name)) { return $false }
+    }
+    $left = @(Get-ChildItem -LiteralPath $TargetDir -Directory -Filter "tiktoken-*.dist-info" -ErrorAction SilentlyContinue)
+    return ($left.Count -eq 0)
+}
+
+function Retire-SidecarAfterFailedTiktoken {
+    # The cleanup left part of tiktoken behind: the sidecar is not one to keep. Best
+    # effort, as the cleanup was; what this cannot remove the runtime withholds at
+    # activation, and the next update rebuilds it.
+    param(
+        [Parameter(Mandatory = $true)][string]$TargetDir,
+        [Parameter(Mandatory = $true)][string]$DirName
+    )
+    Remove-Item -LiteralPath $TargetDir -Recurse -Force -ErrorAction SilentlyContinue
+    substep "$DirName/ kept part of a failed tiktoken install; retired, rebuilt on the next update" "Yellow"
 }
 
 function Repair-SidecarTiktoken {
@@ -5931,8 +5952,11 @@ function Repair-SidecarTiktoken {
     # metadata and read as present on the next run.
     $output = Fast-Install-Sidecar --target $TargetDir --no-deps --upgrade tiktoken 2>&1 | Out-String
     if ($LASTEXITCODE -ne 0) {
-        Remove-SidecarTiktoken -TargetDir $TargetDir
-        substep "Could not install tiktoken into $DirName/ -- Qwen tokenizers may fail" "Yellow"
+        if (Remove-SidecarTiktoken -TargetDir $TargetDir) {
+            substep "Could not install tiktoken into $DirName/ -- Qwen tokenizers may fail" "Yellow"
+        } else {
+            Retire-SidecarAfterFailedTiktoken -TargetDir $TargetDir -DirName $DirName
+        }
     }
 }
 
@@ -6032,8 +6056,11 @@ function Install-T5Sidecar {
         $tiktokenInstallExit = $LASTEXITCODE
     }
     if ($tiktokenInstallExit -ne 0) {
-        Remove-SidecarTiktoken -TargetDir $TargetDir
-        substep "Could not install tiktoken into $DirName/ -- Qwen tokenizers may fail" "Yellow"
+        if (Remove-SidecarTiktoken -TargetDir $TargetDir) {
+            substep "Could not install tiktoken into $DirName/ -- Qwen tokenizers may fail" "Yellow"
+        } else {
+            Retire-SidecarAfterFailedTiktoken -TargetDir $TargetDir -DirName $DirName
+        }
     }
     step "transformers" "$Version pre-installed"
 }

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2142,10 +2142,32 @@ _SIDECAR_COMMON_PINS="huggingface_hub==1.8.0 hf_xet==1.4.2"
 # unpinned, so nothing else would ever clear it. Every entry the wheel owns, as the
 # runtime's _remove_optional_remnants removes them.
 _sidecar_drop_tiktoken() {
+    # Answers 0 when nothing of tiktoken is left, 1 when an entry would not go (a
+    # permission, a file held open): the caller then retires the whole sidecar, since a
+    # partial tiktoken ahead of site-packages shadows a working ambient copy and the
+    # sidecar predicate (tiktoken optional) would still call the directory current.
     for _sdt_entry in "$1"/tiktoken "$1"/tiktoken_ext "$1"/tiktoken.libs "$1"/tiktoken-*.dist-info; do
-        [ -e "$_sdt_entry" ] && rm -rf "$_sdt_entry"
+        [ -e "$_sdt_entry" ] && rm -rf "$_sdt_entry" 2>/dev/null
+    done
+    _sdt_left=0
+    for _sdt_entry in "$1"/tiktoken "$1"/tiktoken_ext "$1"/tiktoken.libs "$1"/tiktoken-*.dist-info; do
+        [ -e "$_sdt_entry" ] && _sdt_left=1
     done
     unset _sdt_entry
+    if [ "$_sdt_left" = 1 ]; then
+        unset _sdt_left
+        return 1
+    fi
+    unset _sdt_left
+    return 0
+}
+
+_sidecar_retire_after_failed_tiktoken() {
+    # The cleanup left part of tiktoken behind: the sidecar is not one to keep. Best
+    # effort, as the cleanup was; what this cannot remove the runtime withholds at
+    # activation (_optional_package_partly_there), and the next update rebuilds it.
+    rm -rf "$1" 2>/dev/null
+    substep "the $2 sidecar kept part of a failed tiktoken install; retired, rebuilt on the next update"
 }
 
 _sidecar_top_up_tiktoken() {
@@ -2187,8 +2209,11 @@ _sidecar_top_up_tiktoken() {
     # damaged tiktoken/ directory an interrupted install left would be kept under fresh
     # metadata and read as present on the next run.
     if ! fast_install_sidecar --target "$_stt_dir" --no-deps --upgrade "tiktoken" >/dev/null 2>&1; then
-        _sidecar_drop_tiktoken "$_stt_dir"
-        substep "could not install tiktoken into the $_stt_label sidecar -- Qwen tokenizers may fail"
+        if _sidecar_drop_tiktoken "$_stt_dir"; then
+            substep "could not install tiktoken into the $_stt_label sidecar -- Qwen tokenizers may fail"
+        else
+            _sidecar_retire_after_failed_tiktoken "$_stt_dir" "$_stt_label"
+        fi
     fi
     return 0
 }
@@ -2280,8 +2305,11 @@ _install_sidecar() {
     # Optional, as in setup.ps1: a missing tiktoken wheel must not fail the whole setup,
     # and it is retried by _sidecar_top_up_tiktoken on later updates.
     if ! run_quiet_no_exit "install tiktoken for $_is_label" fast_install_sidecar --target "$_is_dir" --no-deps "tiktoken"; then
-        _sidecar_drop_tiktoken "$_is_dir"
-        substep "could not install tiktoken into the $_is_label sidecar -- Qwen tokenizers may fail"
+        if _sidecar_drop_tiktoken "$_is_dir"; then
+            substep "could not install tiktoken into the $_is_label sidecar -- Qwen tokenizers may fail"
+        else
+            _sidecar_retire_after_failed_tiktoken "$_is_dir" "$_is_label"
+        fi
     fi
     step "transformers" "$_is_ver pre-installed"
 }

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2151,7 +2151,10 @@ _sidecar_top_up_tiktoken() {
         fi
     done
     unset _stt_meta
-    if ! fast_install_sidecar --target "$_stt_dir" --no-deps "tiktoken" >/dev/null 2>&1; then
+    # --upgrade: a --target install without it does not replace existing files, so a
+    # damaged tiktoken/ directory an interrupted install left would be kept under fresh
+    # metadata and read as present on the next run.
+    if ! fast_install_sidecar --target "$_stt_dir" --no-deps --upgrade "tiktoken" >/dev/null 2>&1; then
         substep "could not install tiktoken into the $_stt_label sidecar -- Qwen tokenizers may fail"
     fi
     return 0

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2119,33 +2119,19 @@ _target_has_pkg_version() {
     done
     return 1
 }
-# The pins, once. install_manifest.sidecar_is_current audits these exact strings and
-# _install_sidecar installs them, so the check and the install can never disagree about
-# what a current sidecar holds.
-#
-# Every name here has to be one that audit can actually reach. It proves a distribution
-# arrived by looking for its package directory, and falls back to the top-level names in
-# that distribution's own RECORD only when neither spelling of the project name is a
-# directory (six.py has no directory at all; pillow's is PIL). A pin whose payload is
-# neither -- nothing recorded either -- reads as stale forever, and then every update
-# deletes and refetches a healthy several-hundred-MB sidecar.
-#
-# tiktoken is deliberately not a pin. Both shells treat its install as optional (no wheel
-# for the interpreter is a warning, not a failure), so a sidecar without it is a finished
-# sidecar; as a pin it would read stale on every update and be wiped and refetched three
-# times over, for a package the rebuild would fail to add again. _sidecar_top_up_tiktoken
-# retries it alone instead.
+# The pins, once, audited by install_manifest.sidecar_is_current and installed by _install_sidecar.
+# Every name must be one the audit can reach (a package directory, or the RECORD's top-level names:
+# six.py, PIL), or it reads stale forever and every update refetches the sidecar. tiktoken is not a
+# pin: its install is optional, so a sidecar without it is finished; _sidecar_top_up_tiktoken
+# retries it alone.
 _SIDECAR_COMMON_PINS="huggingface_hub==1.8.0 hf_xet==1.4.2"
 
-# What a failed tiktoken install leaves must go: the sidecar sits ahead of site-packages,
-# so a partial tiktoken/ or tiktoken_ext/ shadows a working ambient copy, and tiktoken is
-# unpinned, so nothing else would ever clear it. Every entry the wheel owns, as the
-# runtime's _remove_optional_remnants removes them.
+# A failed tiktoken install's remnants shadow a working ambient copy from ahead of site-packages,
+# and being unpinned nothing else clears them. Every entry the wheel owns, as the runtime's
+# _remove_optional_remnants.
 _sidecar_drop_tiktoken() {
-    # Answers 0 when nothing of tiktoken is left, 1 when an entry would not go (a
-    # permission, a file held open): the caller then retires the whole sidecar, since a
-    # partial tiktoken ahead of site-packages shadows a working ambient copy and the
-    # sidecar predicate (tiktoken optional) would still call the directory current.
+    # 1 when an entry would not go (a permission, a file held open): the caller then retires the
+    # whole sidecar, which the predicate would still call current.
     for _sdt_entry in "$1"/tiktoken "$1"/tiktoken_ext "$1"/tiktoken.libs "$1"/tiktoken-*.dist-info; do
         [ -e "$_sdt_entry" ] && rm -rf "$_sdt_entry" 2>/dev/null
     done
@@ -2163,9 +2149,7 @@ _sidecar_drop_tiktoken() {
 }
 
 _sidecar_retire_after_failed_tiktoken() {
-    # The cleanup left part of tiktoken behind: the sidecar is not one to keep. Best
-    # effort, as the cleanup was; what this cannot remove the runtime withholds at
-    # activation (_optional_package_partly_there), and the next update rebuilds it.
+    # Part of tiktoken remains: the sidecar goes, best effort; the runtime withholds the rest.
     rm -rf "$1" 2>/dev/null
     substep "the $2 sidecar kept part of a failed tiktoken install; retired, rebuilt on the next update"
 }
@@ -2173,16 +2157,11 @@ _sidecar_retire_after_failed_tiktoken() {
 _sidecar_top_up_tiktoken() {
     _stt_dir="$1"
     _stt_label="$2"
-    # The payload AND a complete dist-info (RECORD is written last), as
-    # Repair-SidecarTiktoken and the runtime's _optional_package_absent check: an
-    # interrupted install can leave the dist-info with no package beside it, or METADATA
-    # and the package without the native extension and RECORD; the sidecar predicate
-    # accepts the sidecar either way (tiktoken is unpinned and optional), and a weaker
-    # check would skip this top-up forever while Qwen tokenizers fail.
-    # A dist-info with no RECORD is one uv cannot uninstall: --upgrade warns and lands
-    # the new version beside it, and importlib.metadata may keep answering the stale
-    # one. It goes before the package is declared present, so a complete install that
-    # a retry put beside an older recordless record does not keep the record forever.
+    # The payload AND a complete dist-info (RECORD is written last), as Repair-SidecarTiktoken and
+    # the runtime check: an interrupted install leaves either without the other, the predicate
+    # accepts both, and a weaker check would skip this top-up while Qwen tokenizers fail. A
+    # recordless dist-info goes first: uv cannot uninstall it and importlib.metadata may keep
+    # answering it.
     for _stt_info in "$_stt_dir"/tiktoken-*.dist-info; do
         if [ -d "$_stt_info" ] && [ ! -f "$_stt_info/RECORD" ]; then
             rm -rf "$_stt_info"
@@ -2196,18 +2175,13 @@ _sidecar_top_up_tiktoken() {
         fi
     done
     unset _stt_meta
-    # Not present, so every tiktoken dist-info still here describes a payload that is
-    # missing or damaged. It goes before the install: --upgrade replaces the package
-    # but lands the new version's dist-info under its own name beside the old one, and
-    # importlib.metadata may keep answering the stale version (the runtime's
-    # _stage_optional_package clears the others for the same reason).
+    # Not present, so every tiktoken dist-info here describes a missing or damaged payload and goes
+    # before the install: --upgrade lands the new dist-info beside the old one.
     for _stt_info in "$_stt_dir"/tiktoken-*.dist-info; do
         [ -d "$_stt_info" ] && rm -rf "$_stt_info"
     done
     unset _stt_info
-    # --upgrade: a --target install without it does not replace existing files, so a
-    # damaged tiktoken/ directory an interrupted install left would be kept under fresh
-    # metadata and read as present on the next run.
+    # --upgrade: a --target install without it keeps a damaged tiktoken/ under fresh metadata.
     if ! fast_install_sidecar --target "$_stt_dir" --no-deps --upgrade "tiktoken" >/dev/null 2>&1; then
         if _sidecar_drop_tiktoken "$_stt_dir"; then
             substep "could not install tiktoken into the $_stt_label sidecar -- Qwen tokenizers may fail"
@@ -2219,20 +2193,14 @@ _sidecar_top_up_tiktoken() {
 }
 
 _sidecar_current() {
-    # One predicate for both shells: install_manifest.py answers, setup.ps1 asks the same
-    # way. A shell reimplementation is what let the two drift the last time -- the
-    # version grep below sees a transformers 5.3.0 METADATA and calls a sidecar whose
-    # package tree an interrupted pip left half-written "current", and the training
-    # worker then dies on `import transformers` with the setup log reporting success.
+    # One predicate for both shells (install_manifest.py): the version grep called a half-written
+    # sidecar with a transformers 5.3.0 METADATA "current".
     _sc_dir="$1"
     _sc_ver="$2"
     [ -d "$_sc_dir" ] || return 1
-    # No venv interpreter is the Colab path (_COLAB_NO_VENV), where the backend deps go
-    # into system Python and $VENV_DIR/bin/python never exists. The shim is stdlib-only,
-    # so the `python` the installer itself runs under there asks it the same question;
-    # the version grep this replaced sees only transformers, and a sidecar install
-    # interrupted after transformers landed read as current on every later run. Only a
-    # tree with no interpreter to ask at all falls back to the grep.
+    # No venv interpreter is the Colab path (_COLAB_NO_VENV); the stdlib-only shim runs under the
+    # installer's own `python` there. Only a tree with no interpreter at all falls back to the grep,
+    # which read an interrupted sidecar as current.
     _sc_python="$VENV_DIR/bin/python"
     if [ ! -x "$_sc_python" ]; then
         _sc_python=$(command -v python 2>/dev/null || command -v python3 2>/dev/null || true)
@@ -2242,10 +2210,8 @@ _sidecar_current() {
         _target_has_pkg_version "$_sc_dir" "transformers" "$_sc_ver"
         return $?
     fi
-    # Bounded where a timeout exists: the shim's own scan budget starts after it has
-    # globbed and read every RECORD and cannot interrupt a stalled read, so a Studio
-    # home on a wedged mount would otherwise hold setup here forever. A timeout reads
-    # as stale, and the rebuild that follows is the installer's own fallback.
+    # Bounded where a timeout exists: the shim cannot interrupt a stalled RECORD read (a wedged
+    # mount). A timeout reads as stale, and the rebuild follows.
     # shellcheck disable=SC2086 - the pins are a deliberate word-split list
     if command -v timeout >/dev/null 2>&1; then
         _sc_out=$(timeout -k 5 60 "$_sc_python" "$SCRIPT_DIR/install_manifest.py" sidecar "$_sc_dir" \
@@ -2256,15 +2222,13 @@ _sidecar_current() {
             "transformers==$_sc_ver" $_SIDECAR_COMMON_PINS 2>/dev/null)
         _sc_rc=$?
     fi
-    # 124 is the TERM after 60 s; 137 is the KILL five seconds later when the audit
-    # ignored the TERM. Both are an audit that did not answer.
+    # 124 is the TERM after 60 s, 137 the KILL after it: an audit that did not answer.
     if [ "$_sc_rc" -eq 124 ] || [ "$_sc_rc" -eq 137 ]; then
         _sc_out="sidecar: audit did not answer within 60 seconds"
     fi
     unset _sc_python
-    # The marker, not the exit code alone. An install_manifest.py predating the shim has
-    # no __main__ block at all, so running it exits 0 with no output -- and reading that
-    # silence as "current" would retire the sidecar rebuild entirely.
+    # The marker, not the exit code alone: an install_manifest.py predating the shim exits 0
+    # silently.
     case "$_sc_out" in
         "sidecar: current")
             unset _sc_out _sc_rc
@@ -2277,10 +2241,7 @@ _sidecar_current() {
             ;;
     esac
     unset _sc_out
-    # No marker and a failure: the audit started and died (an exception in the shim, an
-    # interpreter that cannot run it). That is not the legacy silent exit 0 the version
-    # grep below stands in for, and reading it as current would retire the audit for
-    # exactly the trees it could not read. Stale, and the rebuild follows.
+    # No marker and a failure: the audit died, which is not the legacy silent exit 0. Stale.
     if [ "$_sc_rc" -ne 0 ]; then
         verbose_substep "sidecar $_sc_dir: audit failed (exit $_sc_rc)"
         unset _sc_rc
@@ -2302,8 +2263,7 @@ _install_sidecar() {
     run_quiet "install transformers $_is_ver" fast_install_sidecar --target "$_is_dir" --no-deps "transformers==$_is_ver"
     run_quiet "install huggingface_hub for $_is_label" fast_install_sidecar --target "$_is_dir" --no-deps "huggingface_hub==1.8.0"
     run_quiet "install hf_xet for $_is_label" fast_install_sidecar --target "$_is_dir" --no-deps "hf_xet==1.4.2"
-    # Optional, as in setup.ps1: a missing tiktoken wheel must not fail the whole setup,
-    # and it is retried by _sidecar_top_up_tiktoken on later updates.
+    # Optional, as in setup.ps1: retried by _sidecar_top_up_tiktoken on later updates.
     if ! run_quiet_no_exit "install tiktoken for $_is_label" fast_install_sidecar --target "$_is_dir" --no-deps "tiktoken"; then
         if _sidecar_drop_tiktoken "$_is_dir"; then
             substep "could not install tiktoken into the $_is_label sidecar -- Qwen tokenizers may fail"
@@ -2314,11 +2274,8 @@ _install_sidecar() {
     step "transformers" "$_is_ver pre-installed"
 }
 
-# Per tier, not one flag for all three. The old single flag rebuilt every sidecar
-# whenever any one of them was stale, and -- through the `_SKIP_PYTHON_DEPS = false`
-# clause that used to sit at the end of this list -- on every update that touched the
-# dependency pass at all, whether or not a sidecar had moved. That is three wipes and
-# twelve `--target` installs, measured at 60-90 s on Windows, for work already done.
+# Per tier: the old single flag (with its `_SKIP_PYTHON_DEPS = false` clause) rebuilt all three
+# sidecars on every update that touched the dependency pass, 60-90 s on Windows for nothing.
 _NEED_T5_530=false
 _NEED_T5_550=false
 _NEED_T5_510=false

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2129,7 +2129,29 @@ _target_has_pkg_version() {
 # directory (six.py has no directory at all; pillow's is PIL). A pin whose payload is
 # neither -- nothing recorded either -- reads as stale forever, and then every update
 # deletes and refetches a healthy several-hundred-MB sidecar.
-_SIDECAR_COMMON_PINS="huggingface_hub==1.8.0 hf_xet==1.4.2 tiktoken"
+#
+# tiktoken is deliberately not a pin. Both shells treat its install as optional (no wheel
+# for the interpreter is a warning, not a failure), so a sidecar without it is a finished
+# sidecar; as a pin it would read stale on every update and be wiped and refetched three
+# times over, for a package the rebuild would fail to add again. _sidecar_top_up_tiktoken
+# retries it alone instead.
+_SIDECAR_COMMON_PINS="huggingface_hub==1.8.0 hf_xet==1.4.2"
+
+_sidecar_top_up_tiktoken() {
+    _stt_dir="$1"
+    _stt_label="$2"
+    for _stt_meta in "$_stt_dir"/tiktoken-*.dist-info/METADATA; do
+        if [ -f "$_stt_meta" ]; then
+            unset _stt_meta
+            return 0
+        fi
+    done
+    unset _stt_meta
+    if ! fast_install_sidecar --target "$_stt_dir" --no-deps "tiktoken" >/dev/null 2>&1; then
+        substep "could not install tiktoken into the $_stt_label sidecar -- Qwen tokenizers may fail"
+    fi
+    return 0
+}
 
 _sidecar_current() {
     # One predicate for both shells: install_manifest.py answers, setup.ps1 asks the same
@@ -2182,7 +2204,11 @@ _install_sidecar() {
     run_quiet "install transformers $_is_ver" fast_install_sidecar --target "$_is_dir" --no-deps "transformers==$_is_ver"
     run_quiet "install huggingface_hub for $_is_label" fast_install_sidecar --target "$_is_dir" --no-deps "huggingface_hub==1.8.0"
     run_quiet "install hf_xet for $_is_label" fast_install_sidecar --target "$_is_dir" --no-deps "hf_xet==1.4.2"
-    run_quiet "install tiktoken for $_is_label" fast_install_sidecar --target "$_is_dir" --no-deps "tiktoken"
+    # Optional, as in setup.ps1: a missing tiktoken wheel must not fail the whole setup,
+    # and it is retried by _sidecar_top_up_tiktoken on later updates.
+    if ! run_quiet_no_exit "install tiktoken for $_is_label" fast_install_sidecar --target "$_is_dir" --no-deps "tiktoken"; then
+        substep "could not install tiktoken into the $_is_label sidecar -- Qwen tokenizers may fail"
+    fi
     step "transformers" "$_is_ver pre-installed"
 }
 
@@ -2214,16 +2240,19 @@ if [ "$_NEED_T5_530" = true ]; then
     _install_sidecar "$VENV_T5_530_DIR" "5.3.0" "5.3"
 else
     step "transformers" "5.3.0 sidecar current"
+    _sidecar_top_up_tiktoken "$VENV_T5_530_DIR" "5.3"
 fi
 if [ "$_NEED_T5_550" = true ]; then
     _install_sidecar "$VENV_T5_550_DIR" "5.5.0" "5.5"
 else
     step "transformers" "5.5.0 sidecar current"
+    _sidecar_top_up_tiktoken "$VENV_T5_550_DIR" "5.5"
 fi
 if [ "$_NEED_T5_510" = true ]; then
     _install_sidecar "$VENV_T5_510_DIR" "5.10.2" "5.10"
 else
     step "transformers" "5.10.2 sidecar current"
+    _sidecar_top_up_tiktoken "$VENV_T5_510_DIR" "5.10"
 fi
 fi
 

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2146,6 +2146,16 @@ _sidecar_top_up_tiktoken() {
     # and the package without the native extension and RECORD; the sidecar predicate
     # accepts the sidecar either way (tiktoken is unpinned and optional), and a weaker
     # check would skip this top-up forever while Qwen tokenizers fail.
+    # A dist-info with no RECORD is one uv cannot uninstall: --upgrade warns and lands
+    # the new version beside it, and importlib.metadata may keep answering the stale
+    # one. It goes before the package is declared present, so a complete install that
+    # a retry put beside an older recordless record does not keep the record forever.
+    for _stt_info in "$_stt_dir"/tiktoken-*.dist-info; do
+        if [ -d "$_stt_info" ] && [ ! -f "$_stt_info/RECORD" ]; then
+            rm -rf "$_stt_info"
+        fi
+    done
+    unset _stt_info
     for _stt_meta in "$_stt_dir"/tiktoken-*.dist-info/METADATA; do
         if [ -f "$_stt_meta" ] && [ -f "${_stt_meta%METADATA}RECORD" ] && [ -f "$_stt_dir/tiktoken/__init__.py" ]; then
             unset _stt_meta
@@ -2153,16 +2163,6 @@ _sidecar_top_up_tiktoken() {
         fi
     done
     unset _stt_meta
-    # A dist-info with no RECORD is one uv cannot uninstall: --upgrade warns and lands
-    # the new version beside it, and importlib.metadata may keep answering the stale
-    # one. Nothing here has both a RECORD and the payload (the loop above returned
-    # otherwise), so the recordless metadata goes first.
-    for _stt_info in "$_stt_dir"/tiktoken-*.dist-info; do
-        if [ -d "$_stt_info" ] && [ ! -f "$_stt_info/RECORD" ]; then
-            rm -rf "$_stt_info"
-        fi
-    done
-    unset _stt_info
     # --upgrade: a --target install without it does not replace existing files, so a
     # damaged tiktoken/ directory an interrupted install left would be kept under fresh
     # metadata and read as present on the next run.

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2122,6 +2122,13 @@ _target_has_pkg_version() {
 # The pins, once. install_manifest.sidecar_is_current audits these exact strings and
 # _install_sidecar installs them, so the check and the install can never disagree about
 # what a current sidecar holds.
+#
+# Every name here has to be one that audit can actually reach. It proves a distribution
+# arrived by looking for its package directory, and falls back to the top-level names in
+# that distribution's own RECORD only when neither spelling of the project name is a
+# directory (six.py has no directory at all; pillow's is PIL). A pin whose payload is
+# neither -- nothing recorded either -- reads as stale forever, and then every update
+# deletes and refetches a healthy several-hundred-MB sidecar.
 _SIDECAR_COMMON_PINS="huggingface_hub==1.8.0 hf_xet==1.4.2 tiktoken"
 
 _sidecar_current() {

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2163,6 +2163,15 @@ _sidecar_top_up_tiktoken() {
         fi
     done
     unset _stt_meta
+    # Not present, so every tiktoken dist-info still here describes a payload that is
+    # missing or damaged. It goes before the install: --upgrade replaces the package
+    # but lands the new version's dist-info under its own name beside the old one, and
+    # importlib.metadata may keep answering the stale version (the runtime's
+    # _stage_optional_package clears the others for the same reason).
+    for _stt_info in "$_stt_dir"/tiktoken-*.dist-info; do
+        [ -d "$_stt_info" ] && rm -rf "$_stt_info"
+    done
+    unset _stt_info
     # --upgrade: a --target install without it does not replace existing files, so a
     # damaged tiktoken/ directory an interrupted install left would be kept under fresh
     # metadata and read as present on the next run.

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2198,7 +2198,9 @@ _sidecar_current() {
             "transformers==$_sc_ver" $_SIDECAR_COMMON_PINS 2>/dev/null)
         _sc_rc=$?
     fi
-    if [ "$_sc_rc" -eq 124 ]; then
+    # 124 is the TERM after 60 s; 137 is the KILL five seconds later when the audit
+    # ignored the TERM. Both are an audit that did not answer.
+    if [ "$_sc_rc" -eq 124 ] || [ "$_sc_rc" -eq 137 ]; then
         _sc_out="sidecar: audit did not answer within 60 seconds"
     fi
     unset _sc_python _sc_rc

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2140,12 +2140,14 @@ _SIDECAR_COMMON_PINS="huggingface_hub==1.8.0 hf_xet==1.4.2"
 _sidecar_top_up_tiktoken() {
     _stt_dir="$1"
     _stt_label="$2"
-    # The payload, not the dist-info alone, as Repair-SidecarTiktoken checks: an
-    # interrupted install can leave the dist-info with no package beside it, the sidecar
-    # predicate accepts the sidecar (tiktoken is unpinned and optional), and a
-    # dist-info-only check would skip this top-up forever while Qwen tokenizers fail.
+    # The payload AND a complete dist-info (RECORD is written last), as
+    # Repair-SidecarTiktoken and the runtime's _optional_package_absent check: an
+    # interrupted install can leave the dist-info with no package beside it, or METADATA
+    # and the package without the native extension and RECORD; the sidecar predicate
+    # accepts the sidecar either way (tiktoken is unpinned and optional), and a weaker
+    # check would skip this top-up forever while Qwen tokenizers fail.
     for _stt_meta in "$_stt_dir"/tiktoken-*.dist-info/METADATA; do
-        if [ -f "$_stt_meta" ] && [ -f "$_stt_dir/tiktoken/__init__.py" ]; then
+        if [ -f "$_stt_meta" ] && [ -f "${_stt_meta%METADATA}RECORD" ] && [ -f "$_stt_dir/tiktoken/__init__.py" ]; then
             unset _stt_meta
             return 0
         fi
@@ -2203,23 +2205,33 @@ _sidecar_current() {
     if [ "$_sc_rc" -eq 124 ] || [ "$_sc_rc" -eq 137 ]; then
         _sc_out="sidecar: audit did not answer within 60 seconds"
     fi
-    unset _sc_python _sc_rc
+    unset _sc_python
     # The marker, not the exit code alone. An install_manifest.py predating the shim has
     # no __main__ block at all, so running it exits 0 with no output -- and reading that
     # silence as "current" would retire the sidecar rebuild entirely.
     case "$_sc_out" in
         "sidecar: current")
-            unset _sc_out
+            unset _sc_out _sc_rc
             return 0
             ;;
         sidecar:*)
             verbose_substep "sidecar $_sc_dir: ${_sc_out#sidecar: }"
-            unset _sc_out
+            unset _sc_out _sc_rc
             return 1
             ;;
     esac
     unset _sc_out
-    # An old or unusable tree: fall back to the version grep this replaced.
+    # No marker and a failure: the audit started and died (an exception in the shim, an
+    # interpreter that cannot run it). That is not the legacy silent exit 0 the version
+    # grep below stands in for, and reading it as current would retire the audit for
+    # exactly the trees it could not read. Stale, and the rebuild follows.
+    if [ "$_sc_rc" -ne 0 ]; then
+        verbose_substep "sidecar $_sc_dir: audit failed (exit $_sc_rc)"
+        unset _sc_rc
+        return 1
+    fi
+    unset _sc_rc
+    # An old shim (clean, silent exit 0): fall back to the version grep this replaced.
     _target_has_pkg_version "$_sc_dir" "transformers" "$_sc_ver"
 }
 

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2153,6 +2153,16 @@ _sidecar_top_up_tiktoken() {
         fi
     done
     unset _stt_meta
+    # A dist-info with no RECORD is one uv cannot uninstall: --upgrade warns and lands
+    # the new version beside it, and importlib.metadata may keep answering the stale
+    # one. Nothing here has both a RECORD and the payload (the loop above returned
+    # otherwise), so the recordless metadata goes first.
+    for _stt_info in "$_stt_dir"/tiktoken-*.dist-info; do
+        if [ -d "$_stt_info" ] && [ ! -f "$_stt_info/RECORD" ]; then
+            rm -rf "$_stt_info"
+        fi
+    done
+    unset _stt_info
     # --upgrade: a --target install without it does not replace existing files, so a
     # damaged tiktoken/ directory an interrupted install left would be kept under fresh
     # metadata and read as present on the next run.

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2137,6 +2137,17 @@ _target_has_pkg_version() {
 # retries it alone instead.
 _SIDECAR_COMMON_PINS="huggingface_hub==1.8.0 hf_xet==1.4.2"
 
+# What a failed tiktoken install leaves must go: the sidecar sits ahead of site-packages,
+# so a partial tiktoken/ or tiktoken_ext/ shadows a working ambient copy, and tiktoken is
+# unpinned, so nothing else would ever clear it. Every entry the wheel owns, as the
+# runtime's _remove_optional_remnants removes them.
+_sidecar_drop_tiktoken() {
+    for _sdt_entry in "$1"/tiktoken "$1"/tiktoken_ext "$1"/tiktoken.libs "$1"/tiktoken-*.dist-info; do
+        [ -e "$_sdt_entry" ] && rm -rf "$_sdt_entry"
+    done
+    unset _sdt_entry
+}
+
 _sidecar_top_up_tiktoken() {
     _stt_dir="$1"
     _stt_label="$2"
@@ -2176,6 +2187,7 @@ _sidecar_top_up_tiktoken() {
     # damaged tiktoken/ directory an interrupted install left would be kept under fresh
     # metadata and read as present on the next run.
     if ! fast_install_sidecar --target "$_stt_dir" --no-deps --upgrade "tiktoken" >/dev/null 2>&1; then
+        _sidecar_drop_tiktoken "$_stt_dir"
         substep "could not install tiktoken into the $_stt_label sidecar -- Qwen tokenizers may fail"
     fi
     return 0
@@ -2268,6 +2280,7 @@ _install_sidecar() {
     # Optional, as in setup.ps1: a missing tiktoken wheel must not fail the whole setup,
     # and it is retried by _sidecar_top_up_tiktoken on later updates.
     if ! run_quiet_no_exit "install tiktoken for $_is_label" fast_install_sidecar --target "$_is_dir" --no-deps "tiktoken"; then
+        _sidecar_drop_tiktoken "$_is_dir"
         substep "could not install tiktoken into the $_is_label sidecar -- Qwen tokenizers may fail"
     fi
     step "transformers" "$_is_ver pre-installed"

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2184,10 +2184,24 @@ _sidecar_current() {
         _target_has_pkg_version "$_sc_dir" "transformers" "$_sc_ver"
         return $?
     fi
+    # Bounded where a timeout exists: the shim's own scan budget starts after it has
+    # globbed and read every RECORD and cannot interrupt a stalled read, so a Studio
+    # home on a wedged mount would otherwise hold setup here forever. A timeout reads
+    # as stale, and the rebuild that follows is the installer's own fallback.
     # shellcheck disable=SC2086 - the pins are a deliberate word-split list
-    _sc_out=$("$_sc_python" "$SCRIPT_DIR/install_manifest.py" sidecar "$_sc_dir" \
-        "transformers==$_sc_ver" $_SIDECAR_COMMON_PINS 2>/dev/null)
-    unset _sc_python
+    if command -v timeout >/dev/null 2>&1; then
+        _sc_out=$(timeout -k 5 60 "$_sc_python" "$SCRIPT_DIR/install_manifest.py" sidecar "$_sc_dir" \
+            "transformers==$_sc_ver" $_SIDECAR_COMMON_PINS 2>/dev/null)
+        _sc_rc=$?
+    else
+        _sc_out=$("$_sc_python" "$SCRIPT_DIR/install_manifest.py" sidecar "$_sc_dir" \
+            "transformers==$_sc_ver" $_SIDECAR_COMMON_PINS 2>/dev/null)
+        _sc_rc=$?
+    fi
+    if [ "$_sc_rc" -eq 124 ]; then
+        _sc_out="sidecar: audit did not answer within 60 seconds"
+    fi
+    unset _sc_python _sc_rc
     # The marker, not the exit code alone. An install_manifest.py predating the shim has
     # no __main__ block at all, so running it exits 0 with no output -- and reading that
     # silence as "current" would retire the sidecar rebuild entirely.

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2133,26 +2133,33 @@ _sidecar_current() {
     _sc_dir="$1"
     _sc_ver="$2"
     [ -d "$_sc_dir" ] || return 1
-    [ -x "$VENV_DIR/bin/python" ] || return 1
+    # No venv interpreter is the Colab path (_COLAB_NO_VENV), where the backend deps go
+    # into system Python and $VENV_DIR/bin/python never exists. Reporting every sidecar
+    # stale there rebuilt all three -- three wipes and twelve --target installs -- on
+    # every single run, so fall back to the version grep instead of answering "stale":
+    # it is the same answer this function gives for any other tree it cannot ask.
+    if [ ! -x "$VENV_DIR/bin/python" ]; then
+        _target_has_pkg_version "$_sc_dir" "transformers" "$_sc_ver"
+        return $?
+    fi
     # shellcheck disable=SC2086 - the pins are a deliberate word-split list
     _sc_out=$("$VENV_DIR/bin/python" "$SCRIPT_DIR/install_manifest.py" sidecar "$_sc_dir" \
         "transformers==$_sc_ver" $_SIDECAR_COMMON_PINS 2>/dev/null)
-    _sc_rc=$?
     # The marker, not the exit code alone. An install_manifest.py predating the shim has
     # no __main__ block at all, so running it exits 0 with no output -- and reading that
     # silence as "current" would retire the sidecar rebuild entirely.
     case "$_sc_out" in
         "sidecar: current")
-            unset _sc_out _sc_rc
+            unset _sc_out
             return 0
             ;;
         sidecar:*)
             verbose_substep "sidecar $_sc_dir: ${_sc_out#sidecar: }"
-            unset _sc_out _sc_rc
+            unset _sc_out
             return 1
             ;;
     esac
-    unset _sc_out _sc_rc
+    unset _sc_out
     # An old or unusable tree: fall back to the version grep this replaced.
     _target_has_pkg_version "$_sc_dir" "transformers" "$_sc_ver"
 }

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2163,17 +2163,24 @@ _sidecar_current() {
     _sc_ver="$2"
     [ -d "$_sc_dir" ] || return 1
     # No venv interpreter is the Colab path (_COLAB_NO_VENV), where the backend deps go
-    # into system Python and $VENV_DIR/bin/python never exists. Reporting every sidecar
-    # stale there rebuilt all three -- three wipes and twelve --target installs -- on
-    # every single run, so fall back to the version grep instead of answering "stale":
-    # it is the same answer this function gives for any other tree it cannot ask.
-    if [ ! -x "$VENV_DIR/bin/python" ]; then
+    # into system Python and $VENV_DIR/bin/python never exists. The shim is stdlib-only,
+    # so the `python` the installer itself runs under there asks it the same question;
+    # the version grep this replaced sees only transformers, and a sidecar install
+    # interrupted after transformers landed read as current on every later run. Only a
+    # tree with no interpreter to ask at all falls back to the grep.
+    _sc_python="$VENV_DIR/bin/python"
+    if [ ! -x "$_sc_python" ]; then
+        _sc_python=$(command -v python 2>/dev/null || command -v python3 2>/dev/null || true)
+    fi
+    if [ -z "$_sc_python" ]; then
+        unset _sc_python
         _target_has_pkg_version "$_sc_dir" "transformers" "$_sc_ver"
         return $?
     fi
     # shellcheck disable=SC2086 - the pins are a deliberate word-split list
-    _sc_out=$("$VENV_DIR/bin/python" "$SCRIPT_DIR/install_manifest.py" sidecar "$_sc_dir" \
+    _sc_out=$("$_sc_python" "$SCRIPT_DIR/install_manifest.py" sidecar "$_sc_dir" \
         "transformers==$_sc_ver" $_SIDECAR_COMMON_PINS 2>/dev/null)
+    unset _sc_python
     # The marker, not the exit code alone. An install_manifest.py predating the shim has
     # no __main__ block at all, so running it exits 0 with no output -- and reading that
     # silence as "current" would retire the sidecar rebuild entirely.

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2119,7 +2119,67 @@ _target_has_pkg_version() {
     done
     return 1
 }
-_NEED_T5_INSTALL=false
+# The pins, once. install_manifest.sidecar_is_current audits these exact strings and
+# _install_sidecar installs them, so the check and the install can never disagree about
+# what a current sidecar holds.
+_SIDECAR_COMMON_PINS="huggingface_hub==1.8.0 hf_xet==1.4.2 tiktoken"
+
+_sidecar_current() {
+    # One predicate for both shells: install_manifest.py answers, setup.ps1 asks the same
+    # way. A shell reimplementation is what let the two drift the last time -- the
+    # version grep below sees a transformers 5.3.0 METADATA and calls a sidecar whose
+    # package tree an interrupted pip left half-written "current", and the training
+    # worker then dies on `import transformers` with the setup log reporting success.
+    _sc_dir="$1"
+    _sc_ver="$2"
+    [ -d "$_sc_dir" ] || return 1
+    [ -x "$VENV_DIR/bin/python" ] || return 1
+    # shellcheck disable=SC2086 - the pins are a deliberate word-split list
+    _sc_out=$("$VENV_DIR/bin/python" "$SCRIPT_DIR/install_manifest.py" sidecar "$_sc_dir" \
+        "transformers==$_sc_ver" $_SIDECAR_COMMON_PINS 2>/dev/null)
+    _sc_rc=$?
+    # The marker, not the exit code alone. An install_manifest.py predating the shim has
+    # no __main__ block at all, so running it exits 0 with no output -- and reading that
+    # silence as "current" would retire the sidecar rebuild entirely.
+    case "$_sc_out" in
+        "sidecar: current")
+            unset _sc_out _sc_rc
+            return 0
+            ;;
+        sidecar:*)
+            verbose_substep "sidecar $_sc_dir: ${_sc_out#sidecar: }"
+            unset _sc_out _sc_rc
+            return 1
+            ;;
+    esac
+    unset _sc_out _sc_rc
+    # An old or unusable tree: fall back to the version grep this replaced.
+    _target_has_pkg_version "$_sc_dir" "transformers" "$_sc_ver"
+}
+
+_install_sidecar() {
+    _is_dir="$1"
+    _is_ver="$2"
+    _is_label="$3"
+    _assert_studio_owned_or_absent "$_is_dir" "transformers $_is_label sidecar venv"
+    [ -d "$_is_dir" ] && rm -rf "$_is_dir"
+    mkdir -p "$_is_dir"
+    : > "$_is_dir/$_STUDIO_OWNED_MARKER" 2>/dev/null || true
+    run_quiet "install transformers $_is_ver" fast_install_sidecar --target "$_is_dir" --no-deps "transformers==$_is_ver"
+    run_quiet "install huggingface_hub for $_is_label" fast_install_sidecar --target "$_is_dir" --no-deps "huggingface_hub==1.8.0"
+    run_quiet "install hf_xet for $_is_label" fast_install_sidecar --target "$_is_dir" --no-deps "hf_xet==1.4.2"
+    run_quiet "install tiktoken for $_is_label" fast_install_sidecar --target "$_is_dir" --no-deps "tiktoken"
+    step "transformers" "$_is_ver pre-installed"
+}
+
+# Per tier, not one flag for all three. The old single flag rebuilt every sidecar
+# whenever any one of them was stale, and -- through the `_SKIP_PYTHON_DEPS = false`
+# clause that used to sit at the end of this list -- on every update that touched the
+# dependency pass at all, whether or not a sidecar had moved. That is three wipes and
+# twelve `--target` installs, measured at 60-90 s on Windows, for work already done.
+_NEED_T5_530=false
+_NEED_T5_550=false
+_NEED_T5_510=false
 if [ -d "$STUDIO_HOME/.venv_t5" ]; then
     # Legacy layout — migrate. The tiered venvs a staged run builds land under the
     # stage root and may never be activated, so removing the live legacy one here
@@ -2128,47 +2188,28 @@ if [ -d "$STUDIO_HOME/.venv_t5" ]; then
         _assert_studio_owned_or_absent "$STUDIO_HOME/.venv_t5" "legacy transformers sidecar venv"
         rm -rf "$STUDIO_HOME/.venv_t5"
     fi
-    _NEED_T5_INSTALL=true
+    _NEED_T5_530=true
+    _NEED_T5_550=true
+    _NEED_T5_510=true
 fi
-[ ! -d "$VENV_T5_530_DIR" ] && _NEED_T5_INSTALL=true
-[ ! -d "$VENV_T5_550_DIR" ] && _NEED_T5_INSTALL=true
-[ ! -d "$VENV_T5_510_DIR" ] && _NEED_T5_INSTALL=true
-_target_has_pkg_version "$VENV_T5_530_DIR" "transformers" "5.3.0" || _NEED_T5_INSTALL=true
-_target_has_pkg_version "$VENV_T5_550_DIR" "transformers" "5.5.0" || _NEED_T5_INSTALL=true
-_target_has_pkg_version "$VENV_T5_510_DIR" "transformers" "5.10.2" || _NEED_T5_INSTALL=true
-# Also reinstall when python deps were updated (packages may need rebuild)
-[ "$_SKIP_PYTHON_DEPS" = false ] && _NEED_T5_INSTALL=true
+_sidecar_current "$VENV_T5_530_DIR" "5.3.0" || _NEED_T5_530=true
+_sidecar_current "$VENV_T5_550_DIR" "5.5.0" || _NEED_T5_550=true
+_sidecar_current "$VENV_T5_510_DIR" "5.10.2" || _NEED_T5_510=true
 
-if [ "$_NEED_T5_INSTALL" = true ]; then
-    _assert_studio_owned_or_absent "$VENV_T5_530_DIR" "transformers 5.3 sidecar venv"
-    [ -d "$VENV_T5_530_DIR" ] && rm -rf "$VENV_T5_530_DIR"
-    mkdir -p "$VENV_T5_530_DIR"
-    : > "$VENV_T5_530_DIR/$_STUDIO_OWNED_MARKER" 2>/dev/null || true
-    run_quiet "install transformers 5.3.0" fast_install_sidecar --target "$VENV_T5_530_DIR" --no-deps "transformers==5.3.0"
-    run_quiet "install huggingface_hub for t5_530" fast_install_sidecar --target "$VENV_T5_530_DIR" --no-deps "huggingface_hub==1.8.0"
-    run_quiet "install hf_xet for t5_530" fast_install_sidecar --target "$VENV_T5_530_DIR" --no-deps "hf_xet==1.4.2"
-    run_quiet "install tiktoken for t5_530" fast_install_sidecar --target "$VENV_T5_530_DIR" --no-deps "tiktoken"
-    step "transformers" "5.3.0 pre-installed"
-
-    _assert_studio_owned_or_absent "$VENV_T5_550_DIR" "transformers 5.5 sidecar venv"
-    [ -d "$VENV_T5_550_DIR" ] && rm -rf "$VENV_T5_550_DIR"
-    mkdir -p "$VENV_T5_550_DIR"
-    : > "$VENV_T5_550_DIR/$_STUDIO_OWNED_MARKER" 2>/dev/null || true
-    run_quiet "install transformers 5.5.0" fast_install_sidecar --target "$VENV_T5_550_DIR" --no-deps "transformers==5.5.0"
-    run_quiet "install huggingface_hub for t5_550" fast_install_sidecar --target "$VENV_T5_550_DIR" --no-deps "huggingface_hub==1.8.0"
-    run_quiet "install hf_xet for t5_550" fast_install_sidecar --target "$VENV_T5_550_DIR" --no-deps "hf_xet==1.4.2"
-    run_quiet "install tiktoken for t5_550" fast_install_sidecar --target "$VENV_T5_550_DIR" --no-deps "tiktoken"
-    step "transformers" "5.5.0 pre-installed"
-
-    _assert_studio_owned_or_absent "$VENV_T5_510_DIR" "transformers 5.10 sidecar venv"
-    [ -d "$VENV_T5_510_DIR" ] && rm -rf "$VENV_T5_510_DIR"
-    mkdir -p "$VENV_T5_510_DIR"
-    : > "$VENV_T5_510_DIR/$_STUDIO_OWNED_MARKER" 2>/dev/null || true
-    run_quiet "install transformers 5.10.2" fast_install_sidecar --target "$VENV_T5_510_DIR" --no-deps "transformers==5.10.2"
-    run_quiet "install huggingface_hub for t5_510" fast_install_sidecar --target "$VENV_T5_510_DIR" --no-deps "huggingface_hub==1.8.0"
-    run_quiet "install hf_xet for t5_510" fast_install_sidecar --target "$VENV_T5_510_DIR" --no-deps "hf_xet==1.4.2"
-    run_quiet "install tiktoken for t5_510" fast_install_sidecar --target "$VENV_T5_510_DIR" --no-deps "tiktoken"
-    step "transformers" "5.10.2 pre-installed"
+if [ "$_NEED_T5_530" = true ]; then
+    _install_sidecar "$VENV_T5_530_DIR" "5.3.0" "5.3"
+else
+    step "transformers" "5.3.0 sidecar current"
+fi
+if [ "$_NEED_T5_550" = true ]; then
+    _install_sidecar "$VENV_T5_550_DIR" "5.5.0" "5.5"
+else
+    step "transformers" "5.5.0 sidecar current"
+fi
+if [ "$_NEED_T5_510" = true ]; then
+    _install_sidecar "$VENV_T5_510_DIR" "5.10.2" "5.10"
+else
+    step "transformers" "5.10.2 sidecar current"
 fi
 fi
 

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2140,8 +2140,12 @@ _SIDECAR_COMMON_PINS="huggingface_hub==1.8.0 hf_xet==1.4.2"
 _sidecar_top_up_tiktoken() {
     _stt_dir="$1"
     _stt_label="$2"
+    # The payload, not the dist-info alone, as Repair-SidecarTiktoken checks: an
+    # interrupted install can leave the dist-info with no package beside it, the sidecar
+    # predicate accepts the sidecar (tiktoken is unpinned and optional), and a
+    # dist-info-only check would skip this top-up forever while Qwen tokenizers fail.
     for _stt_meta in "$_stt_dir"/tiktoken-*.dist-info/METADATA; do
-        if [ -f "$_stt_meta" ]; then
+        if [ -f "$_stt_meta" ] && [ -f "$_stt_dir/tiktoken/__init__.py" ]; then
             unset _stt_meta
             return 0
         fi

--- a/tests/python/test_tokenizers_and_torch_constraint.py
+++ b/tests/python/test_tokenizers_and_torch_constraint.py
@@ -180,12 +180,14 @@ def test_setup_sh_sidecar_installs_isolate_uv_override():
     result = subprocess.run(["bash", "-c", script], capture_output = True, text = True)
     assert result.returncode == 0 and result.stdout.splitlines() == ["child=unset", "parent=base"]
     sidecars = source.split("# ── 6b.", 1)[1].split("# ── GPU detection", 1)[0]
-    # Four installs, in ONE helper called once per tier. It used to be twelve, written
-    # out three times, which is also why one flag rebuilt all three sidecars: there was
-    # no per-tier body to guard. What has to hold is that every sidecar install goes
-    # through the UV_OVERRIDE-clearing wrapper, whatever the call count.
-    assert sidecars.count("fast_install_sidecar --target") == 4
+    # Four installs in ONE helper called once per tier, plus the optional tiktoken top-up
+    # a current sidecar gets on its own. It used to be twelve, written out three times,
+    # which is also why one flag rebuilt all three sidecars: there was no per-tier body
+    # to guard. What has to hold is that every sidecar install goes through the
+    # UV_OVERRIDE-clearing wrapper, whatever the call count.
+    assert sidecars.count("fast_install_sidecar --target") == 5
     assert sidecars.count('_install_sidecar "$VENV_T5_') == 3
+    assert sidecars.count('_sidecar_top_up_tiktoken "$VENV_T5_') == 3
     assert " fast_install --target" not in sidecars
 
 

--- a/tests/python/test_tokenizers_and_torch_constraint.py
+++ b/tests/python/test_tokenizers_and_torch_constraint.py
@@ -180,7 +180,12 @@ def test_setup_sh_sidecar_installs_isolate_uv_override():
     result = subprocess.run(["bash", "-c", script], capture_output = True, text = True)
     assert result.returncode == 0 and result.stdout.splitlines() == ["child=unset", "parent=base"]
     sidecars = source.split("# ── 6b.", 1)[1].split("# ── GPU detection", 1)[0]
-    assert sidecars.count("fast_install_sidecar --target") == 12
+    # Four installs, in ONE helper called once per tier. It used to be twelve, written
+    # out three times, which is also why one flag rebuilt all three sidecars: there was
+    # no per-tier body to guard. What has to hold is that every sidecar install goes
+    # through the UV_OVERRIDE-clearing wrapper, whatever the call count.
+    assert sidecars.count("fast_install_sidecar --target") == 4
+    assert sidecars.count('_install_sidecar "$VENV_T5_') == 3
     assert " fast_install --target" not in sidecars
 
 

--- a/tests/python/test_tokenizers_and_torch_constraint.py
+++ b/tests/python/test_tokenizers_and_torch_constraint.py
@@ -180,11 +180,8 @@ def test_setup_sh_sidecar_installs_isolate_uv_override():
     result = subprocess.run(["bash", "-c", script], capture_output = True, text = True)
     assert result.returncode == 0 and result.stdout.splitlines() == ["child=unset", "parent=base"]
     sidecars = source.split("# ── 6b.", 1)[1].split("# ── GPU detection", 1)[0]
-    # Four installs in ONE helper called once per tier, plus the optional tiktoken top-up
-    # a current sidecar gets on its own. It used to be twelve, written out three times,
-    # which is also why one flag rebuilt all three sidecars: there was no per-tier body
-    # to guard. What has to hold is that every sidecar install goes through the
-    # UV_OVERRIDE-clearing wrapper, whatever the call count.
+    # Four installs in ONE helper per tier plus the tiktoken top-up (it used to be twelve, written
+    # out three times). Every sidecar install must go through the UV_OVERRIDE-clearing wrapper.
     assert sidecars.count("fast_install_sidecar --target") == 5
     assert sidecars.count('_install_sidecar "$VENV_T5_') == 3
     assert sidecars.count('_sidecar_top_up_tiktoken "$VENV_T5_') == 3

--- a/tests/studio/install/test_install_manifest_pass_evidence.py
+++ b/tests/studio/install/test_install_manifest_pass_evidence.py
@@ -354,6 +354,29 @@ def test_a_truncated_recorded_file_forces_a_rebuild(sidecar: pathlib.Path) -> No
     assert "0 bytes, expected 32" in reason
 
 
+@pytest.mark.parametrize("value", ["1", "true", "YES", "on"])
+def test_the_file_check_kill_switch_reaches_the_setup_predicate(
+    sidecar: pathlib.Path, monkeypatch, value
+) -> None:
+    """The runtime honours UNSLOTH_SKIP_SIDECAR_FILE_CHECK so a false positive can be
+    turned off without a release; a setup-side scan that ignored it would be the one
+    path left that still wipes the sidecar. Package and version checks still apply."""
+    (sidecar / "transformers" / "__init__.py").write_bytes(b"")
+    monkeypatch.setenv(im.SIDECAR_FILE_CHECK_ENV, value)
+    assert im.sidecar_is_current(sidecar, PINS) == (True, "")
+    current, reason = im.sidecar_is_current(sidecar, ("transformers==5.5.0",) + PINS[1:])
+    assert current is False and "5.5.0" in reason
+
+
+@pytest.mark.parametrize("value", ["0", "false", "", "maybe"])
+def test_a_non_true_kill_switch_value_changes_nothing(
+    sidecar: pathlib.Path, monkeypatch, value
+) -> None:
+    (sidecar / "transformers" / "__init__.py").write_bytes(b"")
+    monkeypatch.setenv(im.SIDECAR_FILE_CHECK_ENV, value)
+    assert im.sidecar_is_current(sidecar, PINS)[0] is False
+
+
 def test_a_deleted_recorded_file_forces_a_rebuild(sidecar: pathlib.Path) -> None:
     (sidecar / "transformers" / "__init__.py").unlink()
     current, reason = im.sidecar_is_current(sidecar, PINS)

--- a/tests/studio/install/test_install_manifest_pass_evidence.py
+++ b/tests/studio/install/test_install_manifest_pass_evidence.py
@@ -562,14 +562,20 @@ def test_the_shim_refuses_what_it_does_not_implement() -> None:
         assert _shim(*args).returncode == 2
 
 
-def test_an_optional_packages_leftovers_are_not_damage(sidecar: pathlib.Path) -> None:
-    """An interrupted tiktoken install leaves a dist-info whose RECORD names files that
-    never landed. Reading that as damage made the whole sidecar stale on every update,
-    for a package the rebuild is allowed to fail to add again; setup's top-up is what
-    repairs it. A required package's RECORD is still held to the disk."""
+def test_an_absent_tiktoken_is_optional_but_a_present_one_is_held_to_its_record(
+    sidecar: pathlib.Path,
+) -> None:
+    """Absence is what is optional: a sidecar without tiktoken is current, and setup's
+    top-up adds it. Present, tiktoken's RECORD is held to the disk like every other
+    package's, since a file it names that is not there is a tokenizer that fails at
+    import. A required package's RECORD is held to the disk too."""
     import shutil
 
+    (sidecar / "tiktoken" / "__init__.py").unlink()
+    current, reason = im.sidecar_is_current(sidecar, PINS)
+    assert current is False and "tiktoken" in reason
     shutil.rmtree(sidecar / "tiktoken")
+    shutil.rmtree(next(sidecar.glob("tiktoken-*.dist-info")))
     assert im.sidecar_is_current(sidecar, PINS) == (True, "")
     (sidecar / "hf_xet" / "__init__.py").unlink()
     current, reason = im.sidecar_is_current(sidecar, PINS)

--- a/tests/studio/install/test_install_manifest_pass_evidence.py
+++ b/tests/studio/install/test_install_manifest_pass_evidence.py
@@ -560,3 +560,17 @@ def test_the_shim_marks_its_own_output(sidecar: pathlib.Path) -> None:
 def test_the_shim_refuses_what_it_does_not_implement() -> None:
     for args in ((), ("nonsense",), ("sidecar",)):
         assert _shim(*args).returncode == 2
+
+
+def test_an_optional_packages_leftovers_are_not_damage(sidecar: pathlib.Path) -> None:
+    """An interrupted tiktoken install leaves a dist-info whose RECORD names files that
+    never landed. Reading that as damage made the whole sidecar stale on every update,
+    for a package the rebuild is allowed to fail to add again; setup's top-up is what
+    repairs it. A required package's RECORD is still held to the disk."""
+    import shutil
+
+    shutil.rmtree(sidecar / "tiktoken")
+    assert im.sidecar_is_current(sidecar, PINS) == (True, "")
+    (sidecar / "hf_xet" / "__init__.py").unlink()
+    current, reason = im.sidecar_is_current(sidecar, PINS)
+    assert current is False and "hf_xet" in reason

--- a/tests/studio/install/test_install_manifest_pass_evidence.py
+++ b/tests/studio/install/test_install_manifest_pass_evidence.py
@@ -377,6 +377,23 @@ def test_a_non_true_kill_switch_value_changes_nothing(
     assert im.sidecar_is_current(sidecar, PINS)[0] is False
 
 
+def test_a_pinned_package_without_a_record_forces_a_rebuild(sidecar: pathlib.Path) -> None:
+    """pip and uv write RECORD last: a pinned dist-info without one is an interrupted
+    install whose payload the size check cannot see. The optional package is not held
+    to it, since its own top-up clears a recordless dist-info."""
+    (sidecar / "hf_xet-1.4.2.dist-info" / "RECORD").unlink()
+    (sidecar / "hf_xet" / "__init__.py").write_bytes(b"")
+    ok, reason = im.sidecar_is_current(sidecar, PINS)
+    assert ok is False
+    assert "hf_xet: RECORD is missing" in reason
+    (sidecar / "hf_xet-1.4.2.dist-info" / "RECORD").write_text(
+        "hf_xet/__init__.py,sha256=deadbeef,0\n", encoding = "utf-8"
+    )
+    assert im.sidecar_is_current(sidecar, PINS) == (True, "")
+    (sidecar / "tiktoken-0.9.0.dist-info" / "RECORD").unlink()
+    assert im.sidecar_is_current(sidecar, PINS) == (True, "")
+
+
 def test_a_deleted_recorded_file_forces_a_rebuild(sidecar: pathlib.Path) -> None:
     (sidecar / "transformers" / "__init__.py").unlink()
     current, reason = im.sidecar_is_current(sidecar, PINS)
@@ -507,11 +524,14 @@ def test_a_distribution_with_no_record_at_all_is_not_current(sidecar: pathlib.Pa
     assert current is False and "directory missing" in reason
 
 
-def test_a_sidecar_with_no_record_is_left_alone(sidecar: pathlib.Path) -> None:
-    """An absent RECORD says nothing about damage, and the answer costs a
-    several-hundred-MB refetch."""
+def test_a_pinned_sidecar_package_with_no_record_is_rebuilt(sidecar: pathlib.Path) -> None:
+    """An absent RECORD used to say nothing about damage, since the answer costs a
+    several-hundred-MB refetch; but pip and uv write RECORD last, so a pinned package
+    without one is an interrupted install whose payload the size check cannot see."""
     (sidecar / "transformers-5.3.0.dist-info" / "RECORD").unlink()
-    assert im.sidecar_is_current(sidecar, PINS) == (True, "")
+    ok, reason = im.sidecar_is_current(sidecar, PINS)
+    assert ok is False
+    assert reason == "transformers: RECORD is missing"
 
 
 def test_the_scan_is_bounded(sidecar: pathlib.Path) -> None:

--- a/tests/studio/install/test_setup_fast_path_guard.py
+++ b/tests/studio/install/test_setup_fast_path_guard.py
@@ -138,3 +138,28 @@ def test_the_installer_reports_duplicate_metadata_on_every_platform(script: path
     assert (
         "duplicate metadata found" in text
     ), f"{script.name} detects the conflict but never says so"
+
+
+def test_the_sidecar_predicate_asks_the_shim_on_colab_too():
+    """No venv interpreter on Colab; the shim is stdlib-only and the installer's own
+    `python` asks it. The version grep alone read a sidecar interrupted after
+    transformers landed as current on every later run."""
+    text = SETUP_SH.read_text(encoding = "utf-8")
+    start = text.index("_sidecar_current() {")
+    body = text[start : text.index("\n}\n", start)]
+    assert 'command -v python' in body
+    assert '"$_sc_python" "$SCRIPT_DIR/install_manifest.py" sidecar' in body
+    # The grep is the last resort, for a tree with no interpreter to ask at all.
+    assert body.index('command -v python') < body.index("_target_has_pkg_version")
+
+
+def test_the_ps1_sidecar_predicate_reads_the_shim_answer_under_native_error_promotion():
+    """The shim answers "stale" with exit 1. With $PSNativeCommandUseErrorActionPreference
+    set under ErrorActionPreference Stop that exit is a terminating error, and a catch
+    that discards the output lets the fallback grep accept what the shim rejected."""
+    text = SETUP_PS1.read_text(encoding = "utf-8")
+    start = text.index("function Test-SidecarCurrent {")
+    body = text[start : text.index("\nfunction ", start + 1)]
+    assert "$PSNativeCommandUseErrorActionPreference = $false" in body
+    assert body.index("$PSNativeCommandUseErrorActionPreference = $false") < body.index("& python $shim sidecar")
+    assert "finally" in body

--- a/tests/studio/install/test_setup_fast_path_guard.py
+++ b/tests/studio/install/test_setup_fast_path_guard.py
@@ -153,18 +153,43 @@ def test_the_sidecar_predicate_asks_the_shim_on_colab_too():
     assert body.index("command -v python") < body.index("_target_has_pkg_version")
 
 
-def test_the_ps1_sidecar_predicate_reads_the_shim_answer_under_native_error_promotion():
-    """The shim answers "stale" with exit 1. With $PSNativeCommandUseErrorActionPreference
-    set under ErrorActionPreference Stop that exit is a terminating error, and a catch
-    that discards the output lets the fallback grep accept what the shim rejected."""
+def test_the_ps1_sidecar_predicate_runs_the_shim_as_a_bounded_process():
+    """Two reasons, one mechanism. The shim answers "stale" with exit 1, which a native
+    command turns into a terminating error under $PSNativeCommandUseErrorActionPreference,
+    and the shim's scan budget cannot interrupt a stalled read on a wedged mount. A bounded
+    process has neither problem; a timeout reads as stale."""
     text = SETUP_PS1.read_text(encoding = "utf-8")
     start = text.index("function Test-SidecarCurrent {")
     body = text[start : text.index("\nfunction ", start + 1)]
-    assert "$PSNativeCommandUseErrorActionPreference = $false" in body
-    assert body.index("$PSNativeCommandUseErrorActionPreference = $false") < body.index(
-        "& python $shim sidecar"
-    )
-    assert "finally" in body
+    assert "& python $shim" not in body
+    assert "Invoke-BoundedPythonProbe -PythonExe $pythonExe -Code $code -TimeoutSec 60" in body
+    # The argv travels base64-encoded: a path with quotes or backslashes cannot break -c.
+    assert "[Convert]::ToBase64String" in body and "base64.b64decode" in body
+    assert "runpy.run_path(sys.argv[0], run_name='__main__')" in body
+    assert body.index("$probe.TimedOut") < body.index('$out = "sidecar: audit did not answer')
+    # The shell mirror: the shim call is bounded where a timeout exists and a timeout is stale.
+    sh = SETUP_SH.read_text(encoding = "utf-8")
+    call = sh.index('install_manifest.py" sidecar "$_sc_dir"')
+    window = sh[call - 400 : call + 900]
+    assert "timeout -k 5 60" in window
+    assert '[ "$_sc_rc" -eq 124 ]' in window and "sidecar: audit did not answer" in window
+
+
+def test_the_ps1_sidecar_installs_are_isolated_from_uv_override():
+    """setup.sh routes every sidecar install through fast_install_sidecar, which unsets
+    UV_OVERRIDE; an override naming huggingface_hub or hf_xet would otherwise install
+    another version than the exact pin and the audit would rebuild the sidecar to the
+    same wrong answer on every run. The PowerShell helper mirrors it."""
+    text = SETUP_PS1.read_text(encoding = "utf-8")
+    start = text.index("function Fast-Install-Sidecar {")
+    body = text[start : text.index("\nfunction ", start + 1)]
+    assert "Remove-Item Env:UV_OVERRIDE" in body and "Fast-Install @Args_" in body
+    assert "finally" in body and "$env:UV_OVERRIDE = $savedOverride" in body
+    for name in ("function Repair-SidecarTiktoken {", "function Install-T5Sidecar {"):
+        start = text.index(name)
+        body = text[start : text.index("\nfunction ", start + 1)]
+        assert "Fast-Install --target" not in body, name
+        assert "Fast-Install-Sidecar --target" in body, name
 
 
 def test_the_tiktoken_top_up_checks_the_payload_not_the_dist_info_alone():
@@ -185,11 +210,12 @@ def test_the_tiktoken_top_up_checks_the_payload_not_the_dist_info_alone():
     assert '--no-deps --upgrade "tiktoken"' in sh_body[: sh_body.index("\n}\n")]
 
 
-def test_the_ps1_native_error_preference_is_tested_for_existence_not_version():
-    """The variable exists from PowerShell 7.3; under Set-StrictMode reading an absent
-    variable is a terminating error, so 7.0 to 7.2 must not be sent to that read."""
+def test_the_ps1_sidecar_predicate_reads_no_version_gated_variable():
+    """$PSNativeCommandUseErrorActionPreference exists from PowerShell 7.3 and reading an
+    absent variable under Set-StrictMode is a terminating error; the predicate no longer
+    touches it at all, and must not grow a version check in its place."""
     ps1 = SETUP_PS1.read_text(encoding = "utf-8")
     start = ps1.index("function Test-SidecarCurrent {")
     body = ps1[start : ps1.index("\nfunction ", start + 1)]
-    assert "Get-Variable -Name PSNativeCommandUseErrorActionPreference" in body
+    assert "$PSNativeCommandUseErrorActionPreference =" not in body
     assert "PSVersion.Major -ge 7" not in body

--- a/tests/studio/install/test_setup_fast_path_guard.py
+++ b/tests/studio/install/test_setup_fast_path_guard.py
@@ -204,8 +204,7 @@ def test_the_tiktoken_top_up_checks_the_payload_not_the_dist_info_alone():
     start = ps1.index("function Repair-SidecarTiktoken {")
     body = ps1[start : ps1.index("\nfunction ", start + 1)]
     assert 'Join-Path $payload "__init__.py"' in body
-    # ...and the repair replaces what is there: a --target install without --upgrade
-    # keeps existing files, damaged ones included.
+    # ...and the repair replaces what is there (--target without --upgrade keeps damaged files).
     assert "--no-deps --upgrade tiktoken" in body
     sh_body = sh[sh.index("_sidecar_top_up_tiktoken() {") :]
     assert '--no-deps --upgrade "tiktoken"' in sh_body[: sh_body.index("\n}\n")]

--- a/tests/studio/install/test_setup_fast_path_guard.py
+++ b/tests/studio/install/test_setup_fast_path_guard.py
@@ -178,6 +178,11 @@ def test_the_tiktoken_top_up_checks_the_payload_not_the_dist_info_alone():
     start = ps1.index("function Repair-SidecarTiktoken {")
     body = ps1[start : ps1.index("\nfunction ", start + 1)]
     assert 'Join-Path $payload "__init__.py"' in body
+    # ...and the repair replaces what is there: a --target install without --upgrade
+    # keeps existing files, damaged ones included.
+    assert "--no-deps --upgrade tiktoken" in body
+    sh_body = sh[sh.index("_sidecar_top_up_tiktoken() {") :]
+    assert '--no-deps --upgrade "tiktoken"' in sh_body[: sh_body.index("\n}\n")]
 
 
 def test_the_ps1_native_error_preference_is_tested_for_existence_not_version():

--- a/tests/studio/install/test_setup_fast_path_guard.py
+++ b/tests/studio/install/test_setup_fast_path_guard.py
@@ -172,7 +172,8 @@ def test_the_ps1_sidecar_predicate_runs_the_shim_as_a_bounded_process():
     call = sh.index('install_manifest.py" sidecar "$_sc_dir"')
     window = sh[call - 400 : call + 900]
     assert "timeout -k 5 60" in window
-    assert '[ "$_sc_rc" -eq 124 ]' in window and "sidecar: audit did not answer" in window
+    assert '[ "$_sc_rc" -eq 124 ] || [ "$_sc_rc" -eq 137 ]' in window
+    assert "sidecar: audit did not answer" in window
 
 
 def test_the_ps1_sidecar_installs_are_isolated_from_uv_override():

--- a/tests/studio/install/test_setup_fast_path_guard.py
+++ b/tests/studio/install/test_setup_fast_path_guard.py
@@ -147,10 +147,10 @@ def test_the_sidecar_predicate_asks_the_shim_on_colab_too():
     text = SETUP_SH.read_text(encoding = "utf-8")
     start = text.index("_sidecar_current() {")
     body = text[start : text.index("\n}\n", start)]
-    assert 'command -v python' in body
+    assert "command -v python" in body
     assert '"$_sc_python" "$SCRIPT_DIR/install_manifest.py" sidecar' in body
     # The grep is the last resort, for a tree with no interpreter to ask at all.
-    assert body.index('command -v python') < body.index("_target_has_pkg_version")
+    assert body.index("command -v python") < body.index("_target_has_pkg_version")
 
 
 def test_the_ps1_sidecar_predicate_reads_the_shim_answer_under_native_error_promotion():
@@ -161,5 +161,7 @@ def test_the_ps1_sidecar_predicate_reads_the_shim_answer_under_native_error_prom
     start = text.index("function Test-SidecarCurrent {")
     body = text[start : text.index("\nfunction ", start + 1)]
     assert "$PSNativeCommandUseErrorActionPreference = $false" in body
-    assert body.index("$PSNativeCommandUseErrorActionPreference = $false") < body.index("& python $shim sidecar")
+    assert body.index("$PSNativeCommandUseErrorActionPreference = $false") < body.index(
+        "& python $shim sidecar"
+    )
     assert "finally" in body

--- a/tests/studio/install/test_setup_fast_path_guard.py
+++ b/tests/studio/install/test_setup_fast_path_guard.py
@@ -165,3 +165,26 @@ def test_the_ps1_sidecar_predicate_reads_the_shim_answer_under_native_error_prom
         "& python $shim sidecar"
     )
     assert "finally" in body
+
+
+def test_the_tiktoken_top_up_checks_the_payload_not_the_dist_info_alone():
+    """An interrupted install leaves tiktoken-*.dist-info with no package beside it; the
+    sidecar predicate accepts that sidecar (tiktoken is optional), so the top-up is the
+    only repair left, and a dist-info-only check would skip it forever."""
+    sh = SETUP_SH.read_text(encoding = "utf-8")
+    start = sh.index("_sidecar_top_up_tiktoken() {")
+    assert '"$_stt_dir/tiktoken/__init__.py"' in sh[start : sh.index("\n}\n", start)]
+    ps1 = SETUP_PS1.read_text(encoding = "utf-8")
+    start = ps1.index("function Repair-SidecarTiktoken {")
+    body = ps1[start : ps1.index("\nfunction ", start + 1)]
+    assert 'Join-Path $payload "__init__.py"' in body
+
+
+def test_the_ps1_native_error_preference_is_tested_for_existence_not_version():
+    """The variable exists from PowerShell 7.3; under Set-StrictMode reading an absent
+    variable is a terminating error, so 7.0 to 7.2 must not be sent to that read."""
+    ps1 = SETUP_PS1.read_text(encoding = "utf-8")
+    start = ps1.index("function Test-SidecarCurrent {")
+    body = ps1[start : ps1.index("\nfunction ", start + 1)]
+    assert "Get-Variable -Name PSNativeCommandUseErrorActionPreference" in body
+    assert "PSVersion.Major -ge 7" not in body

--- a/tests/test_installer_interactive_prompts.py
+++ b/tests/test_installer_interactive_prompts.py
@@ -524,9 +524,8 @@ def test_helpers_the_installers_invoke_are_scanned():
             reference = match.group(1).replace("\\", "/")
             name = reference.rsplit("/", 1)[-1]
             if name == "__init__.py":
-                # A package marker the installers test for presence (tiktoken/__init__.py
-                # says the payload landed), never a helper they run; by name alone it
-                # would resolve to studio/__init__.py beside setup.sh.
+                # A presence marker (tiktoken/__init__.py), not a helper they run; by name alone it
+                # would resolve to studio/__init__.py.
                 continue
             for candidate in (
                 path.parent / reference,

--- a/tests/test_installer_interactive_prompts.py
+++ b/tests/test_installer_interactive_prompts.py
@@ -523,6 +523,11 @@ def test_helpers_the_installers_invoke_are_scanned():
             # resolves to the local copy. What resolves nowhere is a filename in a message, not an invocation.
             reference = match.group(1).replace("\\", "/")
             name = reference.rsplit("/", 1)[-1]
+            if name == "__init__.py":
+                # A package marker the installers test for presence (tiktoken/__init__.py
+                # says the payload landed), never a helper they run; by name alone it
+                # would resolve to studio/__init__.py beside setup.sh.
+                continue
             for candidate in (
                 path.parent / reference,
                 REPO_ROOT / reference,


### PR DESCRIPTION
## Summary

The three transformers sidecar venvs (`.venv_t5_530`, `.venv_t5_550`, `.venv_t5_510`) were rebuilt from scratch on every `studio update` that ran the dependency pass, about 60 to 90 s on Windows. This PR rebuilds only a sidecar whose own on-disk evidence fails.

Stacked on #10649 (the dependency-pass evidence), which adds the `sidecar_is_current` predicate and its CLI shim that both shells call.

## Before

`setup.sh` and `setup.ps1` set the rebuild flag for all three tiers whenever the Python dependencies were not skipped, so a routine update deleted and recreated three venvs that had not changed.

## After

- One flag per tier. A tier is current when the directory is non-empty, carries the `.unsloth-studio-owned` marker, every pinned distribution (`transformers==<ver>`, `huggingface_hub`, `hf_xet`, `tiktoken`) is installed at exactly its pin, and a bounded RECORD walk finds no missing or foreign-tagged file. Both shells ask the same Python predicate (`install_manifest.py sidecar <dir> <pins>`), so they cannot disagree; a very old tree that lacks the shim falls back to the version grep.
- A stale tier is rebuilt exactly as today (`rm -rf`, owned marker, `fast_install_sidecar`). The legacy `.venv_t5` migration and `_assert_studio_owned_or_absent` are unchanged. The log says `sidecar current` on a skip and `pre-installed` on a rebuild.

## Compatibility

- Existing sidecars built by any earlier release are accepted when they pass the predicate, and rebuilt once otherwise; the runtime self-heal in `transformers_version._ensure_venv_dir` is untouched.
- Colab and other unmanaged trees: the check answers from the version grep instead of reporting the tier as stale.

## How it was tested

- `tests/python/test_tokenizers_and_torch_constraint.py` and the sidecar tests in the dependency-pass PR; shell tests for both scripts.
- Staging fault injection on three operating systems: deleting one sidecar's `transformers-*.dist-info` rebuilds that tier only; truncating one sidecar file rebuilds that tier only; the following no-op rebuilds nothing.
- AMD Linux and Windows and the three-OS staging no-op: all three tiers report `sidecar current` and their directory mtimes do not change.

## Review follow-ups

- `sidecar_is_current` reads `UNSLOTH_SKIP_SIDECAR_FILE_CHECK` the way the runtime does and skips only the file-damage scan, so the setup-side predicate cannot be the one path that still wipes a sidecar while the hatch is set. Package and version checks still apply.
- tiktoken leaves the freshness pins on both shells. Its install is optional (a missing wheel is a warning, not a failure), so a sidecar without it is finished; as a pin it read stale on every update and was wiped and refetched three times over for a package the rebuild could not add either. A current sidecar that lacks it now gets tiktoken retried on its own, and setup.sh tolerates the failed install the way setup.ps1 already did.
- The runtime treats tiktoken as optional, as setup does, so a sidecar recorded without it is not deleted by the first model on that tier.
- On Colab the predicate asks the manifest shim through the installer's own python instead of the transformers version grep alone.
- The PowerShell probe disables native error promotion around the shim call so its exit 1 answer is read, not discarded.
- The tiktoken top-up requires the package payload, not the dist-info alone; the PowerShell native error preference is tested for existence rather than by version.
