### PR TITLE
fix: materialize strided LayerNorm inputs and gradients

### DIFF
--- a/tests/test_layernorm_gradient_layout.py
+++ b/tests/test_layernorm_gradient_layout.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.gpu
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "CUDA Triton kernels required")
+@pytest.mark.parametrize("layout", ["contiguous", "columns", "rows", "transposed", "expanded"])
+@pytest.mark.parametrize(
+    "dtype", [torch.float32, torch.float16, torch.bfloat16], ids = ["float32", "float16", "bfloat16"]
+)
+@pytest.mark.parametrize(
+    "input_layout", ["contiguous", "columns", "rows", "transposed", "expanded"]
+)
+def test_layernorm_backward_gradient_layout(layout, dtype, input_layout):
+    from unsloth.kernels.layernorm import fast_layernorm
+
+    torch.manual_seed(42)
+    shape = (2, 4, 80)
+    if input_layout == "columns":
+        inputs = torch.randn(2, 4, 160, device = "cuda", dtype = dtype)[..., ::2]
+    elif input_layout == "rows":
+        inputs = torch.randn(2, 8, 80, device = "cuda", dtype = dtype)[:, ::2]
+    elif input_layout == "transposed":
+        inputs = torch.randn(4, 2, 80, device = "cuda", dtype = dtype).transpose(0, 1)
+    elif input_layout == "expanded":
+        inputs = torch.randn(1, 1, 1, device = "cuda", dtype = dtype).expand(shape)
+    else:
+        inputs = torch.randn(shape, device = "cuda", dtype = dtype)
+    layer = torch.nn.LayerNorm(shape[-1], device = "cuda", dtype = dtype)
+    layer.requires_grad_(False)
+    layer.weight.uniform_(0.5, 1.5)
+    layer.bias.uniform_(-0.5, 0.5)
+    if layout == "columns":
+        grad = torch.randn(2, 4, 160, device = "cuda", dtype = dtype)[..., ::2]
+    elif layout == "rows":
+        grad = torch.randn(2, 8, 80, device = "cuda", dtype = dtype)[:, ::2]
+    elif layout == "transposed":
+        grad = torch.randn(4, 2, 80, device = "cuda", dtype = dtype).transpose(0, 1)
+    elif layout == "expanded":
+        grad = torch.ones(1, device = "cuda", dtype = dtype).expand(shape)
+    else:
+        grad = torch.randn(shape, device = "cuda", dtype = dtype)
+    reference_inputs = inputs.clone().requires_grad_()
+    expected = torch.nn.functional.layer_norm(
+        reference_inputs.float(), (shape[-1],), layer.weight.float(), layer.bias.float(), layer.eps
+    ).to(dtype)
+    expected.backward(grad.clone())
+
+    actual_inputs = inputs.detach().requires_grad_()
+    actual = fast_layernorm(layer, actual_inputs)
+    actual.backward(grad)
+    torch.testing.assert_close(actual, expected, rtol = 1e-2, atol = 1e-3)
+    torch.testing.assert_close(actual_inputs.grad, reference_inputs.grad, rtol = 2e-2, atol = 1e-2)

--- a/tests/test_layernorm_gradient_layout.py
+++ b/tests/test_layernorm_gradient_layout.py
@@ -99,6 +99,53 @@ def test_layernorm_gradient_reaches_a_live_strided_source(source_layout):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason = "CUDA Triton kernels required")
+@pytest.mark.parametrize("layout", ["contiguous", "columns", "expanded"])
+@pytest.mark.parametrize(
+    "dtype", [torch.float32, torch.float16, torch.bfloat16], ids = ["float32", "float16", "bfloat16"]
+)
+def test_layernorm_weight_and_bias_layout(layout, dtype):
+    # The kernels read W and b with plain column offsets, no parameter stride, so a
+    # strided affine parameter is mis-read the same way a strided input is. This is the
+    # LayerNorm half of the materialization that #10617 added to the RMSNorm kernel.
+    from unsloth.kernels.layernorm import fast_layernorm
+
+    torch.manual_seed(42)
+    shape = (2, 4, 80)
+    dim = shape[-1]
+    layer = torch.nn.LayerNorm(dim, device = "cuda", dtype = dtype)
+    layer.requires_grad_(False)
+    with torch.no_grad():
+        if layout == "columns":
+            weight = (torch.rand(2 * dim, device = "cuda", dtype = dtype) + 0.5)[::2]
+            bias = (torch.rand(2 * dim, device = "cuda", dtype = dtype) - 0.5)[::2]
+        elif layout == "expanded":
+            weight = torch.rand(1, device = "cuda", dtype = dtype).expand(dim)
+            bias = torch.rand(1, device = "cuda", dtype = dtype).expand(dim)
+        else:
+            weight = torch.rand(dim, device = "cuda", dtype = dtype) + 0.5
+            bias = torch.rand(dim, device = "cuda", dtype = dtype) - 0.5
+        layer.weight = torch.nn.Parameter(weight, requires_grad = False)
+        layer.bias = torch.nn.Parameter(bias, requires_grad = False)
+    assert layer.weight.is_contiguous() == (layout == "contiguous")
+
+    inputs = torch.randn(shape, device = "cuda", dtype = dtype)
+    grad = torch.randn(shape, device = "cuda", dtype = dtype)
+    reference_grad = grad.clone()
+
+    reference_inputs = inputs.clone().requires_grad_()
+    expected = torch.nn.functional.layer_norm(
+        reference_inputs.float(), (dim,), layer.weight.float(), layer.bias.float(), layer.eps
+    ).to(dtype)
+    expected.backward(reference_grad)
+
+    actual_inputs = inputs.detach().requires_grad_()
+    actual = fast_layernorm(layer, actual_inputs)
+    actual.backward(grad)
+    torch.testing.assert_close(actual, expected, rtol = 1e-2, atol = 1e-3)
+    torch.testing.assert_close(actual_inputs.grad, reference_inputs.grad, rtol = 2e-2, atol = 1e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "CUDA Triton kernels required")
 @pytest.mark.parametrize("layout", ["columns", "rows", "transposed", "expanded"])
 @pytest.mark.parametrize(
     "no_grad", [torch.no_grad, torch.inference_mode], ids = ["no_grad", "inference_mode"]

--- a/tests/test_layernorm_gradient_layout.py
+++ b/tests/test_layernorm_gradient_layout.py
@@ -55,3 +55,74 @@ def test_layernorm_backward_gradient_layout(layout, dtype, input_layout):
     actual.backward(grad)
     torch.testing.assert_close(actual, expected, rtol = 1e-2, atol = 1e-3)
     torch.testing.assert_close(actual_inputs.grad, reference_inputs.grad, rtol = 2e-2, atol = 1e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "CUDA Triton kernels required")
+@pytest.mark.parametrize("source_layout", ["columns", "rows", "transposed", "expanded"])
+def test_layernorm_gradient_reaches_a_live_strided_source(source_layout):
+    # The matrix above detaches its strided view into a leaf, so it never checks that
+    # the gradient is scattered back through the slice/transpose/expand that produced it.
+    from unsloth.kernels.layernorm import fast_layernorm
+
+    torch.manual_seed(42)
+    if source_layout == "columns":
+        source = torch.randn(2, 4, 160, device = "cuda")
+        view = lambda tensor: tensor[..., ::2]
+    elif source_layout == "rows":
+        source = torch.randn(2, 8, 80, device = "cuda")
+        view = lambda tensor: tensor[:, ::2]
+    elif source_layout == "transposed":
+        source = torch.randn(4, 2, 80, device = "cuda")
+        view = lambda tensor: tensor.transpose(0, 1)
+    else:
+        source = torch.randn(1, 1, 80, device = "cuda")
+        view = lambda tensor: tensor.expand(2, 4, 80)
+    layer = torch.nn.LayerNorm(80, device = "cuda")
+    layer.requires_grad_(False)
+    layer.weight.uniform_(0.5, 1.5)
+    layer.bias.uniform_(-0.5, 0.5)
+
+    grad = torch.randn(2, 4, 80, device = "cuda")
+    # Snapshot up front: backward writes its result into the buffer it is handed.
+    reference_grad = grad.clone()
+
+    actual_source = source.detach().requires_grad_()
+    fast_layernorm(layer, view(actual_source)).backward(grad)
+
+    reference_source = source.detach().requires_grad_()
+    torch.nn.functional.layer_norm(
+        view(reference_source), (80,), layer.weight, layer.bias, layer.eps
+    ).backward(reference_grad)
+
+    assert actual_source.grad.shape == source.shape
+    torch.testing.assert_close(actual_source.grad, reference_source.grad, rtol = 2e-2, atol = 1e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason = "CUDA Triton kernels required")
+@pytest.mark.parametrize("layout", ["columns", "rows", "transposed", "expanded"])
+@pytest.mark.parametrize("no_grad", [torch.no_grad, torch.inference_mode], ids = ["no_grad", "inference_mode"])
+def test_layernorm_forward_layout_without_autograd(layout, no_grad):
+    # Inference never enters backward, so the forward's own layout handling needs
+    # its own guard rather than riding along on the gradient assertions.
+    from unsloth.kernels.layernorm import fast_layernorm
+
+    torch.manual_seed(42)
+    layer = torch.nn.LayerNorm(80, device = "cuda")
+    layer.requires_grad_(False)
+    layer.weight.uniform_(0.5, 1.5)
+    layer.bias.uniform_(-0.5, 0.5)
+
+    with no_grad():
+        if layout == "columns":
+            inputs = torch.randn(2, 4, 160, device = "cuda")[..., ::2]
+        elif layout == "rows":
+            inputs = torch.randn(2, 8, 80, device = "cuda")[:, ::2]
+        elif layout == "transposed":
+            inputs = torch.randn(4, 2, 80, device = "cuda").transpose(0, 1)
+        else:
+            inputs = torch.randn(1, 1, 80, device = "cuda").expand(2, 4, 80)
+        actual = fast_layernorm(layer, inputs)
+        expected = torch.nn.functional.layer_norm(
+            inputs, (80,), layer.weight, layer.bias, layer.eps
+        )
+    torch.testing.assert_close(actual, expected, rtol = 1e-2, atol = 1e-3)

--- a/tests/test_layernorm_gradient_layout.py
+++ b/tests/test_layernorm_gradient_layout.py
@@ -100,7 +100,9 @@ def test_layernorm_gradient_reaches_a_live_strided_source(source_layout):
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason = "CUDA Triton kernels required")
 @pytest.mark.parametrize("layout", ["columns", "rows", "transposed", "expanded"])
-@pytest.mark.parametrize("no_grad", [torch.no_grad, torch.inference_mode], ids = ["no_grad", "inference_mode"])
+@pytest.mark.parametrize(
+    "no_grad", [torch.no_grad, torch.inference_mode], ids = ["no_grad", "inference_mode"]
+)
 def test_layernorm_forward_layout_without_autograd(layout, no_grad):
     # Inference never enters backward, so the forward's own layout handling needs
     # its own guard rather than riding along on the gradient assertions.

--- a/unsloth/kernels/layernorm.py
+++ b/unsloth/kernels/layernorm.py
@@ -108,6 +108,9 @@ class Fast_Layernorm(torch.autograd.Function):
         shape = X.shape
         dim = shape[-1]
         X = X.reshape(-1, dim).contiguous()
+        # The kernels read W and b at unit stride, and these are the ones saved for backward.
+        W = W.contiguous()
+        b = b.contiguous()
         n_rows, n_cols = X.shape
         BLOCK_SIZE, num_warps = calculate_settings(n_cols)
         device = X.device

--- a/unsloth/kernels/layernorm.py
+++ b/unsloth/kernels/layernorm.py
@@ -107,7 +107,7 @@ class Fast_Layernorm(torch.autograd.Function):
     def forward(ctx, X, W, b, eps):
         shape = X.shape
         dim = shape[-1]
-        X = X.view(-1, dim)
+        X = X.reshape(-1, dim).contiguous()
         n_rows, n_cols = X.shape
         BLOCK_SIZE, num_warps = calculate_settings(n_cols)
         device = X.device
@@ -140,7 +140,7 @@ class Fast_Layernorm(torch.autograd.Function):
     def backward(ctx, dY):
         shape = dY.shape
         dim = shape[-1]
-        dY = dY.view(-1, dim)
+        dY = dY.reshape(-1, dim).contiguous()
         X, W, b, r, mu = ctx.saved_tensors
         n_rows, n_cols = dY.shape
 


### PR DESCRIPTION
The Triton kernels used by `Fast_Layernorm` assume contiguous columns. Column-strided inputs or incoming gradients are read with incorrect offsets, while transposed leading dimensions can fail at `view`. Backward also writes into its gradient buffer, so expanded gradients need non-overlapping storage.

Materialize inputs and incoming gradients with `reshape(...).contiguous()` before launching the kernels. Already-contiguous tensors retain the existing allocation behavior.

The regression compares outputs and input gradients with PyTorch LayerNorm for all combinations of five input layouts, five gradient layouts and FP32/FP16/BF16. All 75 cases pass on one H800; Compute Sanitizer memcheck reports zero errors with expandable segments disabled (`PYTORCH_ALLOC_CONF=expandable_segments:False` and `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False`). Changed-file pre-commit hooks pass.

```bash
pytest -m gpu -q tests/test_layernorm_gradient_layout.py
```

Related to #10617, which covers the separate RMSNorm implementation. This change covers the exported `fast_layernorm` kernel; it does not change `fast_layernorm_compiled`, add affine parameter gradients, or include model-training/performance benchmarks.
