### PR TITLE
Unbreak main: count setup.ps1's exits from the parse tree, not by grepping lines

### DIFF
--- a/tests/sh/test_tauri_retry_failure_context.sh
+++ b/tests/sh/test_tauri_retry_failure_context.sh
@@ -377,13 +377,37 @@ if ! grep -q '\$env:UNSLOTH_TAURI_MODE = if (\$TauriMode)' "$INSTALL_PS1"; then
     exit 1
 fi
 
-_ps_setup_exit_count=$(grep -Ec '^[[:space:]]*exit[[:space:]]+' "$SETUP_PS1" || true)
-if [ "$_ps_setup_exit_count" -ne 1 ] ||
-    ! grep -q '^[[:space:]]*exit \$Code$' "$SETUP_PS1"; then
-    echo "  FAIL: Windows setup has explicit exits outside Exit-SetupFailure"
-    exit 1
+# Counted from the parse tree, not by grepping lines. setup.ps1 builds a probe
+# script inside a here-string and that child legitimately exits on its own, so a
+# line-wise count reads its `exit 1` as this file's own and the guard fails on a
+# correct tree. Filtering here-strings out by regex first does not rescue it:
+# line 909 ends with @' inside a URL-redaction replacement, so a range filter
+# runs from there to the real terminator and silently swallows 785 lines of real
+# code, which would hide exactly the stray exit this is looking for.
+if command -v pwsh >/dev/null 2>&1; then
+    _ps_setup_exits=$(SETUP_PS1="$SETUP_PS1" pwsh -NoProfile -Command '
+        $tokens = $null; $errors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path $env:SETUP_PS1).Path, [ref]$tokens, [ref]$errors)
+        if ($errors.Count) { Write-Output "PARSE_ERROR"; exit 0 }
+        $ast.FindAll({
+            $args[0] -is [System.Management.Automation.Language.ExitStatementAst]
+        }, $true) | ForEach-Object { $_.Extent.Text }' 2>/dev/null)
+    if [ "$_ps_setup_exits" = "PARSE_ERROR" ]; then
+        echo "  FAIL: Windows setup no longer parses as PowerShell"
+        exit 1
+    fi
+    _ps_setup_exit_count=$(printf '%s\n' "$_ps_setup_exits" | grep -c . || true)
+    if [ "$_ps_setup_exit_count" -ne 1 ] ||
+        [ "$(printf '%s' "$_ps_setup_exits" | tr -d '[:space:]')" != 'exit$Code' ]; then
+        echo "  FAIL: Windows setup has explicit exits outside Exit-SetupFailure"
+        printf '        found: %s\n' "$_ps_setup_exits"
+        exit 1
+    fi
+    echo "  PASS: Windows setup routes explicit exits through Exit-SetupFailure"
+else
+    echo "  SKIP: pwsh unavailable, cannot parse setup.ps1 for stray exits"
 fi
-echo "  PASS: Windows setup routes explicit exits through Exit-SetupFailure"
 
 _ps_command_block=$(sed -n \
     '/function Invoke-InstallCommand {/,/function New-StudioShortcuts {/p' \


### PR DESCRIPTION
tests/sh/test_tauri_retry_failure_context.sh fails on a clean checkout of `main`, which makes `Backend CI` red on main and on every PR that merges it.

```
  PASS: Windows setup uses the same failure-context boundaries
  FAIL: Windows setup has explicit exits outside Exit-SetupFailure
```

## What the guard wants, and why it misfires

The assertion is that `studio/setup.ps1` routes every explicit exit through `Exit-SetupFailure`, so a failure always gets its Tauri error line. It enforced that by counting lines:

```sh
_ps_setup_exit_count=$(grep -Ec "^[[:space:]]*exit[[:space:]]+" "$SETUP_PS1" || true)
```

setup.ps1 builds a probe script inside a here-string, and that script runs in a child process and legitimately ends with a bare `exit 1`. A line-wise count reads it as setup.ps1 own exit, so the guard fails on a correct tree. Bisect: `42e7ff098` counted 1, `95feb6979` introduced the probe and made it 2. The probe is right; the counting is not.

## Filtering here-strings by regex is worse than it looks

The obvious repair is to drop here-string spans before counting. That is a trap here. Line 909 is

```powershell
$Text = $Text -replace "(https?://)[^/@\s`]+@", "$1<redacted>@"
```

which ends in `@` followed by a quote, so a range filter treats it as an opener and runs all the way to the real terminator at line 1693, deleting **785 lines of real code**. It happens to report the correct count on main today, and it would hide a stray `exit` anywhere in that span. Openers found by regex: 2. Here-strings found by the parser: 1.

## The change

Ask PowerShell. `ExitStatementAst` nodes are exits; here-string contents are not.

```
parser here-strings: 1
parser exit statements: 1
  line 179: exit $Code
```

The check skips with a message where `pwsh` is unavailable, matching how the Python tests treat it. GitHub ubuntu runners have pwsh, so CI exercises it.

## Mutations

| mutation | result |
|---|---|
| unmutated | PASS |
| stray `exit 7` after the here-string | FAIL |
| stray `exit 9` inside the span a regex filter would swallow | FAIL |
| `Exit-SetupFailure` returning instead of exiting | FAIL |

The third row is the point: the parser catches what the regex repair would have missed.

`tests/sh` goes from 63 passed / 1 failed to **64 passed / 0 failed**.