### PR TITLE
Studio: keep an uploaded document's own name instead of replacing it with underscores

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -4778,8 +4778,8 @@ _roster_failure_logged = False
 # character after them, so one file name can rewrite how the rest of the sentence renders
 # (CVE-2021-42574, "Trojan Source"); U+200B and the joiners split a name into pieces that
 # read as one; ESC is a terminal control sequence in any console or log that echoes the
-# prompt. Only linked folders can carry them -- uploads pass an allowlist at
-# routes/rag.py:_sanitize_filename -- but a linked folder indexes a relative path exactly
+# prompt. Only linked folders can carry them -- routes/rag.py:_sanitize_filename strips
+# them out of an uploaded name -- but a linked folder indexes a relative path exactly
 # as it came off disk, and every byte except "/" and NUL is legal in one.
 #
 # The whitespace-like controls map to a space instead of being dropped, so that a name

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -4778,7 +4778,7 @@ _roster_failure_logged = False
 # character after them, so one file name can rewrite how the rest of the sentence renders
 # (CVE-2021-42574, "Trojan Source"); U+200B and the joiners split a name into pieces that
 # read as one; ESC is a terminal control sequence in any console or log that echoes the
-# prompt. Only linked folders can carry them -- routes/rag.py:_sanitize_filename strips
+# prompt. Only linked folders can carry them -- routes/rag.py:_document_label strips
 # them out of an uploaded name -- but a linked folder indexes a relative path exactly
 # as it came off disk, and every byte except "/" and NUL is legal in one.
 #

--- a/studio/backend/routes/rag.py
+++ b/studio/backend/routes/rag.py
@@ -95,18 +95,14 @@ def _availability(available: bool) -> dict:
     }
 
 
-def _sanitize_filename(name: str) -> str:
+def _document_label(name: str) -> str:
     # A display label, never a path: the bytes are stored at uploads/<uuid><ext>.
     base = "".join(
-        " " if ch.isspace() else "" if unicodedata.category(ch) in ("Cc", "Cf") else ch
+        (" " if ch.isspace() else "") if unicodedata.category(ch) in ("Cc", "Cf") else ch
         for ch in name or ""
     )
-    # Split on the separators themselves, not ntpath.basename: that reads any single
-    # character before a colon as a drive, and macOS stores a Finder "/" as ":" on disk,
-    # so a dropped "P/L statement.pdf" arrives here as "P:L statement.pdf" and would come
-    # out as "L statement.pdf".
-    base = base.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
-    base = re.sub(r"\s+", " ", base).strip() or "document"
+    # Not \s+: U+3000 and the other Zs spaces belong to the name.
+    base = re.sub(r" +", " ", base).strip() or "document"
     if len(base) <= 200:
         return base
     # Trim the stem, not the extension: _save_upload gates on the extension, so
@@ -115,6 +111,21 @@ def _sanitize_filename(name: str) -> str:
     if not ext or len(ext) > 32:
         return base[:200]
     return stem[: 200 - len(ext)] + ext
+
+
+# Names treated as Windows paths. Each is also a legal POSIX filename; the list stays
+# narrow because splitting a real name loses part of it. One leading backslash counts as
+# UNC because multipart parsing unescapes "\\" to "\".
+_LOOKS_LIKE_WINDOWS_PATH = re.compile(r"^(?:[A-Za-z]:[\\/]|\\\\?|\.{1,2}\\)")
+
+
+def _sanitize_filename(name: str) -> str:
+    """Label a browser upload, whose client-supplied name may carry a path."""
+    # Not ntpath.basename: it reads "P:L statement.pdf", how macOS stores a Finder "/",
+    # as drive "P:". Classify first: splitting on "/" would strip the drive from "C:/a\b".
+    raw = name or ""
+    parts = re.split(r"[\\/]", raw) if _LOOKS_LIKE_WINDOWS_PATH.match(raw) else raw.split("/")
+    return _document_label(parts[-1])
 
 
 def _persist_upload_stream(source, filename: str, *, empty_detail: str) -> tuple[str, str, str]:
@@ -189,7 +200,8 @@ def _save_native_path_upload(lease: str) -> tuple[str, str, str]:
     except NativePathLeaseError as exc:
         raise HTTPException(status_code = 400, detail = str(exc)) from exc
 
-    filename = _sanitize_filename(grant.canonical_path.name)
+    # Path.name is one component, so a "\" in it is part of the name, as in "AC\DC.pdf".
+    filename = _document_label(grant.canonical_path.name)
     try:
         with open(grant.canonical_path, "rb") as source:
             return _persist_upload_stream(

--- a/studio/backend/routes/rag.py
+++ b/studio/backend/routes/rag.py
@@ -19,7 +19,6 @@ import hashlib
 import hmac
 import json
 import logging
-import ntpath
 import os
 import re
 import secrets
@@ -102,7 +101,12 @@ def _sanitize_filename(name: str) -> str:
         " " if ch.isspace() else "" if unicodedata.category(ch) in ("Cc", "Cf") else ch
         for ch in name or ""
     )
-    base = re.sub(r"\s+", " ", ntpath.basename(base)).strip() or "document"
+    # Split on the separators themselves, not ntpath.basename: that reads any single
+    # character before a colon as a drive, and macOS stores a Finder "/" as ":" on disk,
+    # so a dropped "P/L statement.pdf" arrives here as "P:L statement.pdf" and would come
+    # out as "L statement.pdf".
+    base = base.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+    base = re.sub(r"\s+", " ", base).strip() or "document"
     if len(base) <= 200:
         return base
     # Trim the stem, not the extension: _save_upload gates on the extension, so

--- a/studio/backend/routes/rag.py
+++ b/studio/backend/routes/rag.py
@@ -98,7 +98,9 @@ def _availability(available: bool) -> dict:
 def _document_label(name: str) -> str:
     # A display label, never a path: the bytes are stored at uploads/<uuid><ext>.
     base = "".join(
-        (" " if ch.isspace() else "") if unicodedata.category(ch) in ("Cc", "Cf") else ch
+        (" " if ch.isspace() else "")
+        if unicodedata.category(ch) in ("Cc", "Cf", "Zl", "Zp")
+        else ch
         for ch in name or ""
     )
     # Not \s+: U+3000 and the other Zs spaces belong to the name.

--- a/studio/backend/routes/rag.py
+++ b/studio/backend/routes/rag.py
@@ -19,11 +19,13 @@ import hashlib
 import hmac
 import json
 import logging
+import ntpath
 import os
 import re
 import secrets
 import sqlite3
 import time
+import unicodedata
 import uuid
 from contextlib import contextmanager
 from typing import Annotated, Iterator
@@ -94,12 +96,13 @@ def _availability(available: bool) -> dict:
     }
 
 
-_SAFE = re.compile(r"[^A-Za-z0-9._-]+")
-
-
 def _sanitize_filename(name: str) -> str:
-    base = os.path.basename(name or "").strip() or "document"
-    base = _SAFE.sub("_", base)
+    # A display label, never a path: the bytes are stored at uploads/<uuid><ext>.
+    base = "".join(
+        " " if ch.isspace() else "" if unicodedata.category(ch) in ("Cc", "Cf") else ch
+        for ch in name or ""
+    )
+    base = re.sub(r"\s+", " ", ntpath.basename(base)).strip() or "document"
     if len(base) <= 200:
         return base
     # Trim the stem, not the extension: _save_upload gates on the extension, so

--- a/studio/backend/tests/test_rag_project_source_upload.py
+++ b/studio/backend/tests/test_rag_project_source_upload.py
@@ -3,12 +3,14 @@
 
 """Project sources upload: the path the create-project dialog drives."""
 
+import io
 import os
 
 import pytest
+from fastapi import UploadFile
 
 from core.rag import ingestion, store
-from routes.rag import _sanitize_filename
+from routes.rag import _sanitize_filename, _save_upload
 from storage import rag_db
 
 
@@ -79,3 +81,51 @@ def test_sanitized_filenames_carry_no_path(raw):
 @pytest.mark.parametrize("raw", ["." * 300, "noext" * 100, "a" * 100 + "." + "e" * 250])
 def test_sanitizer_degrades_safely(raw):
     assert 0 < len(_sanitize_filename(raw)) <= 200
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "报告.pdf",
+        "日本語ドキュメント.txt",
+        "Отчёт 2026.pdf",
+        "résumé.docx",
+        "My Report.pdf",
+        "Q3: Revenue.pdf",
+    ],
+)
+def test_sanitizer_keeps_the_name_the_user_gave(raw):
+    assert _sanitize_filename(raw) == raw
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("a\x00b.pdf", "ab.pdf"),
+        ("a\u202eb.pdf", "ab.pdf"),
+        ("a\u200bb.pdf", "ab.pdf"),
+        ("\ufeff报告.pdf", "报告.pdf"),
+        ("a\nb.pdf", "a b.pdf"),
+        ("C:notes.txt", "notes.txt"),
+    ],
+)
+def test_sanitizer_normalizes_what_a_label_cannot_carry(raw, expected):
+    assert _sanitize_filename(raw) == expected
+
+
+def test_uploaded_unicode_name_is_persisted_verbatim(rag_home, stub_embeddings):
+    payload = b"alpha bravo charlie " * 50
+    stored_path, filename, _ = _save_upload(
+        UploadFile(file = io.BytesIO(payload), filename = "报告 2026.txt")
+    )
+    assert filename == "报告 2026.txt"
+
+    _, job_id = _ingest("P9", filename, stored_path)
+    assert _wait(job_id)["status"] == "completed"
+
+    conn = rag_db.get_connection()
+    try:
+        docs = store.list_documents(conn, store.project_scope("P9"))
+        assert [d["filename"] for d in docs] == ["报告 2026.txt"]
+    finally:
+        conn.close()

--- a/studio/backend/tests/test_rag_project_source_upload.py
+++ b/studio/backend/tests/test_rag_project_source_upload.py
@@ -110,6 +110,7 @@ def test_sanitizer_keeps_the_name_the_user_gave(raw):
         ("a\u200bb.pdf", "ab.pdf"),
         ("\ufeff报告.pdf", "报告.pdf"),
         ("a\nb.pdf", "a b.pdf"),
+        ("a\u2028b.pdf", "a b.pdf"),
         # What a browser actually sends for a file picked on Windows.
         ("C:\\fakepath\\notes.txt", "notes.txt"),
     ],

--- a/studio/backend/tests/test_rag_project_source_upload.py
+++ b/studio/backend/tests/test_rag_project_source_upload.py
@@ -92,6 +92,10 @@ def test_sanitizer_degrades_safely(raw):
         "résumé.docx",
         "My Report.pdf",
         "Q3: Revenue.pdf",
+        # macOS keeps a Finder "/" on disk as ":", so this is how a dropped
+        # "P/L statement.pdf" reaches the sanitizer. Its first component is the name.
+        "P:L statement.pdf",
+        "C:notes.txt",
     ],
 )
 def test_sanitizer_keeps_the_name_the_user_gave(raw):
@@ -106,7 +110,8 @@ def test_sanitizer_keeps_the_name_the_user_gave(raw):
         ("a\u200bb.pdf", "ab.pdf"),
         ("\ufeff报告.pdf", "报告.pdf"),
         ("a\nb.pdf", "a b.pdf"),
-        ("C:notes.txt", "notes.txt"),
+        # What a browser actually sends for a file picked on Windows.
+        ("C:\\fakepath\\notes.txt", "notes.txt"),
     ],
 )
 def test_sanitizer_normalizes_what_a_label_cannot_carry(raw, expected):


### PR DESCRIPTION
Uploading a document replaces every character outside plain ASCII with an underscore. A file called `报告.pdf` shows up as `_.pdf`, two Chinese file names become the same name, and even `My Report.pdf` turns into `My_Report.pdf`. The original name is never stored, so it cannot be recovered. The wrong name shows in the file list, the download, and the citations the model sees.

The stored file is saved under a random id, so the name is never used as a path and never needed cleaning. The name is now kept as the user gave it. Only directory prefixes, control characters, and invisible formatting characters are removed. The existing path traversal tests still pass.
