### PR TITLE
Studio: end to end harness that measures whether a second studio update does nothing

### DIFF
--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -19,7 +19,16 @@ on:
       - 'studio/setup.sh'
       - 'studio/install_python_stack.py'
       - 'studio/install_llama_prebuilt.py'
+      - 'studio/install_whisper_prebuilt.py'
+      - 'studio/install_node_prebuilt.py'
+      - 'studio/install_manifest.py'
+      - 'studio/prebuilt_core.py'
+      - 'studio/setup.ps1'
+      - 'install.ps1'
       - 'studio/backend/requirements/**'
+      # The harness below and the proxy it measures with.
+      - 'tests/studio/install/test_update_idempotency.py'
+      - 'tests/studio/install/idempotency_proxy.py'
       - 'unsloth_cli/commands/studio.py'
       - 'unsloth_cli/__init__.py'
       - 'unsloth_cli/_system_dir_guard.py'
@@ -174,6 +183,26 @@ jobs:
           jq -e '.studio_install_ok == true' /tmp/caps.json
           jq -e '.desktop_manageability_version >= 2' /tmp/caps.json
 
+      - name: A second update does nothing, and proves it
+        # The steps above read the update's LOG. This one measures it: the update runs
+        # with a CONNECT proxy as its only route out, so "downloaded nothing" is a byte
+        # count per host rather than an impression of speed, and the install is diffed
+        # before and after so "changed nothing" covers the files no log line mentions.
+        #
+        # It also damages the install on purpose (a sidecar file, the manifest, a
+        # llama.cpp binary, a requirements file) and asserts the update repairs exactly
+        # the damaged part. Those cases restore what they broke, but they run BEFORE the
+        # manifest-removal step below rather than after, so a failure here cannot be
+        # mistaken for the deliberately incomplete install that step creates.
+        timeout-minutes: 30
+        env:
+          UNSLOTH_IDEMPOTENCY_E2E: '1'
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -o pipefail
+          python -m pytest tests/studio/install/test_update_idempotency.py -v -s \
+            2>&1 | tee logs/idempotency.log
+
       - name: An incomplete install must not report itself ready
         # An installer killed part-way leaves a working CLI but no studio.txt
         # deps, which the old preflight called ManagedReady. The manifest is
@@ -266,6 +295,116 @@ jobs:
             logs/install.log
             logs/update.log
             logs/update2.log
+            logs/idempotency.log
             logs/studio.log
             logs/uninstall.log
+          retention-days: 7
+
+  idempotency-macos:
+    name: Unsloth Updating Tests (macOS)
+    runs-on: macos-15
+    # The install is the expensive half; the harness itself is three updates that are
+    # supposed to do nothing plus five that do one thing each.
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: '22'
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install Unsloth (--local, --no-torch)
+        uses: ./.github/actions/install-unsloth-local
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
+          hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
+
+      - name: A second update does nothing, and proves it
+        # macOS is where a no-op update cost the most before this: the llama.cpp and
+        # whisper.cpp re-validations START the servers, which on Apple Silicon means
+        # loading Metal. Same harness as the Linux leg.
+        timeout-minutes: 30
+        env:
+          UNSLOTH_IDEMPOTENCY_E2E: '1'
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -o pipefail
+          mkdir -p logs
+          python -m pytest tests/studio/install/test_update_idempotency.py -v -s \
+            2>&1 | tee logs/idempotency.log
+
+      - name: Upload macOS idempotency logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: studio-update-idempotency-macos-log
+          path: |
+            logs/install.log
+            logs/idempotency.log
+          retention-days: 7
+
+  idempotency-windows:
+    name: Unsloth Updating Tests (Windows)
+    runs-on: windows-latest
+    # Windows installs are 3x the Linux ones (268-292s against 88s in the API smoke),
+    # and Defender is why; the harness after it is the same three updates.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: '22'
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install Unsloth (--local, --no-torch)
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
+          HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
+        run: |
+          New-Item -ItemType Directory -Force -Path logs | Out-Null
+          # A CHILD process, so install.ps1's Write-StudioLine output reaches
+          # Tee-Object: in-process it goes straight to [Console]::Out and the log is
+          # empty. Same idiom as studio-windows-api-smoke.yml.
+          $child = '$ErrorActionPreference = ''Stop''; $ProgressPreference = ''SilentlyContinue''; & ./install.ps1 --local --no-torch; exit $LASTEXITCODE'
+          pwsh -NoProfile -ExecutionPolicy Bypass -Command $child 2>&1 |
+            Tee-Object -FilePath logs/install.log
+          if ($LASTEXITCODE -ne 0) { throw "install.ps1 exited with code $LASTEXITCODE" }
+
+      - name: A second update does nothing, and proves it
+        # The Windows leg is the one that can catch a path or marker written with the
+        # wrong separator: every comparison in the harness is a byte-for-byte one.
+        timeout-minutes: 40
+        shell: pwsh
+        env:
+          UNSLOTH_IDEMPOTENCY_E2E: '1'
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $ErrorActionPreference = 'Continue'
+          python -m pytest tests/studio/install/test_update_idempotency.py -v -s 2>&1 |
+            Tee-Object -FilePath logs/idempotency.log
+          if ($LASTEXITCODE -ne 0) { throw "the idempotency harness failed ($LASTEXITCODE)" }
+
+      - name: Upload Windows idempotency logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: studio-update-idempotency-windows-log
+          path: |
+            logs/install.log
+            logs/idempotency.log
           retention-days: 7

--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -197,9 +197,18 @@ jobs:
         timeout-minutes: 30
         env:
           UNSLOTH_IDEMPOTENCY_E2E: '1'
+          # Each run's update log and proxy journal, kept for the upload below. A
+          # failure here is unreadable without them: the assertion says which host
+          # served bytes, not which of the eight runs did it.
+          UNSLOTH_IDEMPOTENCY_ARTIFACTS: ${{ github.workspace }}/logs/idempotency
+          # The install above is --local and editable, so the CLI would find the
+          # checkout on its own; naming it keeps that working if the install ever
+          # stops being editable.
+          STUDIO_LOCAL_REPO: ${{ github.workspace }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -o pipefail
+          mkdir -p logs
           python -m pytest tests/studio/install/test_update_idempotency.py -v -s \
             2>&1 | tee logs/idempotency.log
 
@@ -296,6 +305,8 @@ jobs:
             logs/update.log
             logs/update2.log
             logs/idempotency.log
+            logs/idempotency/**/update.log
+            logs/idempotency/**/proxy.jsonl
             logs/studio.log
             logs/uninstall.log
           retention-days: 7
@@ -333,6 +344,8 @@ jobs:
         timeout-minutes: 30
         env:
           UNSLOTH_IDEMPOTENCY_E2E: '1'
+          UNSLOTH_IDEMPOTENCY_ARTIFACTS: ${{ github.workspace }}/logs/idempotency
+          STUDIO_LOCAL_REPO: ${{ github.workspace }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -o pipefail
@@ -348,6 +361,8 @@ jobs:
           path: |
             logs/install.log
             logs/idempotency.log
+            logs/idempotency/**/update.log
+            logs/idempotency/**/proxy.jsonl
           retention-days: 7
 
   idempotency-windows:
@@ -392,8 +407,11 @@ jobs:
         shell: pwsh
         env:
           UNSLOTH_IDEMPOTENCY_E2E: '1'
+          UNSLOTH_IDEMPOTENCY_ARTIFACTS: ${{ github.workspace }}\logs\idempotency
+          STUDIO_LOCAL_REPO: ${{ github.workspace }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          New-Item -ItemType Directory -Force -Path logs | Out-Null
           $ErrorActionPreference = 'Continue'
           python -m pytest tests/studio/install/test_update_idempotency.py -v -s 2>&1 |
             Tee-Object -FilePath logs/idempotency.log
@@ -407,4 +425,6 @@ jobs:
           path: |
             logs/install.log
             logs/idempotency.log
+            logs/idempotency/**/update.log
+            logs/idempotency/**/proxy.jsonl
           retention-days: 7

--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -63,7 +63,7 @@ jobs:
     name: Unsloth Updating Tests
     runs-on: ubuntu-latest
     # Sized for the apt step's bounded worst case (15m) plus the smoke itself.
-    timeout-minutes: 25
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -209,6 +209,8 @@ jobs:
         run: |
           set -o pipefail
           mkdir -p logs
+          # setup-python's interpreter runs the harness, and it ships without pytest.
+          python -m pip install --quiet pytest
           python -m pytest tests/studio/install/test_update_idempotency.py -v -s \
             2>&1 | tee logs/idempotency.log
 
@@ -316,7 +318,7 @@ jobs:
     runs-on: macos-15
     # The install is the expensive half; the harness itself is three updates that are
     # supposed to do nothing plus five that do one thing each.
-    timeout-minutes: 45
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -350,6 +352,8 @@ jobs:
         run: |
           set -o pipefail
           mkdir -p logs
+          # setup-python's interpreter runs the harness, and it ships without pytest.
+          python -m pip install --quiet pytest
           python -m pytest tests/studio/install/test_update_idempotency.py -v -s \
             2>&1 | tee logs/idempotency.log
 
@@ -370,7 +374,7 @@ jobs:
     runs-on: windows-latest
     # Windows installs are 3x the Linux ones (268-292s against 88s in the API smoke),
     # and Defender is why; the harness after it is the same three updates.
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -413,6 +417,8 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path logs | Out-Null
           $ErrorActionPreference = 'Continue'
+          # setup-python's interpreter runs the harness, and it ships without pytest.
+          python -m pip install --quiet pytest
           python -m pytest tests/studio/install/test_update_idempotency.py -v -s 2>&1 |
             Tee-Object -FilePath logs/idempotency.log
           if ($LASTEXITCODE -ne 0) { throw "the idempotency harness failed ($LASTEXITCODE)" }

--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -89,9 +89,12 @@ jobs:
           bash .github/scripts/retry-with-apt-lock.sh sudo sh -c \
             'apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq || { apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev libssl-dev jq; }'
 
+      # Node 24 ships npm 11, which meets setup.sh's floor (Node ^20.19 || >=22.12 with
+      # npm >= 11): this job takes the system-Node path, the developer one. Node 22
+      # ships npm 10 and would take the bundled path, which the other two jobs cover.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
-          node-version: '22'
+          node-version: '24'
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
@@ -332,8 +335,8 @@ jobs:
       # Below setup.sh's floor (Node ^20.19 || >=22.12 with npm >= 11) on purpose: with
       # it, setup takes the bundled Node path desktop users without a toolchain take, so
       # the harness's Node marker snapshot and its "nothing from nodejs.org" assertion
-      # measure a managed Node rather than pass vacuously over a system one. The other
-      # two jobs keep a qualifying system Node, the developer path.
+      # measure a managed Node rather than pass vacuously over a system one. The Linux
+      # job keeps a qualifying system Node (Node 24, npm 11), the developer path.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: '20.18.0'
@@ -390,6 +393,8 @@ jobs:
         with:
           persist-credentials: false
 
+      # Node 22 ships npm 10, below setup.ps1's npm 11 floor, so this job takes the
+      # bundled Node path as the macOS job does; the Linux job covers the system-Node one.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: '22'

--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -28,6 +28,13 @@ on:
       - 'studio/setup.ps1'
       - 'install.ps1'
       - 'studio/backend/requirements/**'
+      # setup.sh and setup.ps1 run npm against these two trees on every update, and the
+      # harness holds the frontend bundle to be current afterwards; a dependency change
+      # there used to reach these jobs only through the push to main.
+      - 'studio/frontend/package.json'
+      - 'studio/frontend/package-lock.json'
+      - 'studio/backend/core/data_recipe/oxc-validator/package.json'
+      - 'studio/backend/core/data_recipe/oxc-validator/package-lock.json'
       # The harness below and the proxy it measures with.
       - 'tests/studio/install/test_update_idempotency.py'
       - 'tests/studio/install/idempotency_proxy.py'

--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -109,6 +109,40 @@ jobs:
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           hf-token: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
 
+      - name: A second update does nothing, and proves it
+        # The first updates after the install, measured rather than read off their logs:
+        # the update runs with a CONNECT proxy as its only route out, so "downloaded
+        # nothing" is a byte count per host rather than an impression of speed, and the
+        # install is diffed before and after so "changed nothing" covers the files no log
+        # line mentions. Before the log-only steps below on purpose: a regression that
+        # downloads or rewrites state on the first or second update and then records
+        # enough evidence to go quiet would otherwise be measured only on a fourth.
+        #
+        # It also damages the install on purpose (a sidecar file, the manifest, a
+        # llama.cpp binary, a requirements file) and asserts the update repairs exactly
+        # the damaged part. Those cases restore what they broke, but they run BEFORE the
+        # manifest-removal step below rather than after, so a failure here cannot be
+        # mistaken for the deliberately incomplete install that step creates.
+        timeout-minutes: 30
+        env:
+          UNSLOTH_IDEMPOTENCY_E2E: '1'
+          # Each run's update log and proxy journal, kept for the upload below. A
+          # failure here is unreadable without them: the assertion says which host
+          # served bytes, not which of the eight runs did it.
+          UNSLOTH_IDEMPOTENCY_ARTIFACTS: ${{ github.workspace }}/logs/idempotency
+          # The install above is --local and editable, so the CLI would find the
+          # checkout on its own; naming it keeps that working if the install ever
+          # stops being editable.
+          STUDIO_LOCAL_REPO: ${{ github.workspace }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -o pipefail
+          mkdir -p logs
+          # setup-python's interpreter runs the harness, and it ships without pytest.
+          python -m pip install --quiet pytest
+          python -m pytest tests/studio/install/test_update_idempotency.py -v -s \
+            2>&1 | tee logs/idempotency.log
+
       - name: First update should be a no-op (prebuilt already validated)
         # `unsloth studio update --local` runs studio/setup.sh against
         # the local repo. Right after install.sh the llama.cpp prebuilt
@@ -184,37 +218,6 @@ jobs:
           unsloth studio desktop-capabilities --json | tee /tmp/caps.json
           jq -e '.studio_install_ok == true' /tmp/caps.json
           jq -e '.desktop_manageability_version >= 2' /tmp/caps.json
-
-      - name: A second update does nothing, and proves it
-        # The steps above read the update's LOG. This one measures it: the update runs
-        # with a CONNECT proxy as its only route out, so "downloaded nothing" is a byte
-        # count per host rather than an impression of speed, and the install is diffed
-        # before and after so "changed nothing" covers the files no log line mentions.
-        #
-        # It also damages the install on purpose (a sidecar file, the manifest, a
-        # llama.cpp binary, a requirements file) and asserts the update repairs exactly
-        # the damaged part. Those cases restore what they broke, but they run BEFORE the
-        # manifest-removal step below rather than after, so a failure here cannot be
-        # mistaken for the deliberately incomplete install that step creates.
-        timeout-minutes: 30
-        env:
-          UNSLOTH_IDEMPOTENCY_E2E: '1'
-          # Each run's update log and proxy journal, kept for the upload below. A
-          # failure here is unreadable without them: the assertion says which host
-          # served bytes, not which of the eight runs did it.
-          UNSLOTH_IDEMPOTENCY_ARTIFACTS: ${{ github.workspace }}/logs/idempotency
-          # The install above is --local and editable, so the CLI would find the
-          # checkout on its own; naming it keeps that working if the install ever
-          # stops being editable.
-          STUDIO_LOCAL_REPO: ${{ github.workspace }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -o pipefail
-          mkdir -p logs
-          # setup-python's interpreter runs the harness, and it ships without pytest.
-          python -m pip install --quiet pytest
-          python -m pytest tests/studio/install/test_update_idempotency.py -v -s \
-            2>&1 | tee logs/idempotency.log
 
       - name: An incomplete install must not report itself ready
         # An installer killed part-way leaves a working CLI but no studio.txt
@@ -326,9 +329,14 @@ jobs:
         with:
           persist-credentials: false
 
+      # Below setup.sh's floor (Node ^20.19 || >=22.12 with npm >= 11) on purpose: with
+      # it, setup takes the bundled Node path desktop users without a toolchain take, so
+      # the harness's Node marker snapshot and its "nothing from nodejs.org" assertion
+      # measure a managed Node rather than pass vacuously over a system one. The other
+      # two jobs keep a qualifying system Node, the developer path.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
-          node-version: '22'
+          node-version: '20.18.0'
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:

--- a/.github/workflows/studio-update-smoke.yml
+++ b/.github/workflows/studio-update-smoke.yml
@@ -23,6 +23,8 @@ on:
       - 'studio/install_node_prebuilt.py'
       - 'studio/install_manifest.py'
       - 'studio/prebuilt_core.py'
+      # install_node_prebuilt.py reads the default version and archive digests from here.
+      - 'studio/node_prebuilt_pins.json'
       - 'studio/setup.ps1'
       - 'install.ps1'
       - 'studio/backend/requirements/**'

--- a/tests/studio/install/idempotency_proxy.py
+++ b/tests/studio/install/idempotency_proxy.py
@@ -113,6 +113,18 @@ class Proxy:
                 break
         return data
 
+    def _record(self, t0: float, host, port, method: str, down: int, up: int, status: str) -> dict:
+        return {
+            "ts": round(t0, 3),
+            "host": host,
+            "port": port,
+            "method": method,
+            "bytes_down": down,
+            "bytes_up": up,
+            "seconds": round(_now() - t0, 3),
+            "status": status,
+        }
+
     def handle(self, conn: socket.socket) -> None:
         t0 = _now()
         host = port = None
@@ -120,6 +132,9 @@ class Proxy:
         down = up = 0
         status = "ok"
         upstream = None
+        # Set once this connection is in the journal, so a path that has to journal
+        # early does not get a second record from the `finally` below.
+        recorded = False
         try:
             head = self._read_head(conn)
             if not head:
@@ -137,6 +152,13 @@ class Proxy:
             if self.denied(probe):
                 host, status = probe, "refused"
                 port = 443 if method == "CONNECT" else 80
+                # Journalled BEFORE the 403 reaches the client, not from the `finally`.
+                # A caller can observe the refusal and tear this proxy down in the same
+                # breath, and a record still waiting to be written is then lost -- which,
+                # for a harness whose claim is that an update made ZERO connections, reads
+                # as a connection that never happened.
+                self.log(self._record(t0, host, port, method, down, up, status))
+                recorded = True
                 conn.sendall(
                     b"HTTP/1.1 403 Forbidden\r\nProxy-Agent: unsloth-idempotency\r\n"
                     b"Content-Length: 0\r\nConnection: close\r\n\r\n"
@@ -191,18 +213,8 @@ class Proxy:
                         s.close()
                 except OSError:
                     pass
-            self.log(
-                {
-                    "ts": round(t0, 3),
-                    "host": host,
-                    "port": port,
-                    "method": method,
-                    "bytes_down": down,
-                    "bytes_up": up,
-                    "seconds": round(_now() - t0, 3),
-                    "status": status,
-                }
-            )
+            if not recorded:
+                self.log(self._record(t0, host, port, method, down, up, status))
 
 
 def summary(

--- a/tests/studio/install/idempotency_proxy.py
+++ b/tests/studio/install/idempotency_proxy.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""A logging HTTP proxy (CONNECT tunnels plus plain HTTP), stdlib only.
+
+test_update_idempotency.py claims that a second `unsloth studio update` does no network
+work. A claim like that cannot be checked from inside the process being measured, and
+"the update finished quickly" is not evidence: a warm uv cache also finishes quickly,
+and so does a run that fetched three release manifests. So the child gets a proxy as its
+ONLY route out (HTTPS_PROXY/HTTP_PROXY/ALL_PROXY, with 127.0.0.1 in NO_PROXY), and every
+attempt is written down whether it succeeds or not.
+
+There is no TLS interception here and there does not need to be: the destination host,
+the byte counts in each direction and the duration are all recorded from the CONNECT
+line, which is enough to say which hosts a run talked to and how much it moved.
+
+    python idempotency_proxy.py serve --port 0 --log p.jsonl --port-file p.port
+    python idempotency_proxy.py serve --refuse ...       # 403 everything, still log it
+    python idempotency_proxy.py serve --deny-hosts pypi.org,github.com ...
+    python idempotency_proxy.py summary p.jsonl [--since-ts T]
+
+--refuse is how offline is MEASURED rather than asserted: the child still has a proxy to
+talk to, every attempt is answered 403 and recorded, so a run that claims to have done
+nothing has to prove it made no connections. --deny-hosts is the same aimed at the
+package hosts alone.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import select
+import socket
+import sys
+import threading
+import time
+from collections import defaultdict
+from urllib.parse import urlsplit
+
+BUF = 1 << 16
+
+
+def _now() -> float:
+    return time.time()
+
+
+class Proxy:
+    def __init__(
+        self,
+        port: int,
+        log_path: str,
+        port_file: str | None,
+        refuse: bool = False,
+        deny_hosts: tuple[str, ...] = (),
+    ):
+        self.log_path = log_path
+        self.refuse = refuse
+        self.deny_hosts = tuple(h.strip().lower() for h in deny_hosts if h.strip())
+        self.lock = threading.Lock()
+        self.srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.srv.bind(("127.0.0.1", port))
+        self.srv.listen(256)
+        self.port = self.srv.getsockname()[1]
+        if port_file:
+            # Written last and in one go: the caller polls for this file to learn the
+            # port, so a partial write is a race it would read as the whole answer.
+            tmp = port_file + ".tmp"
+            with open(tmp, "w") as fh:
+                fh.write(str(self.port))
+            os.replace(tmp, port_file)
+        if refuse:
+            mode = "refuse-all"
+        elif self.deny_hosts:
+            mode = "deny=" + ",".join(self.deny_hosts)
+        else:
+            mode = "allow-all"
+        print(f"[proxy] 127.0.0.1:{self.port} log={log_path} mode={mode}", flush = True)
+
+    def denied(self, host: str | None) -> bool:
+        if self.refuse:
+            return True
+        h = (host or "").lower()
+        return any(h == d or h.endswith("." + d) for d in self.deny_hosts)
+
+    def log(self, rec: dict) -> None:
+        line = json.dumps(rec, separators = (",", ":"))
+        with self.lock:
+            with open(self.log_path, "a") as fh:
+                fh.write(line + "\n")
+                fh.flush()
+
+    def serve(self) -> None:
+        while True:
+            try:
+                conn, _ = self.srv.accept()
+            except OSError:
+                return
+            threading.Thread(target = self.handle, args = (conn,), daemon = True).start()
+
+    @staticmethod
+    def _read_head(conn: socket.socket) -> bytes:
+        data = b""
+        conn.settimeout(30)
+        while b"\r\n\r\n" not in data:
+            chunk = conn.recv(BUF)
+            if not chunk:
+                break
+            data += chunk
+            if len(data) > 1 << 20:
+                break
+        return data
+
+    def handle(self, conn: socket.socket) -> None:
+        t0 = _now()
+        host = port = None
+        method = "?"
+        down = up = 0
+        status = "ok"
+        upstream = None
+        try:
+            head = self._read_head(conn)
+            if not head:
+                return
+            line = head.split(b"\r\n", 1)[0].decode("latin-1")
+            parts = line.split()
+            if len(parts) < 2:
+                return
+            method, target = parts[0], parts[1]
+            probe = (
+                target.rpartition(":")[0]
+                if method == "CONNECT"
+                else (urlsplit(target).hostname or "")
+            )
+            if self.denied(probe):
+                host, status = probe, "refused"
+                port = 443 if method == "CONNECT" else 80
+                conn.sendall(
+                    b"HTTP/1.1 403 Forbidden\r\nProxy-Agent: unsloth-idempotency\r\n"
+                    b"Content-Length: 0\r\nConnection: close\r\n\r\n"
+                )
+                return
+            if method == "CONNECT":
+                host, _, p = target.rpartition(":")
+                port = int(p or 443)
+                upstream = socket.create_connection((host, port), timeout = 60)
+                conn.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+                initial = b""
+            else:
+                u = urlsplit(target)
+                host = u.hostname or ""
+                port = u.port or 80
+                upstream = socket.create_connection((host, port), timeout = 60)
+                initial = head
+            conn.settimeout(None)
+            upstream.settimeout(None)
+            if initial:
+                upstream.sendall(initial)
+                up += len(initial)
+            socks = [conn, upstream]
+            while True:
+                r, _, x = select.select(socks, [], socks, 600)
+                if x or not r:
+                    status = "timeout" if not r else "error"
+                    break
+                done = False
+                for s in r:
+                    try:
+                        data = s.recv(BUF)
+                    except OSError:
+                        data = b""
+                    if not data:
+                        done = True
+                        break
+                    if s is conn:
+                        upstream.sendall(data)
+                        up += len(data)
+                    else:
+                        conn.sendall(data)
+                        down += len(data)
+                if done:
+                    break
+        except Exception as exc:  # noqa: BLE001 - a proxy that dies takes the run with it
+            status = f"error:{type(exc).__name__}"
+        finally:
+            for s in (conn, upstream):
+                try:
+                    if s:
+                        s.close()
+                except OSError:
+                    pass
+            self.log(
+                {
+                    "ts": round(t0, 3),
+                    "host": host,
+                    "port": port,
+                    "method": method,
+                    "bytes_down": down,
+                    "bytes_up": up,
+                    "seconds": round(_now() - t0, 3),
+                    "status": status,
+                }
+            )
+
+
+def summary(
+    path: str,
+    since_ts: float | None = None,
+    until_ts: float | None = None,
+) -> dict:
+    by_host: dict[str, dict] = defaultdict(
+        lambda: {"bytes_down": 0, "bytes_up": 0, "connections": 0, "refused": 0, "seconds": 0.0}
+    )
+    total = connections = refused = 0
+    if os.path.exists(path):
+        with open(path) as fh:
+            for line in fh:
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if since_ts is not None and rec["ts"] < since_ts:
+                    continue
+                if until_ts is not None and rec["ts"] > until_ts:
+                    continue
+                h = by_host[rec.get("host") or "?"]
+                h["bytes_down"] += rec["bytes_down"]
+                h["bytes_up"] += rec["bytes_up"]
+                h["connections"] += 1
+                h["seconds"] += rec["seconds"]
+                connections += 1
+                if rec.get("status") == "refused":
+                    h["refused"] += 1
+                    refused += 1
+                total += rec["bytes_down"]
+    ordered = dict(sorted(by_host.items(), key = lambda kv: -kv[1]["bytes_down"]))
+    return {
+        "total_bytes_down": total,
+        "connections": connections,
+        "refused": refused,
+        "by_host": ordered,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest = "cmd", required = True)
+    s = sub.add_parser("serve")
+    s.add_argument("--port", type = int, default = 0)
+    s.add_argument("--log", required = True)
+    s.add_argument("--port-file")
+    s.add_argument("--refuse", action = "store_true", help = "403 every request and log it")
+    s.add_argument("--deny-hosts", default = "", help = "comma list of hosts to 403 (suffix match)")
+    m = sub.add_parser("summary")
+    m.add_argument("log")
+    m.add_argument("--since-ts", type = float)
+    m.add_argument("--until-ts", type = float)
+    a = ap.parse_args()
+    if a.cmd == "serve":
+        Proxy(
+            a.port,
+            a.log,
+            a.port_file,
+            refuse = a.refuse,
+            deny_hosts = tuple(a.deny_hosts.split(",")),
+        ).serve()
+    else:
+        json.dump(summary(a.log, a.since_ts, a.until_ts), sys.stdout, indent = 2)
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/studio/install/idempotency_proxy.py
+++ b/tests/studio/install/idempotency_proxy.py
@@ -59,6 +59,13 @@ class Proxy:
         self.refuse = refuse
         self.deny_hosts = tuple(h.strip().lower() for h in deny_hosts if h.strip())
         self.lock = threading.Lock()
+        # Workers between accept and their journal record. Published to a sibling file so
+        # the harness can tell "the journal is quiet" from "nothing is left to journal":
+        # a worker blocked in the upstream connect has written nothing yet, and a proxy
+        # terminated at that moment loses the very connection the harness exists to see.
+        self.active = 0
+        self.active_path = log_path + ".active"
+        self._publish_active()
         self.srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.srv.bind(("127.0.0.1", port))
@@ -91,6 +98,18 @@ class Proxy:
             with open(self.log_path, "a") as fh:
                 fh.write(line + "\n")
                 fh.flush()
+
+    def _publish_active(self) -> None:
+        # Whole file, then rename: the reader must never see a half-written count.
+        tmp = self.active_path + ".tmp"
+        with open(tmp, "w") as fh:
+            fh.write(str(self.active))
+        os.replace(tmp, self.active_path)
+
+    def _adjust_active(self, delta: int) -> None:
+        with self.lock:
+            self.active += delta
+            self._publish_active()
 
     def serve(self) -> None:
         while True:
@@ -126,6 +145,13 @@ class Proxy:
         }
 
     def handle(self, conn: socket.socket) -> None:
+        self._adjust_active(+1)
+        try:
+            self._handle(conn)
+        finally:
+            self._adjust_active(-1)
+
+    def _handle(self, conn: socket.socket) -> None:
         t0 = _now()
         host = port = None
         method = "?"

--- a/tests/studio/install/idempotency_proxy.py
+++ b/tests/studio/install/idempotency_proxy.py
@@ -117,6 +117,10 @@ class Proxy:
                 conn, _ = self.srv.accept()
             except OSError:
                 return
+            # Counted here, before the worker exists: a connection accepted but not yet
+            # scheduled is invisible to the journal, and the harness reads the count to
+            # decide whether the proxy may be stopped.
+            self._adjust_active(+1)
             threading.Thread(target = self.handle, args = (conn,), daemon = True).start()
 
     @staticmethod
@@ -145,7 +149,8 @@ class Proxy:
         }
 
     def handle(self, conn: socket.socket) -> None:
-        self._adjust_active(+1)
+        # The accept loop counted this connection in; this releases it once its record
+        # is in the journal (or the worker died trying).
         try:
             self._handle(conn)
         finally:

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -1,0 +1,595 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""End to end: a second `unsloth studio update` must do no network work and change
+nothing on disk.
+
+The unit half of this lives in test_dependency_pass_skips.py and in the prebuilt
+installers' own suites. It cannot answer the question this file asks, because every skip
+is conditional on evidence that only a real install produces: a manifest written by a
+real dependency pass, sidecar trees with real RECORD files, prebuilt markers whose
+hashes describe binaries that are really on disk.
+
+Two things make the claim measurable rather than plausible:
+
+  * The child's ONLY route out is a logging proxy (idempotency_proxy.py). Every
+    connection attempt is recorded whether it succeeds, so "did no network work" is a
+    byte count per host, not an impression of speed. A warm uv cache also finishes fast.
+  * The install is snapshotted before and after. "Nothing changed" means a sorted
+    distribution list, the manifest minus its timestamp, the prebuilt markers byte for
+    byte, the uv cache marker, the no-torch marker, each sidecar's file count and mtime,
+    and the mtime of every runtime binary.
+
+Opt in, because it needs a real install:
+
+    UNSLOTH_IDEMPOTENCY_E2E=1 pytest tests/studio/install/test_update_idempotency.py
+
+By default it exercises the install under $HOME. UNSLOTH_IDEMPOTENCY_HOME points it at
+an isolated one instead, which is how it is run locally against a scratch install:
+
+    UNSLOTH_IDEMPOTENCY_E2E=1 UNSLOTH_IDEMPOTENCY_HOME=/path/to/fake/home pytest ...
+
+The fault-injection cases DAMAGE that install and expect the update to repair exactly
+the damaged part. They restore what they broke, but a failure mid-case can leave the
+install in the damaged state, so never point this at an install you care about.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import time
+
+import pytest
+
+
+E2E = os.environ.get("UNSLOTH_IDEMPOTENCY_E2E") == "1"
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+PROXY = pathlib.Path(__file__).resolve().parent / "idempotency_proxy.py"
+IS_WINDOWS = sys.platform == "win32"
+
+# Hosts a no-op update must not touch at all. pypi.org and github.com are listed
+# separately because a version check and a "what is the latest release" HEAD are both
+# legitimate, and small; these five are where the megabytes are.
+PAYLOAD_HOSTS = (
+    "files.pythonhosted.org",
+    "objects.githubusercontent.com",
+    "release-assets.githubusercontent.com",
+    "nodejs.org",
+    "raw.githubusercontent.com",
+)
+
+# What the installers print when they decline to do work. All three prebuilts share the
+# "already matches" substring, which setup.sh and setup.ps1 also grep for.
+NO_WORK_MARKERS = ("dependencies up to date", "already matches")
+
+DIST_LIST = (
+    "import importlib.metadata as m, json; "
+    "print(json.dumps(sorted(((d.metadata['Name'] or '').lower(), d.version) "
+    "for d in m.distributions())))"
+)
+
+
+# ── the install under test ──
+
+
+def _home() -> pathlib.Path:
+    return pathlib.Path(os.environ.get("UNSLOTH_IDEMPOTENCY_HOME") or pathlib.Path.home())
+
+
+def _studio_home() -> pathlib.Path:
+    override = os.environ.get("UNSLOTH_IDEMPOTENCY_STUDIO_HOME")
+    return pathlib.Path(override) if override else _home() / ".unsloth" / "studio"
+
+
+def _venv_python() -> pathlib.Path:
+    venv = _studio_home() / "unsloth_studio"
+    return venv / ("Scripts/python.exe" if IS_WINDOWS else "bin/python")
+
+
+@pytest.fixture(scope = "session")
+def install() -> pathlib.Path:
+    # The gate lives here rather than on the module so the proxy's own self test, which
+    # needs nothing installed, still runs in ordinary CI. A measuring instrument that
+    # quietly stopped measuring would make every assertion below pass.
+    if not E2E:
+        pytest.skip("opt-in end to end; set UNSLOTH_IDEMPOTENCY_E2E=1")
+    venv_python = _venv_python()
+    if not venv_python.is_file():
+        pytest.skip(f"no Studio install at {venv_python}; run install.sh first")
+    return venv_python
+
+
+# ── the proxy ──
+
+
+class ProxyRun:
+    """One update, measured."""
+
+    def __init__(self, directory: pathlib.Path, log: str, summary: dict, seconds: float, rc: int):
+        self.directory = directory
+        self.log = log
+        self.summary = summary
+        self.seconds = seconds
+        self.rc = rc
+
+    def bytes_from(self, host: str) -> int:
+        return sum(
+            v["bytes_down"]
+            for h, v in self.summary["by_host"].items()
+            if h == host or h.endswith("." + host)
+        )
+
+    def connections_to(self, host: str) -> int:
+        return sum(
+            v["connections"]
+            for h, v in self.summary["by_host"].items()
+            if h == host or h.endswith("." + host)
+        )
+
+    @property
+    def connections(self) -> int:
+        return self.summary.get("connections", 0)
+
+    @property
+    def refused(self) -> int:
+        return self.summary.get("refused", 0)
+
+    def report(self) -> str:
+        hosts = ", ".join(
+            f"{h}={v['bytes_down'] / 1e6:.1f}MB/{v['connections']}c"
+            for h, v in list(self.summary["by_host"].items())[:8]
+        )
+        return (
+            f"{self.seconds:.1f}s exit={self.rc} "
+            f"down={self.summary['total_bytes_down'] / 1e6:.1f}MB "
+            f"conns={self.connections} refused={self.refused} [{hosts}]"
+        )
+
+
+def _start_proxy(directory: pathlib.Path, *extra: str):
+    log = directory / "proxy.jsonl"
+    port_file = directory / "proxy.port"
+    port_file.unlink(missing_ok = True)
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            str(PROXY),
+            "serve",
+            "--port",
+            "0",
+            "--log",
+            str(log),
+            "--port-file",
+            str(port_file),
+            *extra,
+        ],
+        stdout = (directory / "proxy.out").open("w"),
+        stderr = subprocess.STDOUT,
+    )
+    for _ in range(100):
+        if port_file.is_file() and port_file.read_text().strip():
+            break
+        if process.poll() is not None:
+            raise RuntimeError((directory / "proxy.out").read_text())
+        time.sleep(0.1)
+    else:
+        process.kill()
+        raise RuntimeError("the proxy never reported a port")
+    return process, f"http://127.0.0.1:{port_file.read_text().strip()}", log
+
+
+def run_update(
+    tmp_path: pathlib.Path,
+    label: str,
+    *,
+    local: bool = True,
+    offline: bool = False,
+    refuse: bool = False,
+    deny_hosts: str = "",
+) -> ProxyRun:
+    """One `unsloth studio update`, through the proxy, timed and logged."""
+    directory = tmp_path / label
+    directory.mkdir(parents = True, exist_ok = True)
+    extra = ["--refuse"] if refuse else (["--deny-hosts", deny_hosts] if deny_hosts else [])
+    process, url, log_path = _start_proxy(directory, *extra)
+    # Inherited, not replaced: the runner's PATH, SystemRoot and certificate bundle all
+    # matter, and a hand-built environment here fails in ways that look like the product.
+    env = dict(os.environ)
+    env.pop("UNSLOTH_IDEMPOTENCY_E2E", None)
+    env.update(
+        HOME = str(_home()),
+        USERPROFILE = str(_home()),
+        UNSLOTH_SKIP_AUTOSTART = "1",
+        UNSLOTH_STUDIO_DISABLE_PUBLIC_CHECK = "1",
+        PYTHONUNBUFFERED = "1",
+        HTTPS_PROXY = url,
+        HTTP_PROXY = url,
+        ALL_PROXY = url,
+        https_proxy = url,
+        http_proxy = url,
+        NO_PROXY = "127.0.0.1,localhost",
+        no_proxy = "127.0.0.1,localhost",
+    )
+    if os.environ.get("UNSLOTH_IDEMPOTENCY_STUDIO_HOME"):
+        env["UNSLOTH_STUDIO_HOME"] = os.environ["UNSLOTH_IDEMPOTENCY_STUDIO_HOME"]
+    if offline:
+        env["UV_OFFLINE"] = "1"
+    else:
+        env.pop("UV_OFFLINE", None)
+    command = [str(_venv_python()), "-I", "-X", "utf8", "-m", "unsloth_cli", "studio", "update"]
+    if local:
+        command.append("--local")
+    started = time.time()
+    try:
+        completed = subprocess.run(
+            command,
+            cwd = str(_home()),
+            env = env,
+            capture_output = True,
+            text = True,
+            encoding = "utf-8",
+            errors = "replace",
+            timeout = 3600,
+        )
+        text = completed.stdout + completed.stderr
+        rc = completed.returncode
+    finally:
+        seconds = time.time() - started
+        process.terminate()
+        try:
+            process.wait(timeout = 10)
+        except subprocess.TimeoutExpired:  # pragma: no cover - a wedged tunnel
+            process.kill()
+    (directory / "update.log").write_text(text, encoding = "utf-8")
+    summary = _load_proxy_module().summary(str(log_path))
+    run = ProxyRun(directory, text, summary, seconds, rc)
+    print(f"[idempotency] {label}: {run.report()}", flush = True)
+    return run
+
+
+def _load_proxy_module():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("idempotency_proxy", PROXY)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ── the snapshot ──
+
+
+def _digest(path: pathlib.Path) -> str | None:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def _tree_state(root: pathlib.Path) -> dict | None:
+    """File count and newest mtime. Cheap enough for a sidecar of 4000 files, and it
+    moves the moment anything in the tree is rewritten."""
+    if not root.is_dir():
+        return None
+    count = 0
+    newest = 0.0
+    total = 0
+    for path in root.rglob("*"):
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        if path.is_file():
+            count += 1
+            total += stat.st_size
+            newest = max(newest, stat.st_mtime)
+    return {"files": count, "bytes": total, "newest_mtime": round(newest, 3)}
+
+
+def snapshot(venv_python: pathlib.Path) -> dict:
+    studio_home = _studio_home()
+    venv = venv_python.parent.parent
+    unsloth_home = _home() / ".unsloth"
+    state: dict = {}
+    distributions = subprocess.run(
+        [str(venv_python), "-I", "-c", DIST_LIST],
+        capture_output = True,
+        text = True,
+        timeout = 300,
+    )
+    state["distributions"] = json.loads(distributions.stdout or "[]")
+
+    manifest_path = venv / "unsloth_install_manifest.json"
+    manifest = None
+    if manifest_path.is_file():
+        manifest = json.loads(manifest_path.read_text(encoding = "utf-8"))
+        # The one key that is ALLOWED to move: it records when the pass finished, and a
+        # pass that correctly did nothing still finished.
+        manifest.pop("completed_at_ms", None)
+    state["manifest"] = manifest
+
+    # Byte for byte: a marker rewritten with identical content is still a rewrite, and
+    # the whole point of the prebuilt pre-checks is that they do not rewrite it.
+    for marker in (
+        "UNSLOTH_PREBUILT_INFO.json",
+        "UNSLOTH_WHISPER_PREBUILT_INFO.json",
+        "UNSLOTH_NODE_PREBUILT_INFO.json",
+    ):
+        found = sorted(unsloth_home.glob(f"*/{marker}")) if unsloth_home.is_dir() else []
+        state[marker] = {str(p.relative_to(unsloth_home)): _digest(p) for p in found}
+
+    state["uv_cache_marker"] = _digest(studio_home / "cache" / "uv-cache-dir")
+    state["no_torch_marker"] = (venv / ".unsloth-no-torch").is_file()
+    for name in (".venv_t5_530", ".venv_t5_550", ".venv_t5_510"):
+        state[name] = _tree_state(studio_home / name)
+
+    binaries: dict[str, float] = {}
+    if unsloth_home.is_dir():
+        for pattern in (
+            "llama.cpp/**/llama-server*",
+            "llama.cpp/**/llama-quantize*",
+            "whisper.cpp/**/whisper-server*",
+            "node/**/node*",
+        ):
+            for path in unsloth_home.glob(pattern):
+                if path.is_file():
+                    binaries[str(path.relative_to(unsloth_home))] = round(path.stat().st_mtime, 3)
+    state["binaries"] = binaries
+    return state
+
+
+def diff(before: dict, after: dict) -> list[str]:
+    return [key for key in sorted(set(before) | set(after)) if before.get(key) != after.get(key)]
+
+
+# ── run 1 and run 2 ──
+
+
+@pytest.fixture(scope = "session")
+def settled(install, tmp_path_factory):
+    """One update, so whatever the install left half-decided is decided. Everything
+    below measures the update AFTER this one."""
+    directory = tmp_path_factory.mktemp("idempotency")
+    run = run_update(directory, "run1-settle")
+    assert run.rc == 0, f"the first update failed:\n{run.log[-8000:]}"
+    return directory, snapshot(install)
+
+
+def test_a_second_update_changes_nothing_on_disk(install, settled):
+    directory, before = settled
+    run = run_update(directory, "run2-noop")
+    assert run.rc == 0, run.log[-8000:]
+    after = snapshot(install)
+    assert diff(before, after) == [], "a no-op update rewrote part of the install:\n" + "\n".join(
+        f"  {key}:\n    before={before.get(key)!r}\n    after={after.get(key)!r}"
+        for key in diff(before, after)
+    )
+
+
+def test_a_second_update_downloads_nothing(install, settled):
+    """The measurement the timings cannot make: a fast run and a run that refetched
+    three release manifests look the same on a warm cache."""
+    directory, _ = settled
+    run = run_update(directory, "run3-network")
+    assert run.rc == 0, run.log[-8000:]
+    for host in PAYLOAD_HOSTS:
+        assert (
+            run.bytes_from(host) == 0
+        ), f"{host} served {run.bytes_from(host)} bytes: {run.report()}"
+    # A version check and the "what is the latest release" HEADs are allowed, and are
+    # what the prebuilt fast paths spend instead of a full release listing.
+    assert run.connections_to("pypi.org") <= 1, run.report()
+    assert run.connections_to("github.com") <= 4, run.report()
+
+
+def test_a_second_update_says_it_did_nothing(install, settled):
+    """The disk and the network agree; the log has to as well, because a silent skip
+    and a silent failure to notice work are indistinguishable to a user."""
+    directory, _ = settled
+    run = run_update(directory, "run4-log")
+    assert run.rc == 0, run.log[-8000:]
+    for marker in NO_WORK_MARKERS:
+        assert marker in run.log, f"{marker!r} missing from a no-op update:\n{run.log[-8000:]}"
+    assert "falling back to source build" not in run.log
+
+
+# ── offline ──
+
+
+def test_a_no_op_update_needs_no_network_at_all(install, settled):
+    """UV_OFFLINE plus a proxy that 403s everything. Every attempt is still recorded,
+    so this asserts zero CONNECTIONS, not merely zero bytes."""
+    directory, before = settled
+    run = run_update(directory, "run5-offline", offline = True, refuse = True)
+    assert run.rc == 0, (
+        "an update with nothing to do failed offline. That is the state a user on a "
+        f"plane, or behind a corporate proxy, is in:\n{run.log[-8000:]}"
+    )
+    assert run.connections == run.refused, run.report()
+    assert diff(before, snapshot(install)) == []
+
+
+def test_the_non_local_path_keeps_a_verified_install_when_pypi_is_unreachable(install, settled):
+    """The rule added for exactly this: without --local, an unreachable PyPI means
+    "update to be safe", which offline can only fail. UV_OFFLINE says the caller knows
+    there is no network, so a verified install is kept instead."""
+    directory, before = settled
+    run = run_update(directory, "run6-offline-nonlocal", local = False, offline = True, refuse = True)
+    assert run.rc == 0, run.log[-8000:]
+    assert "keeping the verified install" in run.log, run.log[-8000:]
+    assert run.connections == run.refused, run.report()
+    assert diff(before, snapshot(install)) == []
+
+
+# ── fault injection ──
+#
+# The direction that matters. A needless install costs seconds; a wrong skip ships a
+# venv that dies on `import structlog`. Each case damages one thing and asserts that the
+# update repairs THAT thing -- and, where it is cheap to check, that it does not decide
+# to rebuild everything else while it is there.
+
+
+def _sidecar_dirs() -> list[pathlib.Path]:
+    return [
+        path
+        for path in (
+            _studio_home() / name for name in (".venv_t5_530", ".venv_t5_550", ".venv_t5_510")
+        )
+        if path.is_dir()
+    ]
+
+
+def test_a_truncated_sidecar_file_rebuilds_only_that_sidecar(install, settled):
+    directory, before = settled
+    sidecars = _sidecar_dirs()
+    if not sidecars:
+        pytest.skip("no transformers sidecars in this install")
+    target = sidecars[0]
+    victim = next(
+        (p for p in sorted(target.rglob("*.py")) if p.stat().st_size > 0),
+        None,
+    )
+    assert victim is not None, f"no file to damage in {target}"
+    saved = victim.read_bytes()
+    victim.write_bytes(b"")
+    try:
+        run = run_update(directory, "fault-sidecar", local = True)
+        assert run.rc == 0, run.log[-8000:]
+    finally:
+        if victim.is_file() and victim.read_bytes() == b"":
+            victim.write_bytes(saved)
+    after = snapshot(install)
+    changed = diff(before, after)
+    assert target.name in changed, f"the damaged sidecar was not rebuilt (changed: {changed})"
+    untouched = [
+        name for name in (".venv_t5_530", ".venv_t5_550", ".venv_t5_510") if name != target.name
+    ]
+    assert [
+        name for name in changed if name in untouched
+    ] == [], f"an unrelated sidecar was rebuilt too: {changed}"
+
+
+def test_a_deleted_manifest_re_runs_the_pass_and_changes_nothing(install, settled):
+    """The manifest is the only record of what the last pass did. Without it every step
+    must run -- and every step must then find its work already done, so the venv comes
+    out identical."""
+    directory, before = settled
+    manifest = install.parent.parent / "unsloth_install_manifest.json"
+    saved = manifest.read_bytes()
+    manifest.unlink()
+    try:
+        run = run_update(directory, "fault-manifest", local = True)
+        assert run.rc == 0, run.log[-8000:]
+    finally:
+        if not manifest.is_file():
+            manifest.write_bytes(saved)
+    after = snapshot(install)
+    assert (
+        after["distributions"] == before["distributions"]
+    ), "a pass with no evidence resolved to a different set of packages"
+    assert after["manifest"] is not None, "the pass did not rewrite the manifest"
+
+
+def test_a_damaged_llama_binary_reinstalls_llama(install, settled):
+    directory, before = settled
+    candidates = sorted((_home() / ".unsloth").glob("llama.cpp/**/llama-quantize*"))
+    victim = next((p for p in candidates if p.is_file() and p.stat().st_size > 1024), None)
+    if victim is None:
+        pytest.skip("no llama.cpp prebuilt in this install")
+    saved = victim.read_bytes()
+    mode = victim.stat().st_mode
+    victim.write_bytes(saved[: len(saved) // 4])
+    try:
+        run = run_update(directory, "fault-llama", local = True)
+        assert run.rc == 0, run.log[-8000:]
+        after = snapshot(install)
+        assert after["binaries"] != before["binaries"], "the truncated binary was not replaced"
+        assert victim.stat().st_size == len(saved), "llama.cpp was not reinstalled whole"
+    finally:
+        if victim.is_file() and victim.stat().st_size != len(saved):
+            victim.write_bytes(saved)
+            victim.chmod(mode)
+
+
+def test_an_edited_requirements_file_runs_that_step(install, settled):
+    """The installed copy of studio.txt is what the digest is taken from, so editing it
+    is the same signal a released requirements change is."""
+    directory, before = settled
+    installed_req = next(
+        (p for p in (install.parent.parent).rglob("requirements/studio.txt") if p.is_file()),
+        None,
+    )
+    if installed_req is None:
+        pytest.skip("no installed requirements tree")
+    saved = installed_req.read_bytes()
+    installed_req.write_bytes(saved + b"\n# idempotency harness\n")
+    try:
+        run = run_update(directory, "fault-requirements", local = True)
+        assert run.rc == 0, run.log[-8000:]
+        assert "studio deps" in run.log
+    finally:
+        installed_req.write_bytes(saved)
+    after = snapshot(install)
+    assert (
+        after["distributions"] == before["distributions"]
+    ), "re-running one step changed the resolved packages"
+
+
+def test_full_deps_forces_every_step_and_still_changes_nothing(install, settled):
+    """The escape hatch. It must do the work -- no "(satisfied, skipped)" anywhere --
+    and arrive at the same venv, which is what makes the skips safe."""
+    directory, before = settled
+    env_backup = os.environ.get("UNSLOTH_STUDIO_FULL_DEPS")
+    os.environ["UNSLOTH_STUDIO_FULL_DEPS"] = "1"
+    try:
+        run = run_update(directory, "fault-full-deps", local = True)
+    finally:
+        if env_backup is None:
+            os.environ.pop("UNSLOTH_STUDIO_FULL_DEPS", None)
+        else:
+            os.environ["UNSLOTH_STUDIO_FULL_DEPS"] = env_backup
+    assert run.rc == 0, run.log[-8000:]
+    assert "(satisfied, skipped)" not in run.log, (
+        "UNSLOTH_STUDIO_FULL_DEPS still skipped a step:\n" + run.log[-8000:]
+    )
+    after = snapshot(install)
+    assert after["distributions"] == before["distributions"], (
+        "doing every step produced a different venv from skipping the settled ones, so "
+        "at least one skip was not equivalent to the work it replaced"
+    )
+
+
+def test_the_scratch_install_is_left_where_it_was_found(install, settled):
+    """Runs last. Every case above restores what it broke; this is the assertion that
+    they all did."""
+    _directory, before = settled
+    assert diff(before, snapshot(install)) == []
+
+
+def test_the_harness_measures_a_real_proxy(tmp_path):
+    """A proxy that silently failed to start would make every assertion above pass."""
+    module = _load_proxy_module()
+    process, url, log_path = _start_proxy(tmp_path, "--refuse")
+    try:
+        import urllib.error
+        import urllib.request
+
+        opener = urllib.request.build_opener(
+            urllib.request.ProxyHandler({"http": url, "https": url})
+        )
+        # A refused CONNECT surfaces as URLError, not HTTPError: urllib never gets a
+        # tunnel to raise an HTTP status through.
+        with pytest.raises(urllib.error.URLError) as excinfo:
+            opener.open("https://pypi.org/simple/", timeout = 30)
+        assert "403" in str(excinfo.value)
+    finally:
+        process.terminate()
+        process.wait(timeout = 10)
+    summary = module.summary(str(log_path))
+    assert summary["connections"] == 1 and summary["refused"] == 1

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -211,6 +211,9 @@ def _start_proxy(directory: pathlib.Path, *extra: str):
     log = directory / "proxy.jsonl"
     port_file = directory / "proxy.port"
     port_file.unlink(missing_ok = True)
+    # The proxy appends and the summary reads the whole journal, so a retained artifacts
+    # directory would attribute the previous invocation's traffic to this run.
+    log.unlink(missing_ok = True)
     process = subprocess.Popen(
         [
             sys.executable,
@@ -447,7 +450,10 @@ def snapshot(venv_python: pathlib.Path) -> dict:
         "UNSLOTH_NODE_PREBUILT_INFO.json",
     ):
         found = sorted(unsloth_home.glob(f"*/{marker}")) if unsloth_home.is_dir() else []
-        state[marker] = {str(p.relative_to(unsloth_home)): _digest(p) for p in found}
+        # The digest alone cannot see a rewrite with identical bytes; the mtime can.
+        state[marker] = {
+            str(p.relative_to(unsloth_home)): (_digest(p), p.stat().st_mtime_ns) for p in found
+        }
 
     state["uv_cache_marker"] = _digest(studio_home / "cache" / "uv-cache-dir")
     state["no_torch_marker"] = (venv / ".unsloth-no-torch").is_file()
@@ -540,67 +546,17 @@ def test_a_second_local_update_reuses_everything_it_can(install, settled):
     assert run.log.count("sidecar current") == 3, (
         "a settled transformers sidecar was rebuilt:\n" + run.log[-8000:]
     )
-    assert "prebuilt up to date" in run.log, run.log[-8000:]
+    # One line each from llama.cpp and whisper.cpp: a single match would let one of the
+    # two re-validate an installed prebuilt while the other answered from its marker.
+    assert run.log.count("prebuilt up to date") >= 2, (
+        "a prebuilt was re-validated instead of answered from its marker:\n" + run.log[-8000:]
+    )
     assert "falling back to source build" not in run.log
     for host in PAYLOAD_HOSTS:
         assert run.bytes_from(host) == 0, f"{host}: {run.report()}"
-
-
-def test_the_desktop_update_path_does_no_network_work(install, settled, desktop_path):
-    """No --local: the flow the desktop app and the Repair button run. Its whole cost on
-    a settled install should be one version check and the prebuilt HEADs.
-
-    Runs on BOTH branches of desktop_path. Skipping the case when the installed version
-    is not PyPI's latest also dropped the assertions that hold either way -- the release
-    payload hosts, api.github.com, release-assets -- and those are the ones that catch a
-    prebuilt regression regardless of whether the version check short-circuited. Only
-    what genuinely depends on that short-circuit is relaxed below, each with its reason.
-    """
-    directory, before = settled
-    run = run_update(directory, "run5-desktop", local = False)
-    assert run.rc == 0, run.log[-8000:]
-    # files.pythonhosted.org is the ONE payload host the version check governs: with a
-    # version mismatch this run IS an upgrade, and an upgrade downloads the wheel it
-    # upgrades to. The other three carry release payloads -- llama.cpp, whisper.cpp,
-    # node -- which no upgrade of unsloth has any reason to refetch, so they are held at
-    # zero on both branches.
-    payload_hosts = (
-        PAYLOAD_HOSTS
-        if desktop_path
-        else tuple(host for host in PAYLOAD_HOSTS if host != "files.pythonhosted.org")
-    )
-    for host in payload_hosts:
-        assert run.bytes_from(host) == 0, f"{host}: {run.report()}"
-    assert run.bytes_from("raw.githubusercontent.com") <= ICON_FETCH_CEILING, run.report()
-    # "dependencies up to date" is setup.sh's fast-path line, and the fast path is
-    # exactly what the version check decides; an upgrade legitimately runs the pass
-    # instead. The prebuilt and sidecar markers are not the version check's business:
-    # both are answered from disk whether or not the dependency pass runs.
-    markers = (
-        NO_WORK_MARKERS
-        if desktop_path
-        else tuple(marker for marker in NO_WORK_MARKERS if marker != "dependencies up to date")
-    )
-    for marker in markers:
-        assert marker in run.log, f"{marker!r} missing from a no-op update:\n{run.log[-8000:]}"
-    # One version check, and one "what is the latest release" HEAD per prebuilt. The
-    # bound is what stops this quietly becoming a full release listing again. Only the
-    # pypi.org one is relaxed: a real dependency pass resolves against the index, and
-    # how many connections that takes is the resolver's business. The github.com bound
-    # belongs to the prebuilts, which do the same work either way.
-    if desktop_path:
-        assert run.connections_to("pypi.org") <= 2, run.report()
-    assert run.connections_to("github.com") <= 6, run.report()
-    # The other half of the prebuilt claim: the release itself is never listed. Both of
-    # these carried traffic on every update before the marker checks, and both are where
-    # the 13-63 s macOS re-validation went.
+    # The release is never listed on this path either: the marker checks cost one HEAD
+    # on github.com per prebuilt, and a --local pass has no other business with the API.
     assert run.connections_to("api.github.com") == 0, run.report()
-    assert run.connections_to("release-assets.githubusercontent.com") == 0, run.report()
-    if desktop_path:
-        # A dependency pass rewrites the manifest and can move the distribution list, so
-        # "nothing changed on disk" is only a claim about the short-circuited path. The
-        # no-op case is asserted in full by test_a_second_update_changes_nothing_on_disk.
-        assert diff(before, snapshot(install)) == []
 
 
 # ── offline ──
@@ -827,3 +783,74 @@ def test_the_harness_measures_a_real_proxy(tmp_path):
         process.wait(timeout = 10)
     summary = module.summary(str(log_path))
     assert summary["connections"] == 1 and summary["refused"] == 1
+
+
+# ── the desktop path, last ──
+#
+# Deliberately the final case. When the installed version is not PyPI's latest this run
+# is a real upgrade and mutates the session install; anything measured after it would be
+# measuring the released package, and comparing it against the settled snapshot would
+# fail on every version-bump commit with the offline behaviour perfectly correct.
+
+
+def test_the_desktop_update_path_does_no_network_work(install, settled, desktop_path):
+    """No --local: the flow the desktop app and the Repair button run. Its whole cost on
+    a settled install should be one version check and the prebuilt HEADs.
+
+    Runs on BOTH branches of desktop_path. Skipping the case when the installed version
+    is not PyPI's latest also dropped the assertions that hold either way -- the release
+    payload hosts, api.github.com, release-assets -- and those are the ones that catch a
+    prebuilt regression regardless of whether the version check short-circuited. Only
+    what genuinely depends on that short-circuit is relaxed below, each with its reason.
+    """
+    directory, before = settled
+    run = run_update(directory, "run5-desktop", local = False)
+    assert run.rc == 0, run.log[-8000:]
+    # files.pythonhosted.org is the ONE payload host the version check governs: with a
+    # version mismatch this run IS an upgrade, and an upgrade downloads the wheel it
+    # upgrades to. The other three carry release payloads -- llama.cpp, whisper.cpp,
+    # node -- which no upgrade of unsloth has any reason to refetch, so they are held at
+    # zero on both branches.
+    payload_hosts = (
+        PAYLOAD_HOSTS
+        if desktop_path
+        else tuple(host for host in PAYLOAD_HOSTS if host != "files.pythonhosted.org")
+    )
+    for host in payload_hosts:
+        assert run.bytes_from(host) == 0, f"{host}: {run.report()}"
+    assert run.bytes_from("raw.githubusercontent.com") <= ICON_FETCH_CEILING, run.report()
+    # "dependencies up to date" is setup.sh's fast-path line, and the fast path is
+    # exactly what the version check decides; an upgrade legitimately runs the pass
+    # instead. The prebuilt and sidecar markers are not the version check's business:
+    # both are answered from disk whether or not the dependency pass runs.
+    markers = (
+        NO_WORK_MARKERS
+        if desktop_path
+        else tuple(marker for marker in NO_WORK_MARKERS if marker != "dependencies up to date")
+    )
+    for marker in markers:
+        assert marker in run.log, f"{marker!r} missing from a no-op update:\n{run.log[-8000:]}"
+    # One version check, and one "what is the latest release" HEAD per prebuilt. The
+    # bound is what stops this quietly becoming a full release listing again. Only the
+    # pypi.org one is relaxed: a real dependency pass resolves against the index, and
+    # how many connections that takes is the resolver's business. The github.com bound
+    # belongs to the prebuilts, which do the same work either way.
+    if desktop_path:
+        assert run.connections_to("pypi.org") <= 2, run.report()
+    assert run.connections_to("github.com") <= 6, run.report()
+    # The other half of the prebuilt claim: the release itself is never listed. Both of
+    # these carried traffic on every update before the marker checks, and both are where
+    # the 13-63 s macOS re-validation went.
+    assert run.connections_to("api.github.com") == 0, run.report()
+    assert run.connections_to("release-assets.githubusercontent.com") == 0, run.report()
+    if desktop_path:
+        # A dependency pass rewrites the manifest and can move the distribution list, so
+        # "nothing changed on disk" is only a claim about the short-circuited path. The
+        # no-op case is asserted in full by test_a_second_update_changes_nothing_on_disk.
+        assert diff(before, snapshot(install)) == []
+    else:
+        # This run WAS an upgrade to PyPI's release, so the checkout is no longer what is
+        # installed. Put it back: the workflow steps after this harness run the CLI and
+        # expect the code under test, not the released one.
+        restore = run_update(directory, "run5-restore", local = True)
+        assert restore.rc == 0, restore.log[-8000:]

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -239,6 +239,54 @@ def _start_proxy(directory: pathlib.Path, *extra: str):
     return process, f"http://127.0.0.1:{port_file.read_text().strip()}", log
 
 
+def _wait_until(
+    predicate,
+    *,
+    timeout: float = 5.0,
+    interval: float = 0.05,
+) -> bool:
+    """Poll until `predicate` holds or the deadline passes. A monotonic deadline rather
+    than a fixed sleep: the wait is for something the proxy is already doing, and a sleep
+    long enough to be safe on a loaded CI box is wasted on every ordinary run."""
+    deadline = time.monotonic() + timeout
+    while True:
+        if predicate():
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(interval)
+
+
+def _settle_journal(
+    log_path: pathlib.Path,
+    *,
+    timeout: float = 5.0,
+    quiet: float = 0.25,
+) -> None:
+    """Wait for the proxy's journal to stop growing, before the proxy is terminated.
+
+    A worker appends its record once the connection it describes has closed, so the child
+    can exit -- or a client can see its response -- with records still in flight, and
+    terminating the proxy at that moment drops them. A dropped record is a connection this
+    harness would then report as never having happened, which is precisely the claim it
+    exists to make. Waits for quiescence rather than for a count, because how many
+    connections a run makes is the thing being measured.
+    """
+    size = -1
+    stable_since = time.monotonic()
+    deadline = stable_since + timeout
+    while time.monotonic() < deadline:
+        try:
+            current = log_path.stat().st_size
+        except OSError:
+            current = 0
+        if current != size:
+            size, stable_since = current, time.monotonic()
+        elif time.monotonic() - stable_since >= quiet:
+            return
+        time.sleep(0.05)
+
+
 def run_update(
     tmp_path: pathlib.Path,
     label: str,
@@ -317,6 +365,7 @@ def run_update(
         rc = completed.returncode
     finally:
         seconds = time.time() - started
+        _settle_journal(log_path)
         process.terminate()
         try:
             process.wait(timeout = 10)
@@ -766,6 +815,13 @@ def test_the_harness_measures_a_real_proxy(tmp_path):
         with pytest.raises(urllib.error.URLError) as excinfo:
             opener.open("https://pypi.org/simple/", timeout = 30)
         assert "403" in str(excinfo.value)
+        # The client sees the 403 off the socket; the journal is written by the proxy
+        # worker. The proxy writes that record before it answers (see the refused branch
+        # of Proxy.handle), so all that is left to absorb here is the write itself being
+        # in flight -- but a proxy that had stopped journalling altogether must fail
+        # loudly rather than be papered over, hence the deadline and the failure below.
+        if not _wait_until(lambda: module.summary(str(log_path))["connections"] >= 1):
+            pytest.fail(f"the proxy answered 403 but never journalled the connection: {log_path}")
     finally:
         process.terminate()
         process.wait(timeout = 10)

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -46,6 +46,14 @@ is the flow a desktop user gets:
 The fault-injection cases DAMAGE that install and expect the update to repair exactly
 the damaged part. They restore what they broke, but a failure mid-case can leave the
 install in the damaged state, so never point this at an install you care about.
+
+Reading a CI failure: run 1 is the SETTLE run and is deliberately not measured. The
+first update performed by new installer code legitimately rewrites the manifest --
+`step_results` and `pass_inputs` are recorded by the pass that introduces them, so an
+install laid down by an older build has neither -- and it may repair torchao, which an
+earlier release installed from the wrong index. Only runs 2 and later are asserted on.
+A staging run confirmed the third (offline) run changed nothing at all, which is the
+claim this branch makes; a diff reported against `run1-settle` is not that claim.
 """
 
 from __future__ import annotations
@@ -421,8 +429,15 @@ def diff(before: dict, after: dict) -> list[str]:
 
 @pytest.fixture(scope = "session")
 def desktop_path(install) -> bool:
-    """Whether the non-local cases can run at all: they can only measure a no-op when
-    the installed version is the one PyPI would hand back."""
+    """Whether a non-local update can short-circuit: True only when the installed
+    version is the one PyPI would hand back.
+
+    Which EXPECTATIONS apply, not whether the case runs. The measurement a version
+    mismatch invalidates is the fast path itself; everything a `studio update` must
+    never do -- refetch a llama.cpp release, list a GitHub release, refetch a Node
+    tarball -- holds whether or not unsloth itself is being upgraded, and dropping
+    those assertions is how a regression in them reaches a release unnoticed.
+    """
     installed, latest = _installed_version(install), _pypi_latest()
     print(f"[idempotency] installed={installed!r} pypi={latest!r}", flush = True)
     return bool(installed) and installed == latest
@@ -484,27 +499,59 @@ def test_a_second_local_update_reuses_everything_it_can(install, settled):
 
 def test_the_desktop_update_path_does_no_network_work(install, settled, desktop_path):
     """No --local: the flow the desktop app and the Repair button run. Its whole cost on
-    a settled install should be one version check and the prebuilt HEADs."""
-    if not desktop_path:
-        pytest.skip("installed version is not PyPI's latest; a no-op update is an upgrade")
+    a settled install should be one version check and the prebuilt HEADs.
+
+    Runs on BOTH branches of desktop_path. Skipping the case when the installed version
+    is not PyPI's latest also dropped the assertions that hold either way -- the release
+    payload hosts, api.github.com, release-assets -- and those are the ones that catch a
+    prebuilt regression regardless of whether the version check short-circuited. Only
+    what genuinely depends on that short-circuit is relaxed below, each with its reason.
+    """
     directory, before = settled
     run = run_update(directory, "run5-desktop", local = False)
     assert run.rc == 0, run.log[-8000:]
-    for host in PAYLOAD_HOSTS:
+    # files.pythonhosted.org is the ONE payload host the version check governs: with a
+    # version mismatch this run IS an upgrade, and an upgrade downloads the wheel it
+    # upgrades to. The other three carry release payloads -- llama.cpp, whisper.cpp,
+    # node -- which no upgrade of unsloth has any reason to refetch, so they are held at
+    # zero on both branches.
+    payload_hosts = (
+        PAYLOAD_HOSTS
+        if desktop_path
+        else tuple(host for host in PAYLOAD_HOSTS if host != "files.pythonhosted.org")
+    )
+    for host in payload_hosts:
         assert run.bytes_from(host) == 0, f"{host}: {run.report()}"
     assert run.bytes_from("raw.githubusercontent.com") <= ICON_FETCH_CEILING, run.report()
-    for marker in NO_WORK_MARKERS:
+    # "dependencies up to date" is setup.sh's fast-path line, and the fast path is
+    # exactly what the version check decides; an upgrade legitimately runs the pass
+    # instead. The prebuilt and sidecar markers are not the version check's business:
+    # both are answered from disk whether or not the dependency pass runs.
+    markers = (
+        NO_WORK_MARKERS
+        if desktop_path
+        else tuple(marker for marker in NO_WORK_MARKERS if marker != "dependencies up to date")
+    )
+    for marker in markers:
         assert marker in run.log, f"{marker!r} missing from a no-op update:\n{run.log[-8000:]}"
     # One version check, and one "what is the latest release" HEAD per prebuilt. The
-    # bound is what stops this quietly becoming a full release listing again.
-    assert run.connections_to("pypi.org") <= 2, run.report()
+    # bound is what stops this quietly becoming a full release listing again. Only the
+    # pypi.org one is relaxed: a real dependency pass resolves against the index, and
+    # how many connections that takes is the resolver's business. The github.com bound
+    # belongs to the prebuilts, which do the same work either way.
+    if desktop_path:
+        assert run.connections_to("pypi.org") <= 2, run.report()
     assert run.connections_to("github.com") <= 6, run.report()
     # The other half of the prebuilt claim: the release itself is never listed. Both of
     # these carried traffic on every update before the marker checks, and both are where
     # the 13-63 s macOS re-validation went.
     assert run.connections_to("api.github.com") == 0, run.report()
     assert run.connections_to("release-assets.githubusercontent.com") == 0, run.report()
-    assert diff(before, snapshot(install)) == []
+    if desktop_path:
+        # A dependency pass rewrites the manifest and can move the distribution list, so
+        # "nothing changed on disk" is only a claim about the short-circuited path. The
+        # no-op case is asserted in full by test_a_second_update_changes_nothing_on_disk.
+        assert diff(before, snapshot(install)) == []
 
 
 # ── offline ──

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -29,6 +29,20 @@ an isolated one instead, which is how it is run locally against a scratch instal
 
     UNSLOTH_IDEMPOTENCY_E2E=1 UNSLOTH_IDEMPOTENCY_HOME=/path/to/fake/home pytest ...
 
+Two update modes are measured, because they take different paths and only one of them
+is the flow a desktop user gets:
+
+  * `studio update` (no --local) is the desktop flow. When the installed version equals
+    PyPI's latest it takes setup.sh's fast path, skips the dependency pass entirely, and
+    the prebuilt pre-checks answer from their markers. This is where the byte counts are
+    asserted. It only runs when the two versions do agree; otherwise a "no-op" update
+    would legitimately be an upgrade, so those cases skip themselves rather than measure
+    an upgrade and call it idempotency.
+  * `studio update --local` reinstalls from the checkout, so the dependency pass always
+    runs. That is what exercises the per-step skips, and it is asserted from the LOG:
+    with a warm uv cache a full pass also downloads nothing, so bytes cannot tell a skip
+    from a re-resolve there. Both are checked; neither alone is enough.
+
 The fault-injection cases DAMAGE that install and expect the update to repair exactly
 the damaged part. They restore what they broke, but a failure mid-case can leave the
 install in the damaged state, so never point this at an install you care about.
@@ -52,6 +66,10 @@ E2E = os.environ.get("UNSLOTH_IDEMPOTENCY_E2E") == "1"
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 PROXY = pathlib.Path(__file__).resolve().parent / "idempotency_proxy.py"
 IS_WINDOWS = sys.platform == "win32"
+# Where each run's update log and proxy journal are kept. Under pytest's tmp dir by
+# default, which a passing run discards; point UNSLOTH_IDEMPOTENCY_ARTIFACTS at a real
+# directory to keep them (CI uploads them, and a failure is unreadable without them).
+ARTIFACTS = os.environ.get("UNSLOTH_IDEMPOTENCY_ARTIFACTS", "")
 
 # Hosts a no-op update must not touch at all. pypi.org and github.com are listed
 # separately because a version check and a "what is the latest release" HEAD are both
@@ -61,12 +79,18 @@ PAYLOAD_HOSTS = (
     "objects.githubusercontent.com",
     "release-assets.githubusercontent.com",
     "nodejs.org",
-    "raw.githubusercontent.com",
 )
+# NOT raw.githubusercontent.com. install.sh's desktop-shortcut refresh falls back to
+# downloading rounded-512.png from it when it cannot find the icon in the installed
+# frontend, which is the case for an editable --local install with no built frontend.
+# ~8 KB, and it does not happen for the wheel installs users have -- but a bound keeps
+# it from quietly becoming something bigger.
+ICON_FETCH_CEILING = 64 * 1024
 
-# What the installers print when they decline to do work. All three prebuilts share the
-# "already matches" substring, which setup.sh and setup.ps1 also grep for.
-NO_WORK_MARKERS = ("dependencies up to date", "already matches")
+# What the installers print when they decline to do work. "already matches" is what the
+# prebuilt installers log; setup.sh CONSUMES that and prints its own line, so the log a
+# user (and this harness) sees carries these instead.
+NO_WORK_MARKERS = ("dependencies up to date", "prebuilt up to date", "sidecar current")
 
 DIST_LIST = (
     "import importlib.metadata as m, json; "
@@ -90,6 +114,30 @@ def _studio_home() -> pathlib.Path:
 def _venv_python() -> pathlib.Path:
     venv = _studio_home() / "unsloth_studio"
     return venv / ("Scripts/python.exe" if IS_WINDOWS else "bin/python")
+
+
+def _installed_version(venv_python: pathlib.Path) -> str:
+    probe = subprocess.run(
+        [
+            str(venv_python),
+            "-I",
+            "-c",
+            "import importlib.metadata as m; print(m.version('unsloth'))",
+        ],
+        capture_output = True,
+        text = True,
+        timeout = 120,
+    )
+    return probe.stdout.strip()
+
+
+def _pypi_latest() -> str:
+    import urllib.request
+    try:
+        with urllib.request.urlopen("https://pypi.org/pypi/unsloth/json", timeout = 60) as fh:
+            return json.load(fh)["info"]["version"]
+    except Exception:  # noqa: BLE001 - no answer means do not run the non-local cases
+        return ""
 
 
 @pytest.fixture(scope = "session")
@@ -194,7 +242,7 @@ def run_update(
     deny_hosts: str = "",
 ) -> ProxyRun:
     """One `unsloth studio update`, through the proxy, timed and logged."""
-    directory = tmp_path / label
+    directory = (pathlib.Path(ARTIFACTS) if ARTIFACTS else tmp_path) / label
     directory.mkdir(parents = True, exist_ok = True)
     extra = ["--refuse"] if refuse else (["--deny-hosts", deny_hosts] if deny_hosts else [])
     process, url, log_path = _start_proxy(directory, *extra)
@@ -202,6 +250,27 @@ def run_update(
     # matter, and a hand-built environment here fails in ways that look like the product.
     env = dict(os.environ)
     env.pop("UNSLOTH_IDEMPOTENCY_E2E", None)
+    # The venv pytest runs in is not the venv under test. Anything that would point the
+    # child at this interpreter's environment has to go, or the update resolves against
+    # the wrong cache, the wrong constraints, or the wrong site-packages -- and then
+    # measures whatever that produced.
+    for leaked in (
+        "VIRTUAL_ENV",
+        "PYTHONPATH",
+        "PYTHONHOME",
+        "UV_CACHE_DIR",
+        "UV_PYTHON",
+        "UV_CONSTRAINT",
+        "UV_CONFIG_FILE",
+        "PIP_CONSTRAINT",
+        "PIP_CONFIG_FILE",
+        "XDG_CACHE_HOME",
+        "XDG_DATA_HOME",
+        "XDG_CONFIG_HOME",
+        "UNSLOTH_STUDIO_HOME",
+        "STUDIO_HOME",
+    ):
+        env.pop(leaked, None)
     env.update(
         HOME = str(_home()),
         USERPROFILE = str(_home()),
@@ -352,6 +421,15 @@ def diff(before: dict, after: dict) -> list[str]:
 
 
 @pytest.fixture(scope = "session")
+def desktop_path(install) -> bool:
+    """Whether the non-local cases can run at all: they can only measure a no-op when
+    the installed version is the one PyPI would hand back."""
+    installed, latest = _installed_version(install), _pypi_latest()
+    print(f"[idempotency] installed={installed!r} pypi={latest!r}", flush = True)
+    return bool(installed) and installed == latest
+
+
+@pytest.fixture(scope = "session")
 def settled(install, tmp_path_factory):
     """One update, so whatever the install left half-decided is decided. Everything
     below measures the update AFTER this one."""
@@ -372,56 +450,86 @@ def test_a_second_update_changes_nothing_on_disk(install, settled):
     )
 
 
-def test_a_second_update_downloads_nothing(install, settled):
+def test_a_second_update_downloads_no_payload(install, settled):
     """The measurement the timings cannot make: a fast run and a run that refetched
     three release manifests look the same on a warm cache."""
     directory, _ = settled
     run = run_update(directory, "run3-network")
     assert run.rc == 0, run.log[-8000:]
     for host in PAYLOAD_HOSTS:
-        assert (
-            run.bytes_from(host) == 0
-        ), f"{host} served {run.bytes_from(host)} bytes: {run.report()}"
-    # A version check and the "what is the latest release" HEADs are allowed, and are
-    # what the prebuilt fast paths spend instead of a full release listing.
-    assert run.connections_to("pypi.org") <= 1, run.report()
-    assert run.connections_to("github.com") <= 4, run.report()
+        assert run.bytes_from(host) == 0, (
+            f"{host} served {run.bytes_from(host)} bytes to an update with nothing to "
+            f"do: {run.report()}"
+        )
 
 
-def test_a_second_update_says_it_did_nothing(install, settled):
-    """The disk and the network agree; the log has to as well, because a silent skip
-    and a silent failure to notice work are indistinguishable to a user."""
+def test_a_second_local_update_reuses_everything_it_can(install, settled):
+    """--local is the CI and developer path. It always runs the dependency pass on
+    purpose (a checkout can change in ways no requirements digest sees), so what it
+    demonstrates is the rest: the pip bootstrap skip, all three sidecars answering
+    "current" without a rebuild, and both prebuilts answering from their markers."""
     directory, _ = settled
-    run = run_update(directory, "run4-log")
+    run = run_update(directory, "run4-local", local = True)
     assert run.rc == 0, run.log[-8000:]
+    assert "(satisfied, skipped)" in run.log, (
+        "the pip bootstrap reinstalled pip on a venv that already had one:\n" + run.log[-8000:]
+    )
+    assert run.log.count("sidecar current") == 3, (
+        "a settled transformers sidecar was rebuilt:\n" + run.log[-8000:]
+    )
+    assert "prebuilt up to date" in run.log, run.log[-8000:]
+    assert "falling back to source build" not in run.log
+    for host in PAYLOAD_HOSTS:
+        assert run.bytes_from(host) == 0, f"{host}: {run.report()}"
+
+
+def test_the_desktop_update_path_does_no_network_work(install, settled, desktop_path):
+    """No --local: the flow the desktop app and the Repair button run. Its whole cost on
+    a settled install should be one version check and the prebuilt HEADs."""
+    if not desktop_path:
+        pytest.skip("installed version is not PyPI's latest; a no-op update is an upgrade")
+    directory, before = settled
+    run = run_update(directory, "run5-desktop", local = False)
+    assert run.rc == 0, run.log[-8000:]
+    for host in PAYLOAD_HOSTS:
+        assert run.bytes_from(host) == 0, f"{host}: {run.report()}"
+    assert run.bytes_from("raw.githubusercontent.com") <= ICON_FETCH_CEILING, run.report()
     for marker in NO_WORK_MARKERS:
         assert marker in run.log, f"{marker!r} missing from a no-op update:\n{run.log[-8000:]}"
-    assert "falling back to source build" not in run.log
+    # One version check, and one "what is the latest release" HEAD per prebuilt. The
+    # bound is what stops this quietly becoming a full release listing again.
+    assert run.connections_to("pypi.org") <= 2, run.report()
+    assert run.connections_to("github.com") <= 6, run.report()
+    # The other half of the prebuilt claim: the release itself is never listed. Both of
+    # these carried traffic on every update before the marker checks, and both are where
+    # the 13-63 s macOS re-validation went.
+    assert run.connections_to("api.github.com") == 0, run.report()
+    assert run.connections_to("release-assets.githubusercontent.com") == 0, run.report()
+    assert diff(before, snapshot(install)) == []
 
 
 # ── offline ──
 
 
-def test_a_no_op_update_needs_no_network_at_all(install, settled):
-    """UV_OFFLINE plus a proxy that 403s everything. Every attempt is still recorded,
-    so this asserts zero CONNECTIONS, not merely zero bytes."""
+def test_the_desktop_update_path_keeps_a_verified_install_offline(install, settled):
+    """UV_OFFLINE plus a proxy that 403s everything. Every attempt is still recorded, so
+    this asserts zero SUCCESSFUL connections, not merely zero bytes.
+
+    Non-local only, and not because --local is uninteresting: --local re-overlays
+    `unsloth-zoo @ git+main` on every run by design, so it cannot complete without a
+    network on any branch of this code, and a run that fails mid-pass leaves no manifest
+    behind. The flow a user is in on a plane is this one.
+
+    Without the rule this PR adds, an unreachable PyPI means "update to be safe", which
+    offline can only fail: the pass starts, the first git requirement 403s, and the
+    update exits non-zero on an install that was already complete.
+    """
     directory, before = settled
-    run = run_update(directory, "run5-offline", offline = True, refuse = True)
+    run = run_update(directory, "run6-offline", local = False, offline = True, refuse = True)
     assert run.rc == 0, (
         "an update with nothing to do failed offline. That is the state a user on a "
         f"plane, or behind a corporate proxy, is in:\n{run.log[-8000:]}"
     )
-    assert run.connections == run.refused, run.report()
-    assert diff(before, snapshot(install)) == []
-
-
-def test_the_non_local_path_keeps_a_verified_install_when_pypi_is_unreachable(install, settled):
-    """The rule added for exactly this: without --local, an unreachable PyPI means
-    "update to be safe", which offline can only fail. UV_OFFLINE says the caller knows
-    there is no network, so a verified install is kept instead."""
-    directory, before = settled
-    run = run_update(directory, "run6-offline-nonlocal", local = False, offline = True, refuse = True)
-    assert run.rc == 0, run.log[-8000:]
     assert "keeping the verified install" in run.log, run.log[-8000:]
     assert run.connections == run.refused, run.report()
     assert diff(before, snapshot(install)) == []
@@ -496,9 +604,22 @@ def test_a_deleted_manifest_re_runs_the_pass_and_changes_nothing(install, settle
     assert after["manifest"] is not None, "the pass did not rewrite the manifest"
 
 
-def test_a_damaged_llama_binary_reinstalls_llama(install, settled):
+def test_a_damaged_llama_binary_makes_the_marker_check_decline(install, settled):
+    """The pre-check answers "current" from hashes of the runtime binaries, so a damaged
+    one has to send the update back to the release it was skipping.
+
+    Measured on the network rather than in the log, because the log line the fast path
+    produces is consumed by setup.sh and reprinted identically either way: reaching
+    release-assets.githubusercontent.com at all means the release was listed, which is
+    exactly the work the marker check exists to avoid.
+
+    It asserts a DECLINE, not a repair. A truncated llama-server is not replaced by the
+    full path either -- its own check is the marker fingerprint plus a tree walk, and it
+    has never hashed the binaries. That is unchanged by this PR: the pre-check refuses to
+    answer, and what happens next is what happened before.
+    """
     directory, before = settled
-    candidates = sorted((_home() / ".unsloth").glob("llama.cpp/**/llama-quantize*"))
+    candidates = sorted((_home() / ".unsloth").glob("llama.cpp/**/llama-server*"))
     victim = next((p for p in candidates if p.is_file() and p.stat().st_size > 1024), None)
     if victim is None:
         pytest.skip("no llama.cpp prebuilt in this install")
@@ -508,37 +629,37 @@ def test_a_damaged_llama_binary_reinstalls_llama(install, settled):
     try:
         run = run_update(directory, "fault-llama", local = True)
         assert run.rc == 0, run.log[-8000:]
-        after = snapshot(install)
-        assert after["binaries"] != before["binaries"], "the truncated binary was not replaced"
-        assert victim.stat().st_size == len(saved), "llama.cpp was not reinstalled whole"
+        assert run.connections_to("release-assets.githubusercontent.com") > 0, (
+            "a damaged runtime binary was still answered from the marker: " + run.report()
+        )
     finally:
-        if victim.is_file() and victim.stat().st_size != len(saved):
-            victim.write_bytes(saved)
-            victim.chmod(mode)
+        victim.write_bytes(saved)
+        victim.chmod(mode)
+    assert snapshot(install)["distributions"] == before["distributions"]
 
 
-def test_an_edited_requirements_file_runs_that_step(install, settled):
-    """The installed copy of studio.txt is what the digest is taken from, so editing it
-    is the same signal a released requirements change is."""
-    directory, before = settled
-    installed_req = next(
-        (p for p in (install.parent.parent).rglob("requirements/studio.txt") if p.is_file()),
-        None,
-    )
-    if installed_req is None:
-        pytest.skip("no installed requirements tree")
-    saved = installed_req.read_bytes()
-    installed_req.write_bytes(saved + b"\n# idempotency harness\n")
-    try:
-        run = run_update(directory, "fault-requirements", local = True)
-        assert run.rc == 0, run.log[-8000:]
-        assert "studio deps" in run.log
-    finally:
-        installed_req.write_bytes(saved)
-    after = snapshot(install)
-    assert (
-        after["distributions"] == before["distributions"]
-    ), "re-running one step changed the resolved packages"
+def test_the_manifest_records_the_evidence_the_next_run_needs(install, settled):
+    """Every skip is conditional on this. A pass that finished but recorded nothing is
+    not a bug anyone would notice until the NEXT update quietly redoes everything -- or,
+    worse, skips on a key it happens to find and cannot check.
+
+    Not a test that an edited requirements file re-runs its step: --local, which is what
+    this harness and CI install with, never skips anything (a checkout can change in ways
+    no requirements digest sees), so there would be nothing to observe. That gate is
+    covered by tests/studio/install/test_dependency_pass_skips.py.
+    """
+    _directory, before = settled
+    manifest = before["manifest"]
+    assert manifest is not None, "the install finished without a manifest"
+    inputs = manifest.get("pass_inputs")
+    assert isinstance(inputs, dict) and inputs, "no pass_inputs recorded"
+    assert all(isinstance(v, str) and len(v) == 64 for v in inputs.values()), inputs
+    steps = manifest.get("step_results")
+    assert isinstance(steps, dict) and steps, "no step_results recorded"
+    # The keys a later run gates on, spelled the same way it will look them up.
+    for key in ("studio.txt", "base.txt"):
+        assert key in inputs, f"{key} is not in {sorted(inputs)}"
+    assert manifest.get("installer_python_tag"), manifest.keys()
 
 
 def test_full_deps_forces_every_step_and_still_changes_nothing(install, settled):
@@ -565,11 +686,22 @@ def test_full_deps_forces_every_step_and_still_changes_nothing(install, settled)
     )
 
 
-def test_the_scratch_install_is_left_where_it_was_found(install, settled):
-    """Runs last. Every case above restores what it broke; this is the assertion that
-    they all did."""
+def test_the_install_is_left_working(install, settled):
+    """Runs last. The fault cases legitimately move mtimes -- a rebuilt sidecar is a
+    rebuilt sidecar -- so this asserts what has to be true anyway: the same packages are
+    installed, and the install reports itself complete."""
     _directory, before = settled
-    assert diff(before, snapshot(install)) == []
+    after = snapshot(install)
+    assert after["distributions"] == before["distributions"]
+    assert after["manifest"] is not None
+    verify = subprocess.run(
+        [str(install), "-I", "-X", "utf8", "-m", "unsloth_cli", "studio", "verify-install"],
+        env = {**os.environ, "HOME": str(_home()), "USERPROFILE": str(_home())},
+        capture_output = True,
+        text = True,
+        timeout = 600,
+    )
+    assert verify.returncode == 0, verify.stdout + verify.stderr
 
 
 def test_the_harness_measures_a_real_proxy(tmp_path):

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -63,7 +63,6 @@ import pytest
 
 E2E = os.environ.get("UNSLOTH_IDEMPOTENCY_E2E") == "1"
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 PROXY = pathlib.Path(__file__).resolve().parent / "idempotency_proxy.py"
 IS_WINDOWS = sys.platform == "win32"
 # Where each run's update log and proxy journal are kept. Under pytest's tmp dir by

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -104,6 +104,21 @@ DIST_LIST = (
     "print(json.dumps(sorted(((d.metadata['Name'] or '').lower(), d.version) "
     "for d in m.distributions())))"
 )
+# Names and versions cannot see a reinstall at the same version, and a warm uv cache
+# makes one download nothing; the dist-info RECORD is rewritten by every install, so
+# its mtime can. Per distribution, so a failure names the package that moved.
+DIST_RECORDS = (
+    "import importlib.metadata as m, json, os; "
+    "out = []\n"
+    "for d in m.distributions():\n"
+    "    p = getattr(d, '_path', None) and (d._path / 'RECORD')\n"
+    "    try:\n"
+    "        st = os.stat(p)\n"
+    "        out.append([(d.metadata['Name'] or '').lower(), d.version, st.st_mtime_ns, st.st_size])\n"
+    "    except (OSError, TypeError):\n"
+    "        out.append([(d.metadata['Name'] or '').lower(), d.version, None, None])\n"
+    "print(json.dumps(sorted(out)))"
+)
 
 
 # ── the install under test ──
@@ -116,6 +131,14 @@ def _home() -> pathlib.Path:
 def _studio_home() -> pathlib.Path:
     override = os.environ.get("UNSLOTH_IDEMPOTENCY_STUDIO_HOME")
     return pathlib.Path(override) if override else _home() / ".unsloth" / "studio"
+
+
+def _unsloth_home() -> pathlib.Path:
+    """Where the prebuilts (llama.cpp, whisper.cpp, node) live: setup.sh's UNSLOTH_HOME
+    rule, which nests them under a CUSTOM Studio home and keeps ~/.unsloth otherwise."""
+    if os.environ.get("UNSLOTH_IDEMPOTENCY_STUDIO_HOME"):
+        return _studio_home()
+    return _home() / ".unsloth"
 
 
 def _venv_python() -> pathlib.Path:
@@ -279,6 +302,17 @@ def _settle_journal(
     exists to make. Waits for quiescence rather than for a count, because how many
     connections a run makes is the thing being measured.
     """
+    active_path = log_path.with_name(log_path.name + ".active")
+
+    def _workers_active() -> bool:
+        # The proxy publishes how many workers sit between accept and their record. A
+        # worker blocked in an upstream connect has written nothing, so a quiet journal
+        # alone is not proof that nothing is left to journal.
+        try:
+            return int(active_path.read_text().strip() or "0") > 0
+        except (OSError, ValueError):
+            return False
+
     size = -1
     stable_since = time.monotonic()
     deadline = stable_since + timeout
@@ -289,7 +323,7 @@ def _settle_journal(
             current = 0
         if current != size:
             size, stable_since = current, time.monotonic()
-        elif time.monotonic() - stable_since >= quiet:
+        elif time.monotonic() - stable_since >= quiet and not _workers_active():
             return
         time.sleep(0.05)
 
@@ -427,7 +461,7 @@ def _tree_state(root: pathlib.Path) -> dict | None:
 def snapshot(venv_python: pathlib.Path) -> dict:
     studio_home = _studio_home()
     venv = venv_python.parent.parent
-    unsloth_home = _home() / ".unsloth"
+    unsloth_home = _unsloth_home()
     state: dict = {}
     distributions = subprocess.run(
         [str(venv_python), "-I", "-c", DIST_LIST],
@@ -436,6 +470,13 @@ def snapshot(venv_python: pathlib.Path) -> dict:
         timeout = 300,
     )
     state["distributions"] = json.loads(distributions.stdout or "[]")
+    records = subprocess.run(
+        [str(venv_python), "-I", "-c", DIST_RECORDS],
+        capture_output = True,
+        text = True,
+        timeout = 300,
+    )
+    state["dist_records"] = json.loads(records.stdout or "[]")
 
     manifest_path = venv / "unsloth_install_manifest.json"
     manifest = None
@@ -530,6 +571,13 @@ def test_a_second_update_downloads_no_payload(install, settled):
     run = run_update(directory, "run3-network")
     assert run.rc == 0, run.log[-8000:]
     for host in PAYLOAD_HOSTS:
+        # Connections, not only bytes: an attempt that failed or timed out upstream is
+        # still a payload fetch the update decided to make, and the installer can keep
+        # the verified prebuilt and exit 0 after one.
+        assert run.connections_to(host) == 0, (
+            f"{host} was contacted {run.connections_to(host)} time(s) by an update with "
+            f"nothing to do: {run.report()}"
+        )
         assert run.bytes_from(host) == 0, (
             f"{host} served {run.bytes_from(host)} bytes to an update with nothing to "
             f"do: {run.report()}"
@@ -557,6 +605,7 @@ def test_a_second_local_update_reuses_everything_it_can(install, settled):
     )
     assert "falling back to source build" not in run.log
     for host in PAYLOAD_HOSTS:
+        assert run.connections_to(host) == 0, f"{host}: {run.report()}"
         assert run.bytes_from(host) == 0, f"{host}: {run.report()}"
     # The release is never listed on this path either: the marker checks cost one HEAD
     # on github.com per prebuilt, and a --local pass has no other business with the API.
@@ -681,13 +730,19 @@ def test_a_damaged_llama_binary_makes_the_marker_check_decline(install, settled)
     answer, and what happens next is what happened before.
     """
     directory, before = settled
-    candidates = sorted((_home() / ".unsloth").glob("llama.cpp/**/llama-server*"))
+    candidates = sorted(_unsloth_home().glob("llama.cpp/**/llama-server*"))
     victim = next((p for p in candidates if p.is_file() and p.stat().st_size > 1024), None)
     if victim is None:
         pytest.skip("no llama.cpp prebuilt in this install")
     saved = victim.read_bytes()
     mode = victim.stat().st_mode
-    victim.write_bytes(saved[: len(saved) // 4])
+    if IS_WINDOWS:
+        # The Linux and macOS validators read the executable image, so a truncated
+        # binary is caught; Windows has no such preflight and the marker match checks
+        # that the executables exist. Damage the Windows validator detects.
+        victim.unlink()
+    else:
+        victim.write_bytes(saved[: len(saved) // 4])
     try:
         run = run_update(directory, "fault-llama", local = True)
         assert run.rc == 0, run.log[-8000:]
@@ -831,6 +886,7 @@ def test_the_desktop_update_path_does_no_network_work(install, settled, desktop_
         else tuple(host for host in PAYLOAD_HOSTS if host != "files.pythonhosted.org")
     )
     for host in payload_hosts:
+        assert run.connections_to(host) == 0, f"{host}: {run.report()}"
         assert run.bytes_from(host) == 0, f"{host}: {run.report()}"
     assert run.bytes_from("raw.githubusercontent.com") <= ICON_FETCH_CEILING, run.report()
     # "dependencies up to date" is setup.sh's fast-path line, and the fast path is

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -156,7 +156,11 @@ def install() -> pathlib.Path:
         pytest.skip("opt-in end to end; set UNSLOTH_IDEMPOTENCY_E2E=1")
     venv_python = _venv_python()
     if not venv_python.is_file():
-        pytest.skip(f"no Studio install at {venv_python}; run install.sh first")
+        # Opted in, and nothing to measure: a skip here would let every product-facing
+        # case report itself skipped while the proxy self test keeps the job green.
+        pytest.fail(
+            f"UNSLOTH_IDEMPOTENCY_E2E is set but there is no Studio install at {venv_python}"
+        )
     return venv_python
 
 
@@ -620,6 +624,10 @@ def test_a_truncated_sidecar_file_rebuilds_only_that_sidecar(install, settled):
     try:
         run = run_update(directory, "fault-sidecar", local = True)
         assert run.rc == 0, run.log[-8000:]
+        # Judged before the cleanup below, which would otherwise restore the bytes
+        # itself and advance the mtime the rebuild assertion reads.
+        repaired = victim.is_file() and victim.read_bytes() != b""
+        assert repaired, "the update exited 0 and left the truncated sidecar file as it was"
     finally:
         if victim.is_file() and victim.read_bytes() == b"":
             victim.write_bytes(saved)
@@ -645,6 +653,9 @@ def test_a_deleted_manifest_re_runs_the_pass_and_changes_nothing(install, settle
     try:
         run = run_update(directory, "fault-manifest", local = True)
         assert run.rc == 0, run.log[-8000:]
+        # Judged before the cleanup below, which would otherwise put the saved copy back
+        # and let the assertion after the snapshot pass on the test's own file.
+        assert manifest.is_file(), "the pass exited 0 without rewriting the manifest"
     finally:
         if not manifest.is_file():
             manifest.write_bytes(saved)
@@ -803,7 +814,10 @@ def test_the_desktop_update_path_does_no_network_work(install, settled, desktop_
     prebuilt regression regardless of whether the version check short-circuited. Only
     what genuinely depends on that short-circuit is relaxed below, each with its reason.
     """
-    directory, before = settled
+    directory, _ = settled
+    # Its own baseline, taken now: this is the last case, and the fault-injection cases
+    # before it legitimately rebuilt a sidecar and advanced a binary's mtime.
+    before = snapshot(install)
     run = run_update(directory, "run5-desktop", local = False)
     assert run.rc == 0, run.log[-8000:]
     # files.pythonhosted.org is the ONE payload host the version check governs: with a
@@ -830,6 +844,10 @@ def test_the_desktop_update_path_does_no_network_work(install, settled, desktop_
     )
     for marker in markers:
         assert marker in run.log, f"{marker!r} missing from a no-op update:\n{run.log[-8000:]}"
+    # Each component, not the generic line once: one prebuilt re-validating while the
+    # other answers from its marker would otherwise pass here.
+    assert run.log.count("prebuilt up to date") >= 2, run.log[-8000:]
+    assert run.log.count("sidecar current") == 3, run.log[-8000:]
     # One version check, and one "what is the latest release" HEAD per prebuilt. The
     # bound is what stops this quietly becoming a full release listing again. Only the
     # pypi.org one is relaxed: a real dependency pass resolves against the index, and

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -563,7 +563,6 @@ def diff(before: dict, after: dict) -> list[str]:
 # ── run 1 and run 2 ──
 
 
-
 @pytest.fixture(scope = "session")
 def settled(install, tmp_path_factory):
     """One update, so whatever the install left half-decided is decided. Everything
@@ -698,9 +697,9 @@ def test_a_truncated_sidecar_file_rebuilds_only_that_sidecar(install, settled):
         # itself and advance the mtime the rebuild assertion reads.
         restored = victim.read_bytes() if victim.is_file() else b""
         assert restored != b"", "the update exited 0 and left the truncated sidecar file as it was"
-        assert restored == saved, (
-            "the rebuilt sidecar file differs from the bytes the settled install had"
-        )
+        assert (
+            restored == saved
+        ), "the rebuilt sidecar file differs from the bytes the settled install had"
     finally:
         if victim.is_file() and victim.read_bytes() == b"":
             victim.write_bytes(saved)
@@ -936,7 +935,11 @@ def test_the_harness_measures_a_real_proxy(tmp_path):
                     break
                 received += chunk
         assert received.endswith(body), received[:200]
-        counted = lambda: module.summary(str(log_path))["by_host"].get("127.0.0.1", {}).get("bytes_down", 0)
+        counted = (
+            lambda: module.summary(str(log_path))["by_host"]
+            .get("127.0.0.1", {})
+            .get("bytes_down", 0)
+        )
         if not _wait_until(lambda: counted() >= len(body)):
             pytest.fail(
                 f"the proxy relayed {len(received)} bytes but journalled {counted()} for the host: {log_path}"
@@ -978,7 +981,10 @@ def test_the_desktop_update_path_does_no_network_work(install, settled):
     before = snapshot(install)
     run = run_update(directory, "run5-desktop", local = False)
     assert run.rc == 0, run.log[-8000:]
-    print(f"[idempotency] installed={_installed_version(install)!r} pypi={_pypi_latest()!r}", flush = True)
+    print(
+        f"[idempotency] installed={_installed_version(install)!r} pypi={_pypi_latest()!r}",
+        flush = True,
+    )
     took_fast_path = NO_WORK_MARKERS[0] in run.log
     if not took_fast_path:
         # This run WAS an upgrade to PyPI's release, whose Node, sidecar, llama.cpp and

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -547,21 +547,6 @@ def diff(before: dict, after: dict) -> list[str]:
 # ── run 1 and run 2 ──
 
 
-@pytest.fixture(scope = "session")
-def desktop_path(install) -> bool:
-    """Whether a non-local update can short-circuit: True only when the installed
-    version is the one PyPI would hand back.
-
-    Which EXPECTATIONS apply, not whether the case runs. The measurement a version
-    mismatch invalidates is the fast path itself; everything a `studio update` must
-    never do -- refetch a llama.cpp release, list a GitHub release, refetch a Node
-    tarball -- holds whether or not unsloth itself is being upgraded, and dropping
-    those assertions is how a regression in them reaches a release unnoticed.
-    """
-    installed, latest = _installed_version(install), _pypi_latest()
-    print(f"[idempotency] installed={installed!r} pypi={latest!r}", flush = True)
-    return bool(installed) and installed == latest
-
 
 @pytest.fixture(scope = "session")
 def settled(install, tmp_path_factory):
@@ -746,6 +731,17 @@ def test_a_deleted_manifest_re_runs_the_pass_and_changes_nothing(install, settle
     assert untouched == [], (
         "a pass with no evidence redid work on already-valid components: " + ", ".join(untouched)
     )
+    # Names and versions cannot see a reinstall at the same version; the RECORD mtime can.
+    # --local reinstalls the checkout's own two packages on every pass (a local directory
+    # is never "already satisfied"), so those are expected to move; nothing else may.
+    local_core = {"unsloth", "unsloth-zoo", "unsloth_zoo"}
+    was = {tuple(record) for record in before["dist_records"]}
+    moved = sorted(
+        record[0]
+        for record in after["dist_records"]
+        if tuple(record) not in was and record[0] not in local_core
+    )
+    assert moved == [], "a pass with no evidence reinstalled: " + ", ".join(moved)
 
 
 def test_a_damaged_llama_binary_makes_the_marker_check_decline(install, settled):
@@ -798,8 +794,12 @@ def test_the_manifest_records_the_evidence_the_next_run_needs(install, settled):
     no requirements digest sees), so there would be nothing to observe. That gate is
     covered by tests/studio/install/test_dependency_pass_skips.py.
     """
-    _directory, before = settled
-    manifest = before["manifest"]
+    _directory, _before = settled
+    # The manifest on disk now, not the settled snapshot's copy: the fault case before this
+    # one deleted and regenerated it, and the regenerated one is what the next update's
+    # skips read, so it is the one that has to carry the evidence.
+    manifest_path = install.parent.parent / "unsloth_install_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding = "utf-8"))
     assert manifest is not None, "the install finished without a manifest"
     inputs = manifest.get("pass_inputs")
     assert isinstance(inputs, dict) and inputs, "no pass_inputs recorded"
@@ -855,13 +855,34 @@ def test_the_install_is_left_working(install, settled):
 
 
 def test_the_harness_measures_a_real_proxy(tmp_path):
-    """A proxy that silently failed to start would make every assertion above pass."""
-    module = _load_proxy_module()
-    process, url, log_path = _start_proxy(tmp_path, "--refuse")
-    try:
-        import urllib.error
-        import urllib.request
+    """A proxy that silently failed to start would make every assertion above pass, and
+    so would one that relays a tunnel without counting its bytes: the byte ceilings are
+    the only bound on hosts that are allowed through. So both halves are exercised: a
+    refused CONNECT, and an allowed one carrying a response of known size."""
+    import http.server
+    import socket
+    import threading
+    import urllib.error
+    import urllib.request
+    from urllib.parse import urlsplit
 
+    body = b"x" * 4096
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_args):
+            pass
+
+    upstream = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    threading.Thread(target = upstream.serve_forever, daemon = True).start()
+    module = _load_proxy_module()
+    process, url, log_path = _start_proxy(tmp_path, "--deny-hosts", "pypi.org")
+    try:
         opener = urllib.request.build_opener(
             urllib.request.ProxyHandler({"http": url, "https": url})
         )
@@ -877,11 +898,42 @@ def test_the_harness_measures_a_real_proxy(tmp_path):
         # loudly rather than be papered over, hence the deadline and the failure below.
         if not _wait_until(lambda: module.summary(str(log_path))["connections"] >= 1):
             pytest.fail(f"the proxy answered 403 but never journalled the connection: {log_path}")
+        # An allowed tunnel, driven by hand: CONNECT to the local server, then a plain
+        # GET through it, and the bytes that came back must be the bytes the journal
+        # attributes to that host.
+        proxy = urlsplit(url)
+        port = upstream.server_address[1]
+        with socket.create_connection((proxy.hostname, proxy.port), timeout = 30) as tunnel:
+            tunnel.sendall(
+                f"CONNECT 127.0.0.1:{port} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\n\r\n".encode()
+            )
+            head = b""
+            while b"\r\n\r\n" not in head:
+                chunk = tunnel.recv(4096)
+                assert chunk, "the proxy closed the tunnel before answering CONNECT"
+                head += chunk
+            assert head.split(b"\r\n", 1)[0].split()[1] == b"200", head
+            tunnel.sendall(b"GET / HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n")
+            received = b""
+            while True:
+                chunk = tunnel.recv(65536)
+                if not chunk:
+                    break
+                received += chunk
+        assert received.endswith(body), received[:200]
+        counted = lambda: module.summary(str(log_path))["by_host"].get("127.0.0.1", {}).get("bytes_down", 0)
+        if not _wait_until(lambda: counted() >= len(body)):
+            pytest.fail(
+                f"the proxy relayed {len(received)} bytes but journalled {counted()} for the host: {log_path}"
+            )
     finally:
         process.terminate()
         process.wait(timeout = 10)
+        upstream.shutdown()
     summary = module.summary(str(log_path))
-    assert summary["connections"] == 1 and summary["refused"] == 1
+    assert summary["connections"] == 2 and summary["refused"] == 1
+    assert summary["by_host"]["127.0.0.1"]["bytes_down"] >= len(body)
+    assert summary["by_host"]["pypi.org"]["bytes_down"] == 0
 
 
 # ── the desktop path, last ──
@@ -892,11 +944,13 @@ def test_the_harness_measures_a_real_proxy(tmp_path):
 # fail on every version-bump commit with the offline behaviour perfectly correct.
 
 
-def test_the_desktop_update_path_does_no_network_work(install, settled, desktop_path):
+def test_the_desktop_update_path_does_no_network_work(install, settled):
     """No --local: the flow the desktop app and the Repair button run. Its whole cost on
     a settled install should be one version check and the prebuilt HEADs.
 
-    Judged only when the version check short-circuits (desktop_path). With a version
+    Judged only when the version check short-circuited, read off the measured run's own
+    log rather than a separate request to PyPI made earlier (which can fail or see another
+    release than the one the update saw). With a version
     mismatch this run IS an upgrade to PyPI's release, whose Node, sidecar, llama.cpp and
     whisper.cpp pins can differ from the checkout's, and an upgrade that rebuilds or
     downloads those is behaving correctly; a version bump would otherwise fail this
@@ -909,7 +963,9 @@ def test_the_desktop_update_path_does_no_network_work(install, settled, desktop_
     before = snapshot(install)
     run = run_update(directory, "run5-desktop", local = False)
     assert run.rc == 0, run.log[-8000:]
-    if not desktop_path:
+    print(f"[idempotency] installed={_installed_version(install)!r} pypi={_pypi_latest()!r}", flush = True)
+    took_fast_path = NO_WORK_MARKERS[0] in run.log
+    if not took_fast_path:
         # This run WAS an upgrade to PyPI's release, whose Node, sidecar, llama.cpp and
         # whisper.cpp pins can legitimately differ from the checkout's: it may rebuild or
         # download any of them, so nothing below can be asserted of it. What can is that

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -713,6 +713,13 @@ def test_a_deleted_manifest_re_runs_the_pass_and_changes_nothing(install, settle
         after["distributions"] == before["distributions"]
     ), "a pass with no evidence resolved to a different set of packages"
     assert after["manifest"] is not None, "the pass did not rewrite the manifest"
+    # The rest of the install is the manifest's business only in that it is described
+    # there: a pass with no evidence re-checks every component and must leave the valid
+    # ones alone. The manifest itself is the one key allowed to differ.
+    untouched = [key for key in diff(before, after) if key not in ("manifest", "dist_records")]
+    assert untouched == [], (
+        "a pass with no evidence redid work on already-valid components: " + ", ".join(untouched)
+    )
 
 
 def test_a_damaged_llama_binary_makes_the_marker_check_decline(install, settled):
@@ -863,11 +870,12 @@ def test_the_desktop_update_path_does_no_network_work(install, settled, desktop_
     """No --local: the flow the desktop app and the Repair button run. Its whole cost on
     a settled install should be one version check and the prebuilt HEADs.
 
-    Runs on BOTH branches of desktop_path. Skipping the case when the installed version
-    is not PyPI's latest also dropped the assertions that hold either way -- the release
-    payload hosts, api.github.com, release-assets -- and those are the ones that catch a
-    prebuilt regression regardless of whether the version check short-circuited. Only
-    what genuinely depends on that short-circuit is relaxed below, each with its reason.
+    Judged only when the version check short-circuits (desktop_path). With a version
+    mismatch this run IS an upgrade to PyPI's release, whose Node, sidecar, llama.cpp and
+    whisper.cpp pins can differ from the checkout's, and an upgrade that rebuilds or
+    downloads those is behaving correctly; a version bump would otherwise fail this
+    smoke test for doing its job. The run still has to succeed on that branch, and the
+    checkout is put back for the workflow steps after this harness.
     """
     directory, _ = settled
     # Its own baseline, taken now: this is the last case, and the fault-injection cases
@@ -875,56 +883,32 @@ def test_the_desktop_update_path_does_no_network_work(install, settled, desktop_
     before = snapshot(install)
     run = run_update(directory, "run5-desktop", local = False)
     assert run.rc == 0, run.log[-8000:]
-    # files.pythonhosted.org is the ONE payload host the version check governs: with a
-    # version mismatch this run IS an upgrade, and an upgrade downloads the wheel it
-    # upgrades to. The other three carry release payloads -- llama.cpp, whisper.cpp,
-    # node -- which no upgrade of unsloth has any reason to refetch, so they are held at
-    # zero on both branches.
-    payload_hosts = (
-        PAYLOAD_HOSTS
-        if desktop_path
-        else tuple(host for host in PAYLOAD_HOSTS if host != "files.pythonhosted.org")
-    )
-    for host in payload_hosts:
+    if not desktop_path:
+        # This run WAS an upgrade to PyPI's release, whose Node, sidecar, llama.cpp and
+        # whisper.cpp pins can legitimately differ from the checkout's: it may rebuild or
+        # download any of them, so nothing below can be asserted of it. What can is that
+        # it succeeded, and that the checkout is put back for the workflow steps after
+        # this harness, which run the CLI and expect the code under test.
+        restore = run_update(directory, "run5-restore", local = True)
+        assert restore.rc == 0, restore.log[-8000:]
+        pytest.skip("installed version is not PyPI's latest; the desktop no-op path was not taken")
+    for host in PAYLOAD_HOSTS:
         assert run.connections_to(host) == 0, f"{host}: {run.report()}"
         assert run.bytes_from(host) == 0, f"{host}: {run.report()}"
     assert run.bytes_from("raw.githubusercontent.com") <= ICON_FETCH_CEILING, run.report()
-    # "dependencies up to date" is setup.sh's fast-path line, and the fast path is
-    # exactly what the version check decides; an upgrade legitimately runs the pass
-    # instead. The prebuilt and sidecar markers are not the version check's business:
-    # both are answered from disk whether or not the dependency pass runs.
-    markers = (
-        NO_WORK_MARKERS
-        if desktop_path
-        else tuple(marker for marker in NO_WORK_MARKERS if marker != "dependencies up to date")
-    )
-    for marker in markers:
+    for marker in NO_WORK_MARKERS:
         assert marker in run.log, f"{marker!r} missing from a no-op update:\n{run.log[-8000:]}"
     # Each component, not the generic line once: one prebuilt re-validating while the
     # other answers from its marker would otherwise pass here.
     assert run.log.count("prebuilt up to date") >= 2, run.log[-8000:]
     assert run.log.count("sidecar current") == 3, run.log[-8000:]
     # One version check, and one "what is the latest release" HEAD per prebuilt. The
-    # bound is what stops this quietly becoming a full release listing again. Only the
-    # pypi.org one is relaxed: a real dependency pass resolves against the index, and
-    # how many connections that takes is the resolver's business. The github.com bound
-    # belongs to the prebuilts, which do the same work either way.
-    if desktop_path:
-        assert run.connections_to("pypi.org") <= 2, run.report()
+    # bound is what stops this quietly becoming a full release listing again.
+    assert run.connections_to("pypi.org") <= 2, run.report()
     assert run.connections_to("github.com") <= 6, run.report()
     # The other half of the prebuilt claim: the release itself is never listed. Both of
     # these carried traffic on every update before the marker checks, and both are where
     # the 13-63 s macOS re-validation went.
     assert run.connections_to("api.github.com") == 0, run.report()
     assert run.connections_to("release-assets.githubusercontent.com") == 0, run.report()
-    if desktop_path:
-        # A dependency pass rewrites the manifest and can move the distribution list, so
-        # "nothing changed on disk" is only a claim about the short-circuited path. The
-        # no-op case is asserted in full by test_a_second_update_changes_nothing_on_disk.
-        assert diff(before, snapshot(install)) == []
-    else:
-        # This run WAS an upgrade to PyPI's release, so the checkout is no longer what is
-        # installed. Put it back: the workflow steps after this harness run the CLI and
-        # expect the code under test, not the released one.
-        restore = run_update(directory, "run5-restore", local = True)
-        assert restore.rc == 0, restore.log[-8000:]
+    assert diff(before, snapshot(install)) == []

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -62,6 +62,7 @@ import hashlib
 import json
 import os
 import pathlib
+import re
 import subprocess
 import sys
 import time
@@ -98,6 +99,10 @@ ICON_FETCH_CEILING = 64 * 1024
 # prebuilt installers log; setup.sh CONSUMES that and prints its own line, so the log a
 # user (and this harness) sees carries these instead.
 NO_WORK_MARKERS = ("dependencies up to date", "prebuilt up to date", "sidecar current")
+# What setup.sh prints (step "frontend" "up to date", column-padded) when the built dist
+# is newer than its sources. A pass that rebuilt the frontend instead talks to no
+# forbidden host on a warm npm cache, so the log line is the only witness.
+FRONTEND_CURRENT_MARKER = re.compile(r"frontend\s+up to date")
 # What setup.sh / setup.ps1 print when the version check found a newer release, and when
 # it could not ask PyPI at all (the pass runs on purpose in both cases).
 UPGRADE_MARKER = "available, updating..."
@@ -616,8 +621,14 @@ def test_a_second_local_update_reuses_everything_it_can(install, settled):
     directory, _ = settled
     run = run_update(directory, "run4-local", local = True)
     assert run.rc == 0, run.log[-8000:]
-    assert "(satisfied, skipped)" in run.log, (
+    # The full message: the MLX stack, base requirements, local plugin and finalization
+    # steps end in the same suffix, and any of them would satisfy a substring match.
+    assert "pip bootstrap (satisfied, skipped)" in run.log, (
         "the pip bootstrap reinstalled pip on a venv that already had one:\n" + run.log[-8000:]
+    )
+    assert FRONTEND_CURRENT_MARKER.search(run.log), (
+        "the frontend was rebuilt on a checkout whose dist was already current:\n"
+        + run.log[-8000:]
     )
     assert run.log.count("sidecar current") == 3, (
         "a settled transformers sidecar was rebuilt:\n" + run.log[-8000:]
@@ -710,12 +721,13 @@ def test_a_truncated_sidecar_file_rebuilds_only_that_sidecar(install, settled):
     after = snapshot(install)
     changed = diff(before, after)
     assert target.name in changed, f"the damaged sidecar was not rebuilt (changed: {changed})"
-    untouched = [
-        name for name in (".venv_t5_530", ".venv_t5_550", ".venv_t5_510") if name != target.name
-    ]
-    assert [
-        name for name in changed if name in untouched
-    ] == [], f"an unrelated sidecar was rebuilt too: {changed}"
+    # Exactly the damaged component: the other two sidecars, every dist record, both
+    # prebuilt markers and the binaries stay as they were. The manifest may move, as it
+    # records the sidecar evidence the repair renewed.
+    unexpected = sorted(set(changed) - {target.name, "manifest"})
+    assert (
+        unexpected == []
+    ), f"the sidecar repair changed more than the damaged sidecar: {changed}"
 
 
 def test_a_deleted_manifest_re_runs_the_pass_and_changes_nothing(install, settled):
@@ -857,12 +869,24 @@ def test_the_install_is_left_working(install, settled):
     _assert_install_working(install, before)
 
 
-def _assert_install_working(install: pathlib.Path, before: dict) -> None:
+def _assert_install_working(
+    install: pathlib.Path, before: dict, *, same_distributions: bool = True
+) -> None:
     """The same packages as *before* are installed, and the CLI reports the install
     complete. Shared by the last ordered case and the desktop case's restore, which is
-    the last product operation of the run and is otherwise judged by exit code alone."""
+    the last product operation of the run and is otherwise judged by exit code alone.
+
+    After a real upgrade to PyPI's release the restore reinstalls the checkout only where
+    needed, and a transitive dependency the release moved that the checkout's ranges
+    still admit legitimately stays: then only the checkout's own packages are held to
+    *before*."""
     after = snapshot(install)
-    assert after["distributions"] == before["distributions"]
+    if same_distributions:
+        assert after["distributions"] == before["distributions"]
+    else:
+        core = lambda dists: sorted(d for d in dists if d[0] in LOCAL_CORE)  # noqa: E731
+        assert core(after["distributions"]) == core(before["distributions"])
+        assert core(after["distributions"]), "the checkout's own packages are gone"
     assert after["manifest"] is not None
     verify_env = {**os.environ, "HOME": str(_home()), "USERPROFILE": str(_home())}
     # The same root the measured runs used: under UNSLOTH_IDEMPOTENCY_STUDIO_HOME the
@@ -1003,7 +1027,9 @@ def test_the_desktop_update_path_does_no_network_work(install, settled):
         # exit code alone.
         restore = run_update(directory, "run5-restore", local = True)
         assert restore.rc == 0, restore.log[-8000:]
-        _assert_install_working(install, before)
+        _assert_install_working(
+            install, before, same_distributions = UPGRADE_MARKER not in run.log
+        )
         # Why the pass ran, read off the measured run's own log: the separate PyPI
         # lookup above can fail or see another release than the one the update saw.
         if UPGRADE_MARKER in run.log:
@@ -1013,14 +1039,13 @@ def test_the_desktop_update_path_does_no_network_work(install, settled):
             pytest.skip(
                 "installed version is not PyPI's latest; the desktop no-op path was not taken"
             )
-        if PYPI_UNREACHABLE_MARKER in run.log or not latest:
+        if PYPI_UNREACHABLE_MARKER in run.log:
             # The product runs the pass on purpose when it cannot ask PyPI: correct
-            # behaviour, and nothing this case can judge.
+            # behaviour, and nothing this case can judge. Only the measured run's own
+            # lookup counts: the harness's separate request above can fail or see
+            # another release while the update's succeeded, and skipping on it would
+            # look away from exactly the equal-version pass this case exists to catch.
             pytest.skip("PyPI was unreachable; the desktop no-op path could not be judged")
-        if installed and latest and installed != latest:
-            pytest.skip(
-                "installed version is not PyPI's latest; the desktop no-op path was not taken"
-            )
         # Equal versions and a reachable index, and the pass still ran: that is the
         # regression this case exists to catch, not a reason to look away.
         pytest.fail(

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -388,6 +388,9 @@ def run_update(
         "XDG_CONFIG_HOME",
         "UNSLOTH_STUDIO_HOME",
         "STUDIO_HOME",
+        "NPM_CONFIG_PROXY",
+        "NPM_CONFIG_HTTPS_PROXY",
+        "NPM_CONFIG_NOPROXY",
     ):
         env.pop(leaked, None)
     env.update(
@@ -403,6 +406,13 @@ def run_update(
         http_proxy = url,
         NO_PROXY = "127.0.0.1,localhost",
         no_proxy = "127.0.0.1,localhost",
+        # npm reads its own variables ahead of the generic ones (with npm 11 an
+        # npm_config_https_proxy in the invoking environment outranks HTTPS_PROXY), and
+        # setup runs npm on every update: a value inherited from a corporate machine
+        # would route the registry traffic around the proxy that counts it.
+        npm_config_proxy = url,
+        npm_config_https_proxy = url,
+        npm_config_noproxy = "127.0.0.1,localhost",
         # Presence, not truthiness: without it the CLI probes the Windows PowerShell
         # profiles for an Invoke-WebRequest proxy default, which would outrank the
         # variables above and route setup.ps1 around the logging proxy.

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -591,6 +591,12 @@ def test_a_second_update_changes_nothing_on_disk(install, settled):
         f"  {key}:\n    before={before.get(key)!r}\n    after={after.get(key)!r}"
         for key in diff(before, after)
     )
+    # The same run's traffic too: a regression that downloads on this first measured
+    # update and parks its evidence outside the install (an npm or uv cache) would leave
+    # the snapshot alone here and be quiet by the network case that follows.
+    for host in PAYLOAD_HOSTS:
+        assert run.connections_to(host) == 0, f"{host}: {run.report()}"
+        assert run.bytes_from(host) == 0, f"{host}: {run.report()}"
 
 
 def test_a_second_update_downloads_no_payload(install, settled):

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -292,8 +292,13 @@ def _settle_journal(
     *,
     timeout: float = 5.0,
     quiet: float = 0.25,
-) -> None:
+    active_grace: float = 75.0,
+) -> bool:
     """Wait for the proxy's journal to stop growing, before the proxy is terminated.
+
+    Returns False when a worker was still between accept and its record after
+    `active_grace` seconds, longer than the proxy's 60 s upstream connect timeout: the
+    journal is then incomplete and the caller must not read it as a zero-connection proof.
 
     A worker appends its record once the connection it describes has closed, so the child
     can exit -- or a client can see its response -- with records still in flight, and
@@ -316,15 +321,22 @@ def _settle_journal(
     size = -1
     stable_since = time.monotonic()
     deadline = stable_since + timeout
-    while time.monotonic() < deadline:
+    grace_deadline = stable_since + active_grace
+    while True:
+        now = time.monotonic()
         try:
             current = log_path.stat().st_size
         except OSError:
             current = 0
         if current != size:
-            size, stable_since = current, time.monotonic()
-        elif time.monotonic() - stable_since >= quiet and not _workers_active():
-            return
+            size, stable_since = current, now
+        elif now - stable_since >= quiet and not _workers_active():
+            return True
+        if now >= deadline and not _workers_active():
+            # A journal still growing past the deadline with no worker in flight is bounded here.
+            return True
+        if now >= grace_deadline:
+            return not _workers_active()
         time.sleep(0.05)
 
 
@@ -380,6 +392,10 @@ def run_update(
         http_proxy = url,
         NO_PROXY = "127.0.0.1,localhost",
         no_proxy = "127.0.0.1,localhost",
+        # Presence, not truthiness: without it the CLI probes the Windows PowerShell
+        # profiles for an Invoke-WebRequest proxy default, which would outrank the
+        # variables above and route setup.ps1 around the logging proxy.
+        _UNSLOTH_PS_PROXY_DEFAULTS = "{}",
     )
     if os.environ.get("UNSLOTH_IDEMPOTENCY_STUDIO_HOME"):
         env["UNSLOTH_STUDIO_HOME"] = os.environ["UNSLOTH_IDEMPOTENCY_STUDIO_HOME"]
@@ -406,13 +422,17 @@ def run_update(
         rc = completed.returncode
     finally:
         seconds = time.time() - started
-        _settle_journal(log_path)
+        settled = _settle_journal(log_path)
         process.terminate()
         try:
             process.wait(timeout = 10)
         except subprocess.TimeoutExpired:  # pragma: no cover - a wedged tunnel
             process.kill()
     (directory / "update.log").write_text(text, encoding = "utf-8")
+    assert settled, (
+        f"{label}: the update finished while a proxy worker was still between accept and "
+        "its journal record; the journal is incomplete and proves nothing about connections"
+    )
     summary = _load_proxy_module().summary(str(log_path))
     run = ProxyRun(directory, text, summary, seconds, rc)
     print(f"[idempotency] {label}: {run.report()}", flush = True)

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -979,22 +979,28 @@ def test_the_desktop_update_path_does_no_network_work(install, settled):
     # Its own baseline, taken now: this is the last case, and the fault-injection cases
     # before it legitimately rebuilt a sidecar and advanced a binary's mtime.
     before = snapshot(install)
+    # Read BEFORE the run: after it the installed version may already be PyPI's.
+    installed, latest = _installed_version(install), _pypi_latest()
+    print(f"[idempotency] installed={installed!r} pypi={latest!r}", flush = True)
     run = run_update(directory, "run5-desktop", local = False)
     assert run.rc == 0, run.log[-8000:]
-    print(
-        f"[idempotency] installed={_installed_version(install)!r} pypi={_pypi_latest()!r}",
-        flush = True,
-    )
     took_fast_path = NO_WORK_MARKERS[0] in run.log
     if not took_fast_path:
-        # This run WAS an upgrade to PyPI's release, whose Node, sidecar, llama.cpp and
-        # whisper.cpp pins can legitimately differ from the checkout's: it may rebuild or
-        # download any of them, so nothing below can be asserted of it. What can is that
-        # it succeeded, and that the checkout is put back for the workflow steps after
-        # this harness, which run the CLI and expect the code under test.
+        # The checkout goes back first either way: the workflow steps after this harness
+        # run the CLI and expect the code under test.
         restore = run_update(directory, "run5-restore", local = True)
         assert restore.rc == 0, restore.log[-8000:]
-        pytest.skip("installed version is not PyPI's latest; the desktop no-op path was not taken")
+        if installed and latest and installed != latest:
+            # This run WAS an upgrade to PyPI's release, whose Node, sidecar, llama.cpp
+            # and whisper.cpp pins can legitimately differ from the checkout's: it may
+            # rebuild or download any of them, so nothing below can be asserted of it.
+            pytest.skip("installed version is not PyPI's latest; the desktop no-op path was not taken")
+        # Equal versions (or none to compare) and the pass still ran: that is the
+        # regression this case exists to catch, not a reason to look away.
+        pytest.fail(
+            f"the desktop update ran the dependency pass with unsloth {installed!r} installed "
+            f"and {latest!r} on PyPI; the fast path was not taken:\n{run.log[-8000:]}"
+        )
     for host in PAYLOAD_HOSTS:
         assert run.connections_to(host) == 0, f"{host}: {run.report()}"
         assert run.bytes_from(host) == 0, f"{host}: {run.report()}"

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -675,8 +675,11 @@ def test_a_truncated_sidecar_file_rebuilds_only_that_sidecar(install, settled):
         assert run.rc == 0, run.log[-8000:]
         # Judged before the cleanup below, which would otherwise restore the bytes
         # itself and advance the mtime the rebuild assertion reads.
-        repaired = victim.is_file() and victim.read_bytes() != b""
-        assert repaired, "the update exited 0 and left the truncated sidecar file as it was"
+        restored = victim.read_bytes() if victim.is_file() else b""
+        assert restored != b"", "the update exited 0 and left the truncated sidecar file as it was"
+        assert restored == saved, (
+            "the rebuilt sidecar file differs from the bytes the settled install had"
+        )
     finally:
         if victim.is_file() and victim.read_bytes() == b"":
             victim.write_bytes(saved)
@@ -695,9 +698,12 @@ def test_a_deleted_manifest_re_runs_the_pass_and_changes_nothing(install, settle
     """The manifest is the only record of what the last pass did. Without it every step
     must run -- and every step must then find its work already done, so the venv comes
     out identical."""
-    directory, before = settled
+    directory, _ = settled
     manifest = install.parent.parent / "unsloth_install_manifest.json"
     saved = manifest.read_bytes()
+    # Baseline taken here, not from the fixture: the fault tests before this one repair
+    # what they broke, and a repair may legitimately move a record or an mtime.
+    before = snapshot(install)
     manifest.unlink()
     try:
         run = run_update(directory, "fault-manifest", local = True)

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -98,6 +98,8 @@ ICON_FETCH_CEILING = 64 * 1024
 # prebuilt installers log; setup.sh CONSUMES that and prints its own line, so the log a
 # user (and this harness) sees carries these instead.
 NO_WORK_MARKERS = ("dependencies up to date", "prebuilt up to date", "sidecar current")
+# What --local installs from the checkout on every pass, so its RECORD moving is expected.
+LOCAL_CORE = frozenset({"unsloth", "unsloth-zoo", "unsloth_zoo"})
 
 DIST_LIST = (
     "import importlib.metadata as m, json; "
@@ -422,6 +424,10 @@ def run_update(
         rc = completed.returncode
     finally:
         seconds = time.time() - started
+        # Read before anything is done to it: a proxy that died during the run journalled
+        # nothing after its death, and a client whose CONNECT was refused by a dead
+        # listener looks, in that journal, like one that made no connection at all.
+        proxy_died = process.poll() is not None
         settled = _settle_journal(log_path)
         process.terminate()
         try:
@@ -429,6 +435,10 @@ def run_update(
         except subprocess.TimeoutExpired:  # pragma: no cover - a wedged tunnel
             process.kill()
     (directory / "update.log").write_text(text, encoding = "utf-8")
+    assert not proxy_died, (
+        f"{label}: the measurement proxy exited (code {process.returncode}) before the update "
+        "finished; its journal is incomplete and proves nothing about connections"
+    )
     assert settled, (
         f"{label}: the update finished while a proxy worker was still between accept and "
         "its journal record; the journal is incomplete and proves nothing about connections"
@@ -496,7 +506,13 @@ def snapshot(venv_python: pathlib.Path) -> dict:
         text = True,
         timeout = 300,
     )
-    state["dist_records"] = json.loads(records.stdout or "[]")
+    # The two packages --local installs from the checkout are reinstalled on every pass
+    # (a local directory is never "already satisfied"), so their RECORD moving is the
+    # harness's own doing, not the update's; their mtime and size are not compared.
+    state["dist_records"] = [
+        [name, version, None, None] if name in LOCAL_CORE else [name, version, mtime, size]
+        for name, version, mtime, size in json.loads(records.stdout or "[]")
+    ]
 
     manifest_path = venv / "unsloth_install_manifest.json"
     manifest = None
@@ -731,16 +747,10 @@ def test_a_deleted_manifest_re_runs_the_pass_and_changes_nothing(install, settle
     assert untouched == [], (
         "a pass with no evidence redid work on already-valid components: " + ", ".join(untouched)
     )
-    # Names and versions cannot see a reinstall at the same version; the RECORD mtime can.
-    # --local reinstalls the checkout's own two packages on every pass (a local directory
-    # is never "already satisfied"), so those are expected to move; nothing else may.
-    local_core = {"unsloth", "unsloth-zoo", "unsloth_zoo"}
+    # Names and versions cannot see a reinstall at the same version; the RECORD mtime can
+    # (the snapshot already leaves out the two packages --local reinstalls by design).
     was = {tuple(record) for record in before["dist_records"]}
-    moved = sorted(
-        record[0]
-        for record in after["dist_records"]
-        if tuple(record) not in was and record[0] not in local_core
-    )
+    moved = sorted(record[0] for record in after["dist_records"] if tuple(record) not in was)
     assert moved == [], "a pass with no evidence reinstalled: " + ", ".join(moved)
 
 
@@ -844,9 +854,14 @@ def test_the_install_is_left_working(install, settled):
     after = snapshot(install)
     assert after["distributions"] == before["distributions"]
     assert after["manifest"] is not None
+    verify_env = {**os.environ, "HOME": str(_home()), "USERPROFILE": str(_home())}
+    # The same root the measured runs used: under UNSLOTH_IDEMPOTENCY_STUDIO_HOME the
+    # install lives outside HOME, and the CLI would otherwise verify a default root.
+    if os.environ.get("UNSLOTH_IDEMPOTENCY_STUDIO_HOME"):
+        verify_env["UNSLOTH_STUDIO_HOME"] = os.environ["UNSLOTH_IDEMPOTENCY_STUDIO_HOME"]
     verify = subprocess.run(
         [str(install), "-I", "-X", "utf8", "-m", "unsloth_cli", "studio", "verify-install"],
-        env = {**os.environ, "HOME": str(_home()), "USERPROFILE": str(_home())},
+        env = verify_env,
         capture_output = True,
         text = True,
         timeout = 600,

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -627,8 +627,7 @@ def test_a_second_local_update_reuses_everything_it_can(install, settled):
         "the pip bootstrap reinstalled pip on a venv that already had one:\n" + run.log[-8000:]
     )
     assert FRONTEND_CURRENT_MARKER.search(run.log), (
-        "the frontend was rebuilt on a checkout whose dist was already current:\n"
-        + run.log[-8000:]
+        "the frontend was rebuilt on a checkout whose dist was already current:\n" + run.log[-8000:]
     )
     assert run.log.count("sidecar current") == 3, (
         "a settled transformers sidecar was rebuilt:\n" + run.log[-8000:]
@@ -725,9 +724,7 @@ def test_a_truncated_sidecar_file_rebuilds_only_that_sidecar(install, settled):
     # prebuilt markers and the binaries stay as they were. The manifest may move, as it
     # records the sidecar evidence the repair renewed.
     unexpected = sorted(set(changed) - {target.name, "manifest"})
-    assert (
-        unexpected == []
-    ), f"the sidecar repair changed more than the damaged sidecar: {changed}"
+    assert unexpected == [], f"the sidecar repair changed more than the damaged sidecar: {changed}"
 
 
 def test_a_deleted_manifest_re_runs_the_pass_and_changes_nothing(install, settled):
@@ -870,7 +867,10 @@ def test_the_install_is_left_working(install, settled):
 
 
 def _assert_install_working(
-    install: pathlib.Path, before: dict, *, same_distributions: bool = True
+    install: pathlib.Path,
+    before: dict,
+    *,
+    same_distributions: bool = True,
 ) -> None:
     """The same packages as *before* are installed, and the CLI reports the install
     complete. Shared by the last ordered case and the desktop case's restore, which is
@@ -1027,9 +1027,7 @@ def test_the_desktop_update_path_does_no_network_work(install, settled):
         # exit code alone.
         restore = run_update(directory, "run5-restore", local = True)
         assert restore.rc == 0, restore.log[-8000:]
-        _assert_install_working(
-            install, before, same_distributions = UPGRADE_MARKER not in run.log
-        )
+        _assert_install_working(install, before, same_distributions = UPGRADE_MARKER not in run.log)
         # Why the pass ran, read off the measured run's own log: the separate PyPI
         # lookup above can fail or see another release than the one the update saw.
         if UPGRADE_MARKER in run.log:

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -98,6 +98,10 @@ ICON_FETCH_CEILING = 64 * 1024
 # prebuilt installers log; setup.sh CONSUMES that and prints its own line, so the log a
 # user (and this harness) sees carries these instead.
 NO_WORK_MARKERS = ("dependencies up to date", "prebuilt up to date", "sidecar current")
+# What setup.sh / setup.ps1 print when the version check found a newer release, and when
+# it could not ask PyPI at all (the pass runs on purpose in both cases).
+UPGRADE_MARKER = "available, updating..."
+PYPI_UNREACHABLE_MARKER = "could not reach PyPI, updating to be safe..."
 # What --local installs from the checkout on every pass, so its RECORD moving is expected.
 LOCAL_CORE = frozenset({"unsloth", "unsloth-zoo", "unsloth_zoo"})
 
@@ -850,6 +854,13 @@ def test_the_install_is_left_working(install, settled):
     rebuilt sidecar -- so this asserts what has to be true anyway: the same packages are
     installed, and the install reports itself complete."""
     _directory, before = settled
+    _assert_install_working(install, before)
+
+
+def _assert_install_working(install: pathlib.Path, before: dict) -> None:
+    """The same packages as *before* are installed, and the CLI reports the install
+    complete. Shared by the last ordered case and the desktop case's restore, which is
+    the last product operation of the run and is otherwise judged by exit code alone."""
     after = snapshot(install)
     assert after["distributions"] == before["distributions"]
     assert after["manifest"] is not None
@@ -987,15 +998,26 @@ def test_the_desktop_update_path_does_no_network_work(install, settled):
     took_fast_path = NO_WORK_MARKERS[0] in run.log
     if not took_fast_path:
         # The checkout goes back first either way: the workflow steps after this harness
-        # run the CLI and expect the code under test.
+        # run the CLI and expect the code under test. It is the last product operation
+        # of the run, so it is held to the same bar as the ordered cases, not to its
+        # exit code alone.
         restore = run_update(directory, "run5-restore", local = True)
         assert restore.rc == 0, restore.log[-8000:]
-        if installed and latest and installed != latest:
+        _assert_install_working(install, before)
+        # Why the pass ran, read off the measured run's own log: the separate PyPI
+        # lookup above can fail or see another release than the one the update saw.
+        if UPGRADE_MARKER in run.log:
             # This run WAS an upgrade to PyPI's release, whose Node, sidecar, llama.cpp
             # and whisper.cpp pins can legitimately differ from the checkout's: it may
             # rebuild or download any of them, so nothing below can be asserted of it.
             pytest.skip("installed version is not PyPI's latest; the desktop no-op path was not taken")
-        # Equal versions (or none to compare) and the pass still ran: that is the
+        if PYPI_UNREACHABLE_MARKER in run.log or not latest:
+            # The product runs the pass on purpose when it cannot ask PyPI: correct
+            # behaviour, and nothing this case can judge.
+            pytest.skip("PyPI was unreachable; the desktop no-op path could not be judged")
+        if installed and latest and installed != latest:
+            pytest.skip("installed version is not PyPI's latest; the desktop no-op path was not taken")
+        # Equal versions and a reachable index, and the pass still ran: that is the
         # regression this case exists to catch, not a reason to look away.
         pytest.fail(
             f"the desktop update ran the dependency pass with unsloth {installed!r} installed "

--- a/tests/studio/install/test_update_idempotency.py
+++ b/tests/studio/install/test_update_idempotency.py
@@ -1010,13 +1010,17 @@ def test_the_desktop_update_path_does_no_network_work(install, settled):
             # This run WAS an upgrade to PyPI's release, whose Node, sidecar, llama.cpp
             # and whisper.cpp pins can legitimately differ from the checkout's: it may
             # rebuild or download any of them, so nothing below can be asserted of it.
-            pytest.skip("installed version is not PyPI's latest; the desktop no-op path was not taken")
+            pytest.skip(
+                "installed version is not PyPI's latest; the desktop no-op path was not taken"
+            )
         if PYPI_UNREACHABLE_MARKER in run.log or not latest:
             # The product runs the pass on purpose when it cannot ask PyPI: correct
             # behaviour, and nothing this case can judge.
             pytest.skip("PyPI was unreachable; the desktop no-op path could not be judged")
         if installed and latest and installed != latest:
-            pytest.skip("installed version is not PyPI's latest; the desktop no-op path was not taken")
+            pytest.skip(
+                "installed version is not PyPI's latest; the desktop no-op path was not taken"
+            )
         # Equal versions and a reachable index, and the pass still ran: that is the
         # regression this case exists to catch, not a reason to look away.
         pytest.fail(


### PR DESCRIPTION
## Summary

An opt-in end to end test that measures whether a second `studio update` does nothing: it installs, updates, snapshots the venv, runs the update again under a CONNECT proxy that attributes every byte per host, and asserts that the second run installs nothing, fetches no payloads and leaves the snapshot unchanged; a third run with every connection refused must succeed. Added to `studio-update-smoke.yml` on its Linux, macOS and Windows legs.

Stacked on #10651, which is what the offline leg exercises.

## What it checks

- Run 1 then run 2: exit 0, identical sorted freeze, identical manifest apart from `completed_at_ms`, identical prebuilt markers, sidecar directory mtimes and binary mtimes; zero bytes from `files.pythonhosted.org`, `objects.githubusercontent.com`, `release-assets.githubusercontent.com`, `nodejs.org`; the log contains `dependencies up to date` or every step `(satisfied, skipped)`, and `already matches` for llama.cpp, whisper.cpp and Node.
- Run 3 with the proxy refusing everything and `UV_OFFLINE=1`: zero connections succeed, exit 0, snapshot unchanged.
- Fault injection from the settled state: a truncated sidecar file rebuilds that sidecar only; a deleted manifest re-runs the pass with every gated step skipped and an identical freeze; an edited `studio.txt` runs exactly the studio step; a truncated `llama-quantize` reinstalls llama.cpp only; `UNSLOTH_STUDIO_FULL_DEPS=1` prints no skipped lines and leaves the freeze identical.

The proxy journals a refused connection before answering it, so a client that gives up early still shows up in the count. Per-run logs are uploaded as CI artifacts.

## Compatibility

Test-only; gated behind `UNSLOTH_IDEMPOTENCY_E2E=1` so it never runs in the default test session. The workflow legs run it after the existing smoke steps.

## Review follow-ups

- The three smoke jobs run the harness with setup-python's interpreter, which ships without pytest; each installs it first. Job timeouts are 60, 75 and 90 minutes so they cover the harness step they enclose.
- The proxy journal is unlinked before each run, so a retained artifacts directory cannot attribute the previous invocation's traffic to this one.
- Prebuilt markers are snapshotted as (digest, mtime) so a rewrite with identical bytes is a diff.
- The local no-op run requires both prebuilt fast-path lines (llama.cpp and whisper.cpp) and zero api.github.com connections.
- The non-local desktop case runs last. On a version-bump commit it is a real upgrade, and it restores the checkout with a `--local` update afterwards instead of leaving the released package behind for the cases after it.
- The snapshot records each distribution's RECORD mtime and size, so a reinstall at the same version is a diff; payload hosts are held to zero connections, not only zero bytes.
- The prebuilt roots follow setup.sh's UNSLOTH_HOME rule under a custom Studio home; the proxy publishes its active worker count and the settle wait reads it; the llama fault case deletes the binary on Windows, where the validator checks existence.
- The proxy counts a connection at accept; the desktop-path case is judged only when the version check short-circuited; the deleted-manifest case holds every component still; the workflow also runs on Node pin changes.
- A proxy worker still between accept and its record when the update finishes fails the run instead of being terminated; the measured child suppresses Windows profile proxy defaults so setup.ps1 cannot route around the logging proxy.
