### PR TITLE
Read the installers' own code, not the scripts they emit

### DIFF
--- a/tests/sh/_ps1_source.sh
+++ b/tests/sh/_ps1_source.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+#
+# Reading a .ps1 as text, for the suites that assert on installer structure.
+# Sourced, never executed: both runners glob test_*.sh, so this name sits
+# outside the glob.
+#
+# The problem this exists for: our .ps1 files emit other scripts through
+# here-strings. studio/setup.ps1 emits a probe whose body contains `exit 1`, and
+# install.ps1 emits a launcher containing nine `function X {` and two
+# `} finally {`. A grep over the raw file counts those as the installer's own
+# code and answers the wrong question -- #10540 turned
+# test_tauri_retry_failure_context.sh red that way without changing one line of
+# installer control flow.
+#
+# ps1_code blanks here-string bodies, keeping one blank line per body line so
+# `grep -n` line numbers and `sed` line addresses still refer to the real file.
+
+# Blank the body of every here-string in $1. The opener is detected on the line
+# with its quoted strings blanked first: both setup.ps1 and install.ps1 carry a
+# credential-redaction `-replace ... , '$1<redacted>@'` whose line genuinely ends
+# in `@'`, and a scanner that misses that swallows the ~780 lines up to the next
+# terminator. The terminator must sit in column 0 -- that is PowerShell's rule,
+# and install.ps1 has indented `"@echo off",` array entries that a lenient match
+# would close on.
+ps1_code() {
+    awk '
+    function blank_strings(line,   out, i, c, n, q) {
+        out = ""; q = ""; n = length(line)
+        for (i = 1; i <= n; i++) {
+            c = substr(line, i, 1)
+            if (q == "") {
+                # An unquoted # starts a line comment; nothing after it is code.
+                if (c == "#") { break }
+                if (c == "\"" || c == "'"'"'") { q = c }
+                out = out c
+            } else {
+                # ` escapes the next character inside a double-quoted string.
+                if (q == "\"" && c == "`") { i++; out = out "  "; continue }
+                if (c == q) { q = "" }
+                else c = " "
+                out = out c
+            }
+        }
+        return out
+    }
+    {
+        if (delim != "") {
+            closed = (index($0, delim) == 1)
+            print ""
+            if (closed) delim = ""
+            next
+        }
+        code = blank_strings($0)
+        if (code ~ /@'"'"'[ \t]*$/)     { delim = "'"'"'@"; print; next }
+        if (code ~ /@"[ \t]*$/) { delim = "\"@"; print; next }
+        print
+    }
+    END {
+        if (delim != "") {
+            print "ps1_code: unterminated here-string opened in " FILENAME > "/dev/stderr"
+            exit 1
+        }
+    }
+    ' "$1"
+}

--- a/tests/sh/test_install_rollback_lifecycle.sh
+++ b/tests/sh/test_install_rollback_lifecycle.sh
@@ -6,6 +6,8 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPT_DIR/_harness.sh"
+# shellcheck source=tests/sh/_ps1_source.sh
+. "$SCRIPT_DIR/_ps1_source.sh"
 INSTALL_SH="$SCRIPT_DIR/../../install.sh"
 INSTALL_PS1="$SCRIPT_DIR/../../install.ps1"
 ROLLBACK_BLOCK=$(sed -n '/^_VENV_ROLLBACK_DIR=""/,/^trap '\''_on_install_signal 143'\'' TERM$/p' "$INSTALL_SH")
@@ -385,19 +387,29 @@ run_readonly_bin_case dangling-shim \
     "$WORK/readonly-bin-dangling-shim/unsloth_studio/bin/unsloth" 1 no-exe
 
 echo "=== install.ps1 rollback wiring ==="
-if grep -q '^    function Remove-StaleStudioVenvRollbacks {' "$INSTALL_PS1" \
-   && grep -q '^    Remove-StaleStudioVenvRollbacks$' "$INSTALL_PS1"; then
+# The code view throughout: install.ps1 emits a launcher through a here-string,
+# and that launcher has nine `function X {` declarations and its own
+# `} finally {`. Matching those answers a question about the emitted script.
+INSTALL_PS1_CODE=$(ps1_code "$INSTALL_PS1")
+if printf '%s\n' "$INSTALL_PS1_CODE" | grep -q '^    function Remove-StaleStudioVenvRollbacks {' \
+   && printf '%s\n' "$INSTALL_PS1_CODE" | grep -q '^    Remove-StaleStudioVenvRollbacks$'; then
     ok "Windows installer prunes stale rollbacks after success"
 else
     bad "Windows installer does not wire stale rollback cleanup"
 fi
-if grep -q '^    } finally {$' "$INSTALL_PS1" \
-   && grep -A3 '^    } finally {$' "$INSTALL_PS1" | grep -q 'Restore-StudioVenvRollback'; then
+# At least one of the installer's own `} finally {` blocks restores the rollback.
+# The emitted launcher has one too, so before the code view a match there could
+# have stood in for the installer's.
+_finally_hits=$(printf '%s\n' "$INSTALL_PS1_CODE" | grep -c '^    } finally {$' || true)
+_finally_guarded=$(printf '%s\n' "$INSTALL_PS1_CODE" |
+    grep -A3 '^    } finally {$' | grep -c 'Restore-StudioVenvRollback' || true)
+if [ "$_finally_hits" -gt 0 ] && [ "$_finally_guarded" -gt 0 ]; then
     ok "Windows replacement is protected by finally"
 else
     bad "Windows replacement lacks finally rollback"
 fi
-if grep -A18 '^    function Remove-StudioVenvTreeWithRetry {' "$INSTALL_PS1" \
+if printf '%s\n' "$INSTALL_PS1_CODE" \
+   | grep -A18 '^    function Remove-StudioVenvTreeWithRetry {' \
    | grep -q 'ErrorAction Stop'; then
     ok "Windows rollback deletion failures are observable and retried"
 else

--- a/tests/sh/test_ps1_code_view.sh
+++ b/tests/sh/test_ps1_code_view.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+# Guards the here-string filter the installer-structure suites grep through.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/_harness.sh"
+# shellcheck source=tests/sh/_ps1_source.sh
+. "$SCRIPT_DIR/_ps1_source.sh"
+SETUP_PS1="$SCRIPT_DIR/../../studio/setup.ps1"
+INSTALL_PS1="$SCRIPT_DIR/../../install.ps1"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+echo "=== line numbers survive the filter ==="
+for f in "$SETUP_PS1" "$INSTALL_PS1"; do
+    assert_eq "$(basename "$f") keeps its line count" \
+        "$(wc -l < "$f")" "$(ps1_code "$f" | wc -l)"
+done
+
+echo "=== the shipped scripts ==="
+# The claim test_tauri_retry_failure_context.sh makes: setup.ps1 exits in exactly
+# one place, the tail of Exit-SetupFailure. The emitted probe's `exit 1` is the
+# probe's, and counting it is what turned main red after #10540.
+assert_eq "setup.ps1 has one exit in its own code" \
+    1 "$(ps1_code "$SETUP_PS1" | grep -Ec '^[[:space:]]*exit[[:space:]]+' || true)"
+assert_eq "the surviving exit is Exit-SetupFailure's" \
+    1 "$(ps1_code "$SETUP_PS1" | grep -c '^[[:space:]]*exit \$Code$' || true)"
+# install.ps1's emitted launcher declares its own functions and its own finally.
+assert_eq "install.ps1's own '} finally {' blocks are counted, not the launcher's" \
+    3 "$(ps1_code "$INSTALL_PS1" | grep -c '^    } finally {$' || true)"
+
+echo "=== a redaction pattern is not a here-string opener ==="
+# Both scripts carry `-replace '(https?://)[^/@\s`]+@', '$1<redacted>@'`, a line
+# whose raw text ends in @'. Opening there hides everything up to the next
+# terminator, which is how ~780 lines of setup.ps1 stopped being scanned.
+for f in "$SETUP_PS1" "$INSTALL_PS1"; do
+    _redact_line=$(grep -n "redacted" "$f" | head -1 | cut -d: -f1)
+    assert_eq "$(basename "$f") keeps its redaction line as code" \
+        1 "$(ps1_code "$f" | sed -n "${_redact_line}p" | grep -c 'redacted' || true)"
+done
+
+echo "=== an exit added to real code is seen ==="
+cat > "$WORK/added-real.ps1" <<'PS1'
+function Exit-SetupFailure {
+    exit $Code
+}
+$probe = @'
+if ($true) { exit 0 }
+exit 1
+'@
+exit 2
+PS1
+assert_eq "a top-level exit outside the here-string is counted" \
+    2 "$(ps1_code "$WORK/added-real.ps1" | grep -Ec '^[[:space:]]*exit[[:space:]]+' || true)"
+
+echo "=== an exit added inside a here-string is not ==="
+cat > "$WORK/added-emitted.ps1" <<'PS1'
+function Exit-SetupFailure {
+    exit $Code
+}
+$probe = @'
+exit 1
+exit 3
+'@
+PS1
+assert_eq "exits in an emitted script stay out of the count" \
+    1 "$(ps1_code "$WORK/added-emitted.ps1" | grep -Ec '^[[:space:]]*exit[[:space:]]+' || true)"
+
+echo "=== the expandable form is handled too ==="
+cat > "$WORK/expandable.ps1" <<'PS1'
+$launcher = @"
+exit 1
+function Thing {
+}
+"@
+exit 4
+PS1
+assert_eq "@\" ... \"@ bodies are blanked" \
+    1 "$(ps1_code "$WORK/expandable.ps1" | grep -Ec '^[[:space:]]*exit[[:space:]]+' || true)"
+
+echo "=== the terminator must sit in column 0 ==="
+# install.ps1 builds a .bat through an array of strings, one of which is
+# `"@echo off",`. A stripped comparison closes the here-string there and every
+# line after it reads as code again.
+cat > "$WORK/indented-terminator.ps1" <<'PS1'
+$body = @'
+line one
+    "@echo off",
+exit 1
+'@
+exit 5
+PS1
+assert_eq "an indented \"@ does not close a here-string" \
+    1 "$(ps1_code "$WORK/indented-terminator.ps1" | grep -Ec '^[[:space:]]*exit[[:space:]]+' || true)"
+
+echo "=== a comment mentioning a delimiter is not one ==="
+cat > "$WORK/comment-opener.ps1" <<'PS1'
+# the terminator for a literal here-string is @'
+exit 1
+PS1
+assert_eq "a trailing @' in a comment opens nothing" \
+    1 "$(ps1_code "$WORK/comment-opener.ps1" | grep -Ec '^[[:space:]]*exit[[:space:]]+' || true)"
+
+summary

--- a/tests/sh/test_tauri_retry_failure_context.sh
+++ b/tests/sh/test_tauri_retry_failure_context.sh
@@ -4,6 +4,8 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=tests/sh/_ps1_source.sh
+. "$SCRIPT_DIR/_ps1_source.sh"
 INSTALL_SH="$SCRIPT_DIR/../../install.sh"
 INSTALL_PS1="$SCRIPT_DIR/../../install.ps1"
 SETUP_SH="$SCRIPT_DIR/../../studio/setup.sh"
@@ -377,9 +379,14 @@ if ! grep -q '\$env:UNSLOTH_TAURI_MODE = if (\$TauriMode)' "$INSTALL_PS1"; then
     exit 1
 fi
 
-_ps_setup_exit_count=$(grep -Ec '^[[:space:]]*exit[[:space:]]+' "$SETUP_PS1" || true)
+# The code view, not the raw file: setup.ps1 emits a probe script through a
+# here-string, and that probe ends in `exit 1`. Counting it made this assertion
+# read the emitted script's control flow as the installer's own.
+_ps_setup_code=$(ps1_code "$SETUP_PS1")
+_ps_setup_exit_count=$(printf '%s\n' "$_ps_setup_code" |
+    grep -Ec '^[[:space:]]*exit[[:space:]]+' || true)
 if [ "$_ps_setup_exit_count" -ne 1 ] ||
-    ! grep -q '^[[:space:]]*exit \$Code$' "$SETUP_PS1"; then
+    ! printf '%s\n' "$_ps_setup_code" | grep -q '^[[:space:]]*exit \$Code$'; then
     echo "  FAIL: Windows setup has explicit exits outside Exit-SetupFailure"
     exit 1
 fi

--- a/tests/studio/test_installer_av_shapes.py
+++ b/tests/studio/test_installer_av_shapes.py
@@ -43,15 +43,24 @@ def _code_lines(name: str):
     for number, line in enumerate(_text(name).splitlines(), start = 1):
         stripped = line.strip()
         if in_here_string:
-            if stripped in ("'@", '"@'):
+            # PowerShell wants the terminator in column 0, and install.ps1 has
+            # indented `"@echo off",` array entries that a stripped comparison
+            # closes on.
+            if line.startswith(("'@", '"@')):
                 in_here_string = False
             continue
-        if re.search(r"@[\"']$", stripped):
+        # Quoted literals first. Both install.ps1 and studio/setup.ps1 redact
+        # credentials with `-replace ..., '$1<redacted>@'`, whose raw line ends
+        # in `@'`; opening a here-string there swallowed everything up to the
+        # next terminator -- 780 lines of setup.ps1, 740 of install.ps1 -- and
+        # every check below silently stopped looking at them.
+        blanked = _QUOTED.sub('""', line)
+        if re.search(r"@[\"']$", blanked.strip()):
             in_here_string = True
             continue
         if stripped.startswith("#"):
             continue
-        yield number, _QUOTED.sub('""', line)
+        yield number, blanked
 
 
 @pytest.mark.parametrize("name", ALL_SCRIPTS)


### PR DESCRIPTION
`Repo tests (CPU)` has been red on main since #10540, and the installer change is right. The test was reading the wrong text.

## What broke

`tests/sh/test_tauri_retry_failure_context.sh` asserts that `studio/setup.ps1` exits in exactly one place, the tail of `Exit-SetupFailure`. It counted `exit` lines with a grep over the raw file:

```bash
_ps_setup_exit_count=$(grep -Ec '^[[:space:]]*exit[[:space:]]+' "$SETUP_PS1" || true)
if [ "$_ps_setup_exit_count" -ne 1 ] || ! grep -q '^[[:space:]]*exit \$Code$' "$SETUP_PS1"; then
```

#10540 made the Windows installer emit its native path helper instead of compiling it, which put a probe script into a here-string:

```powershell
    $probe = @'                                                    # setup.ps1:1667
...
if ('UnslothStudioEmitProbe' -as [type]) { ...; exit 0 }
exit 1                                                             # setup.ps1:1692
'@                                                                 # setup.ps1:1693
```

That `exit 1` is the emitted probe's control flow, not the installer's. The count went to 2 and the guard fired.

## The fix

`tests/sh/_ps1_source.sh` adds `ps1_code`, which blanks here-string bodies and keeps one blank line per body line so `grep -n` and `sed` addresses still point at the real file. Two details it has to get right, both learned from the files themselves:

- The opener is detected with quoted strings blanked first. Both `studio/setup.ps1:909` and `install.ps1:2280` redact credentials with a `-replace` whose line genuinely ends in `@'`:

  ```powershell
  $Text = $Text -replace '(https?://)[^/@\s`]+@', '$1<redacted>@'
  ```

- The terminator must sit in column 0, which is PowerShell's rule. `install.ps1` builds a `.bat` from an array containing `"@echo off",`, and a lenient match closes the here-string there.

## Two more readers were looking at emitted text

Neither was red, and one of them was quietly wrong:

- `tests/studio/test_installer_av_shapes.py` opened a here-string on that same redaction line and stayed open until the next terminator. Every check in the file silently skipped `setup.ps1:910-1692` and `install.ps1:2281-3024`, about 780 and 740 lines each, including the whole emit-probe region the file exists to police. With the fix those lines are scanned again and all 44 assertions still hold.

- `tests/sh/test_install_rollback_lifecycle.sh` matched `^    } finally {$` at `install.ps1:2894`, inside the emitted launcher (`$launcherContent = @"`, lines 2823-3024). It passed only because `grep -A3` concatenated the context of all four matches and one of the real ones supplied `Restore-StudioVenvRollback`.

## Guarding the filter

`tests/sh/test_ps1_code_view.sh` pins it both ways: an `exit` added to real code is counted, an `exit` added inside a here-string is not. Also covers the redaction line, the column-0 rule, the expandable `@" ... "@` form, a comment that merely mentions a delimiter, and that line numbers survive.

## Verification

All 64 `tests/sh/test_*.sh` suites pass. `tests/studio/test_installer_av_shapes.py` and `tests/test_installer_interactive_prompts.py` pass 136/136.

```
$ . tests/sh/_ps1_source.sh
$ ps1_code studio/setup.ps1 | grep -nE '^[[:space:]]*exit[[:space:]]+'
179:    exit $Code
$ ps1_code install.ps1 | grep -nE '^    \} finally \{$'
7085:    } finally {
7285:    } finally {
7419:    } finally {
```

No production file changes.
