### PR TITLE
Studio: narrower desktop window and a sidebar edge trigger

### DIFF
--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -60,9 +60,11 @@ import {
 } from "./window-layout";
 import {
   type MeasuredWindowLayout,
+  type PixelRatioSource,
   type WindowLayoutGuard,
   finalizeAppWindowLayout,
   measureWindowLayout,
+  observeDevicePixelRatio,
   shouldFinishWindowLayoutWait,
 } from "./window-layout-lifecycle";
 
@@ -199,6 +201,47 @@ async function placeWindow(
     height: Math.round(size.height * scaleFactor) + frameSize.height,
   });
   await win.setPosition(new PhysicalPosition(position.x, position.y));
+}
+
+function windowPixelRatioSource(): PixelRatioSource | null {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return null;
+  }
+  return {
+    devicePixelRatio: () => window.devicePixelRatio,
+    matchResolution: (dppx) => window.matchMedia(`(resolution: ${dppx}dppx)`),
+  };
+}
+
+/**
+ * Reapplies the floor after a zoom change, which Windows text scaling is. The
+ * floor is a CSS-pixel floor scaled into logical pixels, so the ratio it was
+ * scaled by at launch goes stale.
+ */
+async function reapplyWindowSizeConstraints(
+  isCurrent: WindowLayoutGuard,
+): Promise<void> {
+  const windowModule = await import("@tauri-apps/api/window");
+  if (!isCurrent()) return;
+
+  const win = windowModule.getCurrentWindow();
+  const measured = await measureTauriWindowLayout(windowModule, win, isCurrent);
+  if (!measured || !isCurrent()) return;
+
+  const { minimum } = measured.bounds;
+  await win.setSizeConstraints({
+    minWidth: minimum.width,
+    minHeight: minimum.height,
+  });
+  if (!isCurrent()) return;
+  // Grows a window now under the floor. No maximum: the work area has not
+  // changed, and capping here would fight a user's own larger size.
+  await enforceWindowSizeBounds(win, windowModule.LogicalSize, isCurrent, {
+    minimum,
+  });
 }
 
 async function showSetupWindow(isCurrent: WindowLayoutGuard): Promise<void> {
@@ -640,6 +683,17 @@ function TauriWrapper({ children }: { children: ReactNode }) {
       } catch {
         /* swallow; window may still be functional */
       }
+    });
+
+    // The setup window has no constraints to keep current.
+    if (nextMode !== "app") return;
+    const ratioSource = windowPixelRatioSource();
+    if (!ratioSource) return;
+    return observeDevicePixelRatio(ratioSource, () => {
+      if (!isCurrent()) return;
+      reapplyWindowSizeConstraints(isCurrent).catch(() => {
+        /* swallow; the launch-time floor stands */
+      });
     });
   }, [status, windowRevealRevision]);
 

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -174,6 +174,7 @@ function measureTauriWindowLayout(
       outerSize: () => win.outerSize(),
     },
     isCurrent,
+    logicalPerCssPx,
   );
 }
 

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -684,18 +684,34 @@ function TauriWrapper({ children }: { children: ReactNode }) {
         /* swallow; window may still be functional */
       }
     });
+  }, [status, windowRevealRevision]);
 
-    // The setup window has no constraints to keep current.
-    if (nextMode !== "app") return;
+  // Mounted once, deliberately: the layout effect above returns early on a
+  // status change that keeps the window mode, so a listener living there would
+  // be disposed on the first one and never armed again.
+  useEffect(() => {
+    if (!isTauri) return;
     const ratioSource = windowPixelRatioSource();
     if (!ratioSource) return;
-    return observeDevicePixelRatio(ratioSource, () => {
-      if (!isCurrent()) return;
-      reapplyWindowSizeConstraints(isCurrent).catch(() => {
-        /* swallow; the launch-time floor stands */
+
+    let disposed = false;
+    const stop = observeDevicePixelRatio(ratioSource, () => {
+      // The setup window has no constraints to keep current.
+      if (disposed || appliedWindowModeRef.current !== "app") return;
+      // Read on the change, not on mount: a layout pass that starts after this
+      // one owns the constraints, and this one stands down.
+      const generation = windowLayoutGenerationRef.current;
+      reapplyWindowSizeConstraints(
+        () => !disposed && windowLayoutGenerationRef.current === generation,
+      ).catch(() => {
+        /* swallow; the floor in force stands */
       });
     });
-  }, [status, windowRevealRevision]);
+    return () => {
+      disposed = true;
+      stop();
+    };
+  }, []);
 
   useEffect(() => {
     if (!isTauri) {

--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/features/settings";
 import { useTrainingUnloadGuard } from "@/features/training";
 import { TransformersUpgradeDialog } from "@/features/transformers-upgrade";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { useSidebarPin } from "@/hooks/use-sidebar-pin";
 import { type TranslationKey, useT } from "@/i18n";
 import {
@@ -388,6 +389,13 @@ function RootLayout() {
   // Chat, Images, Video and Audio each render their own full-height shell, so all four want the chat-style layout: no outer pt-14 inset, no outer
   // scroll. Keying off isChatRoute alone pushed the picker down and clipped the gallery. Container padding/overflow only; keep-alive stays per route.
   const isChatLike = isChatRoute || isImagesRoute || isVideoRoute || isAudioRoute;
+  // Reserves the navbar the shell actually rendered. Read off the same hook
+  // Navbar uses, not the `md` breakpoint: a narrowed desktop window keeps the
+  // desktop navbar, and a CSS rule would reserve the mobile one's 56px and
+  // leave --studio-titlebar-height at 0 for the pages sized off it.
+  const nonChatTopInset = useIsMobile()
+    ? "pt-14"
+    : "pt-[var(--studio-non-chat-content-top-inset,var(--studio-content-top-inset,0px))] [--studio-titlebar-height:var(--studio-non-chat-content-top-inset,var(--studio-content-top-inset,0px))]";
 
   useTrainingUnloadGuard();
   // Global export driver: streams worker logs and tracks status from any route
@@ -573,7 +581,7 @@ function RootLayout() {
             <Navbar />
             <div
               {...{ [FIND_SCOPE_ATTRIBUTE]: "" }}
-              className={`relative flex min-h-0 min-w-0 flex-1 basis-0 flex-col ${isChatLike ? "overflow-hidden" : "overflow-visible"} ${isChatLike ? "" : "pt-14 md:pt-[var(--studio-non-chat-content-top-inset,var(--studio-content-top-inset,0px))] md:[--studio-titlebar-height:var(--studio-non-chat-content-top-inset,var(--studio-content-top-inset,0px))]"}`}
+              className={`relative flex min-h-0 min-w-0 flex-1 basis-0 flex-col ${isChatLike ? "overflow-hidden" : "overflow-visible"} ${isChatLike ? "" : nonChatTopInset}`}
             >
               {/* The find bar floats over this region and searches it: the workspace on screen,
                   without the sidebar, the navbar, or the off-route workspaces parked here under

--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -4,6 +4,7 @@
 import { useAppShellReadySignal } from "@/components/app-readiness";
 import { AppSidebar } from "@/components/app-sidebar";
 import { Navbar } from "@/components/navbar";
+import { SidebarEdgeTrigger } from "@/components/sidebar-edge-trigger";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { fetchDeviceType, usePlatformStore } from "@/config/env";
 import { videoNavHint } from "@/config/hardware-verdict";
@@ -565,6 +566,7 @@ function RootLayout() {
           className="!min-h-0 h-[calc(100dvh-var(--studio-titlebar-height,0px))] overflow-hidden"
         >
           <AppSidebar />
+          <SidebarEdgeTrigger />
           <SidebarInset
             className={isChatLike ? "overflow-hidden" : "overflow-y-auto"}
           >

--- a/studio/frontend/src/app/routes/__root.tsx
+++ b/studio/frontend/src/app/routes/__root.tsx
@@ -36,7 +36,7 @@ import {
 } from "@/features/settings";
 import { useTrainingUnloadGuard } from "@/features/training";
 import { TransformersUpgradeDialog } from "@/features/transformers-upgrade";
-import { useIsMobile } from "@/hooks/use-mobile";
+import { useIsMobileShell } from "@/hooks/use-mobile";
 import { useSidebarPin } from "@/hooks/use-sidebar-pin";
 import { type TranslationKey, useT } from "@/i18n";
 import {
@@ -393,7 +393,7 @@ function RootLayout() {
   // Navbar uses, not the `md` breakpoint: a narrowed desktop window keeps the
   // desktop navbar, and a CSS rule would reserve the mobile one's 56px and
   // leave --studio-titlebar-height at 0 for the pages sized off it.
-  const nonChatTopInset = useIsMobile()
+  const nonChatTopInset = useIsMobileShell()
     ? "pt-14"
     : "pt-[var(--studio-non-chat-content-top-inset,var(--studio-content-top-inset,0px))] [--studio-titlebar-height:var(--studio-non-chat-content-top-inset,var(--studio-content-top-inset,0px))]";
 

--- a/studio/frontend/src/app/window-layout-lifecycle.ts
+++ b/studio/frontend/src/app/window-layout-lifecycle.ts
@@ -38,10 +38,17 @@ type WindowMonitorReader<Monitor extends WorkAreaMonitor> = {
   outerSize?: () => Promise<PhysicalWindowSize>;
 };
 
-/** Size bounds the window has to stay within on its current monitor. */
+/**
+ * Size bounds the window has to stay within on its current monitor.
+ *
+ * `logicalPerCssPx` reports the webview's zoom above a monitor's display scale,
+ * keeping the resize floor a CSS-pixel floor under Windows text scaling. It
+ * defaults to a no-op, which is every platform without it.
+ */
 export async function measureWindowLayout<Monitor extends WorkAreaMonitor>(
   reader: WindowMonitorReader<Monitor>,
   isCurrent: WindowLayoutGuard,
+  logicalPerCssPx: (monitorScale: number) => number = () => 1,
 ): Promise<MeasuredWindowLayout<Monitor> | null> {
   // Some platforms cannot resolve the monitor for a hidden window.
   const monitor =
@@ -75,7 +82,10 @@ export async function measureWindowLayout<Monitor extends WorkAreaMonitor>(
   }
 
   const bounds = availableInnerSize
-    ? calculateWindowSizeBounds(availableInnerSize)
+    ? calculateWindowSizeBounds(
+        availableInnerSize,
+        monitor ? logicalPerCssPx(monitor.scaleFactor) : 1,
+      )
     : DEFAULT_APP_WINDOW_SIZE_BOUNDS;
   return { bounds, monitor, frameSize };
 }

--- a/studio/frontend/src/app/window-layout-lifecycle.ts
+++ b/studio/frontend/src/app/window-layout-lifecycle.ts
@@ -95,6 +95,45 @@ export function shouldFinishWindowLayoutWait(
 ): boolean {
   return sawPostShowChange;
 }
+
+type ResolutionQuery = {
+  addEventListener: (type: "change", listener: () => void) => void;
+  removeEventListener: (type: "change", listener: () => void) => void;
+};
+
+export type PixelRatioSource = {
+  devicePixelRatio: () => number;
+  matchResolution: (dppx: number) => ResolutionQuery | null;
+};
+
+/**
+ * Reports a change in the webview's device pixel ratio, which moves the
+ * CSS-pixel resize floor and is otherwise only read at launch. There is no
+ * event for the ratio itself, so a query for the ratio in force stands in: it
+ * stops matching, and a fresh query for the new one takes over.
+ */
+export function observeDevicePixelRatio(
+  source: PixelRatioSource,
+  onChange: () => void,
+): () => void {
+  let query: ResolutionQuery | null = null;
+  let disposed = false;
+  const listen = () => {
+    query?.removeEventListener("change", handle);
+    query = disposed ? null : source.matchResolution(source.devicePixelRatio());
+    query?.addEventListener("change", handle);
+  };
+  function handle() {
+    listen();
+    if (!disposed) onChange();
+  }
+  listen();
+  return () => {
+    disposed = true;
+    query?.removeEventListener("change", handle);
+    query = null;
+  };
+}
 type FinalizeAppWindowLayoutOptions<Monitor extends WorkAreaMonitor> = {
   restored: boolean;
   measured: MeasuredWindowLayout<Monitor>;

--- a/studio/frontend/src/app/window-layout.ts
+++ b/studio/frontend/src/app/window-layout.ts
@@ -16,7 +16,20 @@ export type WindowSizeBounds = {
   maximum?: LogicalWindowSize;
 };
 
+/**
+ * Resize floor: a companion width, as other chat apps allow, and no narrower
+ * than the desktop layout it keeps at every size can fit.
+ */
 export const MINIMUM_APP_WINDOW_SIZE: LogicalWindowSize = {
+  width: 460,
+  height: 480,
+};
+
+/**
+ * The size a first launch aims for. Separate from the resize floor: shrinking
+ * the floor must not shrink the window we open.
+ */
+export const NOMINAL_APP_WINDOW_SIZE: LogicalWindowSize = {
   width: 900,
   height: 600,
 };
@@ -42,18 +55,30 @@ function relaxMinimum(preferred: number, maximum: number): number {
   return Math.max(1, Math.floor(maximum * RELAXED_MINIMUM_RATIO));
 }
 
-/** Bounds a frameless window to the monitor work area. */
+/**
+ * Bounds a frameless window to the monitor work area.
+ *
+ * `logicalPerCssPx` keeps the floor a CSS-pixel floor. Windows text scaling
+ * zooms the webview above the display scale, so a window sized in logical
+ * pixels lays out in fewer CSS pixels: at 150% a 460px floor is a 307px
+ * viewport, narrower than the layout can hold.
+ */
 export function calculateWindowSizeBounds(
   workAreaSize: LogicalWindowSize,
+  logicalPerCssPx = 1,
 ): WindowSizeBounds {
   const maximum = {
     width: Math.max(1, Math.floor(workAreaSize.width)),
     height: Math.max(1, Math.floor(workAreaSize.height)),
   };
+  const floor = {
+    width: Math.round(MINIMUM_APP_WINDOW_SIZE.width * logicalPerCssPx),
+    height: Math.round(MINIMUM_APP_WINDOW_SIZE.height * logicalPerCssPx),
+  };
   return {
     minimum: {
-      width: relaxMinimum(MINIMUM_APP_WINDOW_SIZE.width, maximum.width),
-      height: relaxMinimum(MINIMUM_APP_WINDOW_SIZE.height, maximum.height),
+      width: relaxMinimum(floor.width, maximum.width),
+      height: relaxMinimum(floor.height, maximum.height),
     },
     maximum,
   };
@@ -71,23 +96,29 @@ export function fitWindowSize(
 }
 
 export function calculateFirstAppWindowSize(
-  { minimum, maximum }: WindowSizeBounds,
+  { maximum }: WindowSizeBounds,
   cssSafeLogicalWidth?: number,
 ): LogicalWindowSize {
-  if (!maximum) return minimum;
+  if (!maximum) return NOMINAL_APP_WINDOW_SIZE;
 
+  // A first window floors at the nominal size, not the resize floor: opening
+  // at a width the user may shrink to would be a surprise.
+  const nominal = {
+    width: relaxMinimum(NOMINAL_APP_WINDOW_SIZE.width, maximum.width),
+    height: relaxMinimum(NOMINAL_APP_WINDOW_SIZE.height, maximum.height),
+  };
   const width = Math.max(
-    minimum.width,
+    nominal.width,
     Math.round(maximum.width * FIRST_WINDOW_WIDTH_RATIO),
     Math.min(cssSafeLogicalWidth ?? 0, maximum.width),
   );
   // Preserve requested height when the work area is short.
   const heightCap = Math.max(
-    MINIMUM_APP_WINDOW_SIZE.height,
+    NOMINAL_APP_WINDOW_SIZE.height,
     Math.round(maximum.height * FIRST_WINDOW_HEIGHT_RATIO),
   );
   const height = Math.max(
-    minimum.height,
+    nominal.height,
     Math.min(Math.round(width / FIRST_WINDOW_ASPECT_RATIO), heightCap),
   );
   return fitWindowSize({ width, height }, maximum);

--- a/studio/frontend/src/app/window-layout.ts
+++ b/studio/frontend/src/app/window-layout.ts
@@ -96,16 +96,24 @@ export function fitWindowSize(
 }
 
 export function calculateFirstAppWindowSize(
-  { maximum }: WindowSizeBounds,
+  { minimum, maximum }: WindowSizeBounds,
   cssSafeLogicalWidth?: number,
 ): LogicalWindowSize {
   if (!maximum) return NOMINAL_APP_WINDOW_SIZE;
 
   // A first window floors at the nominal size, not the resize floor: opening
-  // at a width the user may shrink to would be a surprise.
+  // at a width the user may shrink to would be a surprise. Never below the
+  // floor either: a work area too small for the nominal size relaxes it, and
+  // the constraints would then grow the window off the centre it was placed on.
   const nominal = {
-    width: relaxMinimum(NOMINAL_APP_WINDOW_SIZE.width, maximum.width),
-    height: relaxMinimum(NOMINAL_APP_WINDOW_SIZE.height, maximum.height),
+    width: Math.max(
+      minimum.width,
+      relaxMinimum(NOMINAL_APP_WINDOW_SIZE.width, maximum.width),
+    ),
+    height: Math.max(
+      minimum.height,
+      relaxMinimum(NOMINAL_APP_WINDOW_SIZE.height, maximum.height),
+    ),
   };
   const width = Math.max(
     nominal.width,

--- a/studio/frontend/src/components/navbar.tsx
+++ b/studio/frontend/src/components/navbar.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/lib/utils";
 import { useState } from "react";
 
 export function Navbar() {
-  const { isMobile, pinned, togglePinned } = useSidebar();
+  const { isMobile, pinned, peeking, togglePinned } = useSidebar();
   const [usesNativeMacTitlebar] = useState(shouldUseNativeMacWindowTitlebar);
   const [usesCustomTitlebar] = useState(shouldUseCustomWindowTitlebar);
 
@@ -28,7 +28,9 @@ export function Navbar() {
           )}
         </header>
 
-        {usesNativeMacTitlebar && !pinned && (
+        {/* A held-out sidebar brings its own copy of this cluster, in the same
+            place. */}
+        {usesNativeMacTitlebar && !pinned && !peeking && (
           <DesktopTitlebarNavigation
             expanded={false}
             onToggleSidebar={togglePinned}

--- a/studio/frontend/src/components/sidebar-edge-trigger.tsx
+++ b/studio/frontend/src/components/sidebar-edge-trigger.tsx
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { shouldUseCustomWindowTitlebar } from "@/components/tauri/window-titlebar";
+import { PanelResizeHandle } from "@/components/ui/panel-resize-handle";
+import { useSidebar } from "@/components/ui/sidebar";
+import {
+  SIDEBAR_WIDTH_MIN,
+  clampSidebarWidth,
+} from "@/hooks/use-sidebar-width";
+import { useT } from "@/i18n";
+import { isTauri } from "@/lib/api-base";
+import { cn } from "@/lib/utils";
+import { type ReactElement, useRef, useState } from "react";
+
+/**
+ * Draggable window edge for the desktop sidebar, which collapses to zero width
+ * and so has no edge of its own to grab. The same handle the pinned sidebar
+ * uses, anchored to the window instead of to an off-screen panel: hover holds
+ * the sidebar out, click pins it, drag resizes it.
+ *
+ * Desktop only. On the web a collapsed sidebar keeps its icon rail, and that
+ * rail already carries the handle.
+ */
+export function SidebarEdgeTrigger({
+  className,
+}: {
+  className?: string;
+}): ReactElement | null {
+  const t = useT();
+  const ref = useRef<HTMLDivElement>(null);
+  const [usesCustomTitlebar] = useState(shouldUseCustomWindowTitlebar);
+  const {
+    isMobile,
+    openMobile,
+    pinned,
+    setPeeking,
+    toggleSidebar,
+    width,
+    storedWidth,
+    maxWidth,
+    setWidth,
+    resetWidth,
+  } = useSidebar();
+
+  const sidebarShowing = isMobile ? openMobile : pinned;
+  if (!isTauri || sidebarShowing) {
+    return null;
+  }
+
+  return (
+    <div ref={ref} className="contents">
+      <PanelResizeHandle
+        edge="right"
+        // Always the collapsed handle: this renders only while the sidebar is away.
+        open={false}
+        width={width}
+        stored={storedWidth}
+        min={SIDEBAR_WIDTH_MIN}
+        max={maxWidth}
+        clamp={clampSidebarWidth}
+        setWidth={setWidth}
+        resetWidth={resetWidth}
+        onToggle={toggleSidebar}
+        // Collapsed to nothing, so a drag grows from zero.
+        measure={() => 0}
+        target={() =>
+          ref.current?.closest<HTMLElement>('[data-slot="sidebar-wrapper"]') ??
+          null
+        }
+        cssVar="--sidebar-width"
+        rootVar="--studio-sidebar-live-width"
+        // No enclosing [data-slot="sidebar"] out here; the handle falls back to `target()`.
+        scopedTarget={() => null}
+        rootVarTargets={() =>
+          Array.from(
+            document.querySelectorAll<HTMLElement>(
+              "[data-titlebar-live-width-scope]",
+            ),
+          )
+        }
+        label={t("shell.aria.resizeSidebar")}
+        toggleLabel={t("shell.aria.openSidebar")}
+        // The sidebar coming out says it better than a label would.
+        hideTooltip={true}
+        onHoverChange={setPeeking}
+        dataSlot="sidebar-edge-trigger"
+        className={cn(
+          // Below the titlebar so the window controls and drag region keep
+          // their clicks, above the panel it holds out so the edge still
+          // answers under the sidebar. `block` beats the handle's
+          // `hidden sm:block`, which a narrowed window would trip.
+          "fixed bottom-0 left-0 right-auto top-[var(--studio-desktop-titlebar-height,48px)] z-[55] block",
+          // The window edge and nothing more: every pixel here takes a click
+          // from the page. Wider where the window is undecorated (Windows,
+          // Linux, see `setup_custom_titlebar`): there the toolkit hit-tests
+          // its own resize border inside the window, so 2px would land
+          // entirely within it. macOS keeps that border outside the content.
+          usesCustomTitlebar ? "w-3" : "w-0.5",
+          // The sidebar sliding out is the hover feedback, not a hairline
+          // hanging down the middle of the page.
+          "after:hidden",
+          // The two-headed resize cursor other chat apps put here, not the
+          // one-way `e-resize` of a collapsed panel border.
+          "cursor-col-resize!",
+          className,
+        )}
+      />
+    </div>
+  );
+}

--- a/studio/frontend/src/components/sidebar-edge-trigger.tsx
+++ b/studio/frontend/src/components/sidebar-edge-trigger.tsx
@@ -33,6 +33,7 @@ export function SidebarEdgeTrigger({
   const {
     isMobile,
     openMobile,
+    peeking,
     pinned,
     setPeeking,
     toggleSidebar,
@@ -42,18 +43,31 @@ export function SidebarEdgeTrigger({
     setWidth,
     resetWidth,
   } = useSidebar();
+  // A drag that reaches the minimum pins the sidebar part-way through, which
+  // would unmount this: the handle would lose pointer capture and the width
+  // would never commit. Hold on until the pointer is released.
+  const [holding, setHolding] = useState(false);
+  const release = () => setHolding(false);
 
   const sidebarShowing = isMobile ? openMobile : pinned;
-  if (!isTauri || sidebarShowing) {
+  if (!isTauri || (sidebarShowing && !holding)) {
     return null;
   }
 
   return (
-    <div ref={ref} className="contents">
+    <div
+      ref={ref}
+      className="contents"
+      onPointerDownCapture={() => setHolding(true)}
+      onPointerUp={release}
+      onPointerCancel={release}
+      onLostPointerCapture={release}
+    >
       <PanelResizeHandle
         edge="right"
-        // Always the collapsed handle: this renders only while the sidebar is away.
-        open={false}
+        // Follows the pin, which a drag flips part-way through: from there the
+        // handle resizes the sidebar it just opened and commits on release.
+        open={pinned}
         width={width}
         stored={storedWidth}
         min={SIDEBAR_WIDTH_MIN}
@@ -62,16 +76,23 @@ export function SidebarEdgeTrigger({
         setWidth={setWidth}
         resetWidth={resetWidth}
         onToggle={toggleSidebar}
-        // Collapsed to nothing, so a drag grows from zero.
-        measure={() => 0}
+        // Start from what is on screen: held out, the panel is already at its
+        // full width, so a drag carries on from there instead of jumping.
+        measure={() => (peeking ? width : 0)}
         target={() =>
           ref.current?.closest<HTMLElement>('[data-slot="sidebar-wrapper"]') ??
           null
         }
         cssVar="--sidebar-width"
         rootVar="--studio-sidebar-live-width"
-        // No enclosing [data-slot="sidebar"] out here; the handle falls back to `target()`.
-        scopedTarget={() => null}
+        // The sidebar declares --sidebar-width on itself, so a live width
+        // painted any higher up is shadowed. Queried, not `closest`: this
+        // strip is the sidebar's sibling.
+        scopedTarget={() =>
+          ref.current
+            ?.closest<HTMLElement>('[data-slot="sidebar-wrapper"]')
+            ?.querySelector<HTMLElement>('[data-slot="sidebar"]') ?? null
+        }
         rootVarTargets={() =>
           Array.from(
             document.querySelectorAll<HTMLElement>(

--- a/studio/frontend/src/components/sidebar-edge-trigger.tsx
+++ b/studio/frontend/src/components/sidebar-edge-trigger.tsx
@@ -17,7 +17,12 @@ import { type ReactElement, useRef, useState } from "react";
  * Draggable window edge for the desktop sidebar, which collapses to zero width
  * and so has no edge of its own to grab. The same handle the pinned sidebar
  * uses, anchored to the window instead of to an off-screen panel: hover holds
- * the sidebar out, click pins it, drag resizes it.
+ * the sidebar out, click or Enter pins it, drag resizes it.
+ *
+ * Hover and the keyboard are what land on macOS. A decorated window keeps its
+ * resize border over the first few CSS pixels of the content and takes the
+ * press there, so at 2px the click and the drag go to the window instead. Both
+ * reach the 12px strip on Windows and Linux.
  *
  * Desktop only. On the web a collapsed sidebar keeps its icon rail, and that
  * rail already carries the handle.

--- a/studio/frontend/src/components/sidebar-edge-trigger.tsx
+++ b/studio/frontend/src/components/sidebar-edge-trigger.tsx
@@ -58,10 +58,19 @@ export function SidebarEdgeTrigger({
     <div
       ref={ref}
       className="contents"
-      onPointerDownCapture={() => setHolding(true)}
+      // Only a primary press takes pointer capture, so only a primary press
+      // has a release to wait for. Holding for any other would never clear.
+      onPointerDownCapture={(event) => {
+        if (event.button === 0) setHolding(true);
+      }}
       onPointerUp={release}
       onPointerCancel={release}
       onLostPointerCapture={release}
+      // Tab reaches the strip with no pointer to hold the sidebar out, so
+      // focus does it instead. focusin and focusout bubble, which leaves the
+      // strip's own focus handling to the shared handle.
+      onFocus={() => setPeeking(true)}
+      onBlur={() => setPeeking(false)}
     >
       <PanelResizeHandle
         edge="right"
@@ -121,6 +130,9 @@ export function SidebarEdgeTrigger({
           // The sidebar sliding out is the hover feedback, not a hairline
           // hanging down the middle of the page.
           "after:hidden",
+          // That hairline is also where the shared handle marks focus, and on
+          // a 2px strip it would sit off-screen, so mark it on the strip.
+          "focus-visible:bg-sidebar-ring/60",
           // The two-headed resize cursor other chat apps put here, not the
           // one-way `e-resize` of a collapsed panel border.
           "cursor-col-resize!",

--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { useIsMobile } from "@/hooks/use-mobile";
+import { useIsMobileShell } from "@/hooks/use-mobile";
 import { useSidebarPin } from "@/hooks/use-sidebar-pin";
 import { useSidebarWidth } from "@/hooks/use-sidebar-width";
 import { isTauri } from "@/lib/api-base";
@@ -200,7 +200,7 @@ export function WindowTitlebar({
   const [maximized, setMaximized] = useState(false);
   const { pinned, togglePinned } = useSidebarPin();
   // Outside SidebarProvider, so read the same media query the provider does.
-  const isMobile = useIsMobile();
+  const isMobile = useIsMobileShell();
 
   const maximizeRefreshSequence = useRef(0);
   const maximizeRefreshTimer = useRef<number | null>(null);

--- a/studio/frontend/src/components/ui/panel-resize-handle.tsx
+++ b/studio/frontend/src/components/ui/panel-resize-handle.tsx
@@ -110,12 +110,19 @@ export type PanelResizeHandleProps = {
   measure: () => number
   label: string
   toggleLabel: string
-  /** Translated tooltip copy; the caller owns the translation layer. */
-  collapseHint: string
-  expandHint: string
-  dragHint: string
+  /**
+   * Translated tooltip copy; the caller owns the translation layer. Optional
+   * only for `hideTooltip`, which has no copy to translate.
+   */
+  collapseHint?: string
+  expandHint?: string
+  dragHint?: string
   /** Shown in the tooltip when the panel has a toggle shortcut. */
   shortcut?: string
+  /** Bare handle, no tooltip: for a panel that answers the hover itself. */
+  hideTooltip?: boolean
+  /** Told when the pointer arrives at or leaves the handle. */
+  onHoverChange?: (hovered: boolean) => void
   dataSlot?: string
   className?: string
   /** Mirrors the live width onto :root for chrome outside the panel. */
@@ -159,6 +166,8 @@ export function PanelResizeHandle({
   expandHint,
   dragHint,
   shortcut,
+  onHoverChange,
+  hideTooltip = false,
   dataSlot = "panel-resize-handle",
   className,
   rootVar,
@@ -351,10 +360,8 @@ export function PanelResizeHandle({
   // Clear a stuck cursor override if we unmount mid-drag.
   React.useEffect(() => endDrag, [endDrag])
 
-  return (
-    <Tooltip open={(hovered || focused) && !dragging}>
-      <TooltipTrigger asChild>
-        <button
+  const handle = (
+    <button
           ref={ref}
           type="button"
           data-slot={dataSlot}
@@ -376,8 +383,14 @@ export function PanelResizeHandle({
             if (Date.now() - handledAtRef.current < CLICK_COMPAT_WINDOW_MS) return
             onToggle()
           }}
-          onPointerEnter={() => setHovered(true)}
-          onPointerLeave={() => setHovered(false)}
+          onPointerEnter={() => {
+            setHovered(true)
+            onHoverChange?.(true)
+          }}
+          onPointerLeave={() => {
+            setHovered(false)
+            onHoverChange?.(false)
+          }}
           onFocus={(event) => setFocused(event.target.matches(":focus-visible"))}
           onBlur={() => setFocused(false)}
           className={cn(
@@ -398,7 +411,15 @@ export function PanelResizeHandle({
             className,
           )}
         />
-      </TooltipTrigger>
+  )
+
+  if (hideTooltip) {
+    return handle
+  }
+
+  return (
+    <Tooltip open={(hovered || focused) && !dragging}>
+      <TooltipTrigger asChild>{handle}</TooltipTrigger>
       <TooltipContent
         side={edge === "left" ? "left" : "right"}
         align="center"

--- a/studio/frontend/src/components/ui/sidebar.tsx
+++ b/studio/frontend/src/components/ui/sidebar.tsx
@@ -412,6 +412,11 @@ function Sidebar({
         // crosses between them, and only leaving both retracts it.
         onPointerEnter={holdsOut ? () => setPeeking(true) : undefined}
         onPointerLeave={holdsOut ? () => setPeeking(false) : undefined}
+        // The same for focus, which arrives by Shift+Tab off the edge strip.
+        // Without it the strip's own blur retracts the panel around the focus
+        // that just landed in it, and going inert drops that focus entirely.
+        onFocus={holdsOut ? () => setPeeking(true) : undefined}
+        onBlur={holdsOut ? () => setPeeking(false) : undefined}
         className={cn(
           hasPinMode
             ? cn(

--- a/studio/frontend/src/components/ui/sidebar.tsx
+++ b/studio/frontend/src/components/ui/sidebar.tsx
@@ -30,7 +30,7 @@ import {
 import { PanelResizeHandle } from "@/components/ui/panel-resize-handle"
 import { PANEL_RESIZE_SCOPED_VARS_ENABLED } from "@/components/ui/panel-resize-recalc-flags"
 import { useT } from "@/i18n"
-import { useIsMobile } from "@/hooks/use-mobile"
+import { useIsMobileShell } from "@/hooks/use-mobile"
 import {
   SIDEBAR_WIDTH_DEFAULT,
   SIDEBAR_WIDTH_MIN,
@@ -97,7 +97,9 @@ function SidebarProvider({
   setPinned?: (value: boolean) => void
   togglePinned?: () => void
 }) {
-  const isMobile = useIsMobile()
+  // The shell decision, not the viewport: a narrowed desktop window keeps the
+  // desktop sidebar. Panels with only room to overlay still read useIsMobile.
+  const isMobile = useIsMobileShell()
   const [openMobile, setOpenMobile] = React.useState(false)
   const {
     width,

--- a/studio/frontend/src/components/ui/sidebar.tsx
+++ b/studio/frontend/src/components/ui/sidebar.tsx
@@ -156,10 +156,6 @@ function SidebarProvider({
   // or clear it.
   useShortcut("toggleSidebar", toggleSidebar)
 
-  // We add a state so that we can do data-state="expanded" or "collapsed".
-  // This makes it easier to style the sidebar with Tailwind classes.
-  const state = open ? "expanded" : "collapsed"
-
   const pinned = pinnedProp ?? false
   const setPinned = setPinnedProp ?? noop
   const togglePinned = togglePinnedProp ?? noop
@@ -181,6 +177,12 @@ function SidebarProvider({
   React.useEffect(() => {
     if (pinned || isMobile) setPeekingState(false)
   }, [pinned, isMobile])
+
+  // We add a state so that we can do data-state="expanded" or "collapsed".
+  // This makes it easier to style the sidebar with Tailwind classes. Held out
+  // counts as expanded: the panel is on screen, so the rows it renders are the
+  // ones its tooltips, disclosures and chat chords should see.
+  const state = open || peeking ? "expanded" : "collapsed"
 
   const contextValue = React.useMemo<SidebarContextProps>(
     () => ({
@@ -451,7 +453,15 @@ function Sidebar({
         >
           {children}
         </div>
-        {(!collapseToZero || pinned) && <SidebarResizeHandle side={side} />}
+        {(!collapseToZero || pinned) && (
+          <SidebarResizeHandle
+            side={side}
+            // The shared handle hides itself below `sm`, a viewport rule that
+            // does not hold for a desktop window the user narrowed: there the
+            // sidebar is still the desktop one and still resizable.
+            className={collapseToZero ? "block" : undefined}
+          />
+        )}
       </div>
     </div>
   )

--- a/studio/frontend/src/components/ui/sidebar.tsx
+++ b/studio/frontend/src/components/ui/sidebar.tsx
@@ -57,6 +57,9 @@ type SidebarContextProps = {
   pinned: boolean
   setPinned: (value: boolean) => void
   togglePinned: () => void
+  /** The unpinned sidebar is held out over the content, from the window edge. */
+  peeking: boolean
+  setPeeking: (value: boolean) => void
   width: number
   storedWidth: number
   maxWidth: number
@@ -161,6 +164,24 @@ function SidebarProvider({
   const setPinned = setPinnedProp ?? noop
   const togglePinned = togglePinnedProp ?? noop
 
+  // Reaches a collapsed sidebar from the window edge without pinning it.
+  const [peeking, setPeekingState] = React.useState(false)
+  const retractRef = React.useRef<number | undefined>(undefined)
+  // Deferred so the handoff from the edge strip to the panel cannot flicker.
+  const setPeeking = React.useCallback((next: boolean) => {
+    window.clearTimeout(retractRef.current)
+    if (next) {
+      setPeekingState(true)
+      return
+    }
+    retractRef.current = window.setTimeout(() => setPeekingState(false), 120)
+  }, [])
+  React.useEffect(() => () => window.clearTimeout(retractRef.current), [])
+  // Nothing to hold out once it is pinned, or once it is a mobile sheet.
+  React.useEffect(() => {
+    if (pinned || isMobile) setPeekingState(false)
+  }, [pinned, isMobile])
+
   const contextValue = React.useMemo<SidebarContextProps>(
     () => ({
       state,
@@ -174,13 +195,15 @@ function SidebarProvider({
       pinned,
       setPinned,
       togglePinned,
+      peeking,
+      setPeeking,
       width,
       storedWidth,
       maxWidth,
       setWidth,
       resetWidth,
     }),
-    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar, hasPinMode, pinned, setPinned, togglePinned, width, storedWidth, maxWidth, setWidth, resetWidth]
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar, hasPinMode, pinned, setPinned, togglePinned, peeking, setPeeking, width, storedWidth, maxWidth, setWidth, resetWidth]
   )
 
   return (
@@ -273,8 +296,11 @@ function Sidebar({
   collapsible?: "offcanvas" | "icon" | "none"
   collapseToZero?: boolean
 }) {
-  const { isMobile, state, openMobile, setOpenMobile, hasPinMode, pinned, width } =
+  const { isMobile, state, openMobile, setOpenMobile, hasPinMode, pinned, peeking, setPeeking, width } =
     useSidebar()
+  // Only a sidebar that collapses to nothing has an edge to be held out from.
+  const holdsOut = hasPinMode && !pinned && collapseToZero
+  const heldOut = holdsOut && peeking
 
   // The scoped home for --sidebar-width: every consumer (this element,
   // sidebar-gap, sidebar-container) is inside it and the chat thread is not.
@@ -343,8 +369,9 @@ function Sidebar({
       data-side={side}
       data-slot="sidebar"
       style={scopedWidthStyle}
-      aria-hidden={(hasPinMode && !pinned && collapseToZero) || undefined}
-      inert={(hasPinMode && !pinned && collapseToZero) || undefined}
+      // Held out, it is on screen and must answer the pointer again.
+      aria-hidden={(holdsOut && !heldOut) || undefined}
+      inert={(holdsOut && !heldOut) || undefined}
     >
       {/* This is what handles the sidebar gap on desktop */}
       <div
@@ -376,6 +403,11 @@ function Sidebar({
       <div
         data-slot="sidebar-container"
         data-side={side}
+        data-held-out={heldOut || undefined}
+        // A hover state of the panel as much as of the edge: the pointer
+        // crosses between them, and only leaving both retracts it.
+        onPointerEnter={holdsOut ? () => setPeeking(true) : undefined}
+        onPointerLeave={holdsOut ? () => setPeeking(false) : undefined}
         className={cn(
           hasPinMode
             ? cn(
@@ -384,7 +416,17 @@ function Sidebar({
                 pinned
                   ? "w-(--sidebar-width)"
                   : collapseToZero
-                    ? "w-0 overflow-hidden"
+                    ? cn(
+                        // Full width all along, parked off-screen: animating a
+                        // width reflows the panel's contents every frame, a
+                        // transform does not.
+                        "w-(--sidebar-width)",
+                        // The transition rides on the held-out class alone, so
+                        // collapsing a pinned sidebar still goes instantly.
+                        heldOut
+                          ? "z-[45] translate-x-0 transition-transform duration-200 ease-out"
+                          : "-translate-x-full pointer-events-none",
+                      )
                     : "w-(--sidebar-width-icon)",
               )
             : cn(

--- a/studio/frontend/src/hooks/use-mobile.ts
+++ b/studio/frontend/src/hooks/use-mobile.ts
@@ -1,18 +1,24 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { isTauri } from "@/lib/api-base";
 import { useSyncExternalStore } from "react";
 
 const MOBILE_BREAKPOINT = 768;
 const MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`;
 
+// A narrowed desktop window is still a desktop window. The mobile shell has its
+// own sidebar (a sheet over a dimmed page) and header, so crossing the
+// breakpoint by dragging the window edge would restyle the app, not fit it.
+const FOLLOWS_BREAKPOINT = !isTauri;
+
 function getSnapshot(): boolean {
-  if (typeof window === "undefined") return false;
+  if (typeof window === "undefined" || !FOLLOWS_BREAKPOINT) return false;
   return window.matchMedia(MEDIA_QUERY).matches;
 }
 
 function subscribe(callback: () => void): () => void {
-  if (typeof window === "undefined") return () => {};
+  if (typeof window === "undefined" || !FOLLOWS_BREAKPOINT) return () => {};
   const mql = window.matchMedia(MEDIA_QUERY);
   mql.addEventListener("change", callback);
   return () => mql.removeEventListener("change", callback);

--- a/studio/frontend/src/hooks/use-mobile.ts
+++ b/studio/frontend/src/hooks/use-mobile.ts
@@ -7,23 +7,32 @@ import { useSyncExternalStore } from "react";
 const MOBILE_BREAKPOINT = 768;
 const MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`;
 
-// A narrowed desktop window is still a desktop window. The mobile shell has its
-// own sidebar (a sheet over a dimmed page) and header, so crossing the
-// breakpoint by dragging the window edge would restyle the app, not fit it.
-const FOLLOWS_BREAKPOINT = !isTauri;
-
 function getSnapshot(): boolean {
-  if (typeof window === "undefined" || !FOLLOWS_BREAKPOINT) return false;
+  if (typeof window === "undefined") return false;
   return window.matchMedia(MEDIA_QUERY).matches;
 }
 
 function subscribe(callback: () => void): () => void {
-  if (typeof window === "undefined" || !FOLLOWS_BREAKPOINT) return () => {};
+  if (typeof window === "undefined") return () => {};
   const mql = window.matchMedia(MEDIA_QUERY);
   mql.addEventListener("change", callback);
   return () => mql.removeEventListener("change", callback);
 }
 
+/**
+ * A viewport too narrow to put a panel beside the content. Every platform: a
+ * submenu or a settings panel that only has room to overlay has to overlay.
+ */
 export function useIsMobile(): boolean {
   return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}
+
+/**
+ * Whether to swap in the mobile shell: a sheet sidebar over a dimmed page, its
+ * own width, its own header. Never in the desktop app, where a narrowed window
+ * is still a desktop window, and restyling the shell around it is not the same
+ * as fitting it.
+ */
+export function useIsMobileShell(): boolean {
+  return useIsMobile() && !isTauri;
 }

--- a/studio/frontend/tests/window-layout.test.ts
+++ b/studio/frontend/tests/window-layout.test.ts
@@ -59,6 +59,18 @@ test("lets a window stay squeezed to a companion width", () => {
   );
 });
 
+test("never opens a first window below the resize floor", () => {
+  // Small enough that the nominal size relaxes: 85% of it is under the floor.
+  const bounds = calculateWindowSizeBounds({ width: 700, height: 500 });
+  const first = calculateFirstAppWindowSize(bounds);
+
+  // Opening under the floor leaves the size constraints to grow the window
+  // afterwards, away from the centre it was just placed on.
+  assert.ok(first.width >= bounds.minimum.width, `width ${first.width}`);
+  assert.ok(first.height >= bounds.minimum.height, `height ${first.height}`);
+  assert.deepEqual(first, { width: 595, height: 480 });
+});
+
 test("keeps the resize floor a CSS-pixel floor under webview zoom", () => {
   const workAreaSize = { width: 1920, height: 1040 };
 

--- a/studio/frontend/tests/window-layout.test.ts
+++ b/studio/frontend/tests/window-layout.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 
 import {
   DEFAULT_APP_WINDOW_SIZE_BOUNDS,
+  MINIMUM_APP_WINDOW_SIZE,
   PREFERRED_SETUP_WINDOW_SIZE,
   calculateCenteredPosition,
   calculateFirstAppWindowSize,
@@ -39,11 +40,40 @@ test("waits for the first native restore event before settling", () => {
 test("keeps the nominal minimum and preferred size on a roomy work area", () => {
   const bounds = calculateWindowSizeBounds({ width: 1920, height: 1040 });
 
-  assert.deepEqual(bounds.minimum, { width: 900, height: 600 });
+  // The resize floor is a companion width, not the size a first launch opens.
+  assert.deepEqual(bounds.minimum, MINIMUM_APP_WINDOW_SIZE);
   assert.deepEqual(calculateFirstAppWindowSize(bounds), {
     width: 1440,
     height: 884,
   });
+});
+
+test("lets a window stay squeezed to a companion width", () => {
+  const bounds = calculateWindowSizeBounds({ width: 1920, height: 1040 });
+  const squeezed = { width: 480, height: 700 };
+
+  // Nothing widens it back to a desktop size once the user has narrowed it.
+  assert.deepEqual(
+    constrainWindowSize(squeezed, bounds.minimum, bounds),
+    squeezed,
+  );
+});
+
+test("keeps the resize floor a CSS-pixel floor under webview zoom", () => {
+  const workAreaSize = { width: 1920, height: 1040 };
+
+  // Windows text scaling: the window measures in logical pixels but lays out
+  // in fewer CSS pixels, so the floor has to grow by the same ratio.
+  const zoomed = calculateWindowSizeBounds(workAreaSize, 1.5);
+  assert.deepEqual(zoomed.minimum, {
+    width: MINIMUM_APP_WINDOW_SIZE.width * 1.5,
+    height: MINIMUM_APP_WINDOW_SIZE.height * 1.5,
+  });
+  // No zoom, no change: every platform without text scaling.
+  assert.deepEqual(
+    calculateWindowSizeBounds(workAreaSize, 1).minimum,
+    MINIMUM_APP_WINDOW_SIZE,
+  );
 });
 
 test("fits a 1366x768 panel at 125% scaling above the taskbar", () => {
@@ -290,10 +320,9 @@ test("remeasures a restored window after show on its compact secondary", async (
     "constraints",
     "enforce",
   ]);
-  assert.deepEqual(constrainedMinimum, { width: 900, height: 494 });
-  assert.deepEqual(enforcementBounds, {
-    minimum: { width: 900, height: 494 },
-  });
+  assert.deepEqual(constrainedMinimum, MINIMUM_APP_WINDOW_SIZE);
+  assert.deepEqual(enforcementBounds, { minimum: MINIMUM_APP_WINDOW_SIZE });
+  // The restored size survives: the floor no longer inflates a saved window.
   assert.deepEqual(savedSize, { width: 900, height: 556 });
 });
 

--- a/studio/frontend/tests/window-layout.test.ts
+++ b/studio/frontend/tests/window-layout.test.ts
@@ -18,6 +18,7 @@ import {
   finalizeAppWindowLayout,
   shouldFinishWindowLayoutWait,
   measureWindowLayout,
+  observeDevicePixelRatio,
 } from "../src/app/window-layout-lifecycle.ts";
 
 // A work area is the panel minus the taskbar, in logical pixels.
@@ -57,6 +58,56 @@ test("lets a window stay squeezed to a companion width", () => {
     constrainWindowSize(squeezed, bounds.minimum, bounds),
     squeezed,
   );
+});
+
+function pixelRatioHarness(initial: number) {
+  const queries: { dppx: number; listeners: Array<() => void> }[] = [];
+  let ratio = initial;
+  const source = {
+    devicePixelRatio: () => ratio,
+    matchResolution: (dppx: number) => {
+      const entry = { dppx, listeners: [] as Array<() => void> };
+      queries.push(entry);
+      return {
+        addEventListener: (_type: "change", listener: () => void) => {
+          entry.listeners.push(listener);
+        },
+        removeEventListener: (_type: "change", listener: () => void) => {
+          entry.listeners = entry.listeners.filter((l) => l !== listener);
+        },
+      };
+    },
+  };
+  const change = (next: number) => {
+    ratio = next;
+    for (const listener of [...queries[queries.length - 1].listeners]) {
+      listener();
+    }
+  };
+  return { source, queries, change };
+}
+
+test("rearms the resolution query on every pixel ratio change", () => {
+  const { source, queries, change } = pixelRatioHarness(1);
+  let changes = 0;
+  const dispose = observeDevicePixelRatio(source, () => {
+    changes += 1;
+  });
+
+  // The query that reports a change is the one that stopped matching, so the
+  // next change has to come off a query for the ratio now in force.
+  change(1.5);
+  assert.equal(changes, 1);
+  change(2);
+  assert.equal(changes, 2);
+  assert.deepEqual(
+    queries.map((query) => query.dppx),
+    [1, 1.5, 2],
+  );
+
+  dispose();
+  change(1);
+  assert.equal(changes, 2);
 });
 
 test("never opens a first window below the resize floor", () => {


### PR DESCRIPTION
## What this changes

Three related fixes to the desktop app's window sizing and to the collapsed sidebar.

### The window can narrow to a companion width

The resize floor was 900x600, the same size a first launch opens at, so the window could not be squeezed down to sit beside another one. The floor is now a separate constant from the first-launch size and is lowered to 460x480. First launch is unchanged.

The floor is applied in CSS pixels rather than logical pixels. Windows text scaling zooms the webview above the display scale, so a 460 logical pixel window would lay out as a 307px viewport at 150%, which is narrower than the layout can hold.

### A narrowed desktop window keeps the desktop shell

`useIsMobile()` follows a 768px media query, so dragging the window narrow crossed into the mobile shell: the sidebar became an overlay sheet over a dimmed page, at a different width, under a different header. The desktop app now ignores the breakpoint, so the layout at 460px is the same one as at 1440px, only tighter.

### The collapsed sidebar can be reached from the window edge

On desktop the sidebar collapses to zero width, so once it was away the titlebar toggle was the only way back to it. There is now a strip on the left window edge:

- hover holds the sidebar out over the content, without pinning it
- Tab reaches it, and from there the keyboard behaves as it does on the sidebar's own edge: Enter pins, the arrows resize, Home resets
- click pins it and drag resizes it on Windows and Linux, where the strip is 12px

On macOS the strip is 2px and hover plus the keyboard are what land there: a decorated window keeps its resize border over the first few CSS pixels of the content and takes the press, so a click or a drag on the strip goes to the window. Hover is the affordance that matters there, and it is the one the sidebar's own edge never offered.

It is the existing `PanelResizeHandle`, anchored to the window instead of to an off-screen panel, so the cursor, the drag-past-minimum-to-reopen and the keyboard handling are the ones already in use. I added two props to it, `onHoverChange` and `hideTooltip`, both optional and both no-ops for existing callers.

The pinned sidebar looks exactly as it did. No shadow, no new transition, and collapsing a pinned sidebar is still instant.

## Platform notes

The edge strip is 2px on macOS. On Windows and Linux the window is undecorated (`setup_custom_titlebar` calls `set_decorations(false)`) and the toolkit hit-tests its own resize border inside the window, so a 2px strip there would land entirely inside that border. It is 12px on those platforms.

## Testing

- `npm test`: 7212 passing, including new cases for the resize floor, the CSS pixel floor and the pixel-ratio listener
- `npm run typecheck`: clean
- `npm run i18n:check`: parity passes
- By hand in a build on macOS: the window clamps to exactly 460x480, the desktop layout stays intact at that size with no dimmed overlay and no misplaced sidebar toggle, and hovering the edge holds the sidebar out. Press and drag on the 2px strip do not reach the webview there, confirmed from a pointer event log: moves arrive at clientX 0 to 5, a press at the same x produces no event and hits the window's resize border instead. A synthetic drag on the strip was used to confirm the resize path itself commits (live width painted on the sidebar mid-drag, width committed and the panel pinned on release).

Windows and Linux were worked out from the source rather than on hardware, so the edge strip width, the press and drag on that wider strip, and the CSS pixel floor are the parts worth a second look from someone on those platforms.
