### PR TITLE
Add durable project task ownership and bounded execution lanes

### DIFF
--- a/.github/workflows/studio-project-tasks-ci.yml
+++ b/.github/workflows/studio-project-tasks-ci.yml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+name: Studio project task engine
+
+on:
+  pull_request:
+    paths:
+      - 'studio/backend/core/agent_workspace/task_*.py'
+      - 'studio/backend/storage/studio_db.py'
+      - 'studio/backend/tests/test_project_task_state.py'
+      - 'studio/backend/tests/test_chat_history_storage.py'
+      - '.github/workflows/studio-project-tasks-ci.yml'
+  merge_group:
+  push:
+    branches: [main, 'codex/project-tasks-*']
+    paths:
+      - 'studio/backend/core/agent_workspace/task_*.py'
+      - 'studio/backend/storage/studio_db.py'
+      - 'studio/backend/tests/test_project_task_state.py'
+      - 'studio/backend/tests/test_chat_history_storage.py'
+      - '.github/workflows/studio-project-tasks-ci.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  task-engine:
+    name: tasks (${{ matrix.os }}, Python ${{ matrix.python }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, windows-latest, macos-15]
+        python: ['3.11', '3.12']
+    env:
+      PYTHONIOENCODING: utf-8
+      PYTHONUTF8: '1'
+      UNSLOTH_STUDIO_DISABLE_DEVICE_PROBE: '1'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install focused test dependencies
+        run: python -m pip install pytest pytest-timeout structlog rich psutil huggingface-hub
+      - name: Check task ownership, scheduling, and project storage
+        working-directory: studio/backend
+        run: >-
+          python -m pytest tests/test_project_task_state.py tests/test_chat_history_storage.py
+          -q --tb=short --timeout=30

--- a/.github/workflows/studio-project-tasks-ci.yml
+++ b/.github/workflows/studio-project-tasks-ci.yml
@@ -52,8 +52,15 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install focused test dependencies
         run: python -m pip install pytest pytest-timeout structlog rich psutil huggingface-hub
-      - name: Check task ownership, scheduling, and project storage
+      - name: Check task ownership and scheduling
         working-directory: studio/backend
         run: >-
-          python -m pytest tests/test_project_task_state.py tests/test_chat_history_storage.py
+          python -m pytest tests/test_project_task_state.py
           -q --tb=short --timeout=30
+      - name: Check adjacent project storage
+        working-directory: studio/backend
+        # The 900-thread storage fixture performs thousands of durable commits;
+        # allow Windows filesystem latency without weakening task-engine timeouts.
+        run: >-
+          python -m pytest tests/test_chat_history_storage.py
+          -q --tb=short --timeout=120

--- a/studio/backend/core/agent_workspace/task_runner.py
+++ b/studio/backend/core/agent_workspace/task_runner.py
@@ -332,9 +332,10 @@ class ProjectTaskRunner:
                     context.check()
                 except TaskCancelled:
                     status = "cancelled"
-                except Exception as exc:
+                except BaseException as exc:
                     # Exceptions can contain provider credentials. Persist a
                     # bounded generic diagnostic; the executor owns safe detail.
+                    # SystemExit from an executor must not kill this worker lane.
                     status = "failed"
                     result = None
                     error = f"Task executor failed ({type(exc).__name__})."

--- a/studio/backend/core/agent_workspace/task_runner.py
+++ b/studio/backend/core/agent_workspace/task_runner.py
@@ -1,0 +1,370 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Bounded execution lanes for durable project tasks.
+
+The executor is trusted server code. It must enforce the captured runtime and
+workspace policy, check ownership before each operation, pass cancellation to
+active operations, and release any model admission lease before waiting for a
+child. This engine owns scheduling; it does not confer tool or filesystem access.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import math
+import queue
+import threading
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from . import task_state as state
+
+log = logging.getLogger(__name__)
+
+
+class TaskCancelled(state.TaskStateError):
+    pass
+
+
+@dataclass(frozen = True)
+class TaskContext:
+    """One attempt's private capability, never a renderer-supplied session ID."""
+
+    _runner: ProjectTaskRunner = field(repr = False)
+    _work: _Work = field(repr = False)
+
+    @property
+    def task(self) -> dict:
+        return copy.deepcopy(self._work.task)
+
+    @property
+    def cancel_event(self) -> threading.Event:
+        return self._work.cancel
+
+    @property
+    def deadline(self) -> float:
+        return self._work.deadline
+
+    def check(self) -> dict:
+        if self.cancel_event.is_set() or time.monotonic() >= self.deadline:
+            raise TaskCancelled("Task cancellation or deadline reached.")
+        return state.validate_owner(self._work.task["id"], self._work.owner)
+
+    def delegate(
+        self,
+        instruction: str,
+        *,
+        role: str,
+        max_output_tokens: int = 4096,
+    ) -> dict:
+        self.check()
+        return self._runner._delegate(self._work, instruction, role, max_output_tokens)
+
+    def wait_child(
+        self,
+        task_id: str,
+        *,
+        timeout: float = 60,
+    ) -> dict | None:
+        self.check()
+        child = state.get_task(self._work.task["projectId"], task_id)
+        if child["parentId"] != self._work.task["id"]:
+            raise state.TaskStateError("Only this attempt's children can be awaited.")
+        return self._runner.wait(child["projectId"], task_id, timeout = timeout, check = self.check)
+
+    def retry_child(self, task_id: str) -> dict:
+        self.check()
+        child = state.get_task(self._work.task["projectId"], task_id)
+        if child["parentId"] != self._work.task["id"]:
+            raise state.TaskStateError("Only this attempt's children can be retried.")
+        return self._runner._retry(child, parent = self._work)
+
+
+@dataclass
+class _Work:
+    task: dict
+    owner: str
+    deadline: float
+    cancel: threading.Event = field(default_factory = threading.Event)
+
+
+def _seconds(value: float, maximum: float) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or not 0 < value <= maximum
+    ):
+        raise state.TaskStateError("Invalid task time bound.")
+    return float(value)
+
+
+class ProjectTaskRunner:
+    """Explicit submission only: opening a runner never replays stored work."""
+
+    def __init__(
+        self,
+        executor: Callable[[TaskContext], dict],
+        *,
+        root_workers: int = 2,
+        child_workers: int = 2,
+        heartbeat_seconds: float = 1,
+        drain_seconds: float = 10,
+    ):
+        if not callable(executor):
+            raise TypeError("A server task executor is required.")
+        state._integer(root_workers, 1, 4, "root-worker bound")
+        state._integer(child_workers, 1, 8, "child-worker bound")
+        self._heartbeat_seconds = _seconds(heartbeat_seconds, state.LEASE_MS / 3000)
+        self._drain_seconds = _seconds(drain_seconds, 30)
+        self._executor = executor
+        self._condition = threading.Condition(threading.RLock())
+        self._work: dict[str, _Work] = {}
+        self._closing = False
+        self._lanes = {
+            "root": queue.Queue(maxsize = state.MAX_ACTIVE_TASKS),
+            "child": queue.Queue(maxsize = state.MAX_ACTIVE_TASKS),
+        }
+        self._workers = []
+        state.reconcile_expired_tasks()
+        for lane, count in (("root", root_workers), ("child", child_workers)):
+            for index in range(count):
+                thread = threading.Thread(
+                    target = self._worker,
+                    args = (lane,),
+                    daemon = True,
+                    name = f"studio-task-{lane}-{index}",
+                )
+                self._workers.append(thread)
+                thread.start()
+        self._watcher = threading.Thread(target = self._watch, daemon = True, name = "studio-task-leases")
+        self._watcher.start()
+
+    def _open(self):
+        if self._closing:
+            raise state.TaskStateError("The task runner is shutting down.")
+
+    def _enqueue(self, task: dict, deadline: float) -> dict:
+        owner = str(uuid.uuid4())
+        state.reserve_dispatch(task["projectId"], task["id"], owner)
+        work = _Work(task = task, owner = owner, deadline = deadline)
+        lane = "child" if task["parentId"] else "root"
+        try:
+            with self._condition:
+                self._open()
+                self._work[task["id"]] = work
+                try:
+                    self._lanes[lane].put_nowait(work)
+                except queue.Full:
+                    self._work.pop(task["id"], None)
+                    raise state.TaskStateError("The task worker queue is full.") from None
+                self._condition.notify_all()
+        except state.TaskStateError:
+            state.cancel_task(task["projectId"], task["id"])
+            raise
+        return task
+
+    def submit(
+        self,
+        project_id: str,
+        instruction: str,
+        snapshot: dict,
+        *,
+        max_output_tokens: int = 8192,
+        child_limit: int = 0,
+        child_budget: int = 0,
+        timeout: float = 900,
+    ) -> dict:
+        duration = _seconds(timeout, 3600)
+        with self._condition:
+            self._open()
+        task = state.create_task(
+            project_id,
+            instruction,
+            snapshot,
+            max_output_tokens = max_output_tokens,
+            child_limit = child_limit,
+            child_budget = child_budget,
+        )
+        return self._enqueue(task, time.monotonic() + duration)
+
+    def _delegate(self, parent: _Work, instruction: str, role: str, max_output_tokens: int) -> dict:
+        with self._condition:
+            self._open()
+        task = state.create_child(
+            parent.task["id"],
+            parent.owner,
+            instruction,
+            parent.task["snapshot"],
+            role = role,
+            max_output_tokens = max_output_tokens,
+        )
+        return self._enqueue(task, parent.deadline)
+
+    def _retry(
+        self,
+        task: dict,
+        *,
+        parent: _Work | None = None,
+        timeout: float = 900,
+    ) -> dict:
+        duration = _seconds(timeout, 3600)
+        with self._condition:
+            self._open()
+            if task["id"] in self._work or (
+                parent is None
+                and any(w.task["rootId"] == task["rootId"] for w in self._work.values())
+            ):
+                raise state.TaskStateError("The previous attempt's workers have not stopped.")
+        retried = state.retry_task(
+            task["projectId"], task["id"], parent_owner = parent.owner if parent else None
+        )
+        return self._enqueue(retried, parent.deadline if parent else time.monotonic() + duration)
+
+    def retry(
+        self,
+        project_id: str,
+        task_id: str,
+        *,
+        timeout: float = 900,
+    ) -> dict:
+        task = state.get_task(project_id, task_id)
+        if task["parentId"]:
+            raise state.TaskStateError("Child retries require the active parent worker.")
+        return self._retry(task, timeout = timeout)
+
+    def cancel(self, project_id: str, task_id: str) -> dict:
+        with self._condition:
+            for work in self._work.values():
+                if work.task["projectId"] == project_id and (
+                    work.task["id"] == task_id or work.task["parentId"] == task_id
+                ):
+                    work.cancel.set()
+            self._condition.notify_all()
+        return state.cancel_task(project_id, task_id)
+
+    def project_is_idle(self, project_id: str) -> bool:
+        """Durable expiry alone cannot prove an in-process executor has stopped."""
+        with self._condition:
+            if any(work.task["projectId"] == project_id for work in self._work.values()):
+                return False
+        return not state.project_has_active_tasks(project_id)
+
+    def wait(
+        self,
+        project_id: str,
+        task_id: str,
+        *,
+        timeout: float = 60,
+        check: Callable[[], object] | None = None,
+    ) -> dict | None:
+        deadline = time.monotonic() + _seconds(timeout, 3600)
+        while True:
+            if check is not None:
+                check()
+            row = state.get_task(project_id, task_id)
+            with self._condition:
+                if row["status"] in state.TERMINAL and task_id not in self._work:
+                    return row
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return None
+                self._condition.wait(min(remaining, 0.05))
+
+    def _watch(self):
+        while True:
+            with self._condition:
+                if self._closing and not self._work:
+                    return
+                work_items = list(self._work.values())
+            for work in work_items:
+                try:
+                    if work.cancel.is_set() or time.monotonic() >= work.deadline:
+                        self.cancel(work.task["projectId"], work.task["id"])
+                    if not state.heartbeat(work.task["id"], work.owner):
+                        work.cancel.set()
+                except state.TaskStateError:
+                    work.cancel.set()
+                except Exception:
+                    work.cancel.set()
+                    log.exception("Failed to renew project task ownership")
+            with self._condition:
+                self._condition.wait(self._heartbeat_seconds)
+
+    def _settle_children(self, work: _Work) -> bool:
+        children = state.list_children(work.task["projectId"], work.task["id"])
+        for child in children:
+            if child["status"] not in state.TERMINAL:
+                self.cancel(child["projectId"], child["id"])
+        deadline = time.monotonic() + self._drain_seconds
+        for child in children:
+            remaining = deadline - time.monotonic()
+            if (
+                remaining <= 0
+                or self.wait(child["projectId"], child["id"], timeout = remaining) is None
+            ):
+                return False
+        return True
+
+    def _worker(self, lane: str):
+        while True:
+            try:
+                work = self._lanes[lane].get(timeout = 0.05)
+            except queue.Empty:
+                with self._condition:
+                    if self._closing:
+                        return
+                continue
+            try:
+                work.task = state.claim_task(work.task["projectId"], work.task["id"], work.owner)
+                context = TaskContext(self, work)
+                result, error, status = None, None, "completed"
+                try:
+                    context.check()
+                    result = self._executor(context)
+                    if not isinstance(result, dict):
+                        raise state.TaskStateError("A task executor must return an object.")
+                    state._json(result, 1024 * 1024, "Task result")
+                    context.check()
+                except TaskCancelled:
+                    status = "cancelled"
+                except Exception as exc:
+                    # Exceptions can contain provider credentials. Persist a
+                    # bounded generic diagnostic; the executor owns safe detail.
+                    status = "failed"
+                    result = None
+                    error = f"Task executor failed ({type(exc).__name__})."
+                if not self._settle_children(work):
+                    state.interrupt_task(work.task["id"], work.owner)
+                else:
+                    state.finish_task(
+                        work.task["id"], work.owner, status, result = result, error = error
+                    )
+            except state.TaskStateError:
+                # A cancellation/expiry may win before claim or finalization.
+                # Never resurrect ownership or publish a stale result.
+                pass
+            except Exception:
+                work.cancel.set()
+                log.exception("Project task worker could not finalize its attempt")
+            finally:
+                self._lanes[lane].task_done()
+                with self._condition:
+                    self._work.pop(work.task["id"], None)
+                    self._condition.notify_all()
+
+    def shutdown(self, *, timeout: float = 10) -> bool:
+        """Cancel and drain; False means an executor still has not returned."""
+        deadline = time.monotonic() + _seconds(timeout, 60)
+        with self._condition:
+            self._closing = True
+            for work in self._work.values():
+                work.cancel.set()
+            self._condition.notify_all()
+        for thread in [*self._workers, self._watcher]:
+            thread.join(max(0, deadline - time.monotonic()))
+        return not any(t.is_alive() for t in [*self._workers, self._watcher])

--- a/studio/backend/core/agent_workspace/task_state.py
+++ b/studio/backend/core/agent_workspace/task_state.py
@@ -154,9 +154,15 @@ def _public(row) -> dict:
     }
 
 
-def _project_available(conn, project_id: str, now: int) -> None:
+def _project_available(
+    conn,
+    project_id: str,
+    now: int,
+    *,
+    allow_archived: bool = False,
+) -> None:
     row = conn.execute("SELECT archived FROM chat_projects WHERE id=?", (project_id,)).fetchone()
-    if row is None or row["archived"]:
+    if row is None or (row["archived"] and not allow_archived):
         raise TaskStateError("Project not found.")
     retiring = conn.execute(
         "SELECT 1 FROM studio_project_task_retirements WHERE project_id=? AND lease_expires_at>?",
@@ -592,7 +598,7 @@ def begin_project_retirement(project_id: str, owner: str) -> None:
     if not isinstance(owner, str) or not owner or len(owner) > 128:
         raise TaskStateError("A retirement ownership token is required.")
     with _transaction() as (conn, now):
-        _project_available(conn, project_id, now)
+        _project_available(conn, project_id, now, allow_archived = True)
         conn.execute(
             "INSERT INTO studio_project_task_retirements(project_id,owner,lease_expires_at) VALUES(?,?,?) "
             "ON CONFLICT(project_id) DO UPDATE SET owner=excluded.owner,lease_expires_at=excluded.lease_expires_at",

--- a/studio/backend/core/agent_workspace/task_state.py
+++ b/studio/backend/core/agent_workspace/task_state.py
@@ -1,0 +1,674 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Durable project task ownership, bounded delegation, and explicit retries.
+
+Runtime selections and workspace identities are captured by the server before
+creation. A lease token never leaves the worker API. Reads reconcile expired
+leases; neither a restart nor a read silently repeats a model/tool operation.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from contextlib import contextmanager
+from typing import Any
+
+from storage.studio_db import get_connection
+
+
+class TaskStateError(RuntimeError):
+    """A task request cannot preserve the durable ownership contract."""
+
+
+TERMINAL = frozenset({"completed", "failed", "cancelled", "interrupted"})
+ACTIVE = frozenset({"queued", "running", "cancelling"})
+MAX_CHILDREN = 8
+MAX_ATTEMPTS = 3
+MAX_OUTPUT_TOKENS = 32768
+MAX_DELEGATED_TOKENS = 131072
+MAX_ACTIVE_TASKS = 128
+LEASE_MS = 30000
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS studio_project_tasks (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL REFERENCES chat_projects(id) ON DELETE CASCADE,
+    parent_id TEXT REFERENCES studio_project_tasks(id),
+    root_id TEXT NOT NULL REFERENCES studio_project_tasks(id),
+    retry_of TEXT REFERENCES studio_project_tasks(id),
+    attempt INTEGER NOT NULL CHECK(attempt BETWEEN 1 AND 3),
+    role TEXT NOT NULL CHECK(role IN ('root', 'reviewer', 'implementer')),
+    instruction TEXT NOT NULL,
+    snapshot_json TEXT NOT NULL,
+    status TEXT NOT NULL CHECK(status IN ('queued','running','cancelling','completed','failed','cancelled','interrupted')),
+    revision INTEGER NOT NULL DEFAULT 1,
+    cancel_requested INTEGER NOT NULL DEFAULT 0 CHECK(cancel_requested IN (0,1)),
+    owner TEXT,
+    lease_expires_at INTEGER,
+    max_output_tokens INTEGER NOT NULL CHECK(max_output_tokens BETWEEN 1 AND 32768),
+    child_limit INTEGER NOT NULL CHECK(child_limit BETWEEN 0 AND 8),
+    child_budget INTEGER NOT NULL CHECK(child_budget BETWEEN 0 AND 131072),
+    child_allocated INTEGER NOT NULL DEFAULT 0,
+    child_count INTEGER NOT NULL DEFAULT 0,
+    result_json TEXT,
+    error TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    started_at INTEGER,
+    completed_at INTEGER
+);
+CREATE INDEX IF NOT EXISTS studio_project_tasks_project ON studio_project_tasks(project_id,created_at,id);
+CREATE INDEX IF NOT EXISTS studio_project_tasks_parent ON studio_project_tasks(parent_id,status);
+CREATE INDEX IF NOT EXISTS studio_project_tasks_lease ON studio_project_tasks(status,lease_expires_at);
+CREATE TABLE IF NOT EXISTS studio_project_task_events (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL REFERENCES studio_project_tasks(id) ON DELETE CASCADE,
+    revision INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    UNIQUE(task_id,revision)
+);
+CREATE TABLE IF NOT EXISTS studio_project_task_retirements (
+    project_id TEXT PRIMARY KEY REFERENCES chat_projects(id) ON DELETE CASCADE,
+    owner TEXT NOT NULL,
+    lease_expires_at INTEGER NOT NULL
+);
+"""
+
+
+def _now() -> int:
+    return time.time_ns() // 1000000
+
+
+def _integer(value: Any, lower: int, upper: int, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or not lower <= value <= upper:
+        raise TaskStateError(f"Invalid {label}.")
+    return value
+
+
+def _json(value: Any, limit: int, label: str) -> str:
+    try:
+        result = json.dumps(value, ensure_ascii = False, allow_nan = False, separators = (",", ":"))
+        if len(result.encode("utf-8")) > limit:
+            raise TaskStateError(f"{label} is too large.")
+        return result
+    except (TypeError, ValueError, UnicodeError, RecursionError) as exc:
+        raise TaskStateError(f"Invalid {label}.") from exc
+
+
+def _instruction(value: str) -> str:
+    if not isinstance(value, str) or not value.strip() or "\x00" in value:
+        raise TaskStateError("Task instructions are required.")
+    try:
+        size = len(value.encode("utf-8"))
+    except UnicodeError as exc:
+        raise TaskStateError("Invalid task instructions.") from exc
+    if size > 65536:
+        raise TaskStateError("Task instructions are too large.")
+    return value
+
+
+def _event(conn, task_id: str, kind: str, now: int) -> None:
+    conn.execute(
+        "INSERT INTO studio_project_task_events(task_id,revision,kind,created_at) "
+        "SELECT id,revision,?,? FROM studio_project_tasks WHERE id=?",
+        (kind, now, task_id),
+    )
+
+
+def _row(conn, task_id: str):
+    row = conn.execute("SELECT * FROM studio_project_tasks WHERE id=?", (task_id,)).fetchone()
+    if row is None:
+        raise TaskStateError("Task not found.")
+    return row
+
+
+def _public(row) -> dict:
+    return {
+        "id": row["id"],
+        "projectId": row["project_id"],
+        "parentId": row["parent_id"],
+        "rootId": row["root_id"],
+        "retryOf": row["retry_of"],
+        "attempt": row["attempt"],
+        "role": row["role"],
+        "instruction": row["instruction"],
+        "snapshot": json.loads(row["snapshot_json"]),
+        "status": row["status"],
+        "revision": row["revision"],
+        "cancelRequested": bool(row["cancel_requested"]),
+        "maxOutputTokens": row["max_output_tokens"],
+        "childLimit": row["child_limit"],
+        "childBudget": row["child_budget"],
+        "childAllocated": row["child_allocated"],
+        "childCount": row["child_count"],
+        "result": json.loads(row["result_json"]) if row["result_json"] else None,
+        "error": row["error"],
+        "createdAt": row["created_at"],
+        "updatedAt": row["updated_at"],
+        "startedAt": row["started_at"],
+        "completedAt": row["completed_at"],
+    }
+
+
+def _project_available(conn, project_id: str, now: int) -> None:
+    row = conn.execute("SELECT archived FROM chat_projects WHERE id=?", (project_id,)).fetchone()
+    if row is None or row["archived"]:
+        raise TaskStateError("Project not found.")
+    retiring = conn.execute(
+        "SELECT 1 FROM studio_project_task_retirements WHERE project_id=? AND lease_expires_at>?",
+        (project_id, now),
+    ).fetchone()
+    if retiring is not None:
+        raise TaskStateError("Project retirement is in progress.")
+
+
+def _owned(
+    conn,
+    task_id: str,
+    owner: str,
+    now: int,
+    *,
+    allow_cancel: bool = False,
+):
+    row = _row(conn, task_id)
+    statuses = {"running", "cancelling"} if allow_cancel else {"running"}
+    if (
+        not owner
+        or row["owner"] != owner
+        or row["status"] not in statuses
+        or row["lease_expires_at"] is None
+        or row["lease_expires_at"] <= now
+        or (row["cancel_requested"] and not allow_cancel)
+    ):
+        raise TaskStateError("Task ownership is no longer active.")
+    return row
+
+
+def _cancel_rows(conn, rows, now: int) -> None:
+    for row in rows:
+        row = _row(conn, row["id"])
+        if row["status"] not in ACTIVE or row["cancel_requested"]:
+            continue
+        queued = row["status"] == "queued"
+        conn.execute(
+            "UPDATE studio_project_tasks SET cancel_requested=1,status=?,revision=revision+1,"
+            "updated_at=?,completed_at=? WHERE id=?",
+            ("cancelled" if queued else "cancelling", now, now if queued else None, row["id"]),
+        )
+        _event(conn, row["id"], "cancelled" if queued else "cancel_requested", now)
+
+
+def _reconcile(conn, now: int) -> None:
+    expired = conn.execute(
+        "SELECT * FROM studio_project_tasks WHERE status IN ('queued','running','cancelling') AND lease_expires_at<=?",
+        (now,),
+    ).fetchall()
+    for row in expired:
+        row = _row(conn, row["id"])
+        if row["status"] not in ACTIVE:
+            continue
+        conn.execute(
+            "UPDATE studio_project_tasks SET status='interrupted',owner=NULL,lease_expires_at=NULL,"
+            "error='Worker ownership expired; retry requires an explicit request.',revision=revision+1,"
+            "updated_at=?,completed_at=? WHERE id=?",
+            (now, now, row["id"]),
+        )
+        _event(conn, row["id"], "interrupted", now)
+        children = conn.execute(
+            "SELECT * FROM studio_project_tasks WHERE parent_id=?", (row["id"],)
+        ).fetchall()
+        _cancel_rows(conn, children, now)
+
+    archived = conn.execute(
+        "SELECT task.* FROM studio_project_tasks AS task JOIN chat_projects AS project "
+        "ON project.id=task.project_id WHERE project.archived!=0 "
+        "AND task.status IN ('queued','running','cancelling')"
+    ).fetchall()
+    _cancel_rows(conn, archived, now)
+
+
+@contextmanager
+def _transaction():
+    conn = get_connection()
+    try:
+        conn.executescript(_SCHEMA)
+        conn.execute("BEGIN IMMEDIATE")
+        now = _now()
+        _reconcile(conn, now)
+        # Expiry is durable even if the requested operation is refused (for
+        # example, a late worker attempting to renew its revoked ownership).
+        conn.execute("SAVEPOINT task_request")
+        try:
+            yield conn, now
+        except BaseException:
+            conn.execute("ROLLBACK TO task_request")
+            conn.execute("RELEASE task_request")
+            conn.commit()
+            raise
+        conn.execute("RELEASE task_request")
+        conn.commit()
+    except BaseException:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _insert(
+    conn,
+    *,
+    project_id,
+    instruction,
+    snapshot,
+    role,
+    parent_id,
+    root_id,
+    max_output_tokens,
+    child_limit,
+    child_budget,
+    now,
+    retry_of = None,
+    attempt = 1,
+):
+    active = conn.execute(
+        "SELECT COUNT(*) FROM studio_project_tasks WHERE status IN ('queued','running','cancelling')"
+    ).fetchone()[0]
+    if active >= MAX_ACTIVE_TASKS:
+        raise TaskStateError("The project task queue is full.")
+    task_id = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO studio_project_tasks(id,project_id,parent_id,root_id,retry_of,attempt,role,"
+        "instruction,snapshot_json,status,max_output_tokens,child_limit,child_budget,created_at,updated_at,lease_expires_at) "
+        "VALUES(?,?,?,?,?,?,?,?,?,'queued',?,?,?,?,?,?)",
+        (
+            task_id,
+            project_id,
+            parent_id,
+            root_id or task_id,
+            retry_of,
+            attempt,
+            role,
+            instruction,
+            snapshot,
+            max_output_tokens,
+            child_limit,
+            child_budget,
+            now,
+            now,
+            now + LEASE_MS,
+        ),
+    )
+    _event(conn, task_id, "queued", now)
+    return _public(_row(conn, task_id))
+
+
+def create_task(
+    project_id: str,
+    instruction: str,
+    snapshot: dict,
+    *,
+    max_output_tokens: int = 8192,
+    child_limit: int = 0,
+    child_budget: int = 0,
+) -> dict:
+    instruction = _instruction(instruction)
+    snapshot_json = _json(snapshot, 131072, "Runtime/workspace snapshot")
+    if not isinstance(snapshot, dict):
+        raise TaskStateError("A runtime/workspace snapshot is required.")
+    _integer(max_output_tokens, 1, MAX_OUTPUT_TOKENS, "output-token bound")
+    _integer(child_limit, 0, MAX_CHILDREN, "child limit")
+    _integer(child_budget, 0, MAX_DELEGATED_TOKENS, "delegated-token bound")
+    if bool(child_limit) != bool(child_budget):
+        raise TaskStateError("Delegation requires both a child limit and a token budget.")
+    with _transaction() as (conn, now):
+        _project_available(conn, project_id, now)
+        return _insert(
+            conn,
+            project_id = project_id,
+            instruction = instruction,
+            snapshot = snapshot_json,
+            role = "root",
+            parent_id = None,
+            root_id = None,
+            max_output_tokens = max_output_tokens,
+            child_limit = child_limit,
+            child_budget = child_budget,
+            now = now,
+        )
+
+
+def get_task(project_id: str, task_id: str) -> dict:
+    with _transaction() as (conn, _now_ms):
+        row = _row(conn, task_id)
+        if row["project_id"] != project_id:
+            raise TaskStateError("Task not found.")
+        return _public(row)
+
+
+def list_tasks(project_id: str, *, limit: int = 100) -> list[dict]:
+    _integer(limit, 1, 500, "task-list limit")
+    with _transaction() as (conn, _now_ms):
+        return [
+            _public(row)
+            for row in conn.execute(
+                "SELECT * FROM studio_project_tasks WHERE project_id=? ORDER BY created_at DESC,id DESC LIMIT ?",
+                (project_id, limit),
+            )
+        ]
+
+
+def claim_task(project_id: str, task_id: str, owner: str) -> dict:
+    if not isinstance(owner, str) or not owner or len(owner) > 128:
+        raise TaskStateError("A worker ownership token is required.")
+    with _transaction() as (conn, now):
+        _project_available(conn, project_id, now)
+        row = _row(conn, task_id)
+        if row["project_id"] != project_id or row["status"] != "queued":
+            raise TaskStateError("Only a queued task in this project can be claimed.")
+        if row["owner"] is not None and row["owner"] != owner:
+            raise TaskStateError("Task dispatch is owned by another worker.")
+        if row["parent_id"]:
+            parent = _row(conn, row["parent_id"])
+            if parent["status"] != "running" or parent["cancel_requested"]:
+                raise TaskStateError("The parent task is no longer running.")
+        conn.execute(
+            "UPDATE studio_project_tasks SET status='running',owner=?,lease_expires_at=?,"
+            "revision=revision+1,started_at=?,updated_at=? WHERE id=?",
+            (owner, now + LEASE_MS, now, now, task_id),
+        )
+        _event(conn, task_id, "running", now)
+        return _public(_row(conn, task_id))
+
+
+def heartbeat(task_id: str, owner: str) -> bool:
+    with _transaction() as (conn, now):
+        row = _row(conn, task_id)
+        if row["status"] != "queued" or row["owner"] != owner or not owner:
+            row = _owned(conn, task_id, owner, now, allow_cancel = True)
+        conn.execute(
+            "UPDATE studio_project_tasks SET lease_expires_at=? WHERE id=?",
+            (now + LEASE_MS, task_id),
+        )
+        return not row["cancel_requested"]
+
+
+def validate_owner(task_id: str, owner: str) -> dict:
+    with _transaction() as (conn, now):
+        row = _owned(conn, task_id, owner, now)
+        _project_available(conn, row["project_id"], now)
+        return _public(row)
+
+
+def cancel_task(project_id: str, task_id: str) -> dict:
+    with _transaction() as (conn, now):
+        row = _row(conn, task_id)
+        if row["project_id"] != project_id:
+            raise TaskStateError("Task not found.")
+        children = conn.execute(
+            "SELECT * FROM studio_project_tasks WHERE parent_id=?", (task_id,)
+        ).fetchall()
+        _cancel_rows(conn, [row, *children], now)
+        return _public(_row(conn, task_id))
+
+
+def finish_task(
+    task_id: str,
+    owner: str,
+    status: str,
+    *,
+    result: dict | None = None,
+    error: str | None = None,
+) -> dict:
+    if status not in TERMINAL:
+        raise TaskStateError("A terminal task status is required.")
+    if result is not None and not isinstance(result, dict):
+        raise TaskStateError("A task result must be an object.")
+    result_json = _json(result, 1024 * 1024, "Task result") if result is not None else None
+    if error is not None and (not isinstance(error, str) or len(error.encode("utf-8")) > 4096):
+        raise TaskStateError("Task error is too large.")
+    with _transaction() as (conn, now):
+        row = _owned(conn, task_id, owner, now, allow_cancel = True)
+        if conn.execute(
+            "SELECT 1 FROM studio_project_tasks WHERE parent_id=? AND status IN ('queued','running','cancelling') LIMIT 1",
+            (task_id,),
+        ).fetchone():
+            raise TaskStateError("Child tasks must settle before the parent completes.")
+        if row["cancel_requested"]:
+            status = "cancelled"
+        conn.execute(
+            "UPDATE studio_project_tasks SET status=?,result_json=?,error=?,owner=NULL,lease_expires_at=NULL,"
+            "revision=revision+1,updated_at=?,completed_at=? WHERE id=?",
+            (status, result_json, error, now, now, task_id),
+        )
+        _event(conn, task_id, status, now)
+        return _public(_row(conn, task_id))
+
+
+def create_child(
+    parent_id: str,
+    owner: str,
+    instruction: str,
+    snapshot: dict,
+    *,
+    role: str,
+    max_output_tokens: int = 4096,
+) -> dict:
+    instruction = _instruction(instruction)
+    snapshot_json = _json(snapshot, 131072, "Runtime/workspace snapshot")
+    _integer(max_output_tokens, 1, MAX_OUTPUT_TOKENS, "output-token bound")
+    if not isinstance(snapshot, dict) or role not in {"reviewer", "implementer"}:
+        raise TaskStateError("Invalid child-task request.")
+    with _transaction() as (conn, now):
+        parent = _owned(conn, parent_id, owner, now)
+        _project_available(conn, parent["project_id"], now)
+        if parent["parent_id"] is not None:
+            raise TaskStateError("Child tasks cannot delegate further.")
+        if parent["child_count"] >= parent["child_limit"]:
+            raise TaskStateError("The root task's child limit is exhausted.")
+        if parent["child_allocated"] + max_output_tokens > parent["child_budget"]:
+            raise TaskStateError("The root task's delegated-token budget is exhausted.")
+        conn.execute(
+            "UPDATE studio_project_tasks SET child_count=child_count+1,child_allocated=child_allocated+?,"
+            "revision=revision+1,updated_at=? WHERE id=?",
+            (max_output_tokens, now, parent_id),
+        )
+        _event(conn, parent_id, "child_reserved", now)
+        return _insert(
+            conn,
+            project_id = parent["project_id"],
+            instruction = instruction,
+            snapshot = snapshot_json,
+            role = role,
+            parent_id = parent_id,
+            root_id = parent_id,
+            max_output_tokens = max_output_tokens,
+            child_limit = 0,
+            child_budget = 0,
+            now = now,
+        )
+
+
+def retry_task(
+    project_id: str,
+    task_id: str,
+    *,
+    parent_owner: str | None = None,
+) -> dict:
+    with _transaction() as (conn, now):
+        _project_available(conn, project_id, now)
+        row = _row(conn, task_id)
+        if row["project_id"] != project_id or row["status"] not in {
+            "failed",
+            "cancelled",
+            "interrupted",
+        }:
+            raise TaskStateError("Only unsuccessful tasks in this project can be retried.")
+        if row["attempt"] >= MAX_ATTEMPTS:
+            raise TaskStateError("The task attempt limit is exhausted.")
+        if conn.execute(
+            "SELECT 1 FROM studio_project_tasks WHERE retry_of=?", (task_id,)
+        ).fetchone():
+            raise TaskStateError("This attempt already has a retry.")
+        if conn.execute(
+            "SELECT 1 FROM studio_project_tasks WHERE parent_id=? AND status IN ('queued','running','cancelling') LIMIT 1",
+            (task_id,),
+        ).fetchone():
+            raise TaskStateError("Child tasks must settle before retrying the parent.")
+        if row["parent_id"]:
+            parent = _owned(conn, row["parent_id"], parent_owner, now)
+            if parent["child_allocated"] + row["max_output_tokens"] > parent["child_budget"]:
+                raise TaskStateError("The root task's delegated-token budget is exhausted.")
+            conn.execute(
+                "UPDATE studio_project_tasks SET child_allocated=child_allocated+?,revision=revision+1,updated_at=? WHERE id=?",
+                (row["max_output_tokens"], now, parent["id"]),
+            )
+            _event(conn, parent["id"], "child_retry_reserved", now)
+        return _insert(
+            conn,
+            project_id = project_id,
+            instruction = row["instruction"],
+            snapshot = row["snapshot_json"],
+            role = row["role"],
+            parent_id = row["parent_id"],
+            root_id = row["root_id"] if row["parent_id"] else None,
+            max_output_tokens = row["max_output_tokens"],
+            child_limit = row["child_limit"],
+            child_budget = row["child_budget"],
+            now = now,
+            retry_of = row["id"],
+            attempt = row["attempt"] + 1,
+        )
+
+
+def task_events(
+    project_id: str,
+    task_id: str,
+    *,
+    after: int = 0,
+    limit: int = 100,
+) -> list[dict]:
+    _integer(after, 0, 2**63 - 1, "event cursor")
+    _integer(limit, 1, 500, "event-list limit")
+    with _transaction() as (conn, _now_ms):
+        if _row(conn, task_id)["project_id"] != project_id:
+            raise TaskStateError("Task not found.")
+        return [
+            dict(row)
+            for row in conn.execute(
+                "SELECT sequence,revision,kind,created_at AS createdAt FROM studio_project_task_events "
+                "WHERE task_id=? AND sequence>? ORDER BY sequence LIMIT ?",
+                (task_id, after, limit),
+            )
+        ]
+
+
+def reserve_dispatch(project_id: str, task_id: str, owner: str) -> None:
+    """Reserve a queued task while a bounded worker lane is busy."""
+    if not isinstance(owner, str) or not owner or len(owner) > 128:
+        raise TaskStateError("A worker ownership token is required.")
+    with _transaction() as (conn, now):
+        _project_available(conn, project_id, now)
+        row = _row(conn, task_id)
+        if row["project_id"] != project_id or row["status"] != "queued" or row["owner"] is not None:
+            raise TaskStateError("Task dispatch is no longer available.")
+        conn.execute(
+            "UPDATE studio_project_tasks SET owner=?,lease_expires_at=? WHERE id=?",
+            (owner, now + LEASE_MS, task_id),
+        )
+
+
+def reconcile_expired_tasks() -> None:
+    """Recover expired attempts without replaying queued or running work."""
+    with _transaction():
+        pass
+
+
+def begin_project_retirement(project_id: str, owner: str) -> None:
+    """Fence admission before signalling existing work to stop."""
+    if not isinstance(owner, str) or not owner or len(owner) > 128:
+        raise TaskStateError("A retirement ownership token is required.")
+    with _transaction() as (conn, now):
+        _project_available(conn, project_id, now)
+        conn.execute(
+            "INSERT INTO studio_project_task_retirements(project_id,owner,lease_expires_at) VALUES(?,?,?) "
+            "ON CONFLICT(project_id) DO UPDATE SET owner=excluded.owner,lease_expires_at=excluded.lease_expires_at",
+            (project_id, owner, now + LEASE_MS),
+        )
+        _cancel_rows(
+            conn,
+            conn.execute(
+                "SELECT * FROM studio_project_tasks WHERE project_id=?",
+                (project_id,),
+            ).fetchall(),
+            now,
+        )
+
+
+def renew_project_retirement(project_id: str, owner: str) -> None:
+    with _transaction() as (conn, now):
+        changed = conn.execute(
+            "UPDATE studio_project_task_retirements SET lease_expires_at=? "
+            "WHERE project_id=? AND owner=? AND lease_expires_at>?",
+            (now + LEASE_MS, project_id, owner, now),
+        ).rowcount
+        if not changed:
+            raise TaskStateError("Project retirement ownership expired.")
+
+
+def finish_project_retirement(project_id: str, owner: str) -> None:
+    with _transaction() as (conn, _now_ms):
+        conn.execute(
+            "DELETE FROM studio_project_task_retirements WHERE project_id=? AND owner=?",
+            (project_id, owner),
+        )
+
+
+def project_has_active_tasks(project_id: str) -> bool:
+    with _transaction() as (conn, _now_ms):
+        return (
+            conn.execute(
+                "SELECT 1 FROM studio_project_tasks WHERE project_id=? "
+                "AND status IN ('queued','running','cancelling') LIMIT 1",
+                (project_id,),
+            ).fetchone()
+            is not None
+        )
+
+
+def list_children(project_id: str, task_id: str) -> list[dict]:
+    with _transaction() as (conn, _now_ms):
+        if _row(conn, task_id)["project_id"] != project_id:
+            raise TaskStateError("Task not found.")
+        return [
+            _public(row)
+            for row in conn.execute(
+                "SELECT * FROM studio_project_tasks WHERE parent_id=? ORDER BY created_at,id",
+                (task_id,),
+            )
+        ]
+
+
+def interrupt_task(task_id: str, owner: str) -> dict:
+    """Relinquish an attempt whose children could not be drained in time."""
+    with _transaction() as (conn, now):
+        _owned(conn, task_id, owner, now, allow_cancel = True)
+        _cancel_rows(
+            conn,
+            conn.execute(
+                "SELECT * FROM studio_project_tasks WHERE parent_id=?",
+                (task_id,),
+            ).fetchall(),
+            now,
+        )
+        conn.execute(
+            "UPDATE studio_project_tasks SET status='interrupted',owner=NULL,lease_expires_at=NULL,"
+            "cancel_requested=1,error='Child tasks did not settle before the shutdown deadline.',"
+            "revision=revision+1,updated_at=?,completed_at=? WHERE id=?",
+            (now, now, task_id),
+        )
+        _event(conn, task_id, "interrupted", now)
+        return _public(_row(conn, task_id))

--- a/studio/backend/tests/test_project_task_state.py
+++ b/studio/backend/tests/test_project_task_state.py
@@ -431,9 +431,12 @@ def test_expired_worker_cannot_publish_result_or_overlap_retry(task_db, runners)
 
 def test_shutdown_reports_a_worker_that_has_not_stopped(runners):
     started, release = threading.Event(), threading.Event()
+    cancelled_seen = threading.Event()
 
     def execute(context):
         started.set()
+        assert context.cancel_event.wait(3)
+        cancelled_seen.set()
         assert release.wait(3)
         return {}
 
@@ -444,7 +447,8 @@ def test_shutdown_reports_a_worker_that_has_not_stopped(runners):
         assert runner.shutdown(timeout = 0.05) is False
         with pytest.raises(state.TaskStateError, match = "shutting down"):
             runner.submit("one", "More", {})
-        assert state.get_task("one", task["id"])["status"] == "cancelling"
+        assert cancelled_seen.wait(3)
+        assert state.get_task("one", task["id"])["status"] in {"running", "cancelling"}
     finally:
         release.set()
     assert runner.shutdown(timeout = 3)
@@ -613,3 +617,27 @@ def test_task_tables_integrate_with_real_studio_storage():
     assert state.list_tasks("integration")[0]["result"] == {"output": "Done"}
     studio_db.delete_chat_project("integration", delete_files = False)
     assert state.list_tasks("integration") == []
+
+
+def test_retirement_can_fence_an_already_archived_project(task_db):
+    connect, _ = task_db
+    with connect() as conn:
+        conn.execute("UPDATE chat_projects SET archived=1 WHERE id='one'")
+    state.begin_project_retirement("one", "retire")
+    state.renew_project_retirement("one", "retire")
+    with pytest.raises(state.TaskStateError):
+        root()
+    state.finish_project_retirement("one", "retire")
+
+
+def test_executor_system_exit_does_not_remove_worker_capacity(runners):
+    def execute(context):
+        if context.task["instruction"] == "Exit":
+            raise SystemExit(1)
+        return {"output": "Still working"}
+
+    runner = runners(execute, root_workers = 1)
+    first = runner.submit("one", "Exit", {})
+    assert runner.wait("one", first["id"], timeout = 3)["status"] == "failed"
+    second = runner.submit("one", "Continue", {})
+    assert runner.wait("one", second["id"], timeout = 3)["result"] == {"output": "Still working"}

--- a/studio/backend/tests/test_project_task_state.py
+++ b/studio/backend/tests/test_project_task_state.py
@@ -1,0 +1,615 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from core.agent_workspace import task_state as state
+
+
+@pytest.fixture
+def task_db(tmp_path, monkeypatch):
+    path = tmp_path / "tasks.db"
+
+    def connect():
+        conn = sqlite3.connect(path, timeout = 10)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys=ON")
+        return conn
+
+    with connect() as conn:
+        conn.execute("CREATE TABLE chat_projects(id TEXT PRIMARY KEY, archived INTEGER DEFAULT 0)")
+        conn.executemany("INSERT INTO chat_projects(id) VALUES(?)", [("one",), ("two",)])
+    clock = [100000]
+    monkeypatch.setattr(state, "get_connection", connect)
+    monkeypatch.setattr(state, "_now", lambda: clock[0])
+    return connect, clock
+
+
+def root(**kwargs):
+    return state.create_task("one", "Inspect the project", {"model": "local"}, **kwargs)
+
+
+def running_root(**kwargs):
+    row = root(**kwargs)
+    return state.claim_task("one", row["id"], "root-owner")
+
+
+def test_task_round_trip_and_private_ownership(task_db):
+    row = running_root()
+    assert "owner" not in row and "lease_expires_at" not in row
+    finished = state.finish_task(row["id"], "root-owner", "completed", result = {"output": "Done"})
+    assert finished["result"] == {"output": "Done"}
+    assert state.get_task("one", row["id"]) == finished
+    events = state.task_events("one", row["id"])
+    assert [e["kind"] for e in events] == ["queued", "running", "completed"]
+    assert [e["revision"] for e in events] == [1, 2, 3]
+    assert state.task_events("one", row["id"], after = events[1]["sequence"]) == events[2:]
+
+
+def test_only_one_concurrent_claim_wins(task_db):
+    row = root()
+    barrier = threading.Barrier(8)
+
+    def claim(index):
+        barrier.wait(timeout = 5)
+        try:
+            state.claim_task("one", row["id"], str(index))
+            return True
+        except state.TaskStateError:
+            return False
+
+    with ThreadPoolExecutor(max_workers = 8) as pool:
+        assert sum(pool.map(claim, range(8))) == 1
+
+
+def test_dispatch_reservation_is_exclusive_and_keeps_queue_alive(task_db):
+    _, clock = task_db
+    row = root()
+    state.reserve_dispatch("one", row["id"], "dispatch")
+    with pytest.raises(state.TaskStateError):
+        state.reserve_dispatch("one", row["id"], "second")
+    with pytest.raises(state.TaskStateError):
+        state.claim_task("one", row["id"], "second")
+    clock[0] += state.LEASE_MS - 1
+    assert state.heartbeat(row["id"], "dispatch")
+    clock[0] += state.LEASE_MS - 1
+    assert state.claim_task("one", row["id"], "dispatch")["status"] == "running"
+
+
+@pytest.mark.parametrize("claimed", [False, True])
+def test_expiry_does_not_replay_and_failed_renewal_keeps_recovery(task_db, claimed):
+    connect, clock = task_db
+    row = running_root() if claimed else root()
+    clock[0] += state.LEASE_MS
+    with pytest.raises(state.TaskStateError):
+        state.heartbeat(row["id"], "root-owner")
+    # Inspect directly: a later successful accessor must not be necessary to
+    # commit recovery performed during the refused heartbeat.
+    with connect() as conn:
+        stored = conn.execute(
+            "SELECT * FROM studio_project_tasks WHERE id=?", (row["id"],)
+        ).fetchone()
+    assert stored["status"] == "interrupted" and stored["owner"] is None
+    retry = state.retry_task("one", row["id"])
+    assert retry["status"] == "queued" and retry["retryOf"] == row["id"]
+    assert retry["attempt"] == 2 and retry["rootId"] == retry["id"]
+
+
+def test_parent_and_child_expiry_are_idempotent(task_db):
+    _, clock = task_db
+    parent = running_root(child_limit = 2, child_budget = 20)
+    child = state.create_child(
+        parent["id"], "root-owner", "Review", {}, role = "reviewer", max_output_tokens = 10
+    )
+    state.claim_task("one", child["id"], "child-owner")
+    queued = state.create_child(
+        parent["id"], "root-owner", "Implement", {}, role = "implementer", max_output_tokens = 10
+    )
+    clock[0] += state.LEASE_MS
+    state.reconcile_expired_tasks()
+    before = {r["id"]: r for r in state.list_tasks("one")}
+    assert before[parent["id"]]["status"] == "interrupted"
+    assert before[child["id"]]["status"] == "interrupted"
+    assert before[queued["id"]]["status"] in {"cancelled", "interrupted"}
+    state.reconcile_expired_tasks()
+    assert {r["id"]: r for r in state.list_tasks("one")} == before
+    for task in before.values():
+        revisions = [e["revision"] for e in state.task_events("one", task["id"])]
+        assert len(revisions) == len(set(revisions))
+
+
+def test_cancel_cascades_and_parent_waits_for_children(task_db):
+    parent = running_root(child_limit = 1, child_budget = 10)
+    child = state.create_child(
+        parent["id"], "root-owner", "Review", {}, role = "reviewer", max_output_tokens = 10
+    )
+    state.claim_task("one", child["id"], "child-owner")
+    cancelled = state.cancel_task("one", parent["id"])
+    assert cancelled["status"] == "cancelling"
+    assert not state.heartbeat(child["id"], "child-owner")
+    with pytest.raises(state.TaskStateError, match = "settle"):
+        state.finish_task(parent["id"], "root-owner", "completed")
+    assert state.finish_task(child["id"], "child-owner", "completed")["status"] == "cancelled"
+    assert state.finish_task(parent["id"], "root-owner", "completed")["status"] == "cancelled"
+    assert state.cancel_task("one", parent["id"])["revision"] == cancelled["revision"] + 1
+
+
+def test_parent_retry_waits_for_live_children_after_parent_expires(task_db):
+    _, clock = task_db
+    parent = running_root(child_limit = 1, child_budget = 10)
+    child = state.create_child(
+        parent["id"], "root-owner", "Review", {}, role = "reviewer", max_output_tokens = 10
+    )
+    state.claim_task("one", child["id"], "child-owner")
+    clock[0] += state.LEASE_MS - 1
+    state.heartbeat(child["id"], "child-owner")
+    clock[0] += 1
+    with pytest.raises(state.TaskStateError, match = "settle"):
+        state.retry_task("one", parent["id"])
+    state.finish_task(child["id"], "child-owner", "cancelled")
+    assert state.retry_task("one", parent["id"])["attempt"] == 2
+
+
+def test_child_reservations_are_atomic_and_retries_consume_budget(task_db):
+    parent = running_root(child_limit = 1, child_budget = 20)
+    barrier = threading.Barrier(2)
+
+    def create(_):
+        barrier.wait(timeout = 5)
+        try:
+            return state.create_child(
+                parent["id"], "root-owner", "Review", {}, role = "reviewer", max_output_tokens = 10
+            )
+        except state.TaskStateError:
+            return None
+
+    with ThreadPoolExecutor(max_workers = 2) as pool:
+        children = [r for r in pool.map(create, range(2)) if r]
+    assert len(children) == 1
+    child = children[0]
+    state.cancel_task("one", child["id"])
+    retry = state.retry_task("one", child["id"], parent_owner = "root-owner")
+    state.cancel_task("one", retry["id"])
+    with pytest.raises(state.TaskStateError, match = "budget"):
+        state.retry_task("one", retry["id"], parent_owner = "root-owner")
+    updated = state.get_task("one", parent["id"])
+    assert updated["childCount"] == 1 and updated["childAllocated"] == 20
+
+
+def test_children_cannot_delegate(task_db):
+    parent = running_root(child_limit = 1, child_budget = 10)
+    child = state.create_child(
+        parent["id"], "root-owner", "Review", {}, role = "reviewer", max_output_tokens = 10
+    )
+    state.claim_task("one", child["id"], "child-owner")
+    with pytest.raises(state.TaskStateError, match = "cannot delegate"):
+        state.create_child(child["id"], "child-owner", "More", {}, role = "reviewer")
+
+
+def test_failed_enqueue_rolls_back_budget_and_events(task_db, monkeypatch):
+    parent = running_root(child_limit = 1, child_budget = 10)
+    monkeypatch.setattr(state, "MAX_ACTIVE_TASKS", 1)
+    with pytest.raises(state.TaskStateError, match = "queue is full"):
+        state.create_child(
+            parent["id"], "root-owner", "Review", {}, role = "reviewer", max_output_tokens = 10
+        )
+    assert state.get_task("one", parent["id"]) == parent
+    assert [e["kind"] for e in state.task_events("one", parent["id"])] == ["queued", "running"]
+
+
+def test_retries_are_explicit_single_successors_with_attempt_cap(task_db):
+    row = root()
+    for attempt in (2, 3):
+        state.cancel_task("one", row["id"])
+        retry = state.retry_task("one", row["id"])
+        with pytest.raises(state.TaskStateError):
+            state.retry_task("one", row["id"])
+        assert retry["attempt"] == attempt
+        row = retry
+    state.cancel_task("one", row["id"])
+    with pytest.raises(state.TaskStateError, match = "attempt limit"):
+        state.retry_task("one", row["id"])
+
+
+def test_project_scope_and_delete_cascade(task_db):
+    connect, _ = task_db
+    row = root()
+    for operation in (state.get_task, state.cancel_task, state.retry_task, state.task_events):
+        with pytest.raises(state.TaskStateError):
+            operation("two", row["id"])
+    with connect() as conn:
+        conn.execute("DELETE FROM chat_projects WHERE id='one'")
+        assert conn.execute("SELECT COUNT(*) FROM studio_project_task_events").fetchone()[0] == 0
+    assert state.list_tasks("one") == []
+
+
+def test_retirement_fences_creation_and_only_owner_can_release(task_db):
+    _, clock = task_db
+    row = running_root()
+    state.begin_project_retirement("one", "retire-owner")
+    assert state.get_task("one", row["id"])["cancelRequested"]
+    state.finish_project_retirement("one", "wrong-owner")
+    with pytest.raises(state.TaskStateError, match = "retirement"):
+        root()
+    clock[0] += state.LEASE_MS - 1
+    state.renew_project_retirement("one", "retire-owner")
+    clock[0] += state.LEASE_MS - 1
+    with pytest.raises(state.TaskStateError, match = "retirement"):
+        root()
+    state.finish_project_retirement("one", "retire-owner")
+    assert root()["status"] == "queued"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"max_output_tokens": True},
+        {"max_output_tokens": 32769},
+        {"child_limit": 1},
+        {"child_budget": 1},
+        {"child_limit": 9, "child_budget": 1},
+    ],
+)
+def test_invalid_limits_are_refused(task_db, kwargs):
+    with pytest.raises(state.TaskStateError):
+        root(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "instruction",
+    ["", "\x00", "\ud800", "é" * 32769],
+    ids = ["empty", "nul", "surrogate", "utf8-byte-bound"],
+)
+def test_instruction_bounds(task_db, instruction):
+    with pytest.raises(state.TaskStateError):
+        state.create_task("one", instruction, {})
+
+
+def test_snapshot_is_copied_and_bounded(task_db):
+    original = {"model": "first"}
+    row = state.create_task("one", "Task", original)
+    original["model"] = "second"
+    row["snapshot"]["model"] = "third"
+    assert state.get_task("one", row["id"])["snapshot"] == {"model": "first"}
+    with pytest.raises(state.TaskStateError):
+        state.create_task("one", "Task", {"bad": float("nan")})
+    with pytest.raises(state.TaskStateError):
+        state.create_task("one", "Task", {"huge": "é" * 65536})
+
+
+@pytest.fixture
+def runners(task_db):
+    from core.agent_workspace.task_runner import ProjectTaskRunner
+
+    created = []
+
+    def create(executor, **kwargs):
+        runner = ProjectTaskRunner(executor, heartbeat_seconds = 0.01, drain_seconds = 0.2, **kwargs)
+        created.append(runner)
+        return runner
+
+    yield create
+    for runner in created:
+        assert runner.shutdown(timeout = 3), "Task test leaked an executor"
+
+
+def test_all_parent_workers_can_wait_for_children_without_starvation(runners):
+    parents = threading.Barrier(2)
+    children = threading.Barrier(2)
+
+    def execute(context):
+        if context.task["parentId"]:
+            children.wait(timeout = 3)
+            return {"review": context.task["instruction"]}
+        parents.wait(timeout = 3)
+        child = context.delegate("Inspect files", role = "reviewer", max_output_tokens = 10)
+        result = context.wait_child(child["id"], timeout = 3)
+        assert result is not None and result["status"] == "completed"
+        return result["result"]
+
+    runner = runners(execute, root_workers = 2, child_workers = 2)
+    tasks = [runner.submit("one", "Parent", {}, child_limit = 1, child_budget = 10) for _ in range(2)]
+    for task in tasks:
+        result = runner.wait("one", task["id"], timeout = 5)
+        assert result["status"] == "completed"
+        assert result["result"] == {"review": "Inspect files"}
+
+
+def test_cancelled_queued_task_never_executes(runners):
+    started, release = threading.Event(), threading.Event()
+    calls = []
+
+    def execute(context):
+        calls.append(context.task["instruction"])
+        started.set()
+        assert release.wait(3)
+        return {}
+
+    runner = runners(execute, root_workers = 1)
+    first = runner.submit("one", "First", {})
+    assert started.wait(3)
+    second = runner.submit("one", "Second", {})
+    runner.cancel("one", second["id"])
+    release.set()
+    assert runner.wait("one", first["id"], timeout = 3)["status"] == "completed"
+    assert runner.wait("one", second["id"], timeout = 3)["status"] == "cancelled"
+    assert calls == ["First"]
+
+
+def test_parent_failure_cancels_and_drains_its_child(runners):
+    child_started = threading.Event()
+
+    def execute(context):
+        if context.task["parentId"]:
+            child_started.set()
+            assert context.cancel_event.wait(3)
+            context.check()
+        context.delegate("Child", role = "implementer", max_output_tokens = 10)
+        assert child_started.wait(3)
+        raise RuntimeError("secret-value-must-not-be-persisted")
+
+    runner = runners(execute)
+    parent = runner.submit("one", "Parent", {}, child_limit = 1, child_budget = 10)
+    result = runner.wait("one", parent["id"], timeout = 3)
+    assert result["status"] == "failed"
+    assert "secret-value" not in str(result)
+    assert state.list_children("one", parent["id"])[0]["status"] == "cancelled"
+
+
+def test_worker_child_retry_obeys_original_budget(runners):
+    def execute(context):
+        task = context.task
+        if task["parentId"]:
+            if task["attempt"] == 1:
+                raise RuntimeError("Try again")
+            return {"attempt": task["attempt"]}
+        child = context.delegate("Child", role = "reviewer", max_output_tokens = 10)
+        assert context.wait_child(child["id"], timeout = 3)["status"] == "failed"
+        retried = context.retry_child(child["id"])
+        return context.wait_child(retried["id"], timeout = 3)["result"]
+
+    runner = runners(execute)
+    task = runner.submit("one", "Parent", {}, child_limit = 1, child_budget = 20)
+    result = runner.wait("one", task["id"], timeout = 3)
+    assert result["status"] == "completed"
+    assert result["result"] == {"attempt": 2}
+    assert result["childCount"] == 1 and result["childAllocated"] == 20
+
+
+def test_retry_does_not_run_automatically(runners):
+    calls = []
+
+    def execute(context):
+        calls.append(context.task["attempt"])
+        if context.task["attempt"] == 1:
+            raise RuntimeError("Failed")
+        return {}
+
+    runner = runners(execute)
+    task = runner.submit("one", "Task", {})
+    assert runner.wait("one", task["id"], timeout = 3)["status"] == "failed"
+    assert calls == [1]
+    retried = runner.retry("one", task["id"])
+    assert runner.wait("one", retried["id"], timeout = 3)["status"] == "completed"
+    assert calls == [1, 2]
+
+
+def test_starting_runner_never_replays_an_expired_task(task_db, runners):
+    _, clock = task_db
+    task = running_root()
+    clock[0] += state.LEASE_MS
+    calls = []
+    runner = runners(lambda context: calls.append(context.task) or {})
+    assert runner.wait("one", task["id"], timeout = 3)["status"] == "interrupted"
+    assert calls == []
+
+
+def test_expired_worker_cannot_publish_result_or_overlap_retry(task_db, runners):
+    _, clock = task_db
+    started, release = threading.Event(), threading.Event()
+
+    def execute(context):
+        started.set()
+        assert release.wait(3)
+        return {"must_not_publish": True}
+
+    runner = runners(execute)
+    task = runner.submit("one", "Task", {})
+    assert started.wait(3)
+    clock[0] += state.LEASE_MS
+    assert state.get_task("one", task["id"])["status"] == "interrupted"
+    with pytest.raises(state.TaskStateError, match = "have not stopped"):
+        runner.retry("one", task["id"])
+    release.set()
+    result = runner.wait("one", task["id"], timeout = 3)
+    assert result["status"] == "interrupted" and result["result"] is None
+
+
+def test_shutdown_reports_a_worker_that_has_not_stopped(runners):
+    started, release = threading.Event(), threading.Event()
+
+    def execute(context):
+        started.set()
+        assert release.wait(3)
+        return {}
+
+    runner = runners(execute)
+    task = runner.submit("one", "Task", {})
+    assert started.wait(3)
+    try:
+        assert runner.shutdown(timeout = 0.05) is False
+        with pytest.raises(state.TaskStateError, match = "shutting down"):
+            runner.submit("one", "More", {})
+        assert state.get_task("one", task["id"])["status"] == "cancelling"
+    finally:
+        release.set()
+    assert runner.shutdown(timeout = 3)
+    assert state.get_task("one", task["id"])["status"] == "cancelled"
+
+
+def test_deadline_cancels_running_executor(runners):
+    def execute(context):
+        assert context.cancel_event.wait(3)
+        context.check()
+
+    runner = runners(execute)
+    task = runner.submit("one", "Task", {}, timeout = 0.05)
+    assert runner.wait("one", task["id"], timeout = 3)["status"] == "cancelled"
+
+
+def test_project_retirement_signals_existing_worker(runners):
+    started = threading.Event()
+
+    def execute(context):
+        started.set()
+        assert context.cancel_event.wait(3)
+        context.check()
+
+    runner = runners(execute)
+    task = runner.submit("one", "Task", {})
+    assert started.wait(3)
+    state.begin_project_retirement("one", "retire")
+    assert runner.wait("one", task["id"], timeout = 3)["status"] == "cancelled"
+    assert not state.project_has_active_tasks("one")
+    state.finish_project_retirement("one", "retire")
+
+
+@pytest.mark.parametrize("result", [None, [], {"large": "x" * (1024 * 1024)}])
+def test_invalid_executor_result_is_terminal_failure(runners, result):
+    runner = runners(lambda _: result)
+    task = runner.submit("one", "Task", {})
+    outcome = runner.wait("one", task["id"], timeout = 3)
+    assert outcome["status"] == "failed" and outcome["result"] is None
+
+
+def test_context_changes_do_not_change_captured_snapshot(runners):
+    def execute(context):
+        context.task["snapshot"]["model"] = "different"
+        return {"model": context.check()["snapshot"]["model"]}
+
+    runner = runners(execute)
+    task = runner.submit("one", "Task", {"model": "original"})
+    assert runner.wait("one", task["id"], timeout = 3)["result"] == {"model": "original"}
+
+
+def test_late_submission_during_shutdown_is_cancelled(task_db, runners, monkeypatch):
+    entered, release = threading.Event(), threading.Event()
+    create = state.create_task
+
+    def blocked_create(*args, **kwargs):
+        entered.set()
+        assert release.wait(3)
+        return create(*args, **kwargs)
+
+    monkeypatch.setattr(state, "create_task", blocked_create)
+    runner = runners(lambda _: pytest.fail("Closed runner executed a task"))
+    with ThreadPoolExecutor(max_workers = 1) as pool:
+        submission = pool.submit(runner.submit, "one", "Late", {})
+        assert entered.wait(3)
+        try:
+            assert runner.shutdown(timeout = 0.3)
+        finally:
+            release.set()
+        with pytest.raises(state.TaskStateError, match = "shutting down"):
+            submission.result(timeout = 3)
+    assert state.list_tasks("one")[0]["status"] == "cancelled"
+
+
+def test_parent_drain_timeout_does_not_claim_project_idle(runners):
+    child_started, release = threading.Event(), threading.Event()
+
+    def execute(context):
+        if context.task["parentId"]:
+            child_started.set()
+            assert release.wait(3)
+            return {}
+        context.delegate("Child", role = "reviewer", max_output_tokens = 10)
+        assert child_started.wait(3)
+        return {}
+
+    runner = runners(execute)
+    parent = runner.submit("one", "Parent", {}, child_limit = 1, child_budget = 10)
+    try:
+        result = runner.wait("one", parent["id"], timeout = 2)
+        assert result["status"] == "interrupted"
+        assert not runner.project_is_idle("one")
+        with pytest.raises(state.TaskStateError, match = "have not stopped"):
+            runner.retry("one", parent["id"])
+    finally:
+        release.set()
+    child = state.list_children("one", parent["id"])[0]
+    assert runner.wait("one", child["id"], timeout = 3)["status"] == "cancelled"
+    assert runner.project_is_idle("one")
+
+
+def test_archived_project_cancels_task_and_fences_submission(task_db, runners):
+    connect, _ = task_db
+    started = threading.Event()
+
+    def execute(context):
+        started.set()
+        assert context.cancel_event.wait(3)
+        context.check()
+
+    runner = runners(execute)
+    task = runner.submit("one", "Task", {})
+    assert started.wait(3)
+    with connect() as conn:
+        conn.execute("UPDATE chat_projects SET archived=1 WHERE id='one'")
+    assert runner.wait("one", task["id"], timeout = 3)["status"] == "cancelled"
+    with pytest.raises(state.TaskStateError, match = "Project not found"):
+        runner.submit("one", "More", {})
+
+
+def test_shutdown_after_project_deletion_still_stops_executor(task_db, runners):
+    connect, _ = task_db
+    started = threading.Event()
+
+    def execute(context):
+        started.set()
+        assert context.cancel_event.wait(3)
+        return {}
+
+    runner = runners(execute)
+    runner.submit("one", "Task", {})
+    assert started.wait(3)
+    with connect() as conn:
+        conn.execute("DELETE FROM chat_projects WHERE id='one'")
+    assert runner.shutdown(timeout = 3)
+
+
+def test_project_deletion_cascades_child_retries_and_events(task_db):
+    connect, _ = task_db
+    parent = running_root(child_limit = 1, child_budget = 20)
+    child = state.create_child(
+        parent["id"], "root-owner", "Child", {}, role = "reviewer", max_output_tokens = 10
+    )
+    state.cancel_task("one", child["id"])
+    state.retry_task("one", child["id"], parent_owner = "root-owner")
+    with connect() as conn:
+        conn.execute("DELETE FROM chat_projects WHERE id='one'")
+        assert conn.execute("SELECT COUNT(*) FROM studio_project_tasks").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM studio_project_task_events").fetchone()[0] == 0
+
+
+def test_task_tables_integrate_with_real_studio_storage():
+    from storage import studio_db
+
+    studio_db.upsert_chat_project(
+        {
+            "id": "integration",
+            "name": "Task integration",
+            "createdAt": 1000,
+            "updatedAt": 1000,
+        }
+    )
+    task = state.create_task("integration", "Inspect", {"model": "local"})
+    state.claim_task("integration", task["id"], "integration-owner")
+    state.finish_task(task["id"], "integration-owner", "completed", result = {"output": "Done"})
+    assert state.list_tasks("integration")[0]["result"] == {"output": "Done"}
+    studio_db.delete_chat_project("integration", delete_files = False)
+    assert state.list_tasks("integration") == []

--- a/studio/docs/project-task-engine.md
+++ b/studio/docs/project-task-engine.md
@@ -1,0 +1,109 @@
+# Durable project task engine
+
+`core.agent_workspace.task_state` and `task_runner` provide the internal execution
+foundation for project background agents. This layer has no HTTP endpoints,
+renderer controls, model loaders, or tool dispatcher. Importing it starts no work.
+An application constructs `ProjectTaskRunner` with a trusted server executor.
+
+## Ownership and recovery
+
+Each attempt has an immutable instruction and JSON snapshot, a project ID, a
+private worker token, and a 30-second lease. Tokens never appear in public task
+records or events. SQLite write transactions serialize creation, claiming,
+cancellation, child reservations, and retry accounting across connections.
+
+Queued attempts also expire. A submitted task waiting for a worker retains its
+lease through the runner's heartbeat. Expired queued or running attempts become
+`interrupted`; opening the runner never automatically executes saved tasks.
+Recovery commits even when the request that discovered expiry is refused, such
+as a late heartbeat from the old owner. Late workers cannot publish results.
+
+Cancellation moves queued tasks directly to `cancelled` and running tasks to
+`cancelling`. Running tasks retain ownership while their executor unwinds.
+Cancellation takes precedence over a concurrent successful result. Parent
+cancellation also cancels its children. Archiving a project requests cancellation
+on the next store operation; deleting its database row cascades task history.
+
+Retries create new attempts and preserve the previous result and events. They
+require an explicit request, have a single successor per attempt, and stop after
+three attempts. A parent cannot retry while its children are active. The runner
+also checks for local workers that have not returned, even if their database
+leases expired.
+
+## Bounded delegation
+
+The default runner has two root workers and two separate child workers. Two roots
+can therefore wait for their children without occupying the child execution lane.
+The configured bounds are one to four root workers and one to eight child workers.
+The durable queue admits at most 128 active attempts across projects/runners.
+
+A root explicitly reserves a child-count limit (at most eight) and a cumulative
+delegated output-token budget (at most 131,072). Each child reserves at most
+32,768 output tokens. Reservations are not refunded on failure or cancellation;
+child retries consume another reservation. The count is the number of logical
+children; the attempt cap bounds retries. Children cannot delegate recursively.
+Root retries start a new bounded root attempt.
+
+Root attempts default to a 900-second deadline, with a maximum of one hour.
+Children inherit the parent's deadline. The runner signals cancellation when it
+expires. Executors must enforce `maxOutputTokens` across their model turns; the
+engine cannot measure token usage inside an arbitrary callback. Results are
+limited to one MiB of JSON and snapshots to 128 KiB.
+
+## Executor integration contract
+
+The executor receives `TaskContext`, returns a JSON object, and uses
+`context.delegate`, `wait_child`, and `retry_child` for bounded delegation.
+`context.task` is a copy, so changing it cannot change durable authority.
+
+Before accepting a renderer request, the service must resolve the saved model
+selection, permission policy, and project/worktree identity on the server. The
+snapshot must exclude credentials and record enough identity to reject a changed
+runtime or workspace. The engine does not turn arbitrary snapshot fields or a
+role name into authority to access files, run tools, or contact providers.
+
+For each model/tool operation, the adapter must:
+
+1. Call `context.check()` and validate the captured runtime/workspace identity.
+2. Enforce the captured role and permission policy through the existing confined
+   file and supervised command APIs, including their in-flight operation fences.
+3. Pass `context.cancel_event` and the remaining deadline to active operations.
+4. Release model admission while waiting for a child. Separate Python workers do
+   not solve contention for a model slot held by a waiting parent.
+5. Preserve the selected model/provider and output-token cap. An unavailable
+   selection must fail explicitly instead of silently loading or routing elsewhere.
+
+A callback must cooperate with cancellation. Python threads cannot be forcibly
+stopped safely. `shutdown(timeout=...)` stops admission, signals cancellation, and
+returns `False` if any worker or lease watcher has not stopped within the bound.
+Workers are daemon threads so an uncooperative callback cannot hold process exit
+open. Cancellation does not undo operations already performed.
+
+## Project retirement
+
+The lifecycle adapter must call `begin_project_retirement` before draining tasks
+or acquiring the Git/workspace deletion fence. The retirement owner renews its
+lease while the operation is in progress and releases it with
+`finish_project_retirement`; a different owner cannot release it.
+
+`project_has_active_tasks` reports durable state. `runner.project_is_idle` also
+checks live workers in that runner. Check it only while holding the retirement
+admission fence; otherwise a new submission may race the observation. Neither
+check replaces the existing cross-process filesystem/process operation fence.
+Drain every owning runner before removing or merging a workspace.
+
+If a parent returns while children remain active, the engine cancels and drains
+them. A child that exceeds the drain timeout leaves the parent `interrupted` and
+the project busy until that child's worker returns. This is not successful cleanup.
+
+## Validation scope
+
+The focused tests exercise real SQLite transactions and worker threads, including
+concurrent claims and child-budget reservations, both root workers waiting on
+children, late results, retry caps, project retirement, and shutdown races.
+The CI matrix runs the engine and adjacent project-storage tests on Linux,
+Windows, and macOS with Python 3.11 and 3.12.
+
+Model/tool adapters, owned child worktrees, renderer controls, and real-model
+qualification are subsequent integration layers. These tests do not certify
+model admission, tool confinement, or an end-to-end background coding workflow.


### PR DESCRIPTION
The task engine is now included with its first real execution/UI consumer in #10658, as requested in review. This engine-only PR is retained as a draft for source/history reference; review and land the combined task feature through #10658 after its worktree prerequisites. The combined branch runs engine regressions in its integration matrix and removes this duplicate standalone workflow.

The original engine-only scope and validation receipt follow for traceability:

Background tasks need durable ownership and dedicated child capacity before model and workspace adapters can safely use them. This adds an internal project task store and bounded runner: parents can wait for children while separate child workers continue, interrupted attempts require explicit retries, and late workers cannot publish results after losing ownership.

The layer includes atomic child-count/token reservations, retry caps, immutable snapshots, monotonic events, queued/running lease recovery, cancellation and project-retirement admission fences. Shutdown stops admission and reports workers that have not returned; a child that cannot drain leaves its parent interrupted and its project busy. The executor contract documents the required model-admission release and existing filesystem/process fences.

This is the independently reviewable engine layer requested in #9673. No renderer endpoints, model/tool adapters, owned child-worktree wiring, or UI are added here. It does not advance the held existing-folder PR #9859, replace the aggregate #9987 executor, or claim an end-to-end background coding workflow.

Validation at `191ac8ba86943eb0bd54a9f1532c5d2ed384c6c5`:
- All six native jobs passed on Linux, macOS, and Windows with Python 3.11 and 3.12: [run 34387110775](https://github.com/PhilipJohnBasile/unsloth/actions/runs/34387110775). Each job covers 46 task-engine cases and 62 adjacent storage cases, including the actual Studio database integration.
- The same 108 cases passed locally in a clean Python 3.12 environment.
- 112 workflow-trigger regression cases passed; Ruff, repository formatting, and `git diff --check` passed.

The first native run exposed a racy assertion that shutdown had already flushed cancellation to SQLite, and the adjacent 900-thread storage fixture exceeded the 30-second Windows budget. The shutdown test now observes the actual cancellation signal. Storage runs with a separate 120-second budget while engine tests retain 30 seconds; no cases are skipped.

The tests cover concurrent claims and budget reservations, both parent workers waiting on children, stale results, explicit retries, shutdown/submission races, project archival/deletion, an executor that does not stop promptly, and preservation of worker capacity after an executor raises SystemExit. Real model, tool-confinement, and packaged-app qualification belong to the following integration layers.
