### PR TITLE
Studio: keep literal <think> text visible when the request turns thinking off

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -4208,6 +4208,26 @@ def _anthropic_preserve_thinking(llama_backend, payload) -> bool:
     return bool(getattr(llama_backend, "preserve_thinking_default", False))
 
 
+def _resolved_kwargs_think(llama_backend, resolved) -> bool:
+    """Whether the resolved template kwargs leave thinking on.
+
+    Effort-dial templates think at every level except "none" -- which Inkling's
+    numeric dial spells as 0, since _coerce_reasoning_effort rewrites the
+    sentinel before it gets here. With no explicit kwargs the model was launched
+    on the template's own default, so that decides.
+    """
+    if "enable_thinking" in resolved:
+        return bool(resolved["enable_thinking"])
+    if "reasoning_effort" in resolved:
+        effort = resolved["reasoning_effort"]
+        if isinstance(effort, str):
+            return effort.strip().lower() != "none"
+        if isinstance(effort, (int, float)) and not isinstance(effort, bool):
+            return float(effort) != 0.0
+        return True
+    return bool(getattr(llama_backend, "reasoning_default", True))
+
+
 def _think_parsing_expected(llama_backend, payload) -> bool:
     """Whether <think> markup in this reply can be genuine reasoning.
 
@@ -4236,13 +4256,7 @@ def _think_parsing_expected(llama_backend, payload) -> bool:
         )
         or {}
     )
-    if "enable_thinking" in resolved:
-        return bool(resolved["enable_thinking"])
-    if "reasoning_effort" in resolved:
-        # Effort-dial templates think at every level except "none".
-        return resolved["reasoning_effort"] != "none"
-    # No explicit kwargs: the template's own default decides whether it thinks.
-    return bool(getattr(llama_backend, "reasoning_default", True))
+    return _resolved_kwargs_think(llama_backend, resolved)
 
 
 def _anthropic_count_template_kwargs(llama_backend, payload):
@@ -27854,11 +27868,7 @@ def _responses_should_parse_think_markers(
             )
             or {}
         )
-        if "enable_thinking" in resolved:
-            return bool(resolved["enable_thinking"])
-        if "reasoning_effort" in resolved:
-            return resolved["reasoning_effort"] != "none"
-        return True
+        return _resolved_kwargs_think(llama_backend, resolved)
     if chat_req.enable_thinking is True:
         return True
     return chat_req.enable_thinking is None and chat_req.reasoning_effort not in (None, "none")

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3685,6 +3685,33 @@ def _sf_reasoning_prefill_mode(
     return _generation_prompt_opens_think(tpl, enable_thinking, reasoning_effort, messages)
 
 
+def _sf_parse_think_markers(
+    features: dict,
+    enable_thinking: Optional[bool] = None,
+    reasoning_effort: Optional[str] = None,
+) -> bool:
+    """Whether <think> markup in a safetensors/MLX reply can be genuine reasoning.
+
+    Both raw fields reach the template, which reads only the dial it branches on; a
+    hybrid sent both reads enable_thinking first (Kimi-K3).
+    """
+    if features.get("reasoning_always_on"):
+        return True
+    if not features.get("supports_reasoning"):
+        return False
+    style = features.get("reasoning_style")
+    resolved: dict = {}
+    if style == "reasoning_effort":
+        if reasoning_effort is not None:
+            resolved["reasoning_effort"] = reasoning_effort
+    elif enable_thinking is not None:
+        resolved["enable_thinking"] = enable_thinking
+    elif style == "enable_thinking_effort" and reasoning_effort is not None:
+        resolved["reasoning_effort"] = reasoning_effort
+    # No launch default on this backend: an empty dict leaves the template's own.
+    return _resolved_kwargs_think(None, resolved)
+
+
 def _effective_enable_tools(payload) -> Optional[bool]:
     """Resolve `payload.enable_tools` against the process-level tool policy.
 
@@ -24223,6 +24250,11 @@ async def produce_openai_chat_completions(
     except Exception:
         _sf_probe_messages = None
 
+    # Transformers vision generation drops both reasoning fields; MLX forwards them.
+    _sf_vision_drops_reasoning = image is not None and not _sf_model_info.get("is_mlx", False)
+    _sf_gate_enable_thinking = None if _sf_vision_drops_reasoning else payload.enable_thinking
+    _sf_gate_reasoning_effort = None if _sf_vision_drops_reasoning else payload.reasoning_effort
+
     def _sf_response_protocol(
         tools = None,
         template = None,
@@ -24247,8 +24279,10 @@ async def produce_openai_chat_completions(
                 body = _selected[0]
         except Exception:
             logger.debug("safetensors_prefill_template_selection_failed", exc_info = True)
-        parse_think = bool(
-            features.get("supports_reasoning") or features.get("reasoning_always_on")
+        parse_think = _sf_parse_think_markers(
+            features,
+            _sf_gate_enable_thinking,
+            _sf_gate_reasoning_effort,
         )
         reasoning_prefilled = _sf_reasoning_prefill_mode(
             features,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -4211,10 +4211,9 @@ def _anthropic_preserve_thinking(llama_backend, payload) -> bool:
 def _resolved_kwargs_think(llama_backend, resolved) -> bool:
     """Whether the resolved template kwargs leave thinking on.
 
-    Effort-dial templates think at every level except "none" -- which Inkling's
-    numeric dial spells as 0, since _coerce_reasoning_effort rewrites the
-    sentinel before it gets here. With no explicit kwargs the model was launched
-    on the template's own default, so that decides.
+    Effort dials think at every level except "none", which Inkling's
+    _coerce_reasoning_effort rewrites to numeric 0. With no kwargs the model
+    runs on the default it was launched with.
     """
     if "enable_thinking" in resolved:
         return bool(resolved["enable_thinking"])
@@ -27858,7 +27857,7 @@ def _responses_should_parse_think_markers(
             return True
         if not getattr(llama_backend, "supports_reasoning", False):
             return False
-        # Same rule as _think_parsing_expected: decide from the resolved template kwargs.
+        # Same rule as _think_parsing_expected: decide from the resolved kwargs.
         resolved = (
             _reasoning_template_kwargs(
                 llama_backend,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -27842,9 +27842,23 @@ def _responses_should_parse_think_markers(
     if llama_backend is not None and getattr(llama_backend, "is_loaded", False):
         if getattr(llama_backend, "reasoning_always_on", False):
             return True
-        if getattr(llama_backend, "supports_reasoning", False):
-            return True
-        return False
+        if not getattr(llama_backend, "supports_reasoning", False):
+            return False
+        # Same rule as _think_parsing_expected: decide from the resolved template kwargs.
+        resolved = (
+            _reasoning_template_kwargs(
+                llama_backend,
+                chat_req.enable_thinking,
+                chat_req.reasoning_effort,
+                chat_req.preserve_thinking,
+            )
+            or {}
+        )
+        if "enable_thinking" in resolved:
+            return bool(resolved["enable_thinking"])
+        if "reasoning_effort" in resolved:
+            return resolved["reasoning_effort"] != "none"
+        return True
     if chat_req.enable_thinking is True:
         return True
     return chat_req.enable_thinking is None and chat_req.reasoning_effort not in (None, "none")

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -216,6 +216,21 @@ def test_think_parsing_expected_gates_on_capability_and_request():
         _think_parsing_expected(_EffortBackend(), _basic_payload(reasoning_effort = "none")) is False
     )
 
+    # Inkling's dial is numeric: _coerce_reasoning_effort rewrites the "none"
+    # sentinel to 0 on the way out, so zero has to read as off too.
+    class _NumericEffortBackend(_Backend):
+        def _request_reasoning_kwargs(self, enable_thinking, reasoning_effort, preserve_thinking):
+            return {"reasoning_effort": 0.0 if reasoning_effort == "none" else 0.2}
+
+    assert (
+        _think_parsing_expected(_NumericEffortBackend(), _basic_payload(reasoning_effort = "none"))
+        is False
+    )
+    assert (
+        _think_parsing_expected(_NumericEffortBackend(), _basic_payload(enable_thinking = False))
+        is True
+    )
+
 
 def test_anthropic_reasoning_args_maps_effort_only_to_enable_thinking():
     # Effort-only requests must drive enable_thinking-style templates the same

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -216,8 +216,7 @@ def test_think_parsing_expected_gates_on_capability_and_request():
         _think_parsing_expected(_EffortBackend(), _basic_payload(reasoning_effort = "none")) is False
     )
 
-    # Inkling's dial is numeric: _coerce_reasoning_effort rewrites the "none"
-    # sentinel to 0 on the way out, so zero has to read as off too.
+    # Inkling: _coerce_reasoning_effort rewrites the "none" sentinel to 0, so 0 reads as off.
     class _NumericEffortBackend(_Backend):
         def _request_reasoning_kwargs(self, enable_thinking, reasoning_effort, preserve_thinking):
             return {"reasoning_effort": 0.0 if reasoning_effort == "none" else 0.2}

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -5046,24 +5046,45 @@ class TestGgufVisionToolRouting:
         [entry] = result.monitor.snapshot()
         assert entry["reply"] == "visible"
 
-    def test_reasoning_capable_gguf_stream_sanitizes_think_tags_when_disabled(self, monkeypatch):
+    def test_reasoning_capable_gguf_stream_keeps_think_tags_visible_when_disabled(self, monkeypatch):
+        answer = "Use <think>hi</think> in your prompt."
+
         def _generate(**_kwargs):
-            yield "<think>leaked</think>visible"
+            yield answer
             yield _stop_metadata()
 
         result = self._run_gguf_case(
             monkeypatch,
             generate = _generate,
-            payload_kwargs = {"stream": True, "enable_thinking": False},
+            # The shape Studio's own composer sends for an enable_thinking template
+            # once the Thinking toggle is off.
+            payload_kwargs = {"stream": True, "thinking": {"type": "disabled"}},
             backend_kwargs = {"reasoning_always_on": False},
         )
         deltas = [p["choices"][0].get("delta", {}) for p in result.payloads if p.get("choices")]
 
-        assert "".join(d.get("reasoning_content", "") for d in deltas) == "leaked"
-        assert "".join(d.get("content", "") for d in deltas) == "visible"
-        assert all("<think>" not in d.get("content", "") for d in deltas)
+        assert "".join(d.get("reasoning_content", "") for d in deltas) == ""
+        assert "".join(d.get("content", "") for d in deltas) == answer
         [entry] = result.monitor.snapshot()
-        assert entry["reply"] == "visible"
+        assert entry["reply"] == answer
+
+    def test_reasoning_capable_gguf_keeps_think_tags_visible_when_disabled(self, monkeypatch):
+        answer = "Use <think>hi</think> in your prompt."
+
+        def _generate(**_kwargs):
+            yield answer
+            yield _stop_metadata()
+
+        result = self._run_gguf_case(
+            monkeypatch,
+            generate = _generate,
+            payload_kwargs = {"enable_thinking": False},
+            backend_kwargs = {"reasoning_always_on": False},
+        )
+        message = result.body["choices"][0]["message"]
+
+        assert message["content"] == answer
+        assert message.get("reasoning_content") is None
 
     def test_gguf_tool_stream_splits_reasoning_and_strips_gemma_tool_marker(self, monkeypatch):
         def _tools(**_kwargs):

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -5046,7 +5046,9 @@ class TestGgufVisionToolRouting:
         [entry] = result.monitor.snapshot()
         assert entry["reply"] == "visible"
 
-    def test_reasoning_capable_gguf_stream_keeps_think_tags_visible_when_disabled(self, monkeypatch):
+    def test_reasoning_capable_gguf_stream_keeps_think_tags_visible_when_disabled(
+        self, monkeypatch
+    ):
         answer = "Use <think>hi</think> in your prompt."
 
         def _generate(**_kwargs):

--- a/studio/backend/tests/test_responses_tool_passthrough.py
+++ b/studio/backend/tests/test_responses_tool_passthrough.py
@@ -1938,11 +1938,6 @@ class TestResponsesNonStreamingAdapter:
                 is_loaded = True,
                 reasoning_always_on = False,
                 supports_reasoning = True,
-                _request_reasoning_kwargs = (
-                    lambda enable_thinking, reasoning_effort = None, preserve_thinking = None: (
-                        {"enable_thinking": bool(enable_thinking)}
-                    )
-                ),
             ),
         )
 
@@ -1966,6 +1961,74 @@ class TestResponsesNonStreamingAdapter:
                         {"reasoning_effort": "low"}
                     )
                 ),
+            ),
+        )
+
+        assert [item["type"] for item in body["output"]] == ["reasoning", "message"]
+        assert body["output"][0]["content"] == [{"type": "reasoning_text", "text": "plan"}]
+        assert body["output"][1]["content"][0]["text"] == "answer"
+
+    def test_inkling_numeric_zero_effort_keeps_think_tags_visible(self, monkeypatch):
+        # The real resolver, not a stand-in: for an Inkling template
+        # _coerce_reasoning_effort rewrites the "none" sentinel to numeric 0
+        # before the gate sees it, so a string comparison alone reads thinking
+        # as still on and eats the literal tags.
+        from core.inference.llama_cpp import LlamaCppBackend
+
+        backend = LlamaCppBackend.__new__(LlamaCppBackend)
+        backend._process = object()
+        backend._healthy = True
+        backend._supports_reasoning = True
+        backend._reasoning_always_on = False
+        backend._reasoning_style = "reasoning_effort"
+        backend._reasoning_effort_levels = ["none", "low", "medium", "high", "max"]
+        backend._supports_preserve_thinking = False
+        backend._preserve_thinking_default = False
+        backend._reasoning_default = True
+        backend._architecture = "inkling"
+
+        assert backend._request_reasoning_kwargs(False, "none", None) == {"reasoning_effort": 0.0}
+
+        payload = ResponsesRequest(input = "hi", reasoning = {"effort": "none"})
+        body = self._run_with_message(
+            monkeypatch,
+            {"content": "Use <think>hi</think> in your prompt."},
+            payload = payload,
+            llama_backend = backend,
+        )
+
+        assert [item["type"] for item in body["output"]] == ["message"]
+        assert body["output"][0]["content"][0]["text"] == "Use <think>hi</think> in your prompt."
+
+    def test_launch_default_thinking_off_keeps_think_tags_visible(self, monkeypatch):
+        # An SDK client that names no reasoning field sends no override, so the
+        # model answers on the default it was launched with. The Qwen3.5 Small
+        # tier launches thinking off, and its literal tags must survive too.
+        body = self._run_with_message(
+            monkeypatch,
+            {"content": "Use <think>hi</think> in your prompt."},
+            llama_backend = SimpleNamespace(
+                is_loaded = True,
+                reasoning_always_on = False,
+                supports_reasoning = True,
+                reasoning_default = False,
+            ),
+        )
+
+        assert [item["type"] for item in body["output"]] == ["message"]
+        assert body["output"][0]["content"][0]["text"] == "Use <think>hi</think> in your prompt."
+
+    def test_launch_default_thinking_on_still_parses_think_tags(self, monkeypatch):
+        # The mirror: the same unspecified request on a thinking-on default
+        # keeps splitting, so the fix above cannot be read as "never parse".
+        body = self._run_with_message(
+            monkeypatch,
+            {"content": "<think>plan</think>answer"},
+            llama_backend = SimpleNamespace(
+                is_loaded = True,
+                reasoning_always_on = False,
+                supports_reasoning = True,
+                reasoning_default = True,
             ),
         )
 

--- a/studio/backend/tests/test_responses_tool_passthrough.py
+++ b/studio/backend/tests/test_responses_tool_passthrough.py
@@ -1928,21 +1928,49 @@ class TestResponsesNonStreamingAdapter:
         assert body["output"][0]["content"] == [{"type": "reasoning_text", "text": "plan"}]
         assert body["output"][1]["content"][0]["text"] == "answer"
 
-    def test_reasoning_capable_gguf_sanitizes_think_tags_when_disabled(self, monkeypatch):
+    def test_reasoning_capable_gguf_keeps_think_tags_visible_when_disabled(self, monkeypatch):
         payload = ResponsesRequest(input = "hi", reasoning = {"effort": "none"})
         body = self._run_with_message(
             monkeypatch,
-            {"content": "<think>leaked</think>answer"},
+            {"content": "Use <think>hi</think> in your prompt."},
             payload = payload,
             llama_backend = SimpleNamespace(
                 is_loaded = True,
                 reasoning_always_on = False,
                 supports_reasoning = True,
+                _request_reasoning_kwargs = (
+                    lambda enable_thinking, reasoning_effort = None, preserve_thinking = None: (
+                        {"enable_thinking": bool(enable_thinking)}
+                    )
+                ),
+            ),
+        )
+
+        assert [item["type"] for item in body["output"]] == ["message"]
+        assert body["output"][0]["content"][0]["text"] == "Use <think>hi</think> in your prompt."
+
+    def test_effort_dial_gguf_still_parses_think_tags_when_disabled(self, monkeypatch):
+        payload = ResponsesRequest(input = "hi", reasoning = {"effort": "none"})
+        body = self._run_with_message(
+            monkeypatch,
+            {"content": "<think>plan</think>answer"},
+            payload = payload,
+            llama_backend = SimpleNamespace(
+                is_loaded = True,
+                reasoning_always_on = False,
+                supports_reasoning = True,
+                # gpt-oss cannot stop thinking: "none" is not a level it offers, so the
+                # request leaves it on a low effort and genuine markup still streams.
+                _request_reasoning_kwargs = (
+                    lambda enable_thinking, reasoning_effort = None, preserve_thinking = None: (
+                        {"reasoning_effort": "low"}
+                    )
+                ),
             ),
         )
 
         assert [item["type"] for item in body["output"]] == ["reasoning", "message"]
-        assert body["output"][0]["content"] == [{"type": "reasoning_text", "text": "leaked"}]
+        assert body["output"][0]["content"] == [{"type": "reasoning_text", "text": "plan"}]
         assert body["output"][1]["content"][0]["text"] == "answer"
 
     def test_structured_reasoning_content_extracts_text_parts(self, monkeypatch):

--- a/studio/backend/tests/test_responses_tool_passthrough.py
+++ b/studio/backend/tests/test_responses_tool_passthrough.py
@@ -1954,8 +1954,7 @@ class TestResponsesNonStreamingAdapter:
                 is_loaded = True,
                 reasoning_always_on = False,
                 supports_reasoning = True,
-                # gpt-oss cannot stop thinking: "none" is not a level it offers, so the
-                # request leaves it on a low effort and genuine markup still streams.
+                # gpt-oss offers no "none" level, so it stays on low effort and the markup is real.
                 _request_reasoning_kwargs = (
                     lambda enable_thinking, reasoning_effort = None, preserve_thinking = None: (
                         {"reasoning_effort": "low"}
@@ -1969,10 +1968,8 @@ class TestResponsesNonStreamingAdapter:
         assert body["output"][1]["content"][0]["text"] == "answer"
 
     def test_inkling_numeric_zero_effort_keeps_think_tags_visible(self, monkeypatch):
-        # The real resolver, not a stand-in: for an Inkling template
-        # _coerce_reasoning_effort rewrites the "none" sentinel to numeric 0
-        # before the gate sees it, so a string comparison alone reads thinking
-        # as still on and eats the literal tags.
+        # Real resolver, not a stand-in: for Inkling, _coerce_reasoning_effort rewrites
+        # the "none" sentinel to numeric 0, which a string-only check misreads as still on.
         from core.inference.llama_cpp import LlamaCppBackend
 
         backend = LlamaCppBackend.__new__(LlamaCppBackend)
@@ -2001,9 +1998,8 @@ class TestResponsesNonStreamingAdapter:
         assert body["output"][0]["content"][0]["text"] == "Use <think>hi</think> in your prompt."
 
     def test_launch_default_thinking_off_keeps_think_tags_visible(self, monkeypatch):
-        # An SDK client that names no reasoning field sends no override, so the
-        # model answers on the default it was launched with. The Qwen3.5 Small
-        # tier launches thinking off, and its literal tags must survive too.
+        # No reasoning field means no override, so the model runs on the default it was
+        # launched with. The Qwen3.5 Small tier launches thinking off.
         body = self._run_with_message(
             monkeypatch,
             {"content": "Use <think>hi</think> in your prompt."},
@@ -2019,8 +2015,7 @@ class TestResponsesNonStreamingAdapter:
         assert body["output"][0]["content"][0]["text"] == "Use <think>hi</think> in your prompt."
 
     def test_launch_default_thinking_on_still_parses_think_tags(self, monkeypatch):
-        # The mirror: the same unspecified request on a thinking-on default
-        # keeps splitting, so the fix above cannot be read as "never parse".
+        # Mirror: a thinking-on launch default still splits, so the fix is not "never parse".
         body = self._run_with_message(
             monkeypatch,
             {"content": "<think>plan</think>answer"},

--- a/studio/backend/tests/test_safetensors_reasoning_stream.py
+++ b/studio/backend/tests/test_safetensors_reasoning_stream.py
@@ -23,6 +23,7 @@ if _BACKEND_DIR not in sys.path:
 
 from routes.inference import (
     _ResponsesReasoningExtractor,
+    _sf_parse_think_markers,
     _sf_reasoning_prefill_mode,
     _strip_tool_xml_for_display,
 )
@@ -146,6 +147,7 @@ _STRICT_HISTORY_TPL = (
     "{% endif %}<|im_start|>{{ m['role'] }}\n{{ m['content'] }}<|im_end|>\n{% endfor %}"
     "{% if add_generation_prompt %}<|im_start|>assistant\n<think>\n\n</think>\n\n{% endif %}"
 )
+_TINY_PNG_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAE0lEQVR4nGM8ISfHAANMcBZeDgA0dgEMydTl/QAAAABJRU5ErkJggg=="
 _ETHINK = {"reasoning_style": "enable_thinking", "supports_reasoning": True}
 _ETHINK_EFFORT = {"reasoning_style": "enable_thinking_effort", "supports_reasoning": True}
 
@@ -615,7 +617,15 @@ def test_the_eager_import_under_the_stubs_actually_succeeded():
     assert "core.inference.inference" in sys.modules
 
 
-def _sf_route_message(monkeypatch, template, snapshots, **body):
+def _sf_route_message(
+    monkeypatch,
+    template,
+    snapshots,
+    is_vision = False,
+    is_mlx = False,
+    features = None,
+    **body,
+):
     """POST a non-streaming safetensors chat completion and return the assistant message."""
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
@@ -630,7 +640,13 @@ def _sf_route_message(monkeypatch, template, snapshots, **body):
 
     class _Safetensors:
         active_model_name = "qwen"
-        models = {"qwen": {"chat_template_info": {"template": template}}}
+        models = {
+            "qwen": {
+                "chat_template_info": {"template": template},
+                "is_vision": is_vision,
+                "is_mlx": is_mlx,
+            }
+        }
 
         def generate_chat_response(self, **kwargs):
             yield from snapshots
@@ -638,10 +654,13 @@ def _sf_route_message(monkeypatch, template, snapshots, **body):
         def reset_generation_state(self, *_args):
             return None
 
+        def resize_image(self, image):
+            return image
+
     monkeypatch.setattr(
         inference_route,
         "_detect_safetensors_features",
-        lambda backend, chat_template, tools = None: dict(_ETHINK, supports_tools = False),
+        lambda backend, chat_template, tools = None: dict(features or _ETHINK, supports_tools = False),
     )
     monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: _NoGGUF())
     monkeypatch.setattr(inference_route, "get_inference_backend", lambda: _Safetensors())
@@ -669,3 +688,93 @@ def test_route_returns_the_answer_as_content_when_the_template_closes_its_block(
     message = _sf_route_message(monkeypatch, _TEMPLATE_DEFAULT_OFF_TPL, snapshots)
     assert message["content"] == "The capital of Japan is Tokyo."
     assert not message["reasoning_content"]
+
+
+def test_route_keeps_literal_think_text_when_the_request_turns_thinking_off(monkeypatch):
+    answer = "Use <think>hi</think> in your prompt."
+    message = _sf_route_message(
+        monkeypatch,
+        _TEMPLATE_DEFAULT_OFF_TPL,
+        [answer],
+        enable_thinking = False,
+    )
+    assert message["content"] == answer
+    assert not message["reasoning_content"]
+
+
+def test_route_still_splits_real_thinking_when_the_request_leaves_it_on(monkeypatch):
+    message = _sf_route_message(
+        monkeypatch,
+        _TEMPLATE_DEFAULT_OFF_TPL,
+        ["<think>plan</think>answer"],
+        enable_thinking = True,
+    )
+    assert message["content"] == "answer"
+    assert message["reasoning_content"] == "plan"
+
+
+def test_route_still_splits_a_transformers_image_turn_the_request_asked_to_disable(monkeypatch):
+    """Transformers vision generation ignores both reasoning fields."""
+    message = _sf_route_message(
+        monkeypatch,
+        _TEMPLATE_DEFAULT_OFF_TPL,
+        ["<think>plan</think>answer"],
+        is_vision = True,
+        enable_thinking = False,
+        image_base64 = _TINY_PNG_B64,
+    )
+    assert message["content"] == "answer"
+    assert message["reasoning_content"] == "plan"
+
+
+def test_route_keeps_literal_think_text_on_an_mlx_image_turn(monkeypatch):
+    """Effort alone, so a guard that drops it cannot pass on the boolean."""
+    answer = "Use <think>hi</think> in your prompt."
+    message = _sf_route_message(
+        monkeypatch,
+        _EFFORT_SHAPE_TPL,
+        [answer],
+        features = _ETHINK_EFFORT,
+        is_vision = True,
+        is_mlx = True,
+        reasoning_effort = "none",
+        image_base64 = _TINY_PNG_B64,
+    )
+    assert message["content"] == answer
+    assert not message["reasoning_content"]
+
+
+def test_route_carries_the_effort_field_into_the_gate(monkeypatch):
+    answer = "Use <think>hi</think> in your prompt."
+    message = _sf_route_message(
+        monkeypatch,
+        _EFFORT_SHAPE_TPL,
+        [answer],
+        features = _ETHINK_EFFORT,
+        reasoning_effort = "none",
+    )
+    assert message["content"] == answer
+    assert not message["reasoning_content"]
+
+
+def test_parse_think_markers_gates_on_capability_and_request():
+    assert _sf_parse_think_markers(_ETHINK) is True
+    assert _sf_parse_think_markers(_ETHINK, True) is True
+    assert _sf_parse_think_markers(_ETHINK, False) is False
+    assert _sf_parse_think_markers(dict(_ETHINK, reasoning_always_on = True), False) is True
+    assert _sf_parse_think_markers({"supports_reasoning": False}, True) is False
+
+
+def test_parse_think_markers_reads_only_the_dial_the_template_branches_on():
+    # Plain enable_thinking templates ignore the effort.
+    assert _sf_parse_think_markers(_ETHINK, None, "none") is True
+    # Effort-only ladders ignore the boolean.
+    _EFFORT_ONLY = {"reasoning_style": "reasoning_effort", "supports_reasoning": True}
+    assert _sf_parse_think_markers(_EFFORT_ONLY, False, None) is True
+    assert _sf_parse_think_markers(_EFFORT_ONLY, None, "none") is False
+    assert _sf_parse_think_markers(_EFFORT_ONLY, None, "low") is True
+    # Hybrid templates read enable_thinking first (Kimi-K3).
+    assert _sf_parse_think_markers(_ETHINK_EFFORT, True, "none") is True
+    assert _sf_parse_think_markers(_ETHINK_EFFORT, False, "high") is False
+    assert _sf_parse_think_markers(_ETHINK_EFFORT, None, "none") is False
+    assert _sf_parse_think_markers(_ETHINK_EFFORT, None, "high") is True


### PR DESCRIPTION
When a request turns thinking off, the server still runs the think tag splitter on the reply. So if a model writes the literal text `<think>hi</think>` as part of its answer, that text gets cut out of the visible reply and moved into a hidden reasoning block. A stray closing tag is deleted outright. This happens on the chat completions and responses endpoints, and Studio's own composer sends this shape when the Thinking toggle is off.

The gate now checks the request the same way the messages endpoint already does. Thinking off means the tags stay as text. Thinking on, always on reasoning models, and models that map thinking off to a low effort keep splitting as before. Two existing tests that locked in the old behavior are updated, and new tests cover both endpoints.
