### PR TITLE
Studio: Open WebUI llama.cpp residency and explicit load/unload (#10610)

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -26461,6 +26461,27 @@ def _servable_catalog_rows(
     ]
 
 
+def _openai_residency_fields(loaded: bool) -> dict:
+    """Authoritative residency for OpenAI-compatible catalogs.
+
+    Open WebUI's llama.cpp provider ignores a bare ``loaded`` boolean and, when
+    ``status`` is missing, assumes the model is resident
+    (``get_provider_model_loaded_state``). Publish both ``loaded`` and
+    ``status.value`` from the same lifecycle truth so a downloaded-but-unloaded
+    model stays ``loaded: false`` after that merge.
+    """
+    is_loaded = bool(loaded)
+    return {
+        "loaded": is_loaded,
+        "status": {"value": "loaded" if is_loaded else "unloaded"},
+    }
+
+
+def _with_openai_residency(entry: dict) -> dict:
+    """Stamp catalog/list rows with residency fields derived from ``loaded``."""
+    return {**entry, **_openai_residency_fields(bool(entry.get("loaded")))}
+
+
 async def _openai_catalog_objects() -> list[dict]:
     """Every model the server knows about for ``GET /v1/models``: the loaded
     model(s) plus locally available (downloaded/cached) models discovered by
@@ -26472,7 +26493,7 @@ async def _openai_catalog_objects() -> list[dict]:
     # Off-loop: _openai_model_objects() is sync and calls get_inference_backend(), whose cold
     # build waits on detection. Inline, an early GET /v1/models held the loop for the import.
     for entry in await asyncio.to_thread(_openai_model_objects):
-        by_id[entry["id"]] = {**entry, "loaded": True}
+        by_id[entry["id"]] = _with_openai_residency({**entry, "loaded": True})
     orchestrator = _peek_inference_backend()
     resident_id = _orchestrator_public_model_id(orchestrator) if orchestrator else None
 
@@ -26493,7 +26514,7 @@ async def _openai_catalog_objects() -> list[dict]:
             "object": "model",
             "created": _created,
             "owned_by": _OWNED_BY,
-            "loaded": loaded,
+            **_openai_residency_fields(loaded),
         }
         # The id stays bare for OpenAI compat; a client appends ":<quant>" to pin one.
         # For the resident model that must be the quant actually loaded, not the
@@ -26517,7 +26538,7 @@ async def _openai_catalog_objects() -> list[dict]:
     for obj in media:
         by_id.setdefault(obj["id"], obj)
 
-    return list(by_id.values())
+    return [_with_openai_residency(entry) for entry in by_id.values()]
 
 
 # Some OpenAI-compatible clients (notably DEVONthink) probe ``/v1/models/``
@@ -26558,7 +26579,7 @@ async def openai_retrieve_model(model_id: str, current_subject: str = Depends(ge
     for entry in _loaded:
         eid = entry["id"]
         if isinstance(eid, str) and eid.lower() == model_id.lower():
-            return {**entry, "loaded": True}
+            return _with_openai_residency({**entry, "loaded": True})
 
     objects = await _openai_catalog_objects()
     for model in objects:

--- a/studio/backend/routes/llama_compat.py
+++ b/studio/backend/routes/llama_compat.py
@@ -263,7 +263,6 @@ async def _resolve_manageable_model(model_id: str) -> tuple[str, Optional[str], 
     if matched is not None:
         # Catalog-listed (e.g. non-GGUF) without a resolver hit: load by public id.
         from core.inference.openai_auto_download import split_model_ref
-
         base, variant = split_model_ref(matched)
         return base, variant, base
 
@@ -325,8 +324,7 @@ async def manage_load_model(
 @router.post("/models/unload", include_in_schema = False)
 @router.post("/models/unload/", include_in_schema = False)
 async def manage_unload_model(
-    body: _ModelManageBody,
-    current_subject: str = Depends(get_current_subject),
+    body: _ModelManageBody, current_subject: str = Depends(get_current_subject)
 ):
     """Explicit authenticated unload (``POST /models/unload`` with ``{"model":"..."}``).
 

--- a/studio/backend/routes/llama_compat.py
+++ b/studio/backend/routes/llama_compat.py
@@ -5,13 +5,18 @@
 
 Probes for engine endpoints used to land on main.py's SPA catch-all, so ``GET /props``
 returned 200 and a page of HTML. That is worse than a 404: a probe reads the status
-before the body. Served here: ``/props``, ``/v1/props``, ``/version``. Everything else
-in llama-server's table gets an explicit 404, on its real method as well as GET.
+before the body. Served here: ``/props``, ``/v1/props``, ``/version``, and the Open
+WebUI llama.cpp management surface (``GET /models``, ``POST /models/load``,
+``POST /models/unload``). Everything else in llama-server's table gets an explicit
+404, on its real method as well as GET.
 
 Deliberately NOT served: Ollama's ``/api/tags`` and ``/api/show``. Answering them makes
 a client select Ollama and then fail on ``/api/chat``, which Studio does not implement;
 the reporting user's client instead fell back to the OpenAI surface and worked.
 Advertising a protocol we do not have is the HTML 200 again, one layer up.
+
+Also deliberately NOT served yet (Open WebUI follow-ups): ``POST /models`` (download),
+``DELETE /models`` (delete), and ``GET /models/sse`` (model events).
 """
 
 from __future__ import annotations
@@ -20,7 +25,8 @@ import asyncio
 import functools
 from typing import Any, Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
 
 from auth.authentication import get_current_subject
 from loggers import get_logger
@@ -30,8 +36,9 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 
-# llama-server's table (tools/server/server.cpp) minus /props, so the set is complete
-# rather than growing per complaint. Bare only, so it cannot shadow /api/ or /v1/.
+# llama-server's table (tools/server/server.cpp) minus routes Studio serves, so the
+# set is complete rather than growing per complaint. Bare only, so it cannot shadow
+# /api/ or /v1/. Management list/load/unload are served below; download/delete/sse stay.
 _ENGINE_PROBE_PATHS = frozenset(
     {
         "apply-template",
@@ -48,10 +55,8 @@ _ENGINE_PROBE_PATHS = frozenset(
         "infill",
         "lora-adapters",
         "metrics",
-        "models",
-        "models/load",
+        # POST /models (download) and DELETE /models stay denied via explicit routes.
         "models/sse",
-        "models/unload",
         "rerank",
         "reranking",
         "responses",
@@ -60,6 +65,15 @@ _ENGINE_PROBE_PATHS = frozenset(
         "tokenize",
         "tools",
     }
+)
+
+# Paths Studio serves on one method but still must 404 on others (no HTML).
+_MANAGEMENT_METHOD_DENIALS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    # llama.cpp download/delete; Studio keeps these as follow-ups.
+    ("/models", ("POST", "PUT", "PATCH", "DELETE")),
+    # load/unload are POST-only.
+    ("/models/load", ("GET", "PUT", "PATCH", "DELETE", "HEAD")),
+    ("/models/unload", ("GET", "PUT", "PATCH", "DELETE", "HEAD")),
 )
 
 # /slots/:id_slot is the one dynamic entry in that table, and Studio calls it itself.
@@ -84,6 +98,9 @@ _UNSERVED_V1_PROBE_PATHS = frozenset(
 def is_engine_probe_path(full_path: str) -> bool:
     """True for an engine endpoint that must 404 rather than render the app shell."""
     normalized = full_path.strip("/").lower()
+    if normalized in {"models", "models/load", "models/unload"}:
+        # Served routes: the SPA catch-all must not claim these as HTML.
+        return False
     return normalized in _ENGINE_PROBE_PATHS or normalized.startswith(_ENGINE_PROBE_PREFIXES)
 
 
@@ -189,6 +206,157 @@ async def studio_version(current_subject: str = Depends(get_current_subject)):
     return {"version": await asyncio.to_thread(_studio_version)}
 
 
+class _ModelManageBody(BaseModel):
+    """Open WebUI / llama.cpp management body: ``{"model": "<id>"}``."""
+
+    model: str = Field(..., min_length = 1)
+
+
+def _catalog_id_match(catalog: list[dict], model_id: str) -> Optional[str]:
+    """Return the catalog's canonical id for *model_id*, or None."""
+    needle = model_id.strip().lower()
+    if not needle:
+        return None
+    for entry in catalog:
+        eid = entry.get("id")
+        if isinstance(eid, str) and eid.lower() == needle:
+            return eid
+    # ``repo:QUANT`` where the bare repo is listed (Open WebUI may pin a quant).
+    base, sep, _variant = model_id.strip().rpartition(":")
+    if sep and base:
+        base_l = base.strip().lower()
+        for entry in catalog:
+            eid = entry.get("id")
+            if isinstance(eid, str) and eid.lower() == base_l:
+                return model_id.strip()
+    return None
+
+
+async def _resolve_manageable_model(model_id: str) -> tuple[str, Optional[str], str]:
+    """Map a management ``model`` id to ``(load_path, gguf_variant, public_id)``.
+
+    Reuses the public catalog and the same local resolver auto-switch uses. Raises
+    404 when the id is not a downloaded/local model this server can manage.
+    """
+    requested = (model_id or "").strip()
+    if not requested:
+        raise HTTPException(status_code = 400, detail = "model is required")
+
+    inf = _inference()
+    catalog = await inf._openai_catalog_objects()
+    matched = _catalog_id_match(catalog, requested)
+
+    from core.inference.local_model_resolver import (
+        resolve_local_gguf,
+        resolve_trusted_cached_local_gguf,
+    )
+
+    resolved = resolve_trusted_cached_local_gguf(requested)
+    if resolved is None:
+        resolved = await asyncio.to_thread(resolve_local_gguf, requested)
+
+    if resolved is not None:
+        load_path, variant, loader_id = resolved[0], resolved[1], resolved[2]
+        public_id = matched or (loader_id if isinstance(loader_id, str) else requested)
+        return load_path, variant, public_id
+
+    if matched is not None:
+        # Catalog-listed (e.g. non-GGUF) without a resolver hit: load by public id.
+        from core.inference.openai_auto_download import split_model_ref
+
+        base, variant = split_model_ref(matched)
+        return base, variant, base
+
+    raise HTTPException(status_code = 404, detail = "model is not found")
+
+
+# Outside /v1: Open WebUI strips /v1 before management calls (MODEL_MANAGEMENT_ENDPOINTS).
+@router.get("/models", include_in_schema = False)
+@router.get("/models/", include_in_schema = False)
+async def manage_list_models(current_subject: str = Depends(get_current_subject)):
+    """llama.cpp / Open WebUI management catalog (``GET /models``).
+
+    Same downloaded/local catalog as ``GET /v1/models``, including residency
+    metadata. Distinct path: management clients remove the ``/v1`` suffix.
+    """
+    data = await _inference()._openai_catalog_objects()
+    return {"object": "list", "data": data}
+
+
+@router.post("/models/load", include_in_schema = False)
+@router.post("/models/load/", include_in_schema = False)
+async def manage_load_model(
+    body: _ModelManageBody,
+    fastapi_request: Request,
+    current_subject: str = Depends(get_current_subject),
+):
+    """Explicit authenticated load (``POST /models/load`` with ``{"model":"..."}``).
+
+    Reuses ``load_model_gated`` so lifecycle gates, resolution and residency match
+    Studio's ``POST /api/inference/load``. Does not change auto-switch policy.
+    """
+    load_path, variant, public_id = await _resolve_manageable_model(body.model)
+    inf = _inference()
+    from models.inference import LoadRequest
+
+    request = LoadRequest(model_path = load_path, gguf_variant = variant)
+    try:
+        response = await inf.load_model_gated(
+            request,
+            fastapi_request,
+            current_subject,
+            user_initiated = True,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001 -- surface as API error, keep residency consistent
+        logger.error("management load failed for %r: %s", public_id, exc, exc_info = True)
+        raise HTTPException(status_code = 500, detail = "Failed to load model") from exc
+
+    status = getattr(response, "status", None) or "loaded"
+    return {
+        "success": True,
+        "model": public_id,
+        "loaded": True,
+        "status": status,
+    }
+
+
+@router.post("/models/unload", include_in_schema = False)
+@router.post("/models/unload/", include_in_schema = False)
+async def manage_unload_model(
+    body: _ModelManageBody,
+    current_subject: str = Depends(get_current_subject),
+):
+    """Explicit authenticated unload (``POST /models/unload`` with ``{"model":"..."}``).
+
+    Reuses ``_unload_model_impl`` so gates and identity matching match Studio's
+    ``POST /api/inference/unload``.
+    """
+    _load_path, _variant, public_id = await _resolve_manageable_model(body.model)
+    inf = _inference()
+    from models.inference import UnloadRequest
+
+    # Unload under the public id the client named: _unload_model_impl matches
+    # advertised aliases and on-disk identifiers via _names_the_resident_model.
+    request = UnloadRequest(model_path = public_id)
+    try:
+        response = await inf._unload_model_impl(request, current_subject)
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        logger.error("management unload failed for %r: %s", public_id, exc, exc_info = True)
+        raise HTTPException(status_code = 500, detail = "Failed to unload model") from exc
+
+    status = getattr(response, "status", None) or "unloaded"
+    return {
+        "success": True,
+        "model": public_id,
+        "loaded": False,
+        "status": status,
+    }
+
+
 async def _probe_not_found():
     raise HTTPException(status_code = 404, detail = "API endpoint not found")
 
@@ -210,6 +378,15 @@ for _probe_path in sorted(_ENGINE_PROBE_PATHS):
             _form,
             _probe_not_found,
             methods = _PROBE_DENIED_METHODS,
+            include_in_schema = False,
+        )
+
+for _manage_path, _methods in _MANAGEMENT_METHOD_DENIALS:
+    for _form in _both_forms(_manage_path):
+        router.add_api_route(
+            _form,
+            _probe_not_found,
+            methods = list(_methods),
             include_in_schema = False,
         )
 

--- a/studio/backend/tests/test_llama_compat_open_webui_management.py
+++ b/studio/backend/tests/test_llama_compat_open_webui_management.py
@@ -1,0 +1,464 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Open WebUI llama.cpp management compatibility (#10610).
+
+Covers:
+- residency metadata (``loaded`` + ``status.value``) that survives OWUI's merge
+- ``GET /models`` management catalog (outside ``/v1``)
+- authenticated ``POST /models/load`` / ``POST /models/unload``
+- route separation from ``GET /v1/models``
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[1]
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI, HTTPException  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+# ── Open WebUI provider merge (extracted contract from openai.py @ 0a7c158) ──
+
+LLAMACPP_LOADED_STATES = {"loaded", "sleeping"}
+LLAMACPP_UNLOADED_STATES = {"loading", "unloaded"}
+
+
+def get_provider_model_loaded_state(model: dict, provider: str, manual_model_ids: bool = False):
+    """Pinned Open WebUI helper: llama.cpp without ``status`` is assumed loaded."""
+    if provider != "llama.cpp":
+        return None
+    status = model.get("status")
+    if isinstance(status, dict):
+        value = status.get("value")
+        if value in LLAMACPP_LOADED_STATES:
+            return True
+        if value in LLAMACPP_UNLOADED_STATES:
+            return False
+    if not manual_model_ids and "status" not in model:
+        return True
+    return None
+
+
+def get_merged_models(model_lists, *, provider: str = "llama.cpp"):
+    models = {}
+    for model_list in model_lists:
+        if model_list is None or "error" in (model_list or {}):
+            continue
+        for model in model_list:
+            model_id = model.get("id") or model.get("name")
+            if not model_id or model_id in models:
+                continue
+            merged = {**model, "provider": provider}
+            loaded = get_provider_model_loaded_state(model, provider)
+            if loaded is not None:
+                merged["loaded"] = loaded
+            models[model_id] = merged
+    return models
+
+
+# ── llama_compat harness ─────────────────────────────────────────────────────
+
+_MOD = None
+
+
+class _Backend:
+    def __init__(self, *, loaded = False):
+        self.is_loaded = loaded
+        self.model_identifier = "/media/models/qwen/model.gguf"
+        self._openai_advertised_id = "unsloth/Qwen3.8-27B-GGUF"
+        self.context_length = 4096
+        self.hf_variant = "Q4_K_M"
+        self.effective_parallel_slots = 4
+        self.chat_template = ""
+
+    def _query_server_props(self):
+        return None
+
+
+def _catalog(*, resident = "unsloth/Qwen3.8-27B-GGUF", extra_unloaded = True):
+    rows = []
+    if resident:
+        rows.append(
+            {
+                "id": resident,
+                "object": "model",
+                "created": 1,
+                "owned_by": "unsloth-studio",
+                "loaded": True,
+                "status": {"value": "loaded"},
+            }
+        )
+    if extra_unloaded:
+        rows.append(
+            {
+                "id": "unsloth/Laguna-S-2.1-GGUF",
+                "object": "model",
+                "created": 1,
+                "owned_by": "unsloth-studio",
+                "loaded": False,
+                "status": {"value": "unloaded"},
+            }
+        )
+    return rows
+
+
+def _inference_double(catalog, *, load_impl = None, unload_impl = None, backend = None):
+    state = {"resident": {m["id"] for m in catalog if m.get("loaded")}}
+
+    async def _objects():
+        out = []
+        for row in catalog:
+            loaded = row["id"] in state["resident"]
+            out.append(
+                {
+                    **row,
+                    "loaded": loaded,
+                    "status": {"value": "loaded" if loaded else "unloaded"},
+                }
+            )
+        return out
+
+    async def _load(request, fastapi_request, current_subject, *, user_initiated = False):
+        if load_impl is not None:
+            return await load_impl(
+                request, fastapi_request, current_subject, user_initiated = user_initiated
+            )
+        mid = getattr(request, "model_path", None)
+        state["resident"].add(mid)
+        for row in catalog:
+            if row["id"] == mid or mid.endswith(row["id"].split("/")[-1]):
+                state["resident"].add(row["id"])
+        return types.SimpleNamespace(status = "loaded", model = mid)
+
+    async def _unload(request, current_subject):
+        if unload_impl is not None:
+            return await unload_impl(request, current_subject)
+        mid = getattr(request, "model_path", None)
+        state["resident"].discard(mid)
+        return types.SimpleNamespace(status = "unloaded", model = mid)
+
+    inference = types.SimpleNamespace()
+    inference.get_llama_cpp_backend = lambda: backend or _Backend(loaded = bool(state["resident"]))
+    inference._llama_public_model_id = lambda b, fallback = None: getattr(
+        b, "_openai_advertised_id", fallback
+    )
+    inference._peek_inference_backend = lambda: None
+    inference._orchestrator_public_model_id = lambda b: None
+    inference._openai_catalog_objects = _objects
+    inference.load_model_gated = _load
+    inference._unload_model_impl = _unload
+    inference._state = state
+    return inference
+
+
+def _load_mod(catalog = None, **kw):
+    global _MOD
+    if _MOD is None or not hasattr(_MOD, "router"):
+        sys.modules.pop("llama_compat_owui_under_test", None)
+        spec = importlib.util.spec_from_file_location(
+            "llama_compat_owui_under_test",
+            str(_BACKEND / "routes" / "llama_compat.py"),
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["llama_compat_owui_under_test"] = mod
+        spec.loader.exec_module(mod)
+        _MOD = mod
+    double = _inference_double(_catalog() if catalog is None else catalog, **kw)
+    _MOD._inference = lambda d = double: d
+    return _MOD, double
+
+
+def _client(mod, *, auth = True):
+    app = FastAPI()
+    app.include_router(mod.router)
+    if auth:
+        app.dependency_overrides[mod.get_current_subject] = lambda: "test"
+    else:
+        # Force auth failure without pulling the full credential stack.
+        def _deny():
+            raise HTTPException(status_code = 401, detail = "Not authenticated")
+
+        app.dependency_overrides[mod.get_current_subject] = _deny
+    return TestClient(app, raise_server_exceptions = False)
+
+
+@pytest.fixture(scope = "module", autouse = True)
+def _teardown():
+    yield
+    sys.modules.pop("llama_compat_owui_under_test", None)
+
+
+# ── A. Residency / Open WebUI merge regression ───────────────────────────────
+
+
+def test_nonresident_catalog_row_keeps_loaded_false_after_owui_llama_cpp_merge():
+    """THE #10610 REGRESSION: OWUI overwrites loaded=false → true without status."""
+    row = {
+        "id": "unsloth/Laguna-S-2.1-GGUF",
+        "object": "model",
+        "loaded": False,
+        "status": {"value": "unloaded"},
+    }
+    # Control: bare loaded without status is wrongly assumed resident.
+    broken = {"id": "x", "loaded": False}
+    assert get_provider_model_loaded_state(broken, "llama.cpp") is True
+    assert get_merged_models([[broken]])["x"]["loaded"] is True
+
+    # Plain OpenAI provider leaves the boolean alone.
+    openai_merged = get_merged_models([[row]], provider = "openai")
+    assert openai_merged[row["id"]]["loaded"] is False
+
+    merged = get_merged_models([[row]])
+    assert merged[row["id"]]["loaded"] is False
+    assert merged[row["id"]]["status"]["value"] == "unloaded"
+
+
+def test_management_catalog_status_survives_owui_merge():
+    mod, _ = _load_mod(catalog = _catalog(resident = None))
+    with _client(mod) as c:
+        data = c.get("/models").json()["data"]
+    merged = get_merged_models([data])
+    assert merged["unsloth/Laguna-S-2.1-GGUF"]["loaded"] is False
+    assert merged["unsloth/Laguna-S-2.1-GGUF"]["status"]["value"] == "unloaded"
+
+
+# ── B/C/D/E/F. Management routes ─────────────────────────────────────────────
+
+
+def test_get_models_lists_nonresident_downloaded_models():
+    mod, _ = _load_mod()
+    with _client(mod) as c:
+        r = c.get("/models")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["object"] == "list"
+    ids = {m["id"]: m for m in body["data"]}
+    assert ids["unsloth/Laguna-S-2.1-GGUF"]["loaded"] is False
+    assert ids["unsloth/Laguna-S-2.1-GGUF"]["status"]["value"] == "unloaded"
+    assert ids["unsloth/Qwen3.8-27B-GGUF"]["loaded"] is True
+
+
+def test_empty_management_catalog():
+    mod, _ = _load_mod(catalog = [])
+    with _client(mod) as c:
+        r = c.get("/models")
+    assert r.status_code == 200
+    assert r.json() == {"object": "list", "data": []}
+
+
+def test_management_requires_auth():
+    mod, _ = _load_mod()
+    with _client(mod, auth = False) as c:
+        assert c.get("/models").status_code == 401
+        assert c.post("/models/load", json = {"model": "unsloth/Laguna-S-2.1-GGUF"}).status_code == 401
+        assert c.post(
+            "/models/unload", json = {"model": "unsloth/Qwen3.8-27B-GGUF"}
+        ).status_code == 401
+
+
+def test_load_unload_open_webui_contract_and_residency_transition(monkeypatch):
+    catalog = _catalog(resident = None)
+    loads = []
+    unloads = []
+
+    async def _load(request, fastapi_request, current_subject, *, user_initiated = False):
+        loads.append(
+            {
+                "model_path": request.model_path,
+                "gguf_variant": request.gguf_variant,
+                "user_initiated": user_initiated,
+            }
+        )
+        return types.SimpleNamespace(status = "loaded", model = request.model_path)
+
+    async def _unload(request, current_subject):
+        unloads.append(request.model_path)
+        return types.SimpleNamespace(status = "unloaded", model = request.model_path)
+
+    mod, double = _load_mod(catalog = catalog, load_impl = _load, unload_impl = _unload)
+
+    monkeypatch.setattr(
+        "core.inference.local_model_resolver.resolve_trusted_cached_local_gguf",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        "core.inference.local_model_resolver.resolve_local_gguf",
+        lambda requested, **_k: (
+            "/data/Laguna.gguf",
+            "Q4_K_M",
+            "unsloth/Laguna-S-2.1-GGUF",
+        ),
+    )
+
+    with _client(mod) as c:
+        before = {m["id"]: m for m in c.get("/models").json()["data"]}
+        assert before["unsloth/Laguna-S-2.1-GGUF"]["loaded"] is False
+
+        load = c.post("/models/load", json = {"model": "unsloth/Laguna-S-2.1-GGUF"})
+        assert load.status_code == 200, load.text
+        assert load.json()["success"] is True
+        assert load.json()["loaded"] is True
+        assert loads and loads[0]["user_initiated"] is True
+        assert loads[0]["model_path"] == "/data/Laguna.gguf"
+        assert loads[0]["gguf_variant"] == "Q4_K_M"
+
+        double._state["resident"].add("unsloth/Laguna-S-2.1-GGUF")
+        after_load = {m["id"]: m for m in c.get("/models").json()["data"]}
+        assert after_load["unsloth/Laguna-S-2.1-GGUF"]["loaded"] is True
+
+        unload = c.post("/models/unload", json = {"model": "unsloth/Laguna-S-2.1-GGUF"})
+        assert unload.status_code == 200, unload.text
+        assert unload.json()["success"] is True
+        assert unload.json()["loaded"] is False
+        assert unloads == ["unsloth/Laguna-S-2.1-GGUF"]
+
+        double._state["resident"].discard("unsloth/Laguna-S-2.1-GGUF")
+        after_unload = {m["id"]: m for m in c.get("/models").json()["data"]}
+        assert after_unload["unsloth/Laguna-S-2.1-GGUF"]["loaded"] is False
+
+
+def test_load_unknown_model_is_404(monkeypatch):
+    mod, _ = _load_mod(catalog = _catalog(resident = None, extra_unloaded = False))
+    monkeypatch.setattr(
+        "core.inference.local_model_resolver.resolve_trusted_cached_local_gguf",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        "core.inference.local_model_resolver.resolve_local_gguf",
+        lambda *_a, **_k: None,
+    )
+    with _client(mod) as c:
+        r = c.post("/models/load", json = {"model": "nobody/missing-model"})
+    assert r.status_code == 404
+
+
+def test_load_invalid_body_is_4xx():
+    mod, _ = _load_mod()
+    with _client(mod) as c:
+        assert c.post("/models/load", json = {}).status_code == 422
+        assert c.post("/models/load", json = {"model": ""}).status_code == 422
+        assert c.post("/models/unload", json = {"nope": 1}).status_code == 422
+
+
+def test_load_failure_surfaces_error_without_claiming_success(monkeypatch):
+    async def _boom(request, fastapi_request, current_subject, *, user_initiated = False):
+        raise HTTPException(status_code = 500, detail = "Failed to load model")
+
+    mod, double = _load_mod(catalog = _catalog(resident = None), load_impl = _boom)
+    monkeypatch.setattr(
+        "core.inference.local_model_resolver.resolve_trusted_cached_local_gguf",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        "core.inference.local_model_resolver.resolve_local_gguf",
+        lambda requested, **_k: ("/data/x.gguf", "Q4_K_M", "unsloth/Laguna-S-2.1-GGUF"),
+    )
+    with _client(mod) as c:
+        r = c.post("/models/load", json = {"model": "unsloth/Laguna-S-2.1-GGUF"})
+    assert r.status_code == 500
+    assert "unsloth/Laguna-S-2.1-GGUF" not in double._state["resident"]
+
+
+def test_repeated_load_uses_lifecycle_already_loaded(monkeypatch):
+    calls = {"n": 0}
+
+    async def _load(request, fastapi_request, current_subject, *, user_initiated = False):
+        calls["n"] += 1
+        status = "already_loaded" if calls["n"] > 1 else "loaded"
+        return types.SimpleNamespace(status = status, model = request.model_path)
+
+    mod, _ = _load_mod(catalog = _catalog(resident = None), load_impl = _load)
+    monkeypatch.setattr(
+        "core.inference.local_model_resolver.resolve_trusted_cached_local_gguf",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        "core.inference.local_model_resolver.resolve_local_gguf",
+        lambda requested, **_k: ("/data/x.gguf", None, "unsloth/Laguna-S-2.1-GGUF"),
+    )
+    with _client(mod) as c:
+        a = c.post("/models/load", json = {"model": "unsloth/Laguna-S-2.1-GGUF"})
+        b = c.post("/models/load", json = {"model": "unsloth/Laguna-S-2.1-GGUF"})
+    assert a.status_code == 200 and b.status_code == 200
+    assert a.json()["status"] == "loaded"
+    assert b.json()["status"] == "already_loaded"
+
+
+def test_models_routes_are_not_under_v1(monkeypatch):
+    """Management paths must not be registered only as /v1/... aliases."""
+    mod, _ = _load_mod()
+    monkeypatch.setattr(
+        "core.inference.local_model_resolver.resolve_trusted_cached_local_gguf",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        "core.inference.local_model_resolver.resolve_local_gguf",
+        lambda requested, **_k: ("/data/x.gguf", None, "unsloth/Laguna-S-2.1-GGUF"),
+    )
+    paths = {getattr(r, "path", None) for r in mod.router.routes}
+    assert "/models" in paths
+    assert "/models/load" in paths
+    assert "/models/unload" in paths
+    assert "/v1/models/load" not in paths
+    assert "/v1/models/unload" not in paths
+
+    with _client(mod) as c:
+        assert c.get("/models").status_code == 200
+        assert (
+            c.post("/models/load", json = {"model": "unsloth/Laguna-S-2.1-GGUF"}).status_code == 200
+        )
+        # /v1/models is registered on the inference router, not llama_compat.
+        assert c.get("/v1/models").status_code == 404
+
+
+def test_quant_suffix_resolves_through_existing_resolver(monkeypatch):
+    seen = {}
+
+    async def _load(request, fastapi_request, current_subject, *, user_initiated = False):
+        seen["path"] = request.model_path
+        seen["variant"] = request.gguf_variant
+        return types.SimpleNamespace(status = "loaded", model = request.model_path)
+
+    catalog = [
+        {
+            "id": "unsloth/Laguna-S-2.1-GGUF",
+            "object": "model",
+            "created": 1,
+            "owned_by": "unsloth-studio",
+            "loaded": False,
+            "status": {"value": "unloaded"},
+            "quant": "Q4_K_M",
+        }
+    ]
+    mod, _ = _load_mod(catalog = catalog, load_impl = _load)
+    monkeypatch.setattr(
+        "core.inference.local_model_resolver.resolve_trusted_cached_local_gguf",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        "core.inference.local_model_resolver.resolve_local_gguf",
+        lambda requested, **_k: (
+            "/data/Laguna-Q4_K_M.gguf",
+            "Q4_K_M",
+            "unsloth/Laguna-S-2.1-GGUF",
+        )
+        if "Laguna" in requested
+        else None,
+    )
+    with _client(mod) as c:
+        r = c.post("/models/load", json = {"model": "unsloth/Laguna-S-2.1-GGUF:Q4_K_M"})
+    assert r.status_code == 200
+    assert seen["path"] == "/data/Laguna-Q4_K_M.gguf"
+    assert seen["variant"] == "Q4_K_M"

--- a/studio/backend/tests/test_llama_compat_open_webui_management.py
+++ b/studio/backend/tests/test_llama_compat_open_webui_management.py
@@ -35,7 +35,11 @@ LLAMACPP_LOADED_STATES = {"loaded", "sleeping"}
 LLAMACPP_UNLOADED_STATES = {"loading", "unloaded"}
 
 
-def get_provider_model_loaded_state(model: dict, provider: str, manual_model_ids: bool = False):
+def get_provider_model_loaded_state(
+    model: dict,
+    provider: str,
+    manual_model_ids: bool = False,
+):
     """Pinned Open WebUI helper: llama.cpp without ``status`` is assumed loaded."""
     if provider != "llama.cpp":
         return None
@@ -114,7 +118,13 @@ def _catalog(*, resident = "unsloth/Qwen3.8-27B-GGUF", extra_unloaded = True):
     return rows
 
 
-def _inference_double(catalog, *, load_impl = None, unload_impl = None, backend = None):
+def _inference_double(
+    catalog,
+    *,
+    load_impl = None,
+    unload_impl = None,
+    backend = None,
+):
     state = {"resident": {m["id"] for m in catalog if m.get("loaded")}}
 
     async def _objects():
@@ -130,7 +140,13 @@ def _inference_double(catalog, *, load_impl = None, unload_impl = None, backend 
             )
         return out
 
-    async def _load(request, fastapi_request, current_subject, *, user_initiated = False):
+    async def _load(
+        request,
+        fastapi_request,
+        current_subject,
+        *,
+        user_initiated = False,
+    ):
         if load_impl is not None:
             return await load_impl(
                 request, fastapi_request, current_subject, user_initiated = user_initiated
@@ -262,10 +278,12 @@ def test_management_requires_auth():
     mod, _ = _load_mod()
     with _client(mod, auth = False) as c:
         assert c.get("/models").status_code == 401
-        assert c.post("/models/load", json = {"model": "unsloth/Laguna-S-2.1-GGUF"}).status_code == 401
-        assert c.post(
-            "/models/unload", json = {"model": "unsloth/Qwen3.8-27B-GGUF"}
-        ).status_code == 401
+        assert (
+            c.post("/models/load", json = {"model": "unsloth/Laguna-S-2.1-GGUF"}).status_code == 401
+        )
+        assert (
+            c.post("/models/unload", json = {"model": "unsloth/Qwen3.8-27B-GGUF"}).status_code == 401
+        )
 
 
 def test_load_unload_open_webui_contract_and_residency_transition(monkeypatch):
@@ -273,7 +291,13 @@ def test_load_unload_open_webui_contract_and_residency_transition(monkeypatch):
     loads = []
     unloads = []
 
-    async def _load(request, fastapi_request, current_subject, *, user_initiated = False):
+    async def _load(
+        request,
+        fastapi_request,
+        current_subject,
+        *,
+        user_initiated = False,
+    ):
         loads.append(
             {
                 "model_path": request.model_path,
@@ -353,7 +377,13 @@ def test_load_invalid_body_is_4xx():
 
 
 def test_load_failure_surfaces_error_without_claiming_success(monkeypatch):
-    async def _boom(request, fastapi_request, current_subject, *, user_initiated = False):
+    async def _boom(
+        request,
+        fastapi_request,
+        current_subject,
+        *,
+        user_initiated = False,
+    ):
         raise HTTPException(status_code = 500, detail = "Failed to load model")
 
     mod, double = _load_mod(catalog = _catalog(resident = None), load_impl = _boom)
@@ -374,7 +404,13 @@ def test_load_failure_surfaces_error_without_claiming_success(monkeypatch):
 def test_repeated_load_uses_lifecycle_already_loaded(monkeypatch):
     calls = {"n": 0}
 
-    async def _load(request, fastapi_request, current_subject, *, user_initiated = False):
+    async def _load(
+        request,
+        fastapi_request,
+        current_subject,
+        *,
+        user_initiated = False,
+    ):
         calls["n"] += 1
         status = "already_loaded" if calls["n"] > 1 else "loaded"
         return types.SimpleNamespace(status = status, model = request.model_path)
@@ -426,7 +462,13 @@ def test_models_routes_are_not_under_v1(monkeypatch):
 def test_quant_suffix_resolves_through_existing_resolver(monkeypatch):
     seen = {}
 
-    async def _load(request, fastapi_request, current_subject, *, user_initiated = False):
+    async def _load(
+        request,
+        fastapi_request,
+        current_subject,
+        *,
+        user_initiated = False,
+    ):
         seen["path"] = request.model_path
         seen["variant"] = request.gguf_variant
         return types.SimpleNamespace(status = "loaded", model = request.model_path)

--- a/studio/backend/tests/test_llama_compat_routes.py
+++ b/studio/backend/tests/test_llama_compat_routes.py
@@ -42,6 +42,7 @@ CATALOG = [
         "created": 1_700_000_000,
         "owned_by": "unsloth",
         "loaded": True,
+        "status": {"value": "loaded"},
         "quant": "UD-Q4_K_XL",
     },
     {
@@ -50,6 +51,7 @@ CATALOG = [
         "created": 1_700_000_000,
         "owned_by": "unsloth",
         "loaded": False,
+        "status": {"value": "unloaded"},
     },
 ]
 
@@ -80,6 +82,9 @@ def _inference_double(
     backend,
     catalog,
     orchestrator = None,
+    *,
+    load_impl = None,
+    unload_impl = None,
 ):
     """Stand-in for routes.inference. Deliberately not a sys.modules entry: stubbing it
     globally broke two unrelated route tests when the suite ran in one process."""
@@ -93,6 +98,15 @@ def _inference_double(
         return catalog
 
     inference._openai_catalog_objects = _objects
+
+    async def _default_load(request, fastapi_request, current_subject, *, user_initiated = False):
+        return types.SimpleNamespace(status = "loaded", model = request.model_path)
+
+    async def _default_unload(request, current_subject):
+        return types.SimpleNamespace(status = "unloaded", model = request.model_path)
+
+    inference.load_model_gated = load_impl or _default_load
+    inference._unload_model_impl = unload_impl or _default_unload
     return inference
 
 
@@ -103,20 +117,30 @@ def _load(
     backend = None,
     catalog = None,
     orchestrator = None,
+    *,
+    load_impl = None,
+    unload_impl = None,
+    force_reload = False,
 ):
     """The real routes/llama_compat.py, with routes.inference replaced by a double."""
     global _MOD
+    if force_reload or (_MOD is not None and not hasattr(_MOD, "router")):
+        sys.modules.pop("llama_compat_under_test", None)
+        _MOD = None
     if _MOD is None:
         spec = importlib.util.spec_from_file_location(
             "llama_compat_under_test", str(_BACKEND / "routes" / "llama_compat.py")
         )
-        _MOD = importlib.util.module_from_spec(spec)
-        sys.modules["llama_compat_under_test"] = _MOD
-        spec.loader.exec_module(_MOD)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["llama_compat_under_test"] = mod
+        spec.loader.exec_module(mod)
+        _MOD = mod
     double = _inference_double(
         backend if backend is not None else _Backend(),
         CATALOG if catalog is None else catalog,
         orchestrator,
+        load_impl = load_impl,
+        unload_impl = unload_impl,
     )
     _MOD._inference = lambda: double
     return _MOD
@@ -449,11 +473,14 @@ def test_the_probe_paths_are_admitted_under_keyless_inference_scope():
     from utils.keyless_api_access import _INFERENCE_ROUTES
 
     assert ("GET", "/v1/models") in _INFERENCE_ROUTES, "baseline moved; re-derive this"
-    for path in ("/props", "/v1/props", "/version"):
+    for path in ("/props", "/v1/props", "/version", "/models"):
         assert ("GET", path) in _INFERENCE_ROUTES, path
     # Not the Ollama paths: they are not served at all.
     for path in ("/api/tags", "/api/show", "/api/version"):
         assert ("GET", path) not in _INFERENCE_ROUTES, path
+    # Mutating management stays out of the keyless inference grant.
+    assert ("POST", "/models/load") not in _INFERENCE_ROUTES
+    assert ("POST", "/models/unload") not in _INFERENCE_ROUTES
 
 
 # ── round two ─────────────────────────────────────────────────────────────────
@@ -493,9 +520,9 @@ def test_the_nested_slot_endpoint_is_denied_too(path):
 
 
 def test_the_deny_list_matches_llama_servers_own_route_table():
-    """Transcribed from tools/server/server.cpp. /props is the only bare route Studio
-    serves, so anything else missing means a probe still reaches the app shell."""
-    mod = _load()
+    """Transcribed from tools/server/server.cpp. Served bare routes are excluded;
+    anything else missing means a probe still reaches the app shell."""
+    mod = _load(force_reload = True)
     bare_llama_routes = {
         "apply-template",
         "audio/transcriptions",
@@ -524,19 +551,20 @@ def test_the_deny_list_matches_llama_servers_own_route_table():
         "tokenize",
         "tools",
     }
-    served = {"props"}
+    # Studio serves /props and the Open WebUI management trio; sse/download/delete stay probes.
+    served = {"props", "models", "models/load", "models/unload"}
     for route in bare_llama_routes - served:
         assert mod.is_engine_probe_path(route), route
-    assert not mod.is_engine_probe_path("props"), "Studio serves /props"
+    for route in served:
+        assert not mod.is_engine_probe_path(route), route
 
 
 def test_a_bare_llama_route_404s_on_every_method_a_client_would_use():
-    mod = _load()
+    mod = _load(force_reload = True)
     with _client(mod) as c:
         for path in (
             "/chat/completions",
             "/responses",
-            "/models",
             "/tools",
             "/audio/transcriptions",
         ):
@@ -544,6 +572,11 @@ def test_a_bare_llama_route_404s_on_every_method_a_client_would_use():
                 r = c.request(method, path, json = {} if method == "POST" else None)
                 assert r.status_code == 404, (method, path, r.status_code)
                 assert "text/html" not in r.headers.get("content-type", ""), (method, path)
+        # Download/delete remain unsupported on the management catalog path.
+        for method in ("POST", "DELETE"):
+            r = c.request(method, "/models", json = {} if method == "POST" else None)
+            assert r.status_code == 404, (method, r.status_code)
+        assert c.get("/models/sse").status_code == 404
 
 
 def test_props_does_not_advertise_child_endpoints_studio_denies():
@@ -799,12 +832,13 @@ def test_a_get_probe_404s_in_api_only_mode(path):
 
 
 def test_api_only_mode_still_serves_the_three_real_routes():
-    mod = _load()
+    mod = _load(force_reload = True)
     with _api_only_client(mod) as c:
-        for path in ("/props", "/v1/props", "/version"):
+        for path in ("/props", "/v1/props", "/version", "/models"):
             r = c.get(path)
             assert r.status_code == 200, (path, r.status_code)
             assert "application/json" in r.headers["content-type"], path
+        assert c.get("/models").json()["object"] == "list"
 
 
 def test_the_get_denials_are_not_added_when_a_frontend_is_mounted():

--- a/studio/backend/tests/test_llama_compat_routes.py
+++ b/studio/backend/tests/test_llama_compat_routes.py
@@ -99,7 +99,13 @@ def _inference_double(
 
     inference._openai_catalog_objects = _objects
 
-    async def _default_load(request, fastapi_request, current_subject, *, user_initiated = False):
+    async def _default_load(
+        request,
+        fastapi_request,
+        current_subject,
+        *,
+        user_initiated = False,
+    ):
         return types.SimpleNamespace(status = "loaded", model = request.model_path)
 
     async def _default_unload(request, current_subject):

--- a/studio/backend/tests/test_openai_catalog.py
+++ b/studio/backend/tests/test_openai_catalog.py
@@ -77,9 +77,11 @@ def test_catalog_lists_loaded_and_available(monkeypatch):
 
     # Loaded model is present, marked loaded, and keeps context fields.
     assert ids["Qwen3-Q4"]["loaded"] is True
+    assert ids["Qwen3-Q4"]["status"] == {"value": "loaded"}
     assert ids["Qwen3-Q4"]["context_length"] == 4096
     # Not-loaded GGUFs are listed too, with the quant a client appends to pin them.
     assert ids["Llama-8B-Q8"]["loaded"] is False
+    assert ids["Llama-8B-Q8"]["status"] == {"value": "unloaded"}
     assert ids["Llama-8B-Q8"]["quant"] == "Q8_0"
     # The HF-cache GGUF is listed despite model_format being unset.
     assert ids["org/Foo"]["loaded"] is False
@@ -152,6 +154,7 @@ def test_a_manually_loaded_non_gguf_model_has_one_catalog_row(monkeypatch):
             "owned_by": "unsloth-studio",
             "context_length": 8192,
             "loaded": True,
+            "status": {"value": "loaded"},
         }
     ]
 
@@ -265,6 +268,7 @@ def test_retrieve_loaded_model_skips_catalog_scan(monkeypatch):
     model = asyncio.run(inf.openai_retrieve_model("Qwen3-Q4", current_subject = "t"))
     assert model["id"] == "Qwen3-Q4"
     assert model["loaded"] is True
+    assert model["status"] == {"value": "loaded"}
 
 
 def test_cached_local_catalog_offloads_and_caches(monkeypatch):

--- a/studio/backend/utils/keyless_api_access.py
+++ b/studio/backend/utils/keyless_api_access.py
@@ -65,6 +65,9 @@ _INFERENCE_ROUTES = frozenset(
         ("GET", "/props"),
         ("GET", "/v1/props"),
         ("GET", "/version"),
+        # Open WebUI management catalog (same list as /v1/models, outside /v1).
+        # Load/unload stay credentialed: they mutate residency.
+        ("GET", "/models"),
     }
 )
 


### PR DESCRIPTION
## Summary
- Publish authoritative `status.value` (`loaded` / `unloaded`) alongside `loaded` in `/v1/models` so Open WebUI’s `llama.cpp` provider no longer treats downloaded-but-nonresident models as loaded.
- Serve authenticated Open WebUI management endpoints outside `/v1`: `GET /models`, `POST /models/load`, `POST /models/unload`, reusing existing catalog resolution and `load_model_gated` / `_unload_model_impl`.
- Keep download / delete / SSE as follow-ups (`POST /models`, `DELETE /models`, `GET /models/sse` still 404). Auto-switch policy is unchanged.

Fixes #10610

## Test plan
- [x] `pytest studio/backend/tests/test_openai_catalog.py studio/backend/tests/test_llama_compat_routes.py studio/backend/tests/test_llama_compat_open_webui_management.py`
- [x] `pytest studio/backend/tests/test_openai_models_path_leak.py studio/backend/tests/test_llama_extra_args_compatibility.py`
- [x] `pytest studio/backend/tests/test_llama_admission_compat_matrix.py`
- [x] `pytest studio/backend/tests/test_keyless_api_access_adversarial.py`
- [x] `ruff check` on changed files
- [x] Confirm nonresident catalog row stays `loaded: false` after Open WebUI llama.cpp merge (`status.value == "unloaded"`)
- [x] Confirm `POST /models/load` / `/models/unload` with `{"model":"<id>"}` updates residency via existing lifecycle
- [x] Confirm unauthenticated management requests are rejected; `/v1/models` still works independently