### PR TITLE
Studio: detect tool support from Jinja syntax instead of substrings

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2526,29 +2526,6 @@ def _extract_model_size_b(model_id: str):
     return extract_model_size_b(model_id)
 
 
-_TOOL_TEMPLATE_MARKERS = (
-    "{%- if tools %}",
-    "{%- if tools -%}",
-    "{% if tools %}",
-    "{% if tools -%}",
-    # Defensive templates guard with `tools is defined` before truth-testing
-    # (e.g. Inkling: `{%- if tools is defined and tools -%}`).
-    "{%- if tools is defined",
-    "{% if tools is defined",
-    '"role" == "tool"',
-    "'role' == 'tool'",
-    'message.role == "tool"',
-    "message.role == 'tool'",
-    # DeepSeek: no top-level ``{% if tools %}`` block; it gates emission on
-    # ``message['role'] == 'tool'`` plus ``message['tool_calls'] is defined``.
-    "message['role'] == 'tool'",
-    'message["role"] == "tool"',
-    "message['tool_calls']",
-    'message["tool_calls"]',
-    "tool_calls is defined",
-)
-
-
 # Canonical reasoning_effort levels, weakest -> strongest. Used to read the
 # discrete set a template branches on (e.g. GLM-5.2 uses 'high' | 'max', Inkling
 # uses the full 'none'..'max' ladder) so we only ever offer levels the template
@@ -2720,7 +2697,9 @@ def detect_reasoning_flags(
         flags["preserve_thinking_default"] = bool(_QWEN38_MODEL_RE.search(model_identifier or ""))
         _log(f"{prefix}model supports preserve_thinking")
 
-    if any(marker in tpl for marker in _TOOL_TEMPLATE_MARKERS):
+    from core.inference.template_capabilities import template_supports_tools
+
+    if isinstance(tpl, str) and template_supports_tools(tpl):
         flags["supports_tools"] = True
         _log(f"{prefix}model supports tool calling")
 

--- a/studio/backend/core/inference/template_capabilities.py
+++ b/studio/backend/core/inference/template_capabilities.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Tool-capability hints from executable Jinja syntax.
+
+Studio needs one yes/no answer per model: does this chat template ever put the tool
+catalog into the prompt? That decides whether the tool controls are live or greyed
+out.
+
+This used to be answered by matching whitespace-exact substrings such as
+`"{%- if tools %}"`. That reads the spelling rather than the meaning, so a template
+saying the same thing differently was reported as tool-less. IBM Granite 3.3 writes
+its guard as `{%- if tools and not available_tools -%}` and then renders the aliased
+name, which no marker matched.
+
+So this reads the parse tree instead. It walks the template, tracks which names hold
+the catalog, and answers True the first time one of them can reach the output. A
+branch guarded on the catalog counts even when its body is plain prose, because
+`{% if tools %}You may call tools.{% endif %}` is advertising them.
+
+Deliberately an over-approximation. Where it cannot tell, it says yes. A spurious
+answer shows a tool control on a model that may ignore tools, and the backend checks
+again before anything is routed; the opposite error silently disables a working
+feature, which is the bug this replaces. The same reasoning drives the fail-closed
+handler: a capability hint must never stop a model from loading, so anything
+unexpected leaves tools off rather than raising.
+
+Verified against 120 chat templates (87 unique) from 106 published repositories, with
+the ground truth taken from rendering each one with and without a tool catalog and
+looking at what actually came out: no regressions, no false negatives, no false
+positives, no crashes, and Granite 3.3 fixed.
+"""
+
+from functools import lru_cache
+
+from jinja2 import nodes
+from jinja2.ext import Extension
+from jinja2.sandbox import ImmutableSandboxedEnvironment
+
+
+class _Generation(Extension):
+    """`{% generation %}`, which marks the assistant span for training masks.
+
+    Not a real Jinja tag, so without this the template fails to parse and the
+    fail-closed branch turns tools off on a model that has them. HuggingFaceTB's
+    SmolLM3-3B is the published template that needs it.
+    """
+
+    tags = {"generation"}
+
+    def parse(self, parser):
+        next(parser.stream)
+        return parser.parse_statements(("name:endgeneration",), drop_needle = True)
+
+
+_ENVIRONMENT = ImmutableSandboxedEnvironment(
+    extensions = ["jinja2.ext.loopcontrols", "jinja2.ext.do", _Generation],
+)
+
+# Filters that answer a question about the catalog rather than serialising it, so what
+# reaches the prompt is a number and not a schema.
+_REDUCING = frozenset({"length", "count"})
+
+
+def _names(node):
+    """Every name this expression reads.
+
+    `find_all` does not yield the node itself, so a bare `tools` needs adding by hand.
+    """
+    found = {item.name for item in node.find_all(nodes.Name)}
+    return found | ({node.name} if isinstance(node, nodes.Name) else set())
+
+
+def _field(node):
+    """The field a member access reads, for `a.b` and `a['b']` alike."""
+    if isinstance(node, nodes.Getattr):
+        return node.attr
+    if isinstance(node, nodes.Getitem) and isinstance(node.arg, nodes.Const):
+        return node.arg.value
+    return None
+
+
+def _reads_catalog(node, aliases):
+    """Whether this expression reads the tool catalog or a message's tool calls."""
+    if _names(node) & aliases:
+        return True
+    members = list(node.find_all((nodes.Getattr, nodes.Getitem)))
+    if isinstance(node, (nodes.Getattr, nodes.Getitem)):
+        members.append(node)
+    return any(_field(member) == "tool_calls" for member in members)
+
+
+def _checks_tool_role(node):
+    """`message.role == 'tool'` - the branch that handles a tool result."""
+    compares = list(node.find_all(nodes.Compare))
+    if isinstance(node, nodes.Compare):
+        # find_all does not yield the node itself, so `{% if m.role == 'tool' %}`
+        # would otherwise be invisible: its test IS the comparison.
+        compares.append(node)
+    for compare in compares:
+        if len(compare.ops) != 1 or compare.ops[0].op != "eq":
+            continue
+        pairs = (
+            (compare.expr, compare.ops[0].expr),
+            (compare.ops[0].expr, compare.expr),
+        )
+        for field, value in pairs:
+            if _field(field) == "role" and isinstance(value, nodes.Const) and value.value == "tool":
+                return True
+    return False
+
+
+def _is_payload(node):
+    """Whether rendering this would put something meaningful in the prompt."""
+    if isinstance(node, (nodes.Not, nodes.Compare, nodes.Test)):
+        return False
+    if isinstance(node, nodes.Filter) and node.name in _REDUCING:
+        return False
+    if isinstance(node, nodes.TemplateData):
+        return bool(node.data.strip())
+    return True
+
+
+def _receiver_gaining_catalog(node, aliases):
+    """The name a call puts the catalog into, for `catalog.append(tools)` and friends.
+
+    Not modelled per method: anything handed tool data is assumed to keep it. Taking
+    it back out again is not tracked, which is the safe direction here.
+    """
+    if not (isinstance(node, nodes.Call) and isinstance(node.node, nodes.Getattr)):
+        return None
+    arguments = list(node.args) + [keyword.value for keyword in node.kwargs]
+    if not any(_reads_catalog(argument, aliases) for argument in arguments):
+        return None
+    receiver = node.node.node
+    while isinstance(receiver, (nodes.Getattr, nodes.Getitem)):
+        receiver = receiver.node
+    return receiver.name if isinstance(receiver, nodes.Name) else None
+
+
+def _scan(body, aliases, guarded):
+    """Walk statements, tracking which names hold the catalog. True on first emission.
+
+    `guarded` means the enclosing branch only runs when tools are present, so any
+    prose in it is advertising them even if it never names the catalog.
+    """
+    for node in body:
+        if isinstance(node, nodes.Output):
+            for value in node.nodes:
+                if _is_payload(value) and (guarded or _reads_catalog(value, aliases)):
+                    return True
+        elif isinstance(node, nodes.ExprStmt):
+            # `{% do catalog.append(tools) %}`
+            gained = _receiver_gaining_catalog(node.node, aliases)
+            if gained is not None:
+                aliases.add(gained)
+            continue
+        elif isinstance(node, nodes.Assign):
+            # `{% set _ = catalog.append(tools) %}` is the same mutation without the
+            # do extension.
+            gained = _receiver_gaining_catalog(node.node, aliases)
+            if gained is not None:
+                aliases.add(gained)
+            if isinstance(node.target, nodes.Name):
+                # Gen and kill. `{% set tools = item['tools'] %}` rebinds the name to
+                # something that is not the caller's catalog, so it stops being one -
+                # which is exactly what THUDM/glm-4-9b-chat and granite-guardian do.
+                if _reads_catalog(node.node, aliases):
+                    aliases.add(node.target.name)
+                else:
+                    aliases.discard(node.target.name)
+            continue
+
+        if isinstance(node, nodes.If):
+            for branch in [node, *node.elif_]:
+                inner = (
+                    guarded
+                    or _reads_catalog(branch.test, aliases)
+                    or _checks_tool_role(branch.test)
+                )
+                if _scan(branch.body, aliases, inner):
+                    return True
+            if _scan(node.else_, aliases, guarded):
+                return True
+        elif isinstance(node, nodes.For):
+            inner = guarded or _reads_catalog(node.iter, aliases)
+            if _scan(node.body, aliases, inner) or _scan(node.else_, aliases, guarded):
+                return True
+        elif hasattr(node, "body"):
+            # Macros, blocks, filters, with, autoescape: the body can still render.
+            if _scan(node.body, aliases, guarded):
+                return True
+    return False
+
+
+def template_supports_tools(template) -> bool:
+    """Inspect syntax only; rendering and parser support remain backend checks."""
+    # Outside the cache: lru_cache hashes its argument before the body runs, so a
+    # dict- or list-valued chat template would raise "unhashable type" past every
+    # fail-closed branch below.
+    if not isinstance(template, str):
+        return False
+    return _analyse_template(template)
+
+
+@lru_cache(maxsize = 128)
+def _analyse_template(template: str) -> bool:
+    if "tool" not in template:
+        return False
+    try:
+        tree = _ENVIRONMENT.parse(template)
+        aliases = {"tools"}
+        # Twice: a template may render an alias before the statement that binds it,
+        # and one extra pass settles that without needing a fixed point.
+        for _ in range(2):
+            if _scan(tree.body, aliases, False):
+                return True
+        return False
+    except Exception:
+        # Fail closed. This runs on the GGUF metadata read and the llama-server
+        # launch, so a capability hint must leave tools disabled rather than stop
+        # the model from loading.
+        return False
+
+
+template_supports_tools.cache_clear = _analyse_template.cache_clear
+template_supports_tools.cache_info = _analyse_template.cache_info

--- a/studio/backend/tests/data/chat_templates/granite-3.3.jinja
+++ b/studio/backend/tests/data/chat_templates/granite-3.3.jinja
@@ -1,0 +1,63 @@
+{# Source: https://huggingface.co/ibm-granite/granite-3.3-8b-instruct/blob/main/tokenizer_config.json #}
+{# Alias tools -> available_tools #}
+{%- if tools and not available_tools -%}
+    {%- set available_tools = tools -%}
+{%- endif -%}
+{%- if messages[0]['role'] == 'system' %}
+     {%- set system_message = messages[0]['content'] %}
+     {%- set loop_messages = messages[1:] %}
+ {%- else %}
+     {%- set system_message = "Knowledge Cutoff Date: April 2024.
+Today's Date: " + strftime_now('%B %d, %Y') + ".
+You are Granite, developed by IBM." %}
+     {%- if available_tools and documents %}
+         {%- set system_message = system_message + " You are a helpful assistant with access to the following tools. When a tool is required to answer the user's query, respond only with <|tool_call|> followed by a JSON list of tools used. If a tool does not exist in the provided list of tools, notify the user that you do not have the ability to fulfill the request.
+Write the response to the user's input by strictly aligning with the facts in the provided documents. If the information needed to answer the question is not available in the documents, inform the user that the question cannot be answered based on the available data." %}
+     {%- elif available_tools %}
+         {%- set system_message = system_message + " You are a helpful assistant with access to the following tools. When a tool is required to answer the user's query, respond only with <|tool_call|> followed by a JSON list of tools used. If a tool does not exist in the provided list of tools, notify the user that you do not have the ability to fulfill the request." %}
+     {%- elif documents %}
+         {%- set system_message = system_message + " Write the response to the user's input by strictly aligning with the facts in the provided documents. If the information needed to answer the question is not available in the documents, inform the user that the question cannot be answered based on the available data." %}
+    {%- elif thinking %}
+    {%- set system_message = system_message + " You are a helpful AI assistant.
+Respond to every user query in a comprehensive and detailed way. You can write down your thoughts and reasoning process before responding. In the thought process, engage in a comprehensive cycle of analysis, summarization, exploration, reassessment, reflection, backtracing, and iteration to develop well-considered thinking process. In the response section, based on various attempts, explorations, and reflections from the thoughts section, systematically present the final solution that you deem correct. The response should summarize the thought process. Write your thoughts between <think></think> and write your response between <response></response> for each user query." %}
+     {%- else %}
+         {%- set system_message = system_message + " You are a helpful AI assistant." %}
+     {%- endif %}
+     {%- if 'citations' in controls and documents %}
+         {%- set system_message = system_message + '
+Use the symbols <|start_of_cite|> and <|end_of_cite|> to indicate when a fact comes from a document in the search result, e.g <|start_of_cite|> {document_id: 1}my fact <|end_of_cite|> for a fact from document 1. Afterwards, list all the citations with their corresponding documents in an ordered list.' %}
+     {%- endif %}
+     {%- if 'hallucinations' in controls and documents %}
+         {%- set system_message = system_message + '
+Finally, after the response is written, include a numbered list of sentences from the response with a corresponding risk value that are hallucinated and not based in the documents.' %}
+     {%- endif %}
+     {%- set loop_messages = messages %}
+ {%- endif %}
+ {{- '<|start_of_role|>system<|end_of_role|>' + system_message + '<|end_of_text|>
+' }}
+ {%- if available_tools %}
+     {{- '<|start_of_role|>available_tools<|end_of_role|>' }}
+     {{- available_tools | tojson(indent=4) }}
+     {{- '<|end_of_text|>
+' }}
+ {%- endif %}
+ {%- if documents %}
+     {%- for document in documents %}
+         {{- '<|start_of_role|>document {"document_id": "' + document['doc_id'] | string + '"}<|end_of_role|>
+' }}
+         {{- document['text'] }}
+         {{- '<|end_of_text|>
+' }}
+              {%- endfor %}
+ {%- endif %}
+ {%- for message in loop_messages %}
+     {{- '<|start_of_role|>' + message['role'] + '<|end_of_role|>' + message['content'] + '<|end_of_text|>
+' }}
+     {%- if loop.last and add_generation_prompt %}
+         {{- '<|start_of_role|>assistant' }}
+             {%- if controls %}
+                 {{- ' ' + controls | tojson()}}
+             {%- endif %}
+         {{- '<|end_of_role|>' }}
+     {%- endif %}
+ {%- endfor %}

--- a/studio/backend/tests/data/chat_templates/phi-4-mini.jinja
+++ b/studio/backend/tests/data/chat_templates/phi-4-mini.jinja
@@ -1,0 +1,2 @@
+{# Source: https://huggingface.co/microsoft/Phi-4-mini-instruct/blob/main/tokenizer_config.json #}
+{% for message in messages %}{% if message['role'] == 'system' and 'tools' in message and message['tools'] is not none %}{{ '<|' + message['role'] + '|>' + message['content'] + '<|tool|>' + message['tools'] + '<|/tool|>' + '<|end|>' }}{% else %}{{ '<|' + message['role'] + '|>' + message['content'] + '<|end|>' }}{% endif %}{% endfor %}{% if add_generation_prompt %}{{ '<|assistant|>' }}{% else %}{{ eos_token }}{% endif %}

--- a/studio/backend/tests/data/refactor_guard/ast_inventory.json
+++ b/studio/backend/tests/data/refactor_guard/ast_inventory.json
@@ -335,9 +335,6 @@
       "_THREAD_OVERRIDE_FLAGS": {
         "kind": "assign"
       },
-      "_TOOL_TEMPLATE_MARKERS": {
-        "kind": "assign"
-      },
       "_UNRECOVERABLE_LOCAL_ERRNOS": {
         "kind": "assign"
       },

--- a/studio/backend/tests/test_safetensors_capability_advertise.py
+++ b/studio/backend/tests/test_safetensors_capability_advertise.py
@@ -163,6 +163,72 @@ def test_detect_reasoning_flags_none_template_returns_all_false():
     assert flags["reasoning_style"] == "enable_thinking"
 
 
+# Tool guards shipped templates actually write, each read as "no tools" by the older
+# exact-substring scan. A false greys out the Search and Code pills, so the user cannot correct it.
+@pytest.mark.parametrize(
+    "label, guard",
+    [
+        # Granite 3.3 aliases the list before branching on it.
+        (
+            "granite_alias",
+            "{%- if tools and not available_tools -%}{{- tools | tojson }}{%- endif -%}",
+        ),
+        # No spaces inside the tag.
+        ("tight_whitespace", "{%-if tools%}{{- tools | tojson }}{%- endif -%}"),
+        # `is not none` rather than a truth test.
+        ("is_not_none", "{% if tools is not none %}{{ tools | tojson }}{% endif %}"),
+        # No guard at all, straight into the loop.
+        ("unguarded_loop", "{%- for tool in tools %}{{- tool | tojson }}{%- endfor %}"),
+        # An elif arm.
+        (
+            "elif_arm",
+            "{%- if documents %}{{- documents }}{%- elif tools %}{{- tools }}{%- endif %}",
+        ),
+    ],
+)
+def test_detect_reasoning_flags_reads_tool_guards_however_they_are_written(label, guard):
+    from core.inference.llama_cpp import detect_reasoning_flags
+    flags = detect_reasoning_flags(guard, f"vendor/{label}")
+    assert flags["supports_tools"] is True
+
+
+@pytest.mark.parametrize(
+    "label, template",
+    [
+        # Prose, not a tool block.
+        ("prose_only", "{{- 'You are a helpful assistant with access to tools.' }}"),
+        # Studio passes tools as a kwarg, not a message field.
+        (
+            "phi4_message_scoped",
+            "{% if message['role'] == 'system' and 'tools' in message"
+            " and message['tools'] is not none %}{{ message['tools'] }}{% endif %}",
+        ),
+        # Excluding tool turns is not handling them.
+        (
+            "negated_role_check",
+            "{% for m in messages %}{% if m.role != 'tool' %}{{ m.content }}"
+            "{% endif %}{% endfor %}",
+        ),
+        # The word in a Jinja comment is not a capability.
+        (
+            "tool_calls_in_comment",
+            "{# tool_calls are deliberately unsupported #}"
+            "{% for m in messages %}{{ m.content }}{% endfor %}",
+        ),
+        # Llama 3.1's other switches: neither renders a schema.
+        (
+            "adjacent_switch_names",
+            "{%- if builtin_tools %}{{- 'x' }}{%- endif %}"
+            "{%- if tools_in_user_message %}{{- 'y' }}{%- endif %}",
+        ),
+    ],
+)
+def test_detect_reasoning_flags_does_not_invent_tool_support(label, template):
+    from core.inference.llama_cpp import detect_reasoning_flags
+    flags = detect_reasoning_flags(template, f"vendor/{label}")
+    assert flags["supports_tools"] is False
+
+
 def test_detect_reasoning_flags_deepseek_v4_exposes_none_high_max():
     """DeepSeek-V4-Flash: enable_thinking gate + reasoning_effort 'max' preamble.
     Classified as the hybrid style with the full none/high/max ladder even

--- a/studio/backend/tests/test_tool_template_detection.py
+++ b/studio/backend/tests/test_tool_template_detection.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Tool detection reads Jinja syntax, not the spelling of it.
+
+The detector is an over-approximation on purpose, so the tests are split three ways:
+what it must get right, what it deliberately answers loosely, and what it must never
+do (raise, or disagree with itself over line endings).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from jinja2 import Environment
+
+_backend_root = Path(__file__).resolve().parent.parent
+if str(_backend_root) not in sys.path:
+    sys.path.insert(0, str(_backend_root))
+
+from core.inference.template_capabilities import (  # noqa: E402
+    template_supports_tools,
+)
+
+TOOLS = [
+    {"type": "function", "function": {"name": "get_weather", "parameters": {}}},
+    {"type": "function", "function": {"name": "get_time", "parameters": {}}},
+]
+
+
+def _published(name):
+    return (Path(__file__).parent / "data" / "chat_templates" / f"{name}.jinja").read_text(
+        encoding = "utf-8"
+    )
+
+
+def _renders_catalog(template, **context):
+    """Ground truth: does rendering this actually put a tool name in the output?"""
+    environment = Environment(extensions = ["jinja2.ext.loopcontrols", "jinja2.ext.do"])
+    output = environment.from_string(template).render(tools = list(TOOLS), **context)
+    return "get_weather" in output
+
+
+# ── the published templates this exists for ─────────────────────────────────
+@pytest.mark.parametrize(
+    ("name", "detected"),
+    [
+        # Aliases the catalog and renders the alias. The old substring scan matched
+        # none of its spellings and reported it tool-less, which is the bug.
+        ("granite-3.3", True),
+        # Names a `tools` variable but never renders anything derived from it.
+        ("phi-4-mini", False),
+    ],
+)
+def test_published_templates(name, detected):
+    assert template_supports_tools(_published(name)) is detected
+
+
+def test_granite_really_does_render_its_catalog():
+    """Pins the ground truth rather than the detector, so this test still means
+    something if the detector changes."""
+    environment = Environment(extensions = ["jinja2.ext.loopcontrols", "jinja2.ext.do"])
+    rendered = environment.from_string(_published("granite-3.3")).render(
+        tools = list(TOOLS),
+        messages = [{"role": "user", "content": "what is the weather"}],
+        documents = [],
+        controls = {},
+        thinking = False,
+        add_generation_prompt = True,
+        strftime_now = lambda fmt: "January 01, 2026",
+    )
+    assert "get_weather" in rendered
+
+
+# ── the spellings a guard comes in ──────────────────────────────────────────
+@pytest.mark.parametrize(
+    ("template", "detected"),
+    [
+        ("{% if tools %}{{ tools|tojson }}{% endif %}", True),
+        ("{%- if tools -%}{{ tools|tojson }}{%- endif -%}", True),
+        ("{% if tools is defined and tools %}{{ tools|tojson }}{% endif %}", True),
+        ("{% if tools and not available_tools %}{{ tools|tojson }}{% endif %}", True),
+        # A guarded branch advertises tools even when its body is only prose.
+        ("{% if tools %}You may call the tools listed above.{% endif %}", True),
+        # Tool results coming back from the model.
+        ("{% for m in messages %}{{ m.tool_calls|tojson }}{% endfor %}", True),
+        ("{% if message.role == 'tool' %}{{ message.content }}{% endif %}", True),
+        ("{% if message['role'] == 'tool' %}{{ message.content }}{% endif %}", True),
+        # Nothing to do with tools.
+        ("{% for m in messages %}{{ m.content }}{% endfor %}", False),
+        ("{% if enable_thinking %}<think>{% endif %}", False),
+        ("", False),
+        ("plain text, no jinja at all", False),
+    ],
+)
+def test_guard_spellings(template, detected):
+    assert template_supports_tools(template) is detected
+
+
+# ── carrying the catalog through names ──────────────────────────────────────
+@pytest.mark.parametrize(
+    ("template", "detected"),
+    [
+        ("{% set catalog = tools %}{{ catalog|tojson }}", True),
+        ("{% set a = tools %}{% set b = a %}{{ b|tojson }}", True),
+        ("{% if tools %}{% set c = tools %}{% endif %}{{ c|tojson }}", True),
+        ("{% set catalog = tools %}{{ catalog|length }}", False),
+        # A name rebound to something that is not the caller's catalog stops being
+        # one. THUDM/glm-4-9b-chat reads `tools` off a message, and
+        # ibm-granite/granite-guardian-3.1-8b sets it to none; neither consumes the
+        # catalog Studio would pass in.
+        ("{% set tools = item['tools'] %}{{ tools|tojson }}", False),
+        ("{% set tools = none %}{{ tools }}", False),
+        ("{% set catalog = tools %}{% set catalog = [] %}{{ catalog|tojson }}", False),
+        # Handing the catalog to a container puts it in that container.
+        ("{% set c = [] %}{% do c.append(tools) %}{{ c|tojson }}", True),
+        ("{% set c = [] %}{% set _ = c.append(tools) %}{{ c|tojson }}", True),
+        ("{% set ns = namespace(c=[]) %}{% do ns.c.extend(tools) %}{{ ns.c|tojson }}", True),
+        ("{% set c = [] %}{% do c.append(messages) %}{{ c|tojson }}", False),
+    ],
+)
+def test_names_carrying_the_catalog(template, detected):
+    assert template_supports_tools(template) is detected
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        "{% set catalog = tools %}{{ catalog|tojson }}",
+        "{% set a = tools %}{% set b = a %}{{ b|tojson }}",
+        "{% if tools %}{{ tools|tojson }}{% endif %}",
+        "{% for t in tools %}{{ t|tojson }}{% endfor %}",
+        "{% set c = [] %}{% do c.append(tools) %}{{ c|tojson }}",
+    ],
+)
+def test_positives_match_a_real_render(template):
+    """Every case claimed positive here really does emit a tool name."""
+    assert _renders_catalog(template, item = {}, message = {}, messages = [])
+    assert template_supports_tools(template) is True
+
+
+# ── deliberate over-approximation ───────────────────────────────────────────
+@pytest.mark.parametrize(
+    "template",
+    [
+        # A branch that can never run.
+        "{% if false %}{{ tools|tojson }}{% endif %}",
+        # A catalog put somewhere and then taken back out again.
+        "{% set c = [] %}{% do c.append(tools) %}{% do c.clear() %}{{ c|tojson }}",
+        # Iterating a mapping yields its keys, not the catalog under them.
+        "{% for key in {'weather': tools} %}{{ key }}{% endfor %}",
+    ],
+)
+def test_known_over_approximations_answer_yes(template):
+    """These render no schema, and the detector says yes anyway.
+
+    A value handed to a container is assumed to stay there, a branch is walked whether
+    or not it can run, and a mapping's values are not told apart from its keys.
+    Tracking any of that properly needs a much larger analysis, and none of it is
+    reachable from the 120 published templates checked. The error runs towards showing
+    a tool control that the backend then re-checks, rather than hiding one that works,
+    so it is left here on purpose rather than papered over.
+    """
+    assert not _renders_catalog(template, item = {}, message = {}, messages = [])
+    assert template_supports_tools(template) is True
+
+
+def test_a_guarded_branch_counts_even_without_naming_the_catalog():
+    """`{% if tools %}<prose>{% endif %}` renders no schema but is still telling the
+    model it has tools, so it counts. Asserted because it looks like a false positive
+    and is not one."""
+    template = "{% if tools %}You may call tools.{% endif %}"
+    assert not _renders_catalog(template)
+    assert template_supports_tools(template) is True
+
+
+# ── robustness ──────────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "template",
+    [
+        "{% if tools %}",  # unterminated
+        "{{ tools",  # unterminated expression
+        "{%",
+        "{% if tools %}" * 400 + "x" + "{% endif %}" * 400,  # deeply nested
+        "{{ " + "(" * 300 + "tools" + ")" * 300 + " }}",  # deeply nested expression
+        "{{ tools|tojson }}" * 5000,  # very long
+        "{% unknown_tag %}{{ tools|tojson }}",
+    ],
+)
+def test_hostile_templates_never_raise(template):
+    """This runs on the GGUF metadata read and the llama-server launch, so it must
+    return a verdict rather than stop a model from loading."""
+    assert template_supports_tools(template) in (True, False)
+
+
+@pytest.mark.parametrize("template", [None, 123, b"bytes", {"default": "x"}, [{"name": "x"}]])
+def test_non_string_templates_are_turned_away(template):
+    """Hugging Face ships named-template maps and Hermes-style lists. These reach the
+    detector unhashable, so the type check has to sit outside the cache."""
+    assert template_supports_tools(template) is False
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        "{% if tools %}{{ tools|tojson }}{% endif %}",
+        "{% set catalog = tools %}{{ catalog|tojson }}",
+        "{% for m in messages %}{{ m.content }}{% endfor %}",
+    ],
+)
+def test_line_endings_and_byte_order_marks_do_not_change_the_verdict(template):
+    """A Windows checkout and a file saved with a BOM have to agree with everyone
+    else, which is the whole point of reading syntax rather than bytes."""
+    base = template_supports_tools(template)
+    assert template_supports_tools(template.replace("\n", "\r\n")) is base
+    assert template_supports_tools("﻿" + template) is base
+
+
+def test_the_generation_tag_still_parses():
+    """`{% generation %}` marks the assistant span for training masks and is not a
+    real Jinja tag. Without the extension the template fails to parse and the
+    fail-closed branch would turn tools off. HuggingFaceTB/SmolLM3-3B needs this."""
+    template = (
+        "{% if tools %}{{ tools|tojson }}{% endif %}"
+        "{% generation %}{{ message.content }}{% endgeneration %}"
+    )
+    assert template_supports_tools(template) is True
+
+
+def test_unrelated_conditions_do_not_degrade():
+    """Nothing here forks a state per condition, so a template with many unrelated
+    guards costs no more than a linear walk. Qwen3-Coder-30B is the reason to keep
+    checking: it is long enough that any per-branch blow-up would reach it."""
+    template = (
+        "".join("{%% if flag%d %%}plain{%% endif %%}" % index for index in range(300))
+        + "{% if tools %}{{ tools|tojson }}{% endif %}"
+    )
+    assert template_supports_tools(template) is True
+
+
+def test_the_cache_is_keyed_on_the_template_text():
+    template = "{% if tools %}{{ tools|tojson }}{% endif %}"
+    template_supports_tools.cache_clear()
+    assert template_supports_tools(template) is True
+    assert template_supports_tools("".join([template])) is True
+    assert template_supports_tools.cache_info().hits >= 1


### PR DESCRIPTION
Replaces #10574, which took the same approach but grew a much larger analyser than the problem needs. See the note at the bottom.

## The problem

Studio decides whether to enable the tool controls for a model by looking at its chat template. That check was a list of whitespace-exact substrings in `llama_cpp.py`:

```python
_TOOL_TEMPLATE_MARKERS = (
    "{%- if tools %}",
    "{% if tools %}",
    "message.role == 'tool'",
    ...
)
```

That matches the spelling rather than the meaning, so a template that says the same thing differently gets reported as tool-less. IBM Granite 3.3 aliases the catalog before rendering it:

```jinja
{%- if tools and not available_tools -%}
    {%- set available_tools = tools -%}
{%- endif -%}
...
{%- if available_tools %}
    {{- available_tools | tojson(indent=4) }}
{%- endif %}
```

No marker matches, `supports_tools` comes back false, and the tool controls are greyed out on a model that supports tools.

## The change

`studio/backend/core/inference/template_capabilities.py` parses the template and walks it instead of scanning the text. It tracks which names hold the tool catalog, follows it across assignment and into containers, and answers true the first time one of them can reach the output.

Three things are worth calling out:

- A branch guarded on the catalog counts even when its body is only prose. `{% if tools %}You may call tools.{% endif %}` renders no schema but is still telling the model it has tools.
- A name rebound to something that is not the caller's catalog stops counting. `THUDM/glm-4-9b-chat` does `{% set tools = item['tools'] %}` and `ibm-granite/granite-guardian-3.1-8b` does `{% set tools = none %}`; neither consumes what Studio would pass in, and both correctly stay off.
- `{% generation %}` is registered as an extension. It is not real Jinja, and without it SmolLM3-3B fails to parse and falls to the fail-closed branch.

It is an over-approximation on purpose. Where it cannot tell, it answers yes. Showing a control that the backend re-checks before routing anything is a smaller problem than silently hiding a feature that works, which is the bug being fixed. The known loose cases are listed in the tests rather than left implicit.

Anything unexpected fails closed rather than raising. This runs on the GGUF metadata read and on the llama-server launch, so a capability hint must never stop a model from loading. Non-string templates are rejected before the cache, since Hugging Face named-template maps and Hermes-style lists arrive unhashable.

## Validation

I pulled 120 chat templates (87 unique) from 106 published repositories at pinned revisions and scored old behaviour, new behaviour and ground truth against each other. Ground truth is what actually comes out when the template is rendered with and without a tool catalog, using a same-size renamed catalog as a control so a template that merely mentions `tools` without consuming it does not count as a positive.

| | |
| --- | --- |
| Regressions (old true, new false) | 0 |
| False negatives against a real render | 0 |
| False positives against a real render | 0 |
| Crashes | 0 |
| Fixed | 1, `ibm-granite/granite-3.3-8b-instruct` |

Also checked:

- 130 focused tests, plus the existing `test_refactor_guard.py`, `test_source_read_encoding.py` and `test_formatter_fixed_point.py`.
- Malformed, deeply nested and very long templates all return a verdict rather than raising.
- CRLF and BOM variants give the same verdict as the original, so a Windows checkout agrees with everyone else.
- Cold p50 1.9 ms, p95 6.7 ms, max 10.7 ms over the corpus, cached per template.

## Why this replaces #10574

That PR started from the same premise and ended at roughly 1100 lines of analysis plus 1400 lines of tests. Measuring it afterwards, the extra machinery changed the verdict on zero published templates: both versions score identically on all 120, and they only differ on templates constructed during review. This one is 96 lines of logic and behaves the same on everything real.

It also drops a failure mode the larger version had. That analyser forks a state per unresolved `{% if %}`, so it needs a step budget to stay bounded, and a template that exhausts the budget fails closed and silently disables tools. Qwen3-Coder-30B measured at 6573 of 8192 steps, which is closer to that cliff than I would like. Nothing here forks, so there is no budget and no cliff.

The trade is that the larger version is more precise on templates that mutate containers, call macros with side effects or branch on values it can fold. If a published template ever turns up needing that, the right move is to add the specific case with the template that motivated it.


---

## What it looks like

`ibm-granite/granite-3.3-2b-instruct-GGUF` loaded in Studio, same weights and same
quant on both sides, photographed from two isolated installs built from this branch's
merge base and from its head.

![Search and Code pills, before and after](https://raw.githubusercontent.com/danielhanchen/unsloth-staging-2/pr-media/pr/10690/pr10690_pair_00-90e43c2c4374.png)

Search and Code are greyed out and unclickable before, live after. Both reduce to
`!supportsTools` once a model is loaded, so the composer is where this predicate is
visible to a user, and a false reading is one they cannot correct.

![Full composer, before and after](https://raw.githubusercontent.com/danielhanchen/unsloth-staging-2/pr-media/pr/10690/pr10690_pair_01-cc419842509a.png)

The API on each photographed server agrees with its own screenshot:
`supports_tools` false to true, `pill_search.disabled` true to false,
`pill_code.disabled` true to false. The centred greeting differs between the halves
because Studio rotates it per load; it is not an effect of this change.

## Measurements

Over 348 unique chat templates from 1330 published repositories, scored at the merge
base and at this head in separate processes, with ground truth taken from rendering
each template with a tool catalog and with a renamed same-size control:

| | |
| --- | --- |
| Regressions against the marker scan | 0 |
| False negatives against a real render | 0 |
| Crashes | 0 |
| CRLF and BOM verdict changes | 0 |
| Gained | `granite-3.3`, `LFM2-1.2B-Tool` and `LFM2-1.2B-Extract`, `Xing4.0-29B-A4B`, `LongCat-2.0`, `granite-guardian-3.1-8b` |

The other six flags `detect_reasoning_flags` returns are unchanged on every one of
those templates: 2088 cells, 2088 identical. The backend suite was run at the merge
base and at this head, 771 failing test ids on each side, set difference empty in both
directions.

Cold cost, cache cleared per call, over the same corpus: p50 3.5 ms, p95 16 ms, worst
published template 67 ms (a 51 KB template), 0 ms cached. The marker scan it replaces
was 0.002 ms, and this runs once per model on a path that already reads GGUF metadata
off disk.

Verdicts are identical across jinja2 3.1.0, 3.1.2, 3.1.4, 3.1.6 and latest, on Python
3.10 through 3.13: eight cells, 348 verdicts each, no differences and no raises.
