### PR TITLE
fix: budget DGX Spark diffusion loads against system unified memory

### DIFF
--- a/studio/backend/core/inference/diffusion_memory.py
+++ b/studio/backend/core/inference/diffusion_memory.py
@@ -379,22 +379,32 @@ def _cuda_memory(backend: str) -> tuple[Optional[int], Optional[int], str]:
     try:
         import torch
 
-        # Not torch.cuda.mem_get_info directly: on Windows ROCm its free half is an over-report that does not track
-        # residency, and this feeds the activation refusal that exists BECAUSE Windows WDDM spills to host RAM instead
-        # of raising (#8403). Imported lazily to keep this module free of backend imports at module scope.
+        kind = "discrete_vram"
+        try:
+            # Query the CURRENT device; hardcoding 0 would inspect the wrong GPU and misclassify it.
+            props = torch.cuda.get_device_properties(torch.cuda.current_device())
+            if bool(getattr(props, "integrated", False) or getattr(props, "is_integrated", False)):
+                kind = "unified_memory"  # Jetson / GB10 Spark / other integrated SoC
+        except Exception:
+            pass
+        if kind == "unified_memory":
+            # CUDA mem_get_info on GB10 / Spark is often a small carve-out of the unified LPDDR
+            # pool (a few GB free of a 128 GB machine). Offload frees nothing here, so the
+            # oversize refusal must size against the shared system pool, the same way MPS does
+            # and the same pool llama.cpp already uses for integrated CUDA. Discrete cards keep
+            # the CUDA reading below. A missing host reading fails open rather than budgeting
+            # against the carve-out (#9919).
+            sys_total, sys_free = _system_memory_mib()
+            if sys_free is not None:
+                return int(sys_free), None if sys_total is None else int(sys_total), kind
+            return None, None, kind
+        # Not torch.cuda.mem_get_info directly: on Windows ROCm its free half is an over-report
+        # that does not track residency, and this feeds the activation refusal that exists
+        # BECAUSE Windows WDDM spills to host RAM instead of raising (#8403). Imported lazily
+        # to keep this module free of backend imports at module scope.
         from utils.hardware import trusted_mem_get_info
 
         free, total = trusted_mem_get_info()
-        kind = "discrete_vram"
-        try:
-            # query the CURRENT device; hardcoding 0 would inspect the wrong GPU and misclassify it
-            # Query the CURRENT device (mem_get_info reports it); hardcoding 0 would inspect the wrong GPU and
-            # misclassify it.
-            props = torch.cuda.get_device_properties(torch.cuda.current_device())
-            if bool(getattr(props, "integrated", False) or getattr(props, "is_integrated", False)):
-                kind = "unified_memory"  # e.g. Jetson / integrated SoC
-        except Exception:
-            pass
         return int(free // (1024 * 1024)), int(total // (1024 * 1024)), kind
     except Exception:
         return None, None, "discrete_vram"

--- a/studio/backend/tests/test_diffusion_memory.py
+++ b/studio/backend/tests/test_diffusion_memory.py
@@ -517,6 +517,193 @@ def test_snapshot_cuda_reads_mem_get_info(monkeypatch):
     assert snap.free_mib == 10 * 1024 and snap.total_mib == 24 * 1024
 
 
+def _stub_cuda_snapshot(
+    monkeypatch,
+    *,
+    integrated,
+    cuda_free_mib,
+    cuda_total_mib,
+    system_free_mib,
+    system_total_mib,
+    is_integrated = None,
+):
+    """Drive the real snapshot over a faked CUDA driver and a faked host RAM pool."""
+    import core.inference.diffusion_memory as mem
+
+    props_kw = {"integrated": integrated}
+    if is_integrated is not None:
+        props_kw["is_integrated"] = is_integrated
+    props = types.SimpleNamespace(**props_kw)
+    fake_torch = types.ModuleType("torch")
+    fake_torch.cuda = types.SimpleNamespace(
+        mem_get_info = lambda: (
+            int(cuda_free_mib) * 1024 * 1024,
+            int(cuda_total_mib) * 1024 * 1024,
+        ),
+        current_device = lambda: 0,
+        get_device_properties = lambda i: props,
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    hardware = types.ModuleType("utils.hardware")
+    hardware.trusted_mem_get_info = lambda: (
+        int(cuda_free_mib) * 1024 * 1024,
+        int(cuda_total_mib) * 1024 * 1024,
+    )
+    monkeypatch.setitem(sys.modules, "utils.hardware", hardware)
+    monkeypatch.setattr(mem, "_system_memory_mib", lambda: (system_total_mib, system_free_mib))
+    return snapshot_device_memory(_target())
+
+
+@pytest.mark.parametrize(
+    "flag_kwargs",
+    [
+        {"integrated": True},
+        {"integrated": False, "is_integrated": True},
+    ],
+)
+@pytest.mark.parametrize(
+    "cuda_free_mib, cuda_total_mib",
+    [
+        (3 * 1024, 3 * 1024),  # both readings are the carve-out
+        (3 * 1024, 128 * 1024),  # total is the real pool, free is the carve-out
+    ],
+)
+def test_snapshot_unified_cuda_uses_system_pool_not_cuda_carveout(
+    monkeypatch, flag_kwargs, cuda_free_mib, cuda_total_mib
+):
+    """DGX Spark / GB10: CUDA mem_get_info is a few-GB carve-out of unified LPDDR.
+
+    The load is sized against the shared system pool, same as MPS. Either spelling of
+    the driver's integrated flag is enough, and either way the carve-out is reported
+    (tiny total, or full-pool total with tiny free).
+    """
+    snap = _stub_cuda_snapshot(
+        monkeypatch,
+        cuda_free_mib = cuda_free_mib,
+        cuda_total_mib = cuda_total_mib,
+        system_free_mib = 100 * 1024,
+        system_total_mib = 128 * 1024,
+        **flag_kwargs,
+    )
+    assert snap.memory_kind == "unified_memory"
+    assert snap.free_mib == 100 * 1024
+    assert snap.total_mib == 128 * 1024
+
+
+def test_snapshot_discrete_cuda_ignores_system_ram(monkeypatch):
+    """A 4090-class card keeps trusted_mem_get_info even if host RAM is tiny."""
+    snap = _stub_cuda_snapshot(
+        monkeypatch,
+        integrated = False,
+        is_integrated = False,
+        cuda_free_mib = 20 * 1024,
+        cuda_total_mib = 24 * 1024,
+        system_free_mib = 8 * 1024,
+        system_total_mib = 16 * 1024,
+    )
+    assert snap.memory_kind == "discrete_vram"
+    assert snap.free_mib == 20 * 1024
+    assert snap.total_mib == 24 * 1024
+
+
+def test_unified_cuda_spark_gb10_allows_flux2_klein_against_system_ram(monkeypatch):
+    """#9919: flux.2-klein is ~24 GB of weights. A 128 GB Spark must not refuse it
+    just because CUDA reports 3 GB free."""
+    from core.inference.diffusion_memory import unified_memory_shortfall_message
+
+    snap = _stub_cuda_snapshot(
+        monkeypatch,
+        integrated = True,
+        cuda_free_mib = 3 * 1024,
+        cuda_total_mib = 3 * 1024,
+        system_free_mib = 100 * 1024,
+        system_total_mib = 128 * 1024,
+    )
+    # 22 GiB weights + 2 GiB base overhead = 24 GB, matching the reported refusal.
+    plan = plan_diffusion_memory(
+        target = _target(),
+        device_memory = snap,
+        model_dense_mib = 22 * 1024,
+        runtime_headroom_mib = 4096,
+    )
+    assert plan.offload_policy == OFFLOAD_NONE
+    assert unified_memory_shortfall_message(plan, family = "flux.2-klein") is None
+    # The CUDA carve-out would have produced a 0 GB budget; the system pool must not.
+    assert plan.estimates["safe_device_budget_mib"] > 22 * 1024
+
+
+def test_unified_cuda_still_refuses_when_system_ram_is_too_small(monkeypatch):
+    """A 24 GB model on a 16 GB unified box is still genuinely too large."""
+    from core.inference.diffusion_memory import unified_memory_shortfall_message
+
+    snap = _stub_cuda_snapshot(
+        monkeypatch,
+        integrated = True,
+        cuda_free_mib = 3 * 1024,
+        cuda_total_mib = 3 * 1024,
+        system_free_mib = int(16 * 1024 * 0.80),
+        system_total_mib = 16 * 1024,
+    )
+    plan = plan_diffusion_memory(
+        target = _target(),
+        device_memory = snap,
+        model_dense_mib = 22 * 1024,
+        runtime_headroom_mib = 4096,
+    )
+    message = unified_memory_shortfall_message(plan, family = "flux.2-klein")
+    assert message is not None
+    assert "flux.2-klein" in message
+    assert "about 24 GB of memory for its weights" in message
+    # Refused against the 16 GB host pool (~10 GB usable), not the 3 GB CUDA carve-out.
+    assert "about 10 GB is usable" in message
+    assert "13 GB currently free" in message
+
+
+def test_discrete_4090_does_not_refuse_an_oversized_load(monkeypatch):
+    """Discrete VRAM still streams from host RAM; the unified refusal must not fire."""
+    from core.inference.diffusion_memory import unified_memory_shortfall_message
+
+    snap = _stub_cuda_snapshot(
+        monkeypatch,
+        integrated = False,
+        cuda_free_mib = 20 * 1024,
+        cuda_total_mib = 24 * 1024,
+        system_free_mib = 8 * 1024,
+        system_total_mib = 32 * 1024,
+    )
+    plan = plan_diffusion_memory(
+        target = _target(),
+        device_memory = snap,
+        model_dense_mib = 22 * 1024,
+        runtime_headroom_mib = 4096,
+    )
+    assert snap.memory_kind == "discrete_vram"
+    assert unified_memory_shortfall_message(plan, family = "flux.2-klein") is None
+
+
+def test_unified_cuda_fails_open_when_system_ram_is_unreadable(monkeypatch):
+    """A missing host reading must not fall back to the CUDA carve-out and refuse."""
+    from core.inference.diffusion_memory import unified_memory_shortfall_message
+
+    snap = _stub_cuda_snapshot(
+        monkeypatch,
+        integrated = True,
+        cuda_free_mib = 3 * 1024,
+        cuda_total_mib = 3 * 1024,
+        system_free_mib = None,
+        system_total_mib = None,
+    )
+    assert snap.memory_kind == "unified_memory"
+    assert snap.free_mib is None and snap.total_mib is None
+    plan = plan_diffusion_memory(
+        target = _target(),
+        device_memory = snap,
+        model_dense_mib = 22 * 1024,
+        runtime_headroom_mib = 4096,
+    )
+    assert unified_memory_shortfall_message(plan, family = "flux.2-klein") is None
+
+
 def test_snapshot_never_raises_on_probe_failure(monkeypatch):
     import sys
 

--- a/studio/backend/tests/test_diffusion_predownload_guard_platforms.py
+++ b/studio/backend/tests/test_diffusion_predownload_guard_platforms.py
@@ -162,6 +162,39 @@ def test_an_integrated_gpu_is_the_one_machine_that_is_judged(monkeypatch, platfo
     assert verdict(LUMINA_2) is None
 
 
+def test_unified_cuda_spark_gb10_is_judged_against_system_ram_not_the_carveout(monkeypatch):
+    """#9919: CUDA mem_get_info on GB10 is a few-GB carve-out of unified LPDDR.
+
+    The pre-download guard must size against the 128 GB host pool. Lumina (~20 GB)
+    fits that pool and would be refused against the 3 GB carve-out; FLUX.2-dev
+    (~113 GB) is still too large for 128 GB and stays refused.
+    """
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setitem(
+        sys.modules,
+        "torch",
+        types.SimpleNamespace(
+            cuda = types.SimpleNamespace(
+                current_device = lambda: 0,
+                get_device_properties = lambda _i: types.SimpleNamespace(integrated = True),
+            ),
+            xpu = None,
+        ),
+    )
+    hardware = types.ModuleType("utils.hardware")
+    carve = 3 * GIB_MIB * MIB
+    hardware.trusted_mem_get_info = lambda: (carve, carve)
+    monkeypatch.setitem(sys.modules, "utils.hardware", hardware)
+    monkeypatch.setattr(memory_mod, "_system_memory_mib", lambda: (128 * GIB_MIB, 100 * GIB_MIB))
+    snapshot = snapshot_device_memory(_target("cuda"))
+    assert snapshot.memory_kind == "unified_memory"
+    assert snapshot.total_mib == 128 * GIB_MIB
+    assert snapshot.free_mib == 100 * GIB_MIB
+    verdict = _guard(monkeypatch, snapshot)
+    assert verdict(FLUX2_DEV) is not None
+    assert verdict(LUMINA_2) is None
+
+
 def test_apple_silicon_is_judged_the_same_way(monkeypatch):
     snapshot = _classify(
         monkeypatch,


### PR DESCRIPTION
## Summary
- Integrated CUDA (DGX Spark / GB10) was classifying as unified memory but sizing the load against a CUDA carve-out, so flux.2-klein was refused as needing 24 GB with 0 GB usable.
- The snapshot now uses the shared system pool for unified CUDA, matching MPS. Discrete cards are unchanged.

Fixes #9919

## Test plan
- [x] diffusion_memory unified CUDA / Spark snapshot and shortfall tests
- [x] full tests/test_diffusion_memory.py (107 passed, 1 skipped)
- [x] tests/test_diffusion_predownload_guard_platforms.py Spark/GB10 snapshot (52 passed)