### PR TITLE
Studio: keep export status polling single-flight

### DIFF
--- a/studio/frontend/src/features/export/hooks/use-export-runtime-lifecycle.ts
+++ b/studio/frontend/src/features/export/hooks/use-export-runtime-lifecycle.ts
@@ -36,6 +36,7 @@ export function useExportRuntimeLifecycle(): void {
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     let logPolling = false;
     let logPollTimer: ReturnType<typeof setTimeout> | null = null;
+    let statusPolling = false;
 
     const store = useExportRuntimeStore;
 
@@ -153,7 +154,8 @@ export function useExportRuntimeLifecycle(): void {
     };
 
     const pollStatus = async () => {
-      if (!hasAuthToken()) return;
+      if (!hasAuthToken() || statusPolling) return;
+      statusPolling = true;
       try {
         const status = await getExportStatus();
         if (disposed) return;
@@ -164,6 +166,8 @@ export function useExportRuntimeLifecycle(): void {
         }
       } catch {
         // ignore transient status failures
+      } finally {
+        statusPolling = false;
       }
     };
 

--- a/studio/frontend/tests/export-status-poll-stall-guard.test.ts
+++ b/studio/frontend/tests/export-status-poll-stall-guard.test.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { loadWithStubs } from "./helpers/module-stubs.ts";
+
+type ExportLifecycle = {
+  useExportRuntimeLifecycle: () => void;
+};
+
+const STATUS_POLL_INTERVAL_MS = 5_000;
+
+test("status polling does not stack while the previous request is stalled", async (t) => {
+  t.mock.timers.enable({ apis: ["setInterval"] });
+
+  let cleanup: (() => void) | undefined;
+  let finishStatusRequest: (() => void) | undefined;
+  let statusRequests = 0;
+  const stalledStatusRequest = new Promise<void>((resolve) => {
+    finishStatusRequest = resolve;
+  });
+  const state = {
+    isExporting: false,
+    lastSeq: 0,
+    applyBackendStatus: () => {},
+    setConnected: () => {},
+    appendLogs: () => {},
+    appendLog: () => {},
+  };
+
+  const lifecycle = loadWithStubs<ExportLifecycle>(
+    new URL(
+      "../src/features/export/hooks/use-export-runtime-lifecycle.ts",
+      import.meta.url,
+    ),
+    {
+      react: {
+        useEffect: (effect: () => (() => void) | undefined) => {
+          cleanup = effect();
+        },
+      },
+      "@/features/auth": { hasAuthToken: () => true },
+      "../api/export-api": {
+        fetchExportLogs: async () => ({ entries: [] }),
+        getExportStatus: async () => {
+          statusRequests += 1;
+          await stalledStatusRequest;
+          return {};
+        },
+        streamExportLogs: async () => {},
+      },
+      "../stores/export-runtime-store": {
+        useExportRuntimeStore: {
+          getState: () => state,
+          subscribe: () => () => {},
+        },
+      },
+    },
+  );
+
+  try {
+    lifecycle.useExportRuntimeLifecycle();
+    assert.equal(statusRequests, 1, "mount must start one status request");
+
+    t.mock.timers.tick(STATUS_POLL_INTERVAL_MS * 3);
+    assert.equal(
+      statusRequests,
+      1,
+      "timer ticks must not start requests behind a stalled poll",
+    );
+
+    finishStatusRequest?.();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    t.mock.timers.tick(STATUS_POLL_INTERVAL_MS);
+    assert.equal(
+      statusRequests,
+      2,
+      "polling must resume after the request settles",
+    );
+  } finally {
+    cleanup?.();
+    finishStatusRequest?.();
+  }
+});


### PR DESCRIPTION
## What changed

Studio now keeps export-status polling single-flight. If `/api/export/status` is still pending, later timer ticks reuse that wait instead of starting more requests; polling resumes after the request settles or fails.

## Why

The console log attached to #10661 contains 2,236 `/api/export/status` failures after Studio was reloaded with browser tabs open. The interval previously started a new fetch every five seconds even when the prior fetch had not settled, so unavailable-backend requests accumulated and arrived as a burst after restart.

## Test verification (RED → GREEN)

- Upstream source + new regression: 0/1, with 4 requests observed instead of 1.
- Patched source: 1/1; one pending request across three timer intervals, then polling resumed after settlement.
- Production fix reverted: 0/1 again, with 4 requests observed instead of 1.
- Real Chromium: the production-built Studio `/export` route held exactly one pending request in each of two authenticated tabs across three real five-second intervals; restoring the endpoint advanced each tab from one request to two, with no queued burst.
- Changed-line coverage: 100% (91/91, including the regression test; all 5 changed hook lines executed).
- Full local suite (frontend replay): 7,187/7,188 passed versus upstream's 7,186/7,187. The same unrelated `memory-unified-apu.test.ts` assertion is the only failure on both trees.
- Typecheck, locale parity, supply-chain checks, dependency checks, production build, bundle contents, and 75 MB artifact budget passed. The startup bundle check matched upstream's pre-existing 1,582.1 KB result against its 1,582.0 KB budget.

Out of scope: this does not change the five-second cadence, authentication behavior, export log streaming, or the store's intentional export-recovery polling.

Fixes #10661
