### PR TITLE
fix(chat_templates): remove CUDA hardcoded device from stopping criteria

### DIFF
--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -2875,19 +2875,21 @@ def create_stopping_criteria(tokenizer, stop_word = "eos_token"):
     class StoppingCriteriaSub(StoppingCriteria):
         __slots__ = "stop_token", "single_match", "length",
 
-        def __init__(self, stops = "eos_token", device = "cuda", encounters = 1):
+        def __init__(self, stops = "eos_token", encounters = 1):
             super().__init__()
             if stops == "eos_token":
-                self.stop_token = torch.tensor(tokenizer.eos_token_id, device = "cuda")
+                self.stop_token = torch.tensor(tokenizer.eos_token_id)
                 self.length = 1
             else:
                 self.stop_token = tokenizer(["\n" + stops], add_special_tokens = False, return_tensors = "pt")
-                self.stop_token = self.stop_token.input_ids.ravel()[1:].to("cuda")
+                self.stop_token = self.stop_token.input_ids.ravel()[1:]
                 self.length = self.stop_token.shape[0]
             self.single_match = self.length == 1
 
         def __call__(self, input_ids: LongTensor, scores: FloatTensor) -> bool:
             input_ids = input_ids.ravel()
+            if self.stop_token.device != input_ids.device:
+                self.stop_token = self.stop_token.to(input_ids.device)
             last_token = input_ids[-1]
             if self.single_match and (last_token == self.stop_token): return True
 


### PR DESCRIPTION
# What does this PR do?

Removes the CUDA-hardcoded device from the stopping-criteria used during generation, so it works on any accelerator (Ascend NPU, Intel XPU, etc.) without assuming a CUDA device.

## Problem

`StoppingCriteriaSub` builds its stop token on CUDA unconditionally:

```python
def __init__(self, stops = "eos_token", device = "cuda", encounters = 1):
    ...
    self.stop_token = torch.tensor(tokenizer.eos_token_id, device = "cuda")
    ...
    self.stop_token = self.stop_token.input_ids.ravel()[1:].to("cuda")
```

On non-CUDA accelerators (e.g. Ascend NPU with torch_npu, where `torch.cuda` is not compiled in), `torch.tensor(..., device="cuda")` and `.to("cuda")` raise `RuntimeError: Torch not compiled with CUDA enabled`. This makes `create_stopping_criteria` unusable off-CUDA.

## Fix

- Drop the `device="cuda"` parameter and the explicit `.to("cuda")` calls.
- Build the stop token on CPU.
- In `__call__`, lazily move the stop token to `input_ids.device` only when they differ (a one-time move, cached thereafter).

## Verification

Verified on **Ascend NPU (torch 2.14, torch_npu, 910B)**:
- `stop_token` is created on CPU, then correctly moved to `npu:0` on the first `__call__` with an NPU input tensor.
- A CPU input tensor leaves the stop token on CPU (no unnecessary device move).
- The `single_match` and `length` matching logic is unchanged.

Device-agnostic: on CUDA, `input_ids` arrives on CUDA and the stop token is moved there on the first call, preserving existing behavior.
