### PR TITLE
fix: do not default-on tool-call nudging on the external loop

### DIFF
--- a/studio/backend/tests/test_nudge_tool_calls_wiring.py
+++ b/studio/backend/tests/test_nudge_tool_calls_wiring.py
@@ -12,9 +12,12 @@ Mechanism (verified here without loading a model):
   * the GGUF loop and external Unsloth loop use the same normalizer;
   * the external route forwards the request flag into ``ToolLoopPolicy``;
   * the API request models default the flag to ``None`` (opt-in / off);
-  * the Unsloth-facing routes forward the request's flag, and the Unsloth frontend
-    sends ``nudge_tool_calls: true`` -- exercised behaviourally in
-    ``test_safetensors_tool_loop.py`` and ``test_llama_cpp_tool_loop.py``.
+  * the Unsloth-facing routes forward the request's flag;
+  * the Unsloth frontend sends ``nudge_tool_calls`` on the local GGUF/safetensors
+    path and omits it on the external / ``run_tools_locally`` path so that loop
+    stays opt-in unless the request or ``UNSLOTH_TOOL_CALL_NUDGE=1`` sets true --
+    local opt-in is exercised behaviourally in ``test_safetensors_tool_loop.py``
+    and ``test_llama_cpp_tool_loop.py``.
 """
 
 import inspect
@@ -107,9 +110,9 @@ def test_api_request_models_default_the_flag_off():
 
 
 def test_studio_routes_forward_the_request_flag():
-    # The Unsloth chat frontend posts to /v1/chat/completions and /v1/messages
-    # with nudge_tool_calls=true; the route handlers forward the request value
-    # (external API clients that omit it fall back to the opt-in default).
+    # The Unsloth chat frontend posts nudge_tool_calls=true on the local
+    # GGUF/safetensors path; the route handlers forward the request value
+    # (omitted on the external loop, and by API clients, falls back to opt-in).
     from routes import inference as routes_inference
     for handler in (
         routes_inference.produce_openai_chat_completions,
@@ -119,6 +122,20 @@ def test_studio_routes_forward_the_request_flag():
         assert "nudge_tool_calls = payload.nudge_tool_calls" in src, handler.__name__
 
 
-def test_studio_external_adapter_forwards_the_nudge_flag():
+def test_studio_external_adapter_omits_the_nudge_flag_by_default():
     src = _CHAT_ADAPTER_SOURCE.read_text(encoding = "utf-8")
-    assert "nudge_tool_calls: runtime.nudgeToolCalls" in src
+    ext_anchor = src.find("run_tools_locally: true")
+    assert ext_anchor != -1
+    ext_start = src.rfind("supportsStudioToolsForThisTurn", 0, ext_anchor)
+    assert ext_start != -1
+    ext_end = src.find("webSearchEnabledForThisTurn ||", ext_anchor)
+    assert ext_end != -1
+    external_block = src[ext_start:ext_end]
+    # External / run_tools_locally: omit the field so the request does not opt in.
+    assert "nudge_tool_calls: runtime.nudgeToolCalls" not in external_block
+    assert "nudge_tool_calls:" not in external_block
+
+    # Local GGUF / safetensors branch still sends the user setting.
+    local_src = src[:ext_start] + src[ext_end:]
+    assert "nudge_tool_calls: runtime.nudgeToolCalls" in local_src
+    assert "run_tools_locally: true" not in local_src

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -5965,8 +5965,9 @@ export function createOpenAIStreamAdapter(
                     // Self-hosted models often write a call as text rather than emitting structured tool_calls, so
                     // the external loop heals like the local one; omitting this left the process default.
                     auto_heal_tool_calls: runtime.autoHealToolCalls,
-                    // Keep the external server-side loop under the same user setting as the local paths.
-                    nudge_tool_calls: runtime.nudgeToolCalls,
+                    // Omit nudge_tool_calls here so the external loop stays opt-in
+                    // (#9686). Default-on on this path corrupted turns; an explicit
+                    // true on the request still works. Local paths keep the setting.
                     // This branch runs the tools here, so say so by name: enabled_tools ["web_search"] is
                     // byte-identical to an older bundle's hosted search.
                     run_tools_locally: true,


### PR DESCRIPTION
## Summary
- The Studio frontend no longer sends `nudge_tool_calls: true` on the external / `run_tools_locally` chat path.
- GGUF and safetensors loops are unchanged. An explicit `nudge_tool_calls: true` on the request still opts the external loop in.

Fixes #9686

## Test plan
- [x] `test_nudge_tool_calls_wiring.py` and external tool-loop tests
- [x] `hosted-image-tool-with-studio-tools.test.ts` and `code-tool-placement.test.ts`