### PR TITLE
Studio: fit the composer on narrow screens, and scale the greeting with it

### DIFF
--- a/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
+++ b/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
@@ -240,10 +240,12 @@ export const ChatDictationBar: FC<{
           />
         ))}
       </div>
-      <span className="mr-4 shrink-0 tabular-nums text-sm text-muted-foreground">
+      {/* Classed so narrow panes can tighten these; both are shrink-0, so they
+          set the bar's floor and would otherwise overflow the composer. */}
+      <span className="unsloth-dictation-timer mr-4 shrink-0 tabular-nums text-sm text-muted-foreground">
         {formatElapsed(elapsed)}
       </span>
-      <div className="flex shrink-0 items-center gap-2.5">
+      <div className="unsloth-dictation-actions flex shrink-0 items-center gap-2.5">
         <TooltipIconButton
           type="button"
           tooltip={

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -2249,12 +2249,12 @@ const ThreadWelcome: FC<{
         {/* Matches the docked composer's gutter. */}
         <div className="aui-thread-welcome-message flex w-full flex-col justify-center gap-9 px-3 sm:px-4">
           {/* Center the greeting (sloth + title) over the composer. */}
-          <div className="flex flex-row items-center justify-center gap-[15px]">
+          <div className="unsloth-welcome-greeting flex flex-row items-center justify-center gap-[15px]">
             {/* Temporary chat keeps the title on its own, no mascot. */}
             {showGreetingSloth && !incognito && (
               <MascotImg
                 src={currentEmojiSrc}
-                className="size-[44px] -translate-y-[2px]"
+                className="unsloth-welcome-sloth size-[44px] -translate-y-[2px]"
               />
             )}
             <h1 className="aui-thread-welcome-message-inner unsloth-welcome-title fade-in slide-in-from-bottom-1 animate-in text-3xl tracking-[-0.02em] duration-200">

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -2135,8 +2135,9 @@ const ThreadComposerDock: FC<{
             : "top-[10px]",
         )}
       />
-      {/* Narrow windows spend the gutter on the composer instead. */}
-      <div className="relative px-3 pb-2 sm:px-5">
+      {/* Narrow panes spend the gutter on the composer instead; index.css
+          trims it off the pane's width, not the window's. */}
+      <div className="unsloth-composer-dock-inner relative px-5 pb-2">
         <div className="pointer-events-auto mx-auto w-full max-w-(--thread-max-width)">
           <ComposerAnimated
             disabled={disabled}
@@ -2246,8 +2247,8 @@ const ThreadWelcome: FC<{
   return (
     <div className="aui-thread-welcome-root mx-auto my-auto flex w-full max-w-(--thread-max-width) grow flex-col">
       <div className="aui-thread-welcome-center flex w-full grow flex-col items-center justify-start pt-[27.5dvh]">
-        {/* Matches the docked composer's gutter. */}
-        <div className="aui-thread-welcome-message flex w-full flex-col justify-center gap-9 px-3 sm:px-4">
+        {/* Matches the docked composer's gutter; index.css trims both. */}
+        <div className="aui-thread-welcome-message flex w-full flex-col justify-center gap-9 px-4">
           {/* Center the greeting (sloth + title) over the composer. */}
           <div className="unsloth-welcome-greeting flex flex-row items-center justify-center gap-[15px]">
             {/* Temporary chat keeps the title on its own, no mascot. */}

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -6836,7 +6836,9 @@ const ComposerRightControls: FC<{
         </Button>
       ) : (
         <AuiIf condition={({ thread }) => thread.isRunning}>
-          <div className="ml-1.5 flex items-center">
+          {/* Classed so the narrow-screen rules can treat this like the
+              sibling send/stop buttons; it is the flex item, not the button. */}
+          <div className="aui-composer-run-controls ml-1.5 flex items-center">
             {queueDisabled ? (
             <ComposerPrimitive.Cancel asChild={true}>
               <Button

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -2135,7 +2135,8 @@ const ThreadComposerDock: FC<{
             : "top-[10px]",
         )}
       />
-      <div className="relative px-5 pb-2">
+      {/* Narrow windows spend the gutter on the composer instead. */}
+      <div className="relative px-3 pb-2 sm:px-5">
         <div className="pointer-events-auto mx-auto w-full max-w-(--thread-max-width)">
           <ComposerAnimated
             disabled={disabled}
@@ -2245,7 +2246,8 @@ const ThreadWelcome: FC<{
   return (
     <div className="aui-thread-welcome-root mx-auto my-auto flex w-full max-w-(--thread-max-width) grow flex-col">
       <div className="aui-thread-welcome-center flex w-full grow flex-col items-center justify-start pt-[27.5dvh]">
-        <div className="aui-thread-welcome-message flex w-full flex-col justify-center gap-9 px-4">
+        {/* Matches the docked composer's gutter. */}
+        <div className="aui-thread-welcome-message flex w-full flex-col justify-center gap-9 px-3 sm:px-4">
           {/* Center the greeting (sloth + title) over the composer. */}
           <div className="flex flex-row items-center justify-center gap-[15px]">
             {/* Temporary chat keeps the title on its own, no mascot. */}
@@ -2297,7 +2299,10 @@ const ComposerAnimated: FC<{
   disableQueue?: boolean;
 }> = ({ disabled, threadId, menuSide, disableQueue }) => {
   return (
-    <div className="relative mx-auto min-w-0 w-full max-w-[46rem]">
+    // unsloth-composer-shell is the size container the tight (mobile) layout
+    // in index.css queries. It sits outside the surface so those rules can
+    // trim the surface's own padding.
+    <div className="unsloth-composer-shell relative mx-auto min-w-0 w-full max-w-[46rem]">
       <div className="relative z-10 w-full">
         <Composer
           disabled={disabled}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2094,31 +2094,14 @@ html[data-chat-font] .aui-root {
 	}
 
 	/* ~375px and under. Each control is a circle around a much smaller glyph,
-	   so built-in air, not the gap, sets the spacing. Overlap the circles
-	   instead of shrinking them; hit targets stay full size. */
+	   so the built-in air, not the gap, sets the spacing. Shrink the circles
+	   by 4px; overlapping them instead would make adjacent hit areas share
+	   pixels, and the later button would win the taps in between. */
 	@container composer-shell (max-width: 22rem) {
 		.unsloth-composer-line {
 			--composer-tight-gap: 0rem;
 		}
 
-		/* > button skips the hidden file inputs the + menu keeps in this row.
-		   The running state's wrapper div is a flex item here too. */
-		.unsloth-composer-left > button,
-		.unsloth-composer-line .aui-composer-action-wrapper > button,
-		.unsloth-composer-line
-			.aui-composer-action-wrapper
-			> .aui-composer-run-controls {
-			margin-inline: -0.125rem;
-		}
-
-		/* Outer edges give the 2px back, keeping the row's inset. */
-		.unsloth-composer-left {
-			margin-left: 0;
-		}
-
-		.unsloth-composer-line .aui-composer-action-wrapper {
-			margin-right: 0;
-		}
 
 		/* A 32px corner is a big fraction of a box this small. The drop
 		   overlay tracks it, or its edge shows against the surface. */
@@ -2127,17 +2110,18 @@ html[data-chat-font] .aui-root {
 			border-radius: 1.5rem;
 		}
 
-		/* Plus and send were the row's only 36px circles. Match the rest. */
+		/* 32px to 28px for every control, and 36px to 28px for plus and send,
+		   which were the row's only oversized ends. Each selector has to
+		   outrank the compact pill rules, hence the longer shapes. */
 		.unsloth-composer-left > .unsloth-composer-plus,
+		.unsloth-composer-line .unsloth-composer-left > button.composer-pill-btn,
+		.unsloth-composer-line .aui-composer-action-wrapper > button,
 		.unsloth-composer-line .aui-composer-send,
 		.unsloth-composer-line .aui-composer-cancel {
-			width: 2rem;
-			height: 2rem;
-		}
-
-		/* Plus carries less air than the pills, so skip its inward pull. */
-		.unsloth-composer-left > .unsloth-composer-plus {
-			margin-right: 0;
+			width: 1.75rem;
+			height: 1.75rem;
+			/* The thinking pill reserves a text line; that would win over height. */
+			min-height: 1.75rem;
 		}
 
 		/* Send commits, so keep it clear of the toggle strip. Needs the same
@@ -2220,8 +2204,18 @@ html[data-chat-font] .aui-root {
 
 	/* Narrow panes shrink the greeting along with the composer under it, or a
 	   30px title wraps over two lines above a tightened box. Sized off the
-	   text tokens so the UI font scale still applies. */
+	   text tokens so the UI font scale still applies.
+
+	   The gutters here are on the pane's width, not the window's: an artifact
+	   split can leave a 42% thread pane inside a wide window, and a viewport
+	   breakpoint would keep the full 20px there. */
 	@container (max-width: 31.5rem) {
+		.unsloth-composer-dock-inner,
+		.aui-thread-welcome-message {
+			padding-left: 0.75rem;
+			padding-right: 0.75rem;
+		}
+
 		.unsloth-welcome-title {
 			font-size: var(--text-2xl);
 		}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2073,8 +2073,8 @@ html[data-chat-font] .aui-root {
 
 		/* Send's own inset stacks on the gap above; drop it. The running state
 		   puts that inset on a wrapper div instead of the button. */
-		.unsloth-composer-line .aui-composer-send,
-		.unsloth-composer-line .aui-composer-cancel,
+		.unsloth-composer-line .aui-composer-action-wrapper > button.aui-composer-send,
+		.unsloth-composer-line .aui-composer-action-wrapper > button.aui-composer-cancel,
 		.unsloth-composer-line .aui-composer-run-controls {
 			margin-left: 0;
 		}
@@ -2113,10 +2113,13 @@ html[data-chat-font] .aui-root {
 		/* 32px to 28px for every control, and 36px to 28px for plus and send,
 		   which were the row's only oversized ends. Each selector has to
 		   outrank the compact pill rules, hence the longer shapes. */
+		/* Scoped to the right-control cluster. The dictation bar also renders
+		   an .aui-composer-send inside this line, and its stop button carries
+		   neither of our classes, so a looser selector shrinks one of that
+		   pair and not the other. */
 		.unsloth-composer-left > .unsloth-composer-plus,
 		.unsloth-composer-line .aui-composer-action-wrapper > button,
-		.unsloth-composer-line .aui-composer-send,
-		.unsloth-composer-line .aui-composer-cancel {
+		.unsloth-composer-line .aui-composer-run-controls > button {
 			width: 1.75rem;
 			height: 1.75rem;
 			/* The thinking pill reserves a text line; that would win over height. */
@@ -2126,7 +2129,9 @@ html[data-chat-font] .aui-root {
 		/* Tool pills only once the fit hook has collapsed their labels. Applied
 		   unconditionally, a 28px box makes a labelled pill measure as if it
 		   fit, and the hook keeps labels that then overflow it. */
-		.unsloth-composer-left[data-pill-compact="true"] > button.composer-pill-btn {
+		.unsloth-composer-left[data-pill-compact="true"] > button.composer-pill-btn,
+		.unsloth-composer-left[data-pill-compact="first"]
+			> button.composer-pill-btn.composer-pill-permissions {
 			width: 1.75rem;
 			height: 1.75rem;
 			min-height: 1.75rem;
@@ -2232,8 +2237,9 @@ html[data-chat-font] .aui-root {
 			margin-left: -0.5rem;
 			margin-right: -0.5rem;
 			/* w-full would pin the width and the margins would only shift the
-			   box left; auto lets it widen into the gutter on both sides. */
-			width: auto;
+			   box left. An explicit width widens it into the gutter instead;
+			   auto would shrink-wrap, since the parent centres its children. */
+			width: calc(100% + 1rem);
 		}
 
 		.unsloth-welcome-title {

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2034,6 +2034,116 @@ html[data-chat-font] .aui-root {
 		transform: rotate(45deg);
 	}
 
+	/* Size container for the composer. Sits outside the surface so the tight
+	   rules below can trim the surface's own padding. */
+	.unsloth-composer-shell {
+		container-type: inline-size;
+		container-name: composer-shell;
+	}
+
+	/* Mobile and very shrunk windows: the dictate/send cluster was dropping to
+	   a second line. Take the width back from the gutters, not the controls. */
+	@container composer-shell (max-width: 30rem) {
+		/* Was 12px; the 32px corner still clears the plus/send circles. */
+		.unsloth-composer-surface {
+			padding-left: 0.5rem;
+			padding-right: 0.5rem;
+		}
+
+		.unsloth-composer-line {
+			padding-left: 0;
+			padding-right: 0;
+			/* One gap for every control, so the row spaces evenly. */
+			--composer-tight-gap: 0.125rem;
+		}
+
+		.unsloth-composer-left,
+		.unsloth-composer-line .aui-composer-action-wrapper {
+			gap: var(--composer-tight-gap);
+		}
+
+		/* Plus and send hug their edges by the same amount. */
+		.unsloth-composer-left {
+			margin-left: -0.125rem;
+		}
+
+		.unsloth-composer-line .aui-composer-action-wrapper {
+			margin-right: -0.125rem;
+		}
+
+		/* Send's own inset stacks on the gap above; drop it. */
+		.unsloth-composer-line .aui-composer-send,
+		.unsloth-composer-line .aui-composer-cancel {
+			margin-left: 0;
+		}
+
+		/* Keeps the text starting just right of the plus glyph below it. */
+		.unsloth-composer-line[data-expanded="true"] .unsloth-composer-input {
+			padding-left: 0.5rem;
+		}
+	}
+
+	/* ~375px and under. Each control is a circle around a much smaller glyph,
+	   so built-in air, not the gap, sets the spacing. Overlap the circles
+	   instead of shrinking them; hit targets stay full size. */
+	@container composer-shell (max-width: 22rem) {
+		.unsloth-composer-line {
+			--composer-tight-gap: 0rem;
+		}
+
+		/* > button skips the hidden file inputs the + menu keeps in this row. */
+		.unsloth-composer-left > button,
+		.unsloth-composer-line .aui-composer-action-wrapper > button {
+			margin-inline: -0.125rem;
+		}
+
+		/* Outer edges give the 2px back, keeping the row's inset. */
+		.unsloth-composer-left {
+			margin-left: 0;
+		}
+
+		.unsloth-composer-line .aui-composer-action-wrapper {
+			margin-right: 0;
+		}
+
+		/* Plus and send were the row's only 36px circles. Match the rest. */
+		.unsloth-composer-left > .unsloth-composer-plus,
+		.unsloth-composer-line .aui-composer-send,
+		.unsloth-composer-line .aui-composer-cancel {
+			width: 2rem;
+			height: 2rem;
+		}
+
+		/* Plus carries less air than the pills, so skip its inward pull. */
+		.unsloth-composer-left > .unsloth-composer-plus {
+			margin-right: 0;
+		}
+
+		/* Send commits, so keep it clear of the toggle strip. Needs the same
+		   `> button` shape as the pull above to outrank it. */
+		.unsloth-composer-line
+			.aui-composer-action-wrapper
+			> button.aui-composer-send,
+		.unsloth-composer-line
+			.aui-composer-action-wrapper
+			> button.aui-composer-cancel {
+			margin-left: 0.25rem;
+		}
+	}
+
+	/* ~275px and under: trim the vertical padding and row gap so the box is no
+	   taller than the rows it holds. */
+	@container composer-shell (max-width: 16rem) {
+		.unsloth-composer-surface {
+			padding-top: 0.5rem;
+			padding-bottom: 0.5rem;
+		}
+
+		.unsloth-composer-line[data-expanded="true"] {
+			row-gap: 0.5rem;
+		}
+	}
+
 	/* Keyboard focus shows a subtle brand ring, not the browser's blue outline;
 	   mouse clicks (no :focus-visible) stay ring-free. */
 	.composer-pill-btn:focus-visible,
@@ -3340,6 +3450,15 @@ html[data-chat-font] .aui-root {
 	& .unsloth-composer-plus svg {
 		width: calc(var(--ui-icon-size) * 1.375);
 		height: calc(var(--ui-icon-size) * 1.375);
+	}
+	/* ~375px and under the plus sits in a 32px circle, which 1.375x fills.
+	   Step down to the dictate glyph's 1.2x. Must live here: this block is
+	   unlayered, so a copy in @layer utilities would lose to it. */
+	@container composer-shell (max-width: 22rem) {
+		& .unsloth-composer-plus svg {
+			width: calc(var(--ui-icon-size) * 1.2);
+			height: calc(var(--ui-icon-size) * 1.2);
+		}
 	}
 	& svg.size-\[36px\] { width: min(calc(36px * var(--ui-font-scale, 1)), calc(18px + 18px * var(--ui-font-scale, 1))); height: min(calc(36px * var(--ui-font-scale, 1)), calc(18px + 18px * var(--ui-font-scale, 1))); }
 	& svg.w-3 { width: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); }

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2084,6 +2084,27 @@ html[data-chat-font] .aui-root {
 		.unsloth-composer-line[data-expanded="true"] .unsloth-composer-input {
 			padding-left: 0.5rem;
 		}
+
+		/* Recording swaps the input for the dictation bar, whose timer and
+		   actions are shrink-0. They set its floor, and the fieldset is
+		   min-width 0, so past that floor it overflows the surface instead of
+		   shrinking. Trim the same paddings the rest of the row gives up. */
+		.unsloth-dictation-wave {
+			padding-left: 0.5rem;
+			padding-right: 0.25rem;
+		}
+
+		.unsloth-dictation-timer {
+			margin-inline-end: 0.5rem;
+		}
+
+		/* Past its floor the bar has to stop taking width it cannot use. Left
+		   at min-width 0 it keeps shrinking and its shrink-0 children spill
+		   out of the surface, taking send with them; with a floor the pill
+		   row yields first and wraps, which is recoverable. */
+		.unsloth-composer-line[data-dictating="true"] .unsloth-dictation-bar {
+			min-width: min-content;
+		}
 	}
 
 	/* ~400px and under: settle the control row toward the bottom edge, since
@@ -2150,6 +2171,31 @@ html[data-chat-font] .aui-root {
 			.aui-composer-action-wrapper
 			> .aui-composer-run-controls {
 			margin-left: 0.25rem;
+		}
+
+		/* Same 28px as the row above, and both of the bar's buttons together:
+		   stop carries none of our classes, so they have to be sized as a
+		   pair or the recording controls come out mismatched. */
+		.unsloth-dictation-actions {
+			gap: 0.375rem;
+		}
+
+		.unsloth-dictation-actions > button {
+			width: 1.75rem;
+			height: 1.75rem;
+			min-height: 1.75rem;
+		}
+
+		/* The wave is flex-1 and min-width 0, so all it still contributes at
+		   this size is its own padding. Drop it and the bar's min-content is
+		   exactly the timer plus the two buttons. */
+		.unsloth-dictation-wave {
+			padding-left: 0;
+			padding-right: 0;
+		}
+
+		.unsloth-dictation-timer {
+			margin-inline-end: 0.25rem;
 		}
 	}
 

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1964,8 +1964,9 @@ html[data-chat-font] .aui-root {
 	.unsloth-composer-left {
 		@apply flex min-w-0 flex-wrap items-center gap-0.5;
 		order: 1;
-		/* Pull the plus button closer to the composer edge. */
-		margin-left: -0.25rem;
+		/* Pull the plus button closer to the composer edge. Logical, so RTL
+		   pulls it outward instead of into the action group. */
+		margin-inline-start: -0.25rem;
 	}
 
 	.unsloth-composer-line .unsloth-composer-input {
@@ -1974,9 +1975,9 @@ html[data-chat-font] .aui-root {
 
 	.unsloth-composer-line .aui-composer-action-wrapper {
 		order: 3;
-		margin-left: auto;
+		margin-inline-start: auto;
 		/* 12px surface + 4px line padding minus this = 12px edge gap. */
-		margin-right: -0.25rem;
+		margin-inline-end: -0.25rem;
 	}
 
 	.unsloth-composer-line[data-expanded="true"] .unsloth-composer-input {
@@ -2064,11 +2065,11 @@ html[data-chat-font] .aui-root {
 
 		/* Plus and send hug their edges by the same amount. */
 		.unsloth-composer-left {
-			margin-left: -0.125rem;
+			margin-inline-start: -0.125rem;
 		}
 
 		.unsloth-composer-line .aui-composer-action-wrapper {
-			margin-right: -0.125rem;
+			margin-inline-end: -0.125rem;
 		}
 
 		/* Send's own inset stacks on the gap above; drop it. The running state

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2114,13 +2114,21 @@ html[data-chat-font] .aui-root {
 		   which were the row's only oversized ends. Each selector has to
 		   outrank the compact pill rules, hence the longer shapes. */
 		.unsloth-composer-left > .unsloth-composer-plus,
-		.unsloth-composer-line .unsloth-composer-left > button.composer-pill-btn,
 		.unsloth-composer-line .aui-composer-action-wrapper > button,
 		.unsloth-composer-line .aui-composer-send,
 		.unsloth-composer-line .aui-composer-cancel {
 			width: 1.75rem;
 			height: 1.75rem;
 			/* The thinking pill reserves a text line; that would win over height. */
+			min-height: 1.75rem;
+		}
+
+		/* Tool pills only once the fit hook has collapsed their labels. Applied
+		   unconditionally, a 28px box makes a labelled pill measure as if it
+		   fit, and the hook keeps labels that then overflow it. */
+		.unsloth-composer-left[data-pill-compact="true"] > button.composer-pill-btn {
+			width: 1.75rem;
+			height: 1.75rem;
 			min-height: 1.75rem;
 		}
 
@@ -2210,10 +2218,22 @@ html[data-chat-font] .aui-root {
 	   split can leave a 42% thread pane inside a wide window, and a viewport
 	   breakpoint would keep the full 20px there. */
 	@container (max-width: 31.5rem) {
-		.unsloth-composer-dock-inner,
-		.aui-thread-welcome-message {
+		.unsloth-composer-dock-inner {
 			padding-left: 0.75rem;
 			padding-right: 0.75rem;
+		}
+
+		/* The welcome screen is inside the viewport's own 20px gutter, so pull
+		   back to the dock's 12px rather than adding to it; otherwise the empty
+		   state is 40px narrower than the thread it turns into. */
+		.aui-thread-welcome-message {
+			padding-left: 0;
+			padding-right: 0;
+			margin-left: -0.5rem;
+			margin-right: -0.5rem;
+			/* w-full would pin the width and the margins would only shift the
+			   box left; auto lets it widen into the gutter on both sides. */
+			width: auto;
 		}
 
 		.unsloth-welcome-title {

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2071,9 +2071,11 @@ html[data-chat-font] .aui-root {
 			margin-right: -0.125rem;
 		}
 
-		/* Send's own inset stacks on the gap above; drop it. */
+		/* Send's own inset stacks on the gap above; drop it. The running state
+		   puts that inset on a wrapper div instead of the button. */
 		.unsloth-composer-line .aui-composer-send,
-		.unsloth-composer-line .aui-composer-cancel {
+		.unsloth-composer-line .aui-composer-cancel,
+		.unsloth-composer-line .aui-composer-run-controls {
 			margin-left: 0;
 		}
 
@@ -2099,9 +2101,13 @@ html[data-chat-font] .aui-root {
 			--composer-tight-gap: 0rem;
 		}
 
-		/* > button skips the hidden file inputs the + menu keeps in this row. */
+		/* > button skips the hidden file inputs the + menu keeps in this row.
+		   The running state's wrapper div is a flex item here too. */
 		.unsloth-composer-left > button,
-		.unsloth-composer-line .aui-composer-action-wrapper > button {
+		.unsloth-composer-line .aui-composer-action-wrapper > button,
+		.unsloth-composer-line
+			.aui-composer-action-wrapper
+			> .aui-composer-run-controls {
 			margin-inline: -0.125rem;
 		}
 
@@ -2141,7 +2147,10 @@ html[data-chat-font] .aui-root {
 			> button.aui-composer-send,
 		.unsloth-composer-line
 			.aui-composer-action-wrapper
-			> button.aui-composer-cancel {
+			> button.aui-composer-cancel,
+		.unsloth-composer-line
+			.aui-composer-action-wrapper
+			> .aui-composer-run-controls {
 			margin-left: 0.25rem;
 		}
 	}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2083,6 +2083,14 @@ html[data-chat-font] .aui-root {
 		}
 	}
 
+	/* ~400px and under: settle the control row toward the bottom edge, since
+	   12px under a 32px circle is more air than the trimmed sides carry. */
+	@container composer-shell (max-width: 23.5rem) {
+		.unsloth-composer-surface {
+			padding-bottom: 0.5rem;
+		}
+	}
+
 	/* ~375px and under. Each control is a circle around a much smaller glyph,
 	   so built-in air, not the gap, sets the spacing. Overlap the circles
 	   instead of shrinking them; hit targets stay full size. */
@@ -2104,6 +2112,13 @@ html[data-chat-font] .aui-root {
 
 		.unsloth-composer-line .aui-composer-action-wrapper {
 			margin-right: 0;
+		}
+
+		/* A 32px corner is a big fraction of a box this small. The drop
+		   overlay tracks it, or its edge shows against the surface. */
+		.unsloth-composer-surface,
+		.unsloth-composer-surface .aui-composer-drop-overlay {
+			border-radius: 1.5rem;
 		}
 
 		/* Plus and send were the row's only 36px circles. Match the rest. */
@@ -2192,6 +2207,41 @@ html[data-chat-font] .aui-root {
 			var(--font-sans)
 		);
 		font-weight: 500;
+	}
+
+	/* Narrow panes shrink the greeting along with the composer under it, or a
+	   30px title wraps over two lines above a tightened box. Sized off the
+	   text tokens so the UI font scale still applies. */
+	@container (max-width: 31.5rem) {
+		.unsloth-welcome-title {
+			font-size: var(--text-2xl);
+		}
+
+		.unsloth-welcome-sloth {
+			width: 2.125rem;
+			height: 2.125rem;
+		}
+
+		.unsloth-welcome-greeting {
+			gap: 0.625rem;
+		}
+	}
+
+	/* ~300px and under: one step further, so the greeting holds a single line
+	   beside the mascot instead of wrapping over the composer. */
+	@container (max-width: 18.75rem) {
+		.unsloth-welcome-title {
+			font-size: var(--text-xl);
+		}
+
+		.unsloth-welcome-sloth {
+			width: 1.75rem;
+			height: 1.75rem;
+		}
+
+		.unsloth-welcome-greeting {
+			gap: 0.5rem;
+		}
 	}
 
 	/* Right-side Thinking pill (toggle or dropdown). pl-2 matches the left


### PR DESCRIPTION
## Problem

On a phone-width viewport the composer's control row runs out of space and wraps, dropping the dictate and send buttons onto a line of their own under the tool pills. Spacing was also uneven: the tool pills sat at a 2px gap while the right cluster used 6px, plus another 6px inset on send.

The greeting above it kept its full 30px title and 44px mascot at every width, so on a phone it sat oversized over a composer that had just tightened, and wrapped across two lines.

## What changed

`ComposerAnimated` now carries a `composer-shell` size container, which the new rules in `index.css` query. It has to sit outside the composer surface, because those rules trim the surface's own padding and a query rooted on the surface cannot reach it.

Everything is scoped to that container rather than the viewport, so a narrow pane behaves the same as a narrow window.

| container | roughly | change |
| --- | --- | --- |
| 30rem | 500px | dock gutter `px-5` to `px-3` below `sm:`, welcome gutter `px-4` to `px-3`, surface padding 12px to 8px, line gutter to 0, one shared gap for every control, input indent |
| 31.5rem (thread pane) | 500px | greeting title 30px to 24px, mascot 44px to 34px |
| 23.5rem | 400px | padding under the control row 12px to 8px |
| 22rem | 375px | icon circles overlap by 4px, plus and send 36px to 32px, plus glyph 1.375x to 1.2x, wider gap before send, corner 32px to 24px |
| 18.75rem (thread pane) | 300px | greeting title 24px to 20px, mascot 34px to 28px |
| 16rem | 275px | vertical padding and row gap trimmed |

Two details worth calling out:

- The gap was never what separated the icons. Each control is a circle around a much smaller glyph, so the built in air sets the spacing and the glyphs sat 17 to 19px apart. Overlapping the circles closes every inner pair without shrinking any hit target.
- The drag and drop overlay carries its own 32px radius over the surface. It tracks the new value, or it would paint corner slivers against a 24px box while dragging a file in.

Nothing above these widths changes.

## Measurements

Wrap threshold, the smallest viewport that keeps all controls on one row:

| toolbar | before | after |
| --- | --- | --- |
| default (plus, permissions, search, code) | 314px | 246px |
| full (two more tool pills) | 382px | 302px |

Glyph to glyph spacing at a 375px viewport:

| pair | before | after |
| --- | --- | --- |
| plus to shield | 17.5px | 14.0px |
| shield to globe | 19.0px | 13.9px |
| globe to code | 19.0px | 13.9px |
| lightbulb to mic | 18.0px | 12.0px |
| mic to send | 18.4px | 16.4px |

Box height goes 112px to 104px at 375px and to 96px at 275px. Padding under the control row is 8px at 400px and below, 12px above. Edge insets are symmetric at 6px and every control box is 32px across the row.

## Testing

- `bun run typecheck` clean.
- `bun run test`, 7208 passing.
- Checked at 260, 275, 300, 320, 375, 400, 410, 430, 560 and 720px against a static mirror of the composer DOM using the built stylesheet, measuring rendered geometry rather than eyeballing it.
- Compared pre and post geometry at 900px: identical.

## Notes for reviewers

Two cascade quirks, since they explain the odd selector shapes:

- The send gap is written as `> button.aui-composer-send`, because the blanket pull it overrides ends in a `button` type selector which outranks a plain class.
- The plus glyph step down lives next to the existing `--ui-icon-size` rule rather than with the other composer blocks. That block is unlayered, so a copy in `@layer utilities` would lose to it regardless of specificity.

Two things this does not solve:

- `What's on your mind today?` is the longest of the rotating greetings and still wraps to two lines at 260 to 275px and at 320 to 351px. It wrapped there before this change too, at a larger size. Moving the 300px greeting step up to about 352px would close it, at the cost of a smaller greeting in that band. Happy to do that if preferred.
- `bun run bundle:check` fails at 1582.8 KB against a 1582.0 KB budget. It fails identically on `main`, same number and same 82 chunks, so it is not from this PR, but CI may be red for it.

No JavaScript is added. Startup JS transfer is unchanged at 1582.8 KB; CSS grows 308 bytes gzipped.
