### PR TITLE
Raise the startup bundle budget to where main actually is

### DIFF
--- a/studio/frontend/scripts/check-bundle-budget.ts
+++ b/studio/frontend/scripts/check-bundle-budget.ts
@@ -41,7 +41,24 @@ export const BUDGET = {
   // Raised for the audio placement control: same build both sides, merge base
   // 1,560.9 KB transfer against branch 1,562.6 KB, so it crossed the old 1,562.5 KB
   // ceiling by a tenth of a kilobyte.
-  transferBytes: 1_620_000,
+  //
+  // Raised again because main crossed 1,582.0 KB and stayed there. Four builds on
+  // one machine, same toolchain, transfer / raw / chunks:
+  //
+  //   3f2c89537  #10629's parent          1,574.7 / 5,260.1 / 91
+  //   e3e457a7d  #10629 eager Settings    1,579.9 / 5,288.8 / 82
+  //   19c86b3cc  last green Frontend CI   1,576.5 / 5,267.6 / 91
+  //   7436c103e  main                     1,585.6 / 5,306.4 / 82
+  //
+  // No single change is over the line. #10629 is the largest contributor at
+  // +5.2 KB -- it statically imports SettingsDialog and FloatingMonitor to make
+  // Settings eager again, which is the fix it shipped, and which is what folds
+  // nine chunks into the eager graph and takes settings-*.js from 158.0 KB raw to
+  // 208.2 KB. It left 2.1 KB of headroom; the ~40 commits after it spent that.
+  // So this is a deliberate raise, not a regression to lazy-load away.
+  //
+  // Raw is untouched: 5,306.4 KB still has 64.7 KB to spare under 5,500,000.
+  transferBytes: 1_645_000,
   rawBytes: 5_500_000,
 };
 


### PR DESCRIPTION
`Frontend build + bundle sanity` has been red on main since it crossed the 1,582.0 KB eager-transfer ceiling:

```
over the startup budget: transfer 1585.6 KB > 1582.0 KB
Something is now imported statically that the first screen does not need.
```

It is not one change that did it, so I measured rather than guessed. Four builds on one machine, same toolchain, transfer / raw / chunks:

| commit | what it is | transfer | raw | chunks |
| --- | --- | --- | --- | --- |
| `3f2c89537` | #10629's parent | 1,574.7 KB | 5,260.1 KB | 91 |
| `e3e457a7d` | #10629, eager Settings | 1,579.9 KB | 5,288.8 KB | 82 |
| `19c86b3cc` | last green Frontend CI | 1,576.5 KB | 5,267.6 KB | 91 |
| `7436c103e` | main | 1,585.6 KB | 5,306.4 KB | 82 |

#10629 is the largest single contributor at +5.2 KB. It statically imports `SettingsDialog` and `FloatingMonitor`:

```diff
+import { FloatingMonitor } from "@/components/floating-monitor";
+import { SettingsDialog } from "./settings-dialog";
```

which is the fix it shipped, and which is what folds nine chunks into the eager graph and takes `settings-*.js` from 158.0 KB raw to 208.2 KB. Making Settings lazy again would undo that PR rather than fix anything.

It landed with 2.1 KB of headroom left. The commits after it spent it, none of them individually over the line.

So this takes the other branch the guard's own message offers: raise the budget with the measurement. 1,645,000 bytes leaves 20.9 KB spare, about the headroom the previous raise took. Raw is untouched at 5,500,000, still 64.7 KB clear at 5,306.4 KB.

```
$ npm run build && npm run bundle:check
eager startup JS: 5306.4 KB raw, 1585.6 KB transfer, 82 chunks
within budget (20.9 KB transfer, 64.7 KB raw to spare)
```

`tests/bundle-budget-closure.test.ts` passes 32/32.

The measurements are in the comment above `BUDGET` as well, so the next person to look at this does not have to rebuild four commits to find out where the bytes went.
