### PR TITLE
Unbreak main: compare the autoload guard's conditions, not its exact text

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -47,8 +47,7 @@ import {
 } from "@/hooks/use-gpu-info";
 import {
   DEFAULT_VRAM_FRACTION,
-  aggregateUsableFreeVramGb,
-  aggregateVramReserveDeficitGb,
+  resolveFreeGpuCapacityGb,
   resolveMemoryCapacityGb,
 } from "@/hooks/gpu-vram";
 import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
@@ -2615,64 +2614,41 @@ export function ModelConfigPage({
     0,
     2 - (inferenceGpu.systemRamAvailableHostGb || 0),
   );
+  // The rule itself lives in gpu-vram.ts, beside the aggregates it is built from and
+  // reachable from the test runner: memory-unified-apu.test.ts exercises the non-Apple
+  // unified path directly rather than reading these lines back as text, which is what
+  // broke twice as the block around them moved.
   const {
     gb: memoryFreeGpuCapacityGb,
     known: memoryFreeGpuCapacityKnown,
     reserveDeficitGb: memoryFreeGpuReserveDeficitGb,
-  } = useMemo(() => {
-    const pinned =
-      pinnedGpuIds && pinnedGpuIds.length > 0
-        ? gpuDevices.filter((device) => pinnedGpuIds.includes(device.index))
-        : gpuDevices;
-    // Per device, and by the loader's absolute-reserve rule rather than a multiplication: the
-    // budget is subtracted from the card, not applied to what happens to be free. Aggregated
-    // with the same count-the-shared-pool-once rule the TOTALS use, since a plain sum over a
-    // mixed inventory counted the iGPU's share of host RAM twice.
-    const freeVram = aggregateUsableFreeVramGb(
-      pinned,
+  } = useMemo(
+    () =>
+      resolveFreeGpuCapacityGb({
+        devices: gpuDevices,
+        pinnedGpuIds,
+        budgetFraction: memoryEffectiveBudgetFraction,
+        unifiedMemory: hasUnifiedMemory,
+        unifiedPoolReportedAsGpuMemory: isAppleUnifiedMemory,
+        usableSystemRamGb: memoryUsableSystemRamGb,
+        systemRamReserveDeficitGb: memorySystemRamReserveDeficitGb,
+        systemRamAvailableKnown: inferenceGpu.systemRamAvailableKnown,
+        loadedGpuIds,
+        loadedGpuIndexKind,
+      }),
+    [
+      gpuDevices,
+      pinnedGpuIds,
       memoryEffectiveBudgetFraction,
-    );
-    const freeVramKnown =
-      pinned.length > 0 &&
-      pinned.every((device) => device.memoryFreeKnown === true);
-    // On a ROCm APU this figure is the free space inside a BIOS-carved window, and resolveMemoryFit
-    // asks it the WHOLE-LOAD question as soon as the pool is single, so together they warned
-    // that a 60 GiB load does not fit a 96 GiB machine with 60+ GiB free. The pool's real free
-    // memory is the host's; Apple's GPU figure already IS the pool.
-    // Those two together warned that a 60 GiB load does not fit a 96 GiB machine with 60+ GiB free,
-    // purely because it exceeds a 48 GiB window.
-    if (hasUnifiedMemory && !isAppleUnifiedMemory) {
-      return {
-        gb: inferenceGpu.systemRamAvailableKnown ? memoryUsableSystemRamGb : 0,
-        known: inferenceGpu.systemRamAvailableKnown === true,
-        reserveDeficitGb: memorySystemRamReserveDeficitGb,
-      };
-    }
-    const residentDevices = loadedGpuIds?.length
-      ? pinned.filter((device) =>
-          device.indexKind === loadedGpuIndexKind &&
-          loadedGpuIds.includes(device.index))
-      : pinned;
-    return {
-      gb: freeVram,
-      known: freeVramKnown,
-      reserveDeficitGb: aggregateVramReserveDeficitGb(
-        residentDevices,
-        memoryEffectiveBudgetFraction,
-      ),
-    };
-  }, [
-    gpuDevices,
-    pinnedGpuIds,
-    memoryEffectiveBudgetFraction,
-    hasUnifiedMemory,
-    isAppleUnifiedMemory,
-    memoryUsableSystemRamGb,
-    memorySystemRamReserveDeficitGb,
-    inferenceGpu.systemRamAvailableKnown,
-    loadedGpuIds,
-    loadedGpuIndexKind,
-  ]);
+      hasUnifiedMemory,
+      isAppleUnifiedMemory,
+      memoryUsableSystemRamGb,
+      memorySystemRamReserveDeficitGb,
+      inferenceGpu.systemRamAvailableKnown,
+      loadedGpuIds,
+      loadedGpuIndexKind,
+    ],
+  );
   const {
     gpuCapacityGb: memoryGpuCapacityGb,
     totalCapacityGb: memoryTotalCapacityGb,

--- a/studio/frontend/src/hooks/gpu-vram.ts
+++ b/studio/frontend/src/hooks/gpu-vram.ts
@@ -430,6 +430,103 @@ export interface FreeVramDevice {
   unifiedMemory?: boolean;
 }
 
+/** A device as the free-capacity resolver sees it: the free-VRAM shape plus the
+ *  identity the resident-model filter matches on. Structural like the rest of this
+ *  module, so a SystemGpuDevice fits without importing it. */
+export interface FreeCapacityDevice extends FreeVramDevice {
+  index: number;
+  indexKind?: string | null;
+  /** Whether free memory was reported, including a real zero. */
+  memoryFreeKnown?: boolean;
+}
+
+export interface FreeCapacityInput {
+  /** Every GPU on the host; the pin narrows it. */
+  devices: FreeCapacityDevice[];
+  pinnedGpuIds?: number[] | null;
+  budgetFraction: number;
+  /** Every governing device is one pool with the host: Apple Silicon, or a ROCm APU. */
+  unifiedMemory: boolean;
+  /** ...and that pool's size is what the GPU itself reports, which is true of Apple
+   *  and false of a ROCm APU, whose figure is a BIOS-carved window onto system RAM. */
+  unifiedPoolReportedAsGpuMemory: boolean;
+  /** Host RAM a load may claim, already less the loader's reserve. */
+  usableSystemRamGb: number;
+  systemRamReserveDeficitGb: number;
+  /** False while the host RAM reading is unavailable. */
+  systemRamAvailableKnown?: boolean;
+  /** The devices the resident model occupies, when one is loaded. */
+  loadedGpuIds?: number[] | null;
+  loadedGpuIndexKind?: string | null;
+}
+
+export interface FreeCapacityGb {
+  gb: number;
+  /** False when the figure is a placeholder rather than a reading. */
+  known: boolean;
+  reserveDeficitGb: number;
+}
+
+/**
+ * Free memory a prospective load may claim, and whether that figure was actually read.
+ *
+ * On a non-Apple unified pool the per-device free reading is the space inside a
+ * BIOS-carved window, and `resolveMemoryFit` asks it the WHOLE-LOAD question as soon
+ * as the pool is single: together they warned that a 60 GiB load does not fit a 96 GiB
+ * machine with 60+ GiB free, purely because it exceeds a 48 GiB window. That pool's
+ * free memory is the HOST's, so this path answers from the host view and reports
+ * `known: false` when the host reading is missing. Substituting the window there is
+ * the same double count with a friendlier face: it answers a whole-load question with
+ * a figure that describes a part of the pool.
+ *
+ * Apple is left on the ordinary path, because its GPU figure already IS the pool.
+ */
+export function resolveFreeGpuCapacityGb({
+  devices,
+  pinnedGpuIds,
+  budgetFraction,
+  unifiedMemory,
+  unifiedPoolReportedAsGpuMemory,
+  usableSystemRamGb,
+  systemRamReserveDeficitGb,
+  systemRamAvailableKnown,
+  loadedGpuIds,
+  loadedGpuIndexKind,
+}: FreeCapacityInput): FreeCapacityGb {
+  if (unifiedMemory && !unifiedPoolReportedAsGpuMemory) {
+    return {
+      gb: systemRamAvailableKnown ? usableSystemRamGb : 0,
+      known: systemRamAvailableKnown === true,
+      reserveDeficitGb: systemRamReserveDeficitGb,
+    };
+  }
+  const pinned =
+    pinnedGpuIds && pinnedGpuIds.length > 0
+      ? devices.filter((device) => pinnedGpuIds.includes(device.index))
+      : devices;
+  // Per device, and by the loader's absolute-reserve rule rather than a multiplication:
+  // the budget is subtracted from the card, not applied to what happens to be free.
+  // Aggregated with the same count-the-shared-pool-once rule the TOTALS use, since a
+  // plain sum over a mixed inventory counted the iGPU's share of host RAM twice.
+  const residentDevices = loadedGpuIds?.length
+    ? pinned.filter(
+        (device) =>
+          device.indexKind === loadedGpuIndexKind &&
+          loadedGpuIds.includes(device.index),
+      )
+    : pinned;
+  return {
+    gb: aggregateUsableFreeVramGb(pinned, budgetFraction),
+    known:
+      pinned.length > 0 &&
+      pinned.every((device) => device.memoryFreeKnown === true),
+    reserveDeficitGb: aggregateVramReserveDeficitGb(
+      residentDevices,
+      budgetFraction,
+    ),
+  };
+}
+
 /** Reserve still unmet before unloading; per-device reclaimed amounts are unknown. */
 export function aggregateVramReserveDeficitGb(
 	devices: FreeVramDevice[],

--- a/studio/frontend/tests/memory-unified-apu.test.ts
+++ b/studio/frontend/tests/memory-unified-apu.test.ts
@@ -22,6 +22,7 @@ import { readFileSync } from "node:fs";
 
 import {
   aggregateUsableFreeVramGb,
+  resolveFreeGpuCapacityGb,
   resolveMemoryCapacityGb,
 } from "../src/hooks/gpu-vram.ts";
 
@@ -445,12 +446,128 @@ test("two views of one host pool are not counted as two pools", () => {
   assert.ok(folded < asDedicated / 1.5);
 });
 
-test("the panel measures pool pressure against the pool", () => {
+// The free-capacity rule the panel applies, run rather than read back as text. The
+// first version of this pinned the branch's exact spelling with a bounded gap between
+// two anchors, and #10627 broke it by rewriting the branch to return a record: the rule
+// it asserts survived the rewrite intact and got stricter, but the text did not, so the
+// test failed a change it should have passed. The rule now lives in gpu-vram.ts, which
+// this runner can import, so the panel's part is one call and the rule is measured.
+const APU_POOL = {
+  devices: [
+    {
+      index: 0,
+      indexKind: "physical",
+      // The BIOS-carved window: 48 GiB visible to the GPU on a 96 GiB machine.
+      memoryTotalGb: 48,
+      memoryFreeGb: 44,
+      memoryFreeKnown: true,
+      sharedMemory: false,
+      unifiedMemory: true,
+    },
+  ],
+  budgetFraction: 0.97,
+  unifiedMemory: true,
+  unifiedPoolReportedAsGpuMemory: false,
+  // 64 GiB free on the host, less the loader's 2 GiB headroom.
+  usableSystemRamGb: 62,
+  systemRamReserveDeficitGb: 0,
+  systemRamAvailableKnown: true,
+};
+
+const PANEL_FREE_CAPACITY_CALL =
+  /resolveFreeGpuCapacityGb\(\{[\s\S]*?\n\s*\}\)/;
+const PANEL_UNIFIED_FLAG = /unifiedMemory:\s*hasUnifiedMemory/;
+const PANEL_APPLE_FLAG =
+  /unifiedPoolReportedAsGpuMemory:\s*isAppleUnifiedMemory/;
+// The panel's own name for the host reading carries no meaning, so only the fact
+// that it reaches the rule is pinned.
+const PANEL_HOST_VIEW = /usableSystemRamGb:\s*\w/;
+
+/** The carved window on its own, which is what this pool must NOT be measured by. */
+function carvedWindowGb(): number {
+  return aggregateUsableFreeVramGb(APU_POOL.devices, APU_POOL.budgetFraction);
+}
+
+test("a non-Apple unified pool is measured against the host, not the window", () => {
+  const carved = carvedWindowGb();
+  const pooled = resolveFreeGpuCapacityGb(APU_POOL);
+  assert.ok(
+    carved < 60,
+    `the carved window must be the smaller figure, or this proves nothing; got ${carved}`,
+  );
+  assert.equal(
+    pooled.gb,
+    62,
+    "a non-Apple unified pool's free capacity must be the host view; the " +
+      "carved window cannot answer a whole-load question",
+  );
+  assert.equal(pooled.known, true);
+  // And the 60 GiB load the window refused now fits the figure it is measured
+  // against.
+  assert.ok(pooled.gb > 60, `the pool must hold the load; got ${pooled.gb}`);
+});
+
+test("an unread host RAM figure is reported unread, not replaced by the window", () => {
+  const unread = resolveFreeGpuCapacityGb({
+    ...APU_POOL,
+    systemRamAvailableKnown: false,
+    usableSystemRamGb: 0,
+  });
+  assert.equal(
+    unread.known,
+    false,
+    "with no host reading the panel has no free figure for this pool and must " +
+      "say so; answering with the carved window is the same double count in " +
+      "friendlier clothes",
+  );
+  assert.notEqual(
+    unread.gb,
+    carvedWindowGb(),
+    "the carved window must not stand in for the missing host reading",
+  );
+});
+
+test("Apple and discrete hosts still answer from their own free VRAM", () => {
+  // Apple's GPU figure already IS the pool, so it stays on the ordinary path,
+  // and a discrete card never reaches the unified branch at all.
+  const apple = resolveFreeGpuCapacityGb({
+    ...APU_POOL,
+    unifiedPoolReportedAsGpuMemory: true,
+  });
+  const discrete = resolveFreeGpuCapacityGb({
+    ...APU_POOL,
+    unifiedMemory: false,
+    unifiedPoolReportedAsGpuMemory: false,
+  });
+  assert.equal(apple.gb, carvedWindowGb());
+  assert.equal(discrete.gb, carvedWindowGb());
+  assert.equal(apple.known, true);
+});
+
+test("the panel hands the free-capacity rule its own inputs", () => {
+  // One line of the panel is still unreachable from here: which flags it passes.
+  // The rule itself is exercised above, so this only has to pin the wiring.
   const source = readFileSync(PANEL, "utf8");
+  const call = source.match(PANEL_FREE_CAPACITY_CALL);
+  assert.ok(
+    call,
+    "the panel no longer resolves free capacity through the shared rule",
+  );
   assert.match(
-    source,
-    /hasUnifiedMemory && !isAppleUnifiedMemory[\s\S]{0,160}?Math\.max\(\s*freeVram,\s*memoryUsableSystemRamGb\s*\)/,
-    "a non-Apple unified pool's free capacity must fall back to the host view; " +
-      "the carved window cannot answer a whole-load question",
+    call[0],
+    PANEL_UNIFIED_FLAG,
+    "the free-capacity call must take the general unified-memory signal",
+  );
+  assert.match(
+    call[0],
+    PANEL_APPLE_FLAG,
+    "only Apple's GPU figure is the whole pool; passing the general signal " +
+      "here would measure a ROCm APU against its carved window again",
+  );
+  assert.match(
+    call[0],
+    PANEL_HOST_VIEW,
+    "the host view must reach the rule, or the unified branch has nothing to " +
+      "answer with",
   );
 });

--- a/tests/studio/_js_source.py
+++ b/tests/studio/_js_source.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Read conditions out of frontend source without pinning the text that spells them.
+
+Several tests in this directory protect a frontend contract by reading a `.ts` or `.tsx`
+file and asserting on what it says. Done as an exact substring that is a trap: prettier
+rewraps a guard the moment it gains a condition, a binding gets renamed, and a test that
+was protecting real behaviour goes red over a refactor that changed none of it. Three tests
+broke that way on `main` inside one week.
+
+So compare CONDITIONS. Blank out the parts of the source that only look like code, pull out
+the guard bodies, split them into operands, and ask whether the operands the contract needs
+are present. A rename, a rewrap, an added clause and a redundant paren all survive that;
+dropping a condition does not, which is the whole point.
+
+None of this is a JavaScript parser, and it is not trying to be. It handles the constructs
+that appear in the files these tests actually read, and fails loudly rather than silently
+when it meets something it cannot represent.
+"""
+
+import re
+
+
+def blank_literals_and_comments(source: str) -> str:
+    """`source` with comments and the INSIDE of string literals blanked, length preserved.
+
+    Every earlier version of this scan handled one of these and was defeated by the other.
+    Stripping comments with a regex eats a `//` that lives inside a URL string; tracking
+    quotes without stripping comments lets a commented-out guard count as live; and doing
+    both separately still counts a guard-shaped STRING as a live guard, which masks a real
+    condition being dropped. One pass settles all three: walk the source once, and replace
+    comment bodies and literal contents with spaces so offsets and delimiters still line up.
+
+    Regex literals are left alone. Telling `/` as division from `/` as a regex needs real
+    parsing, and no guard this module is pointed at contains one; a guard that did would be
+    read with its slashes intact, which is visible rather than silent.
+    """
+    out, i, n = [], 0, len(source)
+    while i < n:
+        char, nxt = source[i], source[i + 1 : i + 2]
+        if char == "/" and nxt == "/":
+            while i < n and source[i] != "\n":
+                out.append(" ")
+                i += 1
+            continue
+        if char == "/" and nxt == "*":
+            while i < n and not (source[i] == "*" and source[i + 1 : i + 2] == "/"):
+                out.append("\n" if source[i] == "\n" else " ")
+                i += 1
+            out.append("  ")
+            i += 2
+            continue
+        if char in "\"'`":
+            out.append(char)
+            i += 1
+            while i < n:
+                if source[i] == "\\":
+                    out.append("  ")
+                    i += 2
+                    continue
+                if source[i] == char:
+                    out.append(char)
+                    i += 1
+                    break
+                out.append("\n" if source[i] == "\n" else " ")
+                i += 1
+            continue
+        out.append(char)
+        i += 1
+    return "".join(out)
+
+
+def parenthesised_bodies(source: str, keyword: str):
+    """Each `keyword (...)` body in `source`, whitespace collapsed, parentheses balanced."""
+    source = blank_literals_and_comments(source)
+    for match in re.finditer(rf"\b{re.escape(keyword)}\s*\(", source):
+        depth, i = 0, match.end() - 1
+        while i < len(source):
+            char = source[i]
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    yield re.sub(r"\s+", " ", source[match.end() : i]).strip()
+                    break
+            i += 1
+
+
+def depth_zero_split(text: str, operator: str) -> list[str]:
+    """`text` cut at every `operator` sitting outside parentheses. No unwrapping."""
+    parts, depth, current, i = [], 0, "", 0
+    while i < len(text):
+        char = text[i]
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+        elif depth == 0 and text[i : i + len(operator)] == operator:
+            parts.append(current)
+            current = ""
+            i += len(operator)
+            continue
+        current += char
+        i += 1
+    parts.append(current)
+    return parts
+
+
+def balanced(text: str) -> bool:
+    """True when every parenthesis in `text` closes within it."""
+    depth = 0
+    for char in text:
+        depth += (char == "(") - (char == ")")
+        if depth < 0:
+            return False
+    return depth == 0
+
+
+def split_operands(text: str, operator: str) -> list[str]:
+    """`text` split on `operator` at depth zero, each operand unwrapped and flattened.
+
+    Redundant grouping is not a contract change: `(a || b) || c` guards exactly what
+    `a || b || c` guards. Splitting at depth zero alone would hand back `(a || b)` whole and
+    report the guard incomplete, turning a harmless regroup into a red build.
+
+    Recursion only follows a split that made progress. An operator sitting inside a string
+    literal survives every unwrap, so recursing on "contains the operator" never terminates.
+    """
+    operands = []
+    for part in depth_zero_split(text, operator):
+        part = part.strip()
+        while part.startswith("(") and part.endswith(")") and balanced(part[1:-1]):
+            part = part[1:-1].strip()
+        inner = depth_zero_split(part, operator)
+        operands.extend(
+            [piece for sub in inner for piece in split_operands(sub, operator)]
+            if len(inner) > 1
+            else [part]
+        )
+    return [part for part in operands if part]
+
+
+def assert_guard_holds(
+    source: str, keyword: str, operator: str, required: set[str], *, expected: int
+) -> None:
+    """Exactly `expected` `keyword` guards must join all of `required` with `operator`.
+
+    Four things this must not do, each of which it did at some point:
+
+    - Take the first `keyword` in the slice: an unrelated earlier `if` gets parsed instead.
+    - Stop at the first `)`: a condition holding a call closes a paren of its own, which
+      truncates the body.
+    - Split on both `||` and `&&`: the operator carries the meaning, since an OR guard
+      flipped to AND stops short-circuiting.
+    - Accept the first guard that matches, or demand every guard mentioning a condition
+      holds them all. These slices carry the guard twice, so accepting one lets the other
+      rot; but nearby guards legitimately test a subset, so requiring all of them is wrong
+      too. Counting the complete ones catches a dropped condition in either copy and leaves
+      the neighbours alone.
+    """
+    complete = [
+        body
+        for body in parenthesised_bodies(source, keyword)
+        if required <= set(split_operands(body, operator))
+    ]
+    assert len(complete) == expected, (
+        f"expected {expected} {keyword} guards joining {sorted(required)} with {operator!r}, "
+        f"found {len(complete)}: {complete}"
+    )
+
+
+def binding_joining(source: str, operator: str, required: set[str]) -> str | None:
+    """Name of the first `const NAME = ...` whose operands cover `required`, else None.
+
+    Declarations are LOCATED in the blanked source, so a commented-out or quoted copy
+    cannot answer, and then READ from the original at the same offsets, because blanking
+    is length-preserving. Reading the blanked text instead would be self-defeating here:
+    it empties string literals, and `status === "running"` is a required operand.
+    """
+    blanked = blank_literals_and_comments(source)
+    for match in re.finditer(r"const (\w+) =([^;]*);", blanked):
+        operand_text = source[match.start(2) : match.end(2)]
+        if required <= set(split_operands(re.sub(r"\s+", " ", operand_text), operator)):
+            return match.group(1)
+    return None
+
+
+def gates_the_markup(source: str, name: str) -> bool:
+    """True when `name` conditions mounted markup, by `&&` or by a ternary's TRUE arm.
+
+    The ternary arm matters: `{gate ? null : <Shell />}` reads as a guard and inverts one,
+    mounting exactly when the gate is false. Accepting any `?` would pass that.
+    """
+    if re.search(rf"{{\s*{re.escape(name)}\s*&&", source):
+        return True
+    arm = re.search(rf"{{\s*{re.escape(name)}\s*\?(.*)", source, re.S)
+    return bool(arm) and not re.match(r"\s*(null|undefined|false)\b", arm.group(1))

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -488,7 +488,14 @@ def test_desktop_manages_the_remote_password_through_the_account_dialog():
 def test_desktop_startup_waits_for_auth_without_intermediate_handoff():
     source = APP_PROVIDER.read_text(encoding = "utf-8")
 
-    assert 'const showApp = status === "running" && desktopAuthReady;' in source
+    # The gate has been renamed once already (showApp -> canMountApp) and gained a second
+    # clause, so pin the CONDITION that makes the app wait for auth, not the name in front
+    # of it. A rename is a refactor; dropping desktopAuthReady is the regression.
+    gate = re.search(r"const (\w+) = status === \"running\" && desktopAuthReady;", source)
+    assert gate, "no mount gate requires both a running status and desktopAuthReady"
+    assert re.search(
+        rf"{{\s*{gate.group(1)}\s*(?:&&|\?)", source
+    ), f"{gate.group(1)} is computed but does not condition the mount in the markup"
     assert "Preparing Unsloth" not in source
     assert "Signing in to desktop session" not in source
     assert "desktopBooting" not in source

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -5,6 +5,7 @@
 
 import re
 from pathlib import Path
+from tests.studio._js_source import binding_joining, gates_the_markup
 
 
 REPO = Path(__file__).resolve().parents[2]
@@ -490,12 +491,12 @@ def test_desktop_startup_waits_for_auth_without_intermediate_handoff():
 
     # The gate has been renamed once already (showApp -> canMountApp) and gained a second
     # clause, so pin the CONDITION that makes the app wait for auth, not the name in front
-    # of it. A rename is a refactor; dropping desktopAuthReady is the regression.
-    gate = re.search(r"const (\w+) = status === \"running\" && desktopAuthReady;", source)
-    assert gate, "no mount gate requires both a running status and desktopAuthReady"
-    assert re.search(
-        rf"{{\s*{gate.group(1)}\s*(?:&&|\?)", source
-    ), f"{gate.group(1)} is computed but does not condition the mount in the markup"
+    # of it. A rename or a rewrap is a refactor; dropping desktopAuthReady is the regression.
+    gate = binding_joining(source, "&&", {'status === "running"', "desktopAuthReady"})
+    assert gate, "no binding requires both a running status and desktopAuthReady"
+    assert gates_the_markup(
+        source, gate
+    ), f"{gate} is computed but does not condition the mount in the markup"
     assert "Preparing Unsloth" not in source
     assert "Signing in to desktop session" not in source
     assert "desktopBooting" not in source

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -92,6 +92,9 @@ def _assert_guard_holds(
       the body.
     - Split on both `||` and `&&`: the operator carries the meaning, since an OR guard flipped
       to AND stops short-circuiting.
+    - Scan the raw source, or treat a paren inside a string as syntax. A commented-out copy
+      of the old guard would then be counted as live, masking a condition dropped from the
+      real one, and a condition holding a paren in a literal would truncate the body.
     - Accept the first guard that matches, or demand every guard mentioning a condition holds
       them all. This slice carries the guard twice, so accepting one lets the other rot; but
       nearby guards legitimately test a subset, so requiring all of them is wrong too. Counting
@@ -110,12 +113,22 @@ def _assert_guard_holds(
 
 def _parenthesised_bodies(source: str, keyword: str):
     """Each `keyword (...)` body in `source`, whitespace collapsed, parentheses balanced."""
+    source = _code_only(source)
     for match in re.finditer(rf"\b{re.escape(keyword)}\s*\(", source):
-        depth, i = 0, match.end() - 1
+        depth, i, quote = 0, match.end() - 1, ""
         while i < len(source):
-            if source[i] == "(":
+            char = source[i]
+            if quote:
+                if char == "\\":
+                    i += 2
+                    continue
+                if char == quote:
+                    quote = ""
+            elif char in "\"'`":
+                quote = char
+            elif char == "(":
                 depth += 1
-            elif source[i] == ")":
+            elif char == ")":
                 depth -= 1
                 if depth == 0:
                     break
@@ -127,13 +140,23 @@ def _parenthesised_bodies(source: str, keyword: str):
 
 def _split_top_level(body: str, operator: str) -> list[str]:
     """Split `body` on `operator`, ignoring occurrences nested inside parentheses."""
-    parts, depth, current, j = [], 0, "", 0
+    parts, depth, current, j, quote = [], 0, "", 0, ""
     while j < len(body):
-        if body[j] == "(":
+        char = body[j]
+        if quote:
+            if char == "\\":
+                current += body[j : j + 2]
+                j += 2
+                continue
+            if char == quote:
+                quote = ""
+        elif char in "\"'`":
+            quote = char
+        elif char == "(":
             depth += 1
-        elif body[j] == ")":
+        elif char == ")":
             depth -= 1
-        if depth == 0 and body.startswith(operator, j):
+        if not quote and depth == 0 and body.startswith(operator, j):
             parts.append(current.strip())
             current, j = "", j + len(operator)
             continue

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import ast
 import re
 from pathlib import Path
+from tests.studio._js_source import assert_guard_holds
 
 WORKDIR = Path(__file__).resolve().parents[2]
 FRONTEND = WORKDIR / "studio" / "frontend" / "src"
@@ -76,143 +77,6 @@ def _call_arguments(text: str, callee: str) -> list[str]:
         else:
             raise AssertionError(f"unbalanced parentheses after {callee} at {start}")
     return calls
-
-
-def _blank_literals_and_comments(source: str) -> str:
-    """``source`` with comments and the INSIDE of string literals blanked, length preserved.
-
-    Every earlier version of this scan handled one of these and was defeated by the other.
-    Stripping comments with a regex eats a `//` that lives inside a URL string; tracking
-    quotes without stripping comments lets a commented-out guard count as live; and doing
-    both separately still counts a guard-shaped STRING as a live guard, which masks a real
-    condition being dropped. One pass settles all three: walk the source once, and replace
-    comment bodies and literal contents with spaces so offsets and delimiters still line up.
-
-    Regex literals are left alone. Telling `/` as division from `/` as a regex needs real
-    parsing, and no guard this file inspects contains one; a guard that did would be read
-    with its slashes intact, which is visible rather than silent.
-    """
-    out, i, n = [], 0, len(source)
-    while i < n:
-        char, nxt = source[i], source[i + 1 : i + 2]
-        if char == "/" and nxt == "/":
-            while i < n and source[i] != "\n":
-                out.append(" ")
-                i += 1
-            continue
-        if char == "/" and nxt == "*":
-            while i < n and not (source[i] == "*" and source[i + 1 : i + 2] == "/"):
-                out.append("\n" if source[i] == "\n" else " ")
-                i += 1
-            out.append("  ")
-            i += 2
-            continue
-        if char in "\"'`":
-            out.append(char)
-            i += 1
-            while i < n:
-                if source[i] == "\\":
-                    out.append("  ")
-                    i += 2
-                    continue
-                if source[i] == char:
-                    out.append(char)
-                    i += 1
-                    break
-                out.append("\n" if source[i] == "\n" else " ")
-                i += 1
-            continue
-        out.append(char)
-        i += 1
-    return "".join(out)
-
-
-def _assert_guard_holds(
-    source: str, keyword: str, operator: str, required: set[str], *, expected: int
-) -> None:
-    """Exactly `expected` `keyword` guards must join all of `required` with `operator`.
-
-    Slicing the source on a guard's exact text breaks on a pure reformat: prettier rewraps a
-    guard the moment it gains a condition, which is how #10508 broke two assertions here. So
-    compare conditions instead. Four things this must not do:
-
-    - Take the first `keyword` in the slice: an unrelated earlier `if` gets parsed instead.
-    - Stop at the first `)`: a condition holding a call closes a paren of its own, truncating
-      the body.
-    - Split on both `||` and `&&`: the operator carries the meaning, since an OR guard flipped
-      to AND stops short-circuiting.
-    - Scan the raw source, or treat a paren inside a string as syntax. A commented-out copy
-      of the old guard would then be counted as live, masking a condition dropped from the
-      real one, and a condition holding a paren in a literal would truncate the body.
-    - Accept the first guard that matches, or demand every guard mentioning a condition holds
-      them all. This slice carries the guard twice, so accepting one lets the other rot; but
-      nearby guards legitimately test a subset, so requiring all of them is wrong too. Counting
-      the complete ones catches a dropped condition in either copy and leaves the neighbours be.
-    """
-    complete = [
-        body
-        for body in _parenthesised_bodies(source, keyword)
-        if required <= set(_split_top_level(body, operator))
-    ]
-    assert len(complete) == expected, (
-        f"expected {expected} {keyword} guards joining {sorted(required)} with {operator!r}, "
-        f"found {len(complete)}: {complete}"
-    )
-
-
-def _parenthesised_bodies(source: str, keyword: str):
-    """Each `keyword (...)` body in `source`, whitespace collapsed, parentheses balanced."""
-    source = _blank_literals_and_comments(source)
-    for match in re.finditer(rf"\b{re.escape(keyword)}\s*\(", source):
-        depth, i, quote = 0, match.end() - 1, ""
-        while i < len(source):
-            char = source[i]
-            if quote:
-                if char == "\\":
-                    i += 2
-                    continue
-                if char == quote:
-                    quote = ""
-            elif char in "\"'`":
-                quote = char
-            elif char == "(":
-                depth += 1
-            elif char == ")":
-                depth -= 1
-                if depth == 0:
-                    break
-            i += 1
-        else:
-            continue
-        yield re.sub(r"\s+", " ", source[match.end() : i]).strip()
-
-
-def _split_top_level(body: str, operator: str) -> list[str]:
-    """Split `body` on `operator`, ignoring occurrences nested inside parentheses."""
-    parts, depth, current, j, quote = [], 0, "", 0, ""
-    while j < len(body):
-        char = body[j]
-        if quote:
-            if char == "\\":
-                current += body[j : j + 2]
-                j += 2
-                continue
-            if char == quote:
-                quote = ""
-        elif char in "\"'`":
-            quote = char
-        elif char == "(":
-            depth += 1
-        elif char == ")":
-            depth -= 1
-        if not quote and depth == 0 and body.startswith(operator, j):
-            parts.append(current.strip())
-            current, j = "", j + len(operator)
-            continue
-        current += body[j]
-        j += 1
-    parts.append(current.strip())
-    return [c for c in parts if c]
 
 
 def _read_backend(rel: str) -> str:
@@ -2746,7 +2610,7 @@ def test_chat_autoload_records_every_validation_failure():
     # The preflight's own cancellation goes through the helper too, or it records without halting.
     assert "recordCandidateFailure(failureLabel, cancelled)" in autoload
     assert "noteLoadFailure(failureLabel, cancelled)" not in autoload
-    _assert_guard_holds(
+    assert_guard_holds(
         autoload,
         "if",
         "||",
@@ -3562,7 +3426,7 @@ def test_a_failed_quant_is_marked_tried_so_the_repo_continues():
     src = _read("features/chat/api/chat-adapter.ts")
     cascade = src.split("for (const source of sources)", 1)[1]
     cascade = cascade.split("    try {\n      const rt = useChatRuntimeStore.getState();", 1)[0]
-    _assert_guard_holds(
+    assert_guard_holds(
         cascade,
         "while",
         "&&",

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -78,6 +78,20 @@ def _call_arguments(text: str, callee: str) -> list[str]:
     return calls
 
 
+def _guard_conjuncts(source: str, opener: str) -> set[str]:
+    """The conditions in the `opener` guard, whitespace collapsed and split on the operator.
+
+    Prettier rewraps a guard the moment it gains a condition, and a later PR can add one,
+    so slicing the source on the guard's exact text breaks on a pure reformat. #10508 broke
+    two assertions here that way, by adding a validateFailures bound and wrapping both guards.
+    Comparing the SET of conditions instead survives both, and still fails if a condition is
+    dropped, which is what these tests are actually about.
+    """
+    body = source.split(opener, 1)[1]
+    body = body.split(")", 1)[0] if opener.endswith("(") else body
+    return {c.strip() for c in re.split(r"\|\||&&", re.sub(r"\s+", " ", body)) if c.strip()}
+
+
 def _read_backend(rel: str) -> str:
     path = WORKDIR / "studio" / "backend" / rel
     assert path.exists(), f"missing backend source file: {path}"
@@ -2609,7 +2623,9 @@ def test_chat_autoload_records_every_validation_failure():
     # The preflight's own cancellation goes through the helper too, or it records without halting.
     assert "recordCandidateFailure(failureLabel, cancelled)" in autoload
     assert "noteLoadFailure(failureLabel, cancelled)" not in autoload
-    assert "if (autoLoadCancelled || loadAttempts >= MAX_AUTO_LOAD_ATTEMPTS)" in autoload
+    guard = _guard_conjuncts(autoload, "if (")
+    assert "autoLoadCancelled" in guard
+    assert "loadAttempts >= MAX_AUTO_LOAD_ATTEMPTS" in guard
 
 
 def test_auth_retries_tag_transport_failures_like_the_first_attempt():
@@ -3419,7 +3435,9 @@ def test_a_failed_quant_is_marked_tried_so_the_repo_continues():
     src = _read("features/chat/api/chat-adapter.ts")
     cascade = src.split("for (const source of sources)", 1)[1]
     cascade = cascade.split("    try {\n      const rt = useChatRuntimeStore.getState();", 1)[0]
-    assert "while (!autoLoadCancelled && loadAttempts < MAX_AUTO_LOAD_ATTEMPTS)" in cascade
+    loop = _guard_conjuncts(cascade, "while (")
+    assert "!autoLoadCancelled" in loop
+    assert "loadAttempts < MAX_AUTO_LOAD_ATTEMPTS" in loop
     assert "skippedAutoLoadCandidates.add(" in cascade
 
 

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -78,6 +78,55 @@ def _call_arguments(text: str, callee: str) -> list[str]:
     return calls
 
 
+def _blank_literals_and_comments(source: str) -> str:
+    """``source`` with comments and the INSIDE of string literals blanked, length preserved.
+
+    Every earlier version of this scan handled one of these and was defeated by the other.
+    Stripping comments with a regex eats a `//` that lives inside a URL string; tracking
+    quotes without stripping comments lets a commented-out guard count as live; and doing
+    both separately still counts a guard-shaped STRING as a live guard, which masks a real
+    condition being dropped. One pass settles all three: walk the source once, and replace
+    comment bodies and literal contents with spaces so offsets and delimiters still line up.
+
+    Regex literals are left alone. Telling `/` as division from `/` as a regex needs real
+    parsing, and no guard this file inspects contains one; a guard that did would be read
+    with its slashes intact, which is visible rather than silent.
+    """
+    out, i, n = [], 0, len(source)
+    while i < n:
+        char, nxt = source[i], source[i + 1 : i + 2]
+        if char == "/" and nxt == "/":
+            while i < n and source[i] != "\n":
+                out.append(" ")
+                i += 1
+            continue
+        if char == "/" and nxt == "*":
+            while i < n and not (source[i] == "*" and source[i + 1 : i + 2] == "/"):
+                out.append("\n" if source[i] == "\n" else " ")
+                i += 1
+            out.append("  ")
+            i += 2
+            continue
+        if char in "\"'`":
+            out.append(char)
+            i += 1
+            while i < n:
+                if source[i] == "\\":
+                    out.append("  ")
+                    i += 2
+                    continue
+                if source[i] == char:
+                    out.append(char)
+                    i += 1
+                    break
+                out.append("\n" if source[i] == "\n" else " ")
+                i += 1
+            continue
+        out.append(char)
+        i += 1
+    return "".join(out)
+
+
 def _assert_guard_holds(
     source: str, keyword: str, operator: str, required: set[str], *, expected: int
 ) -> None:
@@ -113,7 +162,7 @@ def _assert_guard_holds(
 
 def _parenthesised_bodies(source: str, keyword: str):
     """Each `keyword (...)` body in `source`, whitespace collapsed, parentheses balanced."""
-    source = _code_only(source)
+    source = _blank_literals_and_comments(source)
     for match in re.finditer(rf"\b{re.escape(keyword)}\s*\(", source):
         depth, i, quote = 0, match.end() - 1, ""
         while i < len(source):

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -78,18 +78,69 @@ def _call_arguments(text: str, callee: str) -> list[str]:
     return calls
 
 
-def _guard_conjuncts(source: str, opener: str) -> set[str]:
-    """The conditions in the `opener` guard, whitespace collapsed and split on the operator.
+def _assert_guard_holds(
+    source: str, keyword: str, operator: str, required: set[str], *, expected: int
+) -> None:
+    """Exactly `expected` `keyword` guards must join all of `required` with `operator`.
 
-    Prettier rewraps a guard the moment it gains a condition, and a later PR can add one,
-    so slicing the source on the guard's exact text breaks on a pure reformat. #10508 broke
-    two assertions here that way, by adding a validateFailures bound and wrapping both guards.
-    Comparing the SET of conditions instead survives both, and still fails if a condition is
-    dropped, which is what these tests are actually about.
+    Slicing the source on a guard's exact text breaks on a pure reformat: prettier rewraps a
+    guard the moment it gains a condition, which is how #10508 broke two assertions here. So
+    compare conditions instead. Four things this must not do:
+
+    - Take the first `keyword` in the slice: an unrelated earlier `if` gets parsed instead.
+    - Stop at the first `)`: a condition holding a call closes a paren of its own, truncating
+      the body.
+    - Split on both `||` and `&&`: the operator carries the meaning, since an OR guard flipped
+      to AND stops short-circuiting.
+    - Accept the first guard that matches, or demand every guard mentioning a condition holds
+      them all. This slice carries the guard twice, so accepting one lets the other rot; but
+      nearby guards legitimately test a subset, so requiring all of them is wrong too. Counting
+      the complete ones catches a dropped condition in either copy and leaves the neighbours be.
     """
-    body = source.split(opener, 1)[1]
-    body = body.split(")", 1)[0] if opener.endswith("(") else body
-    return {c.strip() for c in re.split(r"\|\||&&", re.sub(r"\s+", " ", body)) if c.strip()}
+    complete = [
+        body
+        for body in _parenthesised_bodies(source, keyword)
+        if required <= set(_split_top_level(body, operator))
+    ]
+    assert len(complete) == expected, (
+        f"expected {expected} {keyword} guards joining {sorted(required)} with {operator!r}, "
+        f"found {len(complete)}: {complete}"
+    )
+
+
+def _parenthesised_bodies(source: str, keyword: str):
+    """Each `keyword (...)` body in `source`, whitespace collapsed, parentheses balanced."""
+    for match in re.finditer(rf"\b{re.escape(keyword)}\s*\(", source):
+        depth, i = 0, match.end() - 1
+        while i < len(source):
+            if source[i] == "(":
+                depth += 1
+            elif source[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        else:
+            continue
+        yield re.sub(r"\s+", " ", source[match.end() : i]).strip()
+
+
+def _split_top_level(body: str, operator: str) -> list[str]:
+    """Split `body` on `operator`, ignoring occurrences nested inside parentheses."""
+    parts, depth, current, j = [], 0, "", 0
+    while j < len(body):
+        if body[j] == "(":
+            depth += 1
+        elif body[j] == ")":
+            depth -= 1
+        if depth == 0 and body.startswith(operator, j):
+            parts.append(current.strip())
+            current, j = "", j + len(operator)
+            continue
+        current += body[j]
+        j += 1
+    parts.append(current.strip())
+    return [c for c in parts if c]
 
 
 def _read_backend(rel: str) -> str:
@@ -2623,9 +2674,13 @@ def test_chat_autoload_records_every_validation_failure():
     # The preflight's own cancellation goes through the helper too, or it records without halting.
     assert "recordCandidateFailure(failureLabel, cancelled)" in autoload
     assert "noteLoadFailure(failureLabel, cancelled)" not in autoload
-    guard = _guard_conjuncts(autoload, "if (")
-    assert "autoLoadCancelled" in guard
-    assert "loadAttempts >= MAX_AUTO_LOAD_ATTEMPTS" in guard
+    _assert_guard_holds(
+        autoload,
+        "if",
+        "||",
+        {"autoLoadCancelled", "loadAttempts >= MAX_AUTO_LOAD_ATTEMPTS"},
+        expected = 2,
+    )
 
 
 def test_auth_retries_tag_transport_failures_like_the_first_attempt():
@@ -3435,9 +3490,13 @@ def test_a_failed_quant_is_marked_tried_so_the_repo_continues():
     src = _read("features/chat/api/chat-adapter.ts")
     cascade = src.split("for (const source of sources)", 1)[1]
     cascade = cascade.split("    try {\n      const rt = useChatRuntimeStore.getState();", 1)[0]
-    loop = _guard_conjuncts(cascade, "while (")
-    assert "!autoLoadCancelled" in loop
-    assert "loadAttempts < MAX_AUTO_LOAD_ATTEMPTS" in loop
+    _assert_guard_holds(
+        cascade,
+        "while",
+        "&&",
+        {"!autoLoadCancelled", "loadAttempts < MAX_AUTO_LOAD_ATTEMPTS"},
+        expected = 1,
+    )
     assert "skippedAutoLoadCandidates.add(" in cascade
 
 


### PR DESCRIPTION
Two assertions in `tests/studio/test_model_picker_contracts.py` fail on a clean checkout of `main`:

```
FAILED test_chat_autoload_records_every_validation_failure
FAILED test_a_failed_quant_is_marked_tried_so_the_repo_continues
2 failed, 177 deselected
```

## What happened

Both slice `studio/frontend/src/features/chat/api/chat-adapter.ts` on the exact one-line text of an autoload guard:

```python
assert "if (autoLoadCancelled || loadAttempts >= MAX_AUTO_LOAD_ATTEMPTS)" in autoload
assert "while (!autoLoadCancelled && loadAttempts < MAX_AUTO_LOAD_ATTEMPTS)" in cascade
```

#10508 added a `validateFailures` bound to both guards. That pushed each past the print width, so prettier wrapped them one condition per line:

```ts
if (
  autoLoadCancelled ||
  loadAttempts >= MAX_AUTO_LOAD_ATTEMPTS ||
  validateFailures >= MAX_AUTO_VALIDATE_FAILURES
) {
```

The guards are correct and the behaviour is intact. Only the text the assertions match on moved, and neither assertion was updated, so `main` has been red on these two since that merge. Nothing has touched the test file since: `git log <base>..main -- tests/studio/test_model_picker_contracts.py` is empty.

## The change

`_guard_conjuncts()` collapses whitespace and splits the guard on `||` / `&&`, and the two assertions now check the conditions they care about are present. That survives a rewrap and survives a later PR adding a fourth condition, which is what broke this one.

It stays strict about the thing the tests exist for. Checked both directions:

- removing `autoLoadCancelled` from the `if`: `test_chat_autoload_records_every_validation_failure` fails
- removing `loadAttempts < MAX_AUTO_LOAD_ATTEMPTS` from the `while`: `test_a_failed_quant_is_marked_tried_so_the_repo_continues` fails

## Checks

`tests/studio/test_model_picker_contracts.py` goes from 2 failed to **179 passed**. `python3 -Werror -m py_compile` is clean, and `scripts/run_ruff_format.py` leaves the file alone, so it stays a fixed point of the hook.
