### PR TITLE
Studio: keep prompt cache on seeded tool-loop continuations

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -30220,6 +30220,10 @@ class LlamaCppBackend:
         _continuation_max_tokens: Optional[int] = None
         _continuation_credits = 0
         _MAX_CONTINUATION_CREDITS = _MAX_LENGTH_CONTINUATIONS * max(1, max_tool_iterations)
+        # True once an in-loop llama-server body has been built. max_tool_iterations=0
+        # breaks before that and falls straight into the final pass, which must keep
+        # #9979's cold-cache pin for a fixed seed.
+        _in_loop_request_sent = False
         iteration = -1
         while True:
             iteration += 1
@@ -30476,6 +30480,7 @@ class LlamaCppBackend:
             # re-prompt after the first request) extend a prefix already in the slot, so
             # disabling reuse would re-prefill the entire context after every tool call.
             _apply_seeded_llama_request(payload, seed, reuse_prompt_cache = iteration > 0)
+            _in_loop_request_sent = True
 
             _respawn_truncations: list[dict] = []
 
@@ -32946,8 +32951,12 @@ class LlamaCppBackend:
         stream_payload["max_tokens"] = _final_max_tokens
         if stop:
             stream_payload["stop"] = stop
-        # Reached only after at least one in-loop request left KV in the slot.
-        _apply_seeded_llama_request(stream_payload, seed, reuse_prompt_cache = True)
+        # Reuse only when an in-loop request already left KV in the slot. A
+        # max_tool_iterations=0 run never enters the loop and this pass is the first
+        # request, so it must keep the cold-cache pin for a fixed seed.
+        _apply_seeded_llama_request(
+            stream_payload, seed, reuse_prompt_cache = _in_loop_request_sent
+        )
         stream_payload["stream_options"] = {"include_usage": True}
 
         # Progress events feed the first-token deadline; timings stay opt-in.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -631,12 +631,27 @@ _SPEC_KIND_CAPABILITY: dict[str, str] = {
 _LLAMA_RANDOM_SEED = 0xFFFFFFFF
 
 
-def _apply_seeded_llama_request(payload: dict, seed: Optional[int]) -> None:
-    """Disable prompt caching for fixed seeds so repeated requests stay reproducible."""
+def _apply_seeded_llama_request(
+    payload: dict,
+    seed: Optional[int],
+    *,
+    reuse_prompt_cache: bool = False,
+) -> None:
+    """Apply ``seed`` to a llama-server body.
+
+    Fixed seeds normally set ``cache_prompt: false`` so repeating the *same* prompt
+    stays bit-reproducible (#9979). Tool-loop continuations are not that case: each
+    round appends tool results onto a prefix the previous round already evaluated, and
+    forcing a cold cache re-prefills the whole context after every tool call (#10698).
+    Pass ``reuse_prompt_cache=True`` on those growing rounds (and the synthesised final
+    answer) so the seed still applies while KV reuse stays on.
+    """
     if seed is None:
         return
     payload["seed"] = seed
     # Compared as uint32: the schemas also accept 4294967295, the same "pick at random".
+    if reuse_prompt_cache:
+        return
     if (seed & 0xFFFFFFFF) != _LLAMA_RANDOM_SEED:
         payload["cache_prompt"] = False
 
@@ -30457,7 +30472,12 @@ class LlamaCppBackend:
                 _continuation_max_tokens = None
             if stop:
                 payload["stop"] = stop
-            _apply_seeded_llama_request(payload, seed)
+            # Round 0 keeps #9979's cold cache for a fixed seed. Later rounds (and any
+            # re-prompt after the first request) extend a prefix already in the slot, so
+            # disabling reuse would re-prefill the entire context after every tool call.
+            _apply_seeded_llama_request(
+                payload, seed, reuse_prompt_cache = iteration > 0
+            )
 
             _respawn_truncations: list[dict] = []
 
@@ -32928,7 +32948,8 @@ class LlamaCppBackend:
         stream_payload["max_tokens"] = _final_max_tokens
         if stop:
             stream_payload["stop"] = stop
-        _apply_seeded_llama_request(stream_payload, seed)
+        # Reached only after at least one in-loop request left KV in the slot.
+        _apply_seeded_llama_request(stream_payload, seed, reuse_prompt_cache = True)
         stream_payload["stream_options"] = {"include_usage": True}
 
         # Progress events feed the first-token deadline; timings stay opt-in.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -30475,9 +30475,7 @@ class LlamaCppBackend:
             # Round 0 keeps #9979's cold cache for a fixed seed. Later rounds (and any
             # re-prompt after the first request) extend a prefix already in the slot, so
             # disabling reuse would re-prefill the entire context after every tool call.
-            _apply_seeded_llama_request(
-                payload, seed, reuse_prompt_cache = iteration > 0
-            )
+            _apply_seeded_llama_request(payload, seed, reuse_prompt_cache = iteration > 0)
 
             _respawn_truncations: list[dict] = []
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -32954,9 +32954,7 @@ class LlamaCppBackend:
         # Reuse only when an in-loop request already left KV in the slot. A
         # max_tool_iterations=0 run never enters the loop and this pass is the first
         # request, so it must keep the cold-cache pin for a fixed seed.
-        _apply_seeded_llama_request(
-            stream_payload, seed, reuse_prompt_cache = _in_loop_request_sent
-        )
+        _apply_seeded_llama_request(stream_payload, seed, reuse_prompt_cache = _in_loop_request_sent)
         stream_payload["stream_options"] = {"include_usage": True}
 
         # Progress events feed the first-token deadline; timings stay opt-in.

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -337,6 +337,63 @@ def test_plain_random_seed_sentinel_keeps_slot_prompt_cache_reuse(monkeypatch):
     assert "cache_prompt" not in payloads[0]
 
 
+def test_reuse_prompt_cache_keeps_fixed_seed_without_disabling_slot_reuse():
+    """Tool-loop continuations opt out of #9979's cold-cache pin (#10698)."""
+    from core.inference.llama_cpp import _apply_seeded_llama_request
+
+    cold: dict = {}
+    _apply_seeded_llama_request(cold, 3407)
+    assert cold == {"seed": 3407, "cache_prompt": False}
+
+    warm: dict = {}
+    _apply_seeded_llama_request(warm, 3407, reuse_prompt_cache = True)
+    assert warm == {"seed": 3407}
+    assert "cache_prompt" not in warm
+
+
+def test_seeded_tool_loop_keeps_prompt_cache_after_the_first_round(monkeypatch):
+    """#10698: a fixed Seed must not force a full re-prefill after every tool call.
+
+    Round 0 still disables cache reuse for reproducibility (#9979). Round 1+ and the
+    synthesised final answer keep the seed but leave ``cache_prompt`` unset so the
+    growing prefix can reuse the slot KV.
+    """
+    streams = [
+        _structured_tool_call("web_search", {"query": "kernel"}, "call_search"),
+        [_sse({"content": "Linux 6.10."}), _done()],
+    ]
+    backend, payloads = _backend_and_payloads(monkeypatch, streams)
+    monkeypatch.setattr(
+        "core.inference.tools.execute_tool",
+        lambda name, arguments, **_kwargs: "Linux kernel 6.10",
+    )
+
+    list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "search then answer"}],
+            tools = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "web_search",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            seed = 3407,
+            max_tool_iterations = 5,
+            permission_mode = "off",
+        )
+    )
+
+    assert len(payloads) >= 2
+    assert payloads[0]["seed"] == 3407
+    assert payloads[0]["cache_prompt"] is False
+    for later in payloads[1:]:
+        assert later["seed"] == 3407
+        assert "cache_prompt" not in later, later
+
+
 def test_tool_stream_reports_progress_without_leaking_a_content_event(monkeypatch):
     stream = [
         _progress(processed = 512, cached = 0, time_ms = 64),

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -394,6 +394,28 @@ def test_seeded_tool_loop_keeps_prompt_cache_after_the_first_round(monkeypatch):
         assert "cache_prompt" not in later, later
 
 
+def test_seeded_zero_tool_iterations_keeps_cold_cache_on_the_final_pass(monkeypatch):
+    """max_tool_iterations=0 never sends an in-loop request; the final pass is round 0."""
+    backend, payloads = _backend_and_payloads(
+        monkeypatch,
+        [[_sse({"content": "no tools this turn"}), _done()]],
+    )
+
+    list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "just answer"}],
+            tools = [],
+            seed = 3407,
+            max_tool_iterations = 0,
+            permission_mode = "off",
+        )
+    )
+
+    assert len(payloads) == 1
+    assert payloads[0]["seed"] == 3407
+    assert payloads[0]["cache_prompt"] is False
+
+
 def test_tool_stream_reports_progress_without_leaking_a_content_event(monkeypatch):
     stream = [
         _progress(processed = 512, cached = 0, time_ms = 64),

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -9718,6 +9718,9 @@ def test_the_two_seed_helpers_agree_on_which_seeds_are_random():
             payload = {}
             _apply_seeded_llama_request(payload, value)
             assert payload["cache_prompt"] is False, (seed, value)
+            warm = {}
+            _apply_seeded_llama_request(warm, value, reuse_prompt_cache = True)
+            assert warm == {"seed": value}, (seed, value, warm)
 
 
 class TestPassthroughImageNormalization:


### PR DESCRIPTION
## Summary
- Fixes #10698 for the fixed-Seed path introduced by #9979: tool-loop continuations kept `cache_prompt: false`, so llama-server re-prefilled the whole prompt after every tool call even when LCP still matched the slot.
- Round 0 of a tool loop (and plain `generate_chat_completion` / OpenAI passthrough) still disables cache reuse for a fixed seed, so identical-prompt reproducibility from #9979 is unchanged.
- Later tool rounds and the synthesised final-answer pass keep the seed but leave `cache_prompt` unset so the growing prefix can reuse slot KV.

## Approach
`_apply_seeded_llama_request(..., reuse_prompt_cache=False)` gains an opt-in. The tool loop passes `reuse_prompt_cache=iteration > 0` on each round and `True` on the final stream. No change to default Seed (`null`) behaviour.

**Caveat:** the reporter has not yet confirmed Seed was set on the slow run. This PR is still the correct narrow fix for that interaction; if Seed was unset, the logs are still a real regression and we would need a follow-up.

## Test plan
- [x] Unit: helper with/without `reuse_prompt_cache`
- [x] Unit: seeded tool loop — round 0 has `cache_prompt: false`, later rounds do not
- [x] Existing fixed-seed / random-sentinel tests still assert the #9979 contract
- [ ] CI: `tests/test_llama_cpp_tool_loop.py` seed cases + `test_the_two_seed_helpers_agree_on_which_seeds_are_random`
- [ ] Manual (optional): fixed Seed + multi-tool turn; llama-server `prompt_eval` should be a delta after the first tool, not the full context