### PR TITLE
Studio: JSON and Markdown validator blocks

### DIFF
--- a/studio/backend/core/data_recipe/service.py
+++ b/studio/backend/core/data_recipe/service.py
@@ -16,6 +16,10 @@ from .local_callable_validators import (
     register_oxc_local_callable_validators,
     split_oxc_local_callable_validators,
 )
+from .text_format_validators import (
+    register_text_format_local_callable_validators,
+    split_text_format_local_callable_validators,
+)
 
 _IMAGE_CONTEXT_PATCHED = False
 
@@ -264,10 +268,15 @@ def build_config_builder(recipe: dict[str, Any]):
     }
     recipe_core = _strip_frontend_model_config_metadata(recipe_core)
     recipe_core, oxc_local_callable_specs = split_oxc_local_callable_validators(recipe_core)
+    recipe_core, text_format_specs = split_text_format_local_callable_validators(recipe_core)
     builder = DataDesignerConfigBuilder.from_config({"data_designer": recipe_core})
     register_oxc_local_callable_validators(
         builder = builder,
         specs = oxc_local_callable_specs,
+    )
+    register_text_format_local_callable_validators(
+        builder = builder,
+        specs = text_format_specs,
     )
 
     # DataDesignerConfigBuilder.from_config skips processors; re-attach so drop_columns/schema_transform

--- a/studio/backend/core/data_recipe/text_format_validators.py
+++ b/studio/backend/core/data_recipe/text_format_validators.py
@@ -155,9 +155,7 @@ def _build_text_format_validation_function(format_kind: str):
             else [_coerce_validation_value(value) for value in df[value_column].tolist()]
         )
 
-        results = [
-            _validate_text_format(value = value, format_kind = format_kind) for value in values
-        ]
+        results = [_validate_text_format(value = value, format_kind = format_kind) for value in values]
         return pd.DataFrame(results)
 
     _validator.__name__ = f"{format_kind}_format_validator"

--- a/studio/backend/core/data_recipe/text_format_validators.py
+++ b/studio/backend/core/data_recipe/text_format_validators.py
@@ -1,0 +1,266 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+from __future__ import annotations
+
+import json
+import re
+from copy import deepcopy
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any
+
+JSON_VALIDATION_FN_MARKER = "unsloth_json_validator"
+MARKDOWN_VALIDATION_FN_MARKER = "unsloth_markdown_validator"
+
+_MARKDOWN_FENCE_RE = re.compile(r"```")
+
+
+@dataclass(frozen = True)
+class TextFormatLocalCallableValidatorSpec:
+    name: str
+    drop: bool
+    target_columns: list[str]
+    batch_size: int
+    format_kind: str
+
+
+def split_text_format_local_callable_validators(
+    recipe_core: dict[str, Any],
+) -> tuple[dict[str, Any], list[TextFormatLocalCallableValidatorSpec]]:
+    columns = recipe_core.get("columns")
+    if not isinstance(columns, list):
+        return recipe_core, []
+
+    sanitized = deepcopy(recipe_core)
+    sanitized_columns = sanitized.get("columns")
+    if not isinstance(sanitized_columns, list):
+        return sanitized, []
+
+    kept_columns: list[Any] = []
+    specs: list[TextFormatLocalCallableValidatorSpec] = []
+
+    for column in sanitized_columns:
+        if not isinstance(column, dict):
+            kept_columns.append(column)
+            continue
+
+        maybe_spec = _parse_text_format_spec(column = column)
+        if maybe_spec is None:
+            kept_columns.append(column)
+            continue
+        specs.append(maybe_spec)
+
+    sanitized["columns"] = kept_columns
+    return sanitized, specs
+
+
+def register_text_format_local_callable_validators(
+    *, builder, specs: list[TextFormatLocalCallableValidatorSpec]
+) -> None:
+    if not specs:
+        return
+
+    from data_designer.config.column_configs import ValidationColumnConfig
+    from data_designer.config.validator_params import (
+        LocalCallableValidatorParams,
+        ValidatorType,
+    )
+
+    for spec in specs:
+        validation_function = _build_text_format_validation_function(spec.format_kind)
+        builder.add_column(
+            ValidationColumnConfig(
+                name = spec.name,
+                drop = spec.drop,
+                target_columns = spec.target_columns,
+                validator_type = ValidatorType.LOCAL_CALLABLE,
+                validator_params = LocalCallableValidatorParams(
+                    validation_function = validation_function,
+                ),
+                batch_size = spec.batch_size,
+            )
+        )
+
+
+def _parse_text_format_spec(
+    *, column: dict[str, Any]
+) -> TextFormatLocalCallableValidatorSpec | None:
+    if str(column.get("column_type") or "").strip() != "validation":
+        return None
+    if str(column.get("validator_type") or "").strip() != "local_callable":
+        return None
+
+    params = column.get("validator_params")
+    if not isinstance(params, dict):
+        return None
+
+    fn_raw = params.get("validation_function")
+    fn_name = fn_raw.strip() if isinstance(fn_raw, str) else ""
+    format_kind = _text_format_kind_from_marker(fn_name)
+    if format_kind is None:
+        return None
+
+    name = str(column.get("name") or "").strip()
+    if not name:
+        return None
+
+    target_columns_raw = column.get("target_columns")
+    target_columns = (
+        [value.strip() for value in target_columns_raw if isinstance(value, str) and value.strip()]
+        if isinstance(target_columns_raw, list)
+        else []
+    )
+    if not target_columns:
+        return None
+
+    return TextFormatLocalCallableValidatorSpec(
+        name = name,
+        drop = bool(column.get("drop") is True),
+        target_columns = target_columns,
+        batch_size = _parse_batch_size(column.get("batch_size")),
+        format_kind = format_kind,
+    )
+
+
+def _text_format_kind_from_marker(fn_name: str) -> str | None:
+    if fn_name == JSON_VALIDATION_FN_MARKER:
+        return "json"
+    if fn_name == MARKDOWN_VALIDATION_FN_MARKER:
+        return "markdown"
+    return None
+
+
+def _parse_batch_size(value: Any) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 10
+    return parsed if parsed >= 1 else 10
+
+
+@lru_cache(maxsize = 4)
+def _build_text_format_validation_function(format_kind: str):
+    def _validator(df):
+        import pandas as pd
+
+        row_count = int(len(df.index))
+        if row_count == 0:
+            return pd.DataFrame({"is_valid": []})
+
+        value_column = str(df.columns[0]) if len(df.columns) > 0 else ""
+        values = (
+            ["" for _ in range(row_count)]
+            if not value_column
+            else [_coerce_validation_value(value) for value in df[value_column].tolist()]
+        )
+
+        results = [
+            _validate_text_format(value = value, format_kind = format_kind) for value in values
+        ]
+        return pd.DataFrame(results)
+
+    _validator.__name__ = f"{format_kind}_format_validator"
+    return _validator
+
+
+def _coerce_validation_value(value: Any) -> Any:
+    if value is None:
+        return ""
+    if isinstance(value, (dict, list, bool, int, float)):
+        return value
+    return str(value)
+
+
+def _reject_json_constant(constant: str) -> float:
+    raise ValueError(f"Invalid JSON constant: {constant}")
+
+
+def _validate_text_format(*, value: Any, format_kind: str) -> dict[str, Any]:
+    if format_kind == "json":
+        return _validate_json_text(value)
+    if format_kind == "markdown":
+        return _validate_markdown_text(value)
+    return {
+        "is_valid": False,
+        "error_count": 1,
+        "error_message": f"Unsupported format validator: {format_kind}",
+        "severity": None,
+        "code": None,
+        "labels": [],
+        "codeframe": None,
+        "warning_count": 0,
+    }
+
+
+def _validate_json_text(value: Any) -> dict[str, Any]:
+    if isinstance(value, (dict, list)):
+        payload = value
+    else:
+        stripped = str(value).strip()
+        if not stripped:
+            return _invalid_result("JSON value is empty.")
+        try:
+            payload = json.loads(stripped, parse_constant = _reject_json_constant)
+        except (json.JSONDecodeError, ValueError, RecursionError) as exc:
+            return _invalid_result(str(exc))
+    try:
+        json.dumps(payload, allow_nan = False)
+    except (TypeError, ValueError) as exc:
+        return _invalid_result(str(exc))
+    return _valid_result()
+
+
+def _markdown_segments_outside_fences(value: str) -> list[str]:
+    segments: list[str] = []
+    cursor = 0
+    in_fence = False
+    for match in _MARKDOWN_FENCE_RE.finditer(value):
+        if not in_fence:
+            segments.append(value[cursor : match.start()])
+        in_fence = not in_fence
+        cursor = match.end()
+    if not in_fence:
+        segments.append(value[cursor:])
+    return segments
+
+
+def _validate_markdown_text(value: Any) -> dict[str, Any]:
+    stripped = str(value).strip()
+    if not stripped:
+        return _invalid_result("Markdown value is empty.")
+    fence_count = len(_MARKDOWN_FENCE_RE.findall(stripped))
+    if fence_count % 2 != 0:
+        return _invalid_result("Markdown has an unclosed code fence.")
+    for segment in _markdown_segments_outside_fences(stripped):
+        if segment.count("[") != segment.count("]"):
+            return _invalid_result("Markdown has unbalanced link brackets.")
+        if segment.count("(") != segment.count(")"):
+            return _invalid_result("Markdown has unbalanced parentheses.")
+    return _valid_result()
+
+
+def _valid_result() -> dict[str, Any]:
+    return {
+        "is_valid": True,
+        "error_count": 0,
+        "error_message": "",
+        "severity": None,
+        "code": None,
+        "labels": [],
+        "codeframe": None,
+        "warning_count": 0,
+    }
+
+
+def _invalid_result(message: str) -> dict[str, Any]:
+    return {
+        "is_valid": False,
+        "error_count": 1,
+        "error_message": message,
+        "severity": None,
+        "code": None,
+        "labels": [],
+        "codeframe": None,
+        "warning_count": 0,
+    }

--- a/studio/backend/tests/test_text_format_validators.py
+++ b/studio/backend/tests/test_text_format_validators.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+from core.data_recipe.text_format_validators import (
+    JSON_VALIDATION_FN_MARKER,
+    MARKDOWN_VALIDATION_FN_MARKER,
+    _validate_json_text,
+    _validate_markdown_text,
+    split_text_format_local_callable_validators,
+)
+
+
+def test_validate_json_text_accepts_object_payload():
+    result = _validate_json_text('{"answer": "ok"}')
+    assert result["is_valid"] is True
+
+
+def test_validate_json_text_rejects_invalid_payload():
+    result = _validate_json_text("{not json")
+    assert result["is_valid"] is False
+    assert result["error_message"]
+
+
+def test_validate_markdown_text_rejects_unclosed_fence():
+    result = _validate_markdown_text("```python\nprint('hi')")
+    assert result["is_valid"] is False
+    assert "fence" in result["error_message"].lower()
+
+
+def test_validate_markdown_text_accepts_simple_markdown():
+    result = _validate_markdown_text("# Title\n\nSome **bold** text.")
+    assert result["is_valid"] is True
+
+
+def test_split_text_format_local_callable_validators_extracts_json_and_markdown_specs():
+    recipe = {
+        "columns": [
+            {
+                "column_type": "validation",
+                "name": "json_check",
+                "target_columns": ["payload"],
+                "validator_type": "local_callable",
+                "validator_params": {
+                    "validation_function": JSON_VALIDATION_FN_MARKER,
+                },
+            },
+            {
+                "column_type": "validation",
+                "name": "md_check",
+                "target_columns": ["body"],
+                "validator_type": "local_callable",
+                "validator_params": {
+                    "validation_function": MARKDOWN_VALIDATION_FN_MARKER,
+                },
+            },
+            {"column_type": "llm-text", "name": "payload"},
+        ],
+    }
+
+    sanitized, specs = split_text_format_local_callable_validators(recipe)
+
+    assert len(sanitized["columns"]) == 1
+    assert [spec.format_kind for spec in specs] == ["json", "markdown"]

--- a/studio/frontend/src/features/recipe-studio/blocks/definitions.ts
+++ b/studio/frontend/src/features/recipe-studio/blocks/definitions.ts
@@ -53,6 +53,8 @@ export type BlockType =
   | "validator_python"
   | "validator_sql"
   | "validator_oxc"
+  | "validator_json"
+  | "validator_markdown"
   | "expression"
   | "markdown_note"
   | "seed"
@@ -359,6 +361,26 @@ const BLOCK_DEFINITIONS: BlockDefinition[] = [
       makeValidatorConfig(id, "oxc", "javascript", existing),
   },
   {
+    kind: "validator",
+    type: "validator_json",
+    title: "JSON check",
+    description: "Verify a field contains valid JSON and filter out rows that fail.",
+    icon: Shield02Icon,
+    dialogKey: "validator",
+    createConfig: (id, existing) =>
+      makeValidatorConfig(id, "json", "json", existing),
+  },
+  {
+    kind: "validator",
+    type: "validator_markdown",
+    title: "Markdown check",
+    description: "Verify a field contains well-formed markdown and filter out rows that fail.",
+    icon: Shield02Icon,
+    dialogKey: "validator",
+    createConfig: (id, existing) =>
+      makeValidatorConfig(id, "markdown", "markdown", existing),
+  },
+  {
     kind: "expression",
     type: "expression",
     title: "Formula",
@@ -416,6 +438,12 @@ export function getBlockDefinitionForConfig(
     return getBlockDefinition("llm", config.llm_type);
   }
   if (config.kind === "validator") {
+    if (config.validator_type === "json") {
+      return getBlockDefinition("validator", "validator_json");
+    }
+    if (config.validator_type === "markdown") {
+      return getBlockDefinition("validator", "validator_markdown");
+    }
     if (config.validator_type === "oxc") {
       return getBlockDefinition("validator", "validator_oxc");
     }

--- a/studio/frontend/src/features/recipe-studio/components/block-sheet.tsx
+++ b/studio/frontend/src/features/recipe-studio/components/block-sheet.tsx
@@ -85,7 +85,12 @@ type BlockSheetProps = {
   onAddToolProfile: () => void;
   onAddExpression: () => void;
   onAddValidator: (
-    type: "validator_python" | "validator_sql" | "validator_oxc",
+    type:
+      | "validator_python"
+      | "validator_sql"
+      | "validator_oxc"
+      | "validator_json"
+      | "validator_markdown",
   ) => void;
   onAddMarkdownNote: () => void;
   onOpenProcessors: () => void;
@@ -379,7 +384,12 @@ export function BlockSheet({
     }
     if (kind === "validator") {
       onAddValidator(
-        type as "validator_python" | "validator_sql" | "validator_oxc",
+        type as
+          | "validator_python"
+          | "validator_sql"
+          | "validator_oxc"
+          | "validator_json"
+          | "validator_markdown",
       );
       return;
     }

--- a/studio/frontend/src/features/recipe-studio/dialogs/validators/validator-dialog.tsx
+++ b/studio/frontend/src/features/recipe-studio/dialogs/validators/validator-dialog.tsx
@@ -63,10 +63,20 @@ export function ValidatorDialog({
   const advancedOpen = config.advancedOpen === true;
   const selectedOxcMode = normalizeOxcValidationMode(config.oxc_validation_mode);
   const selectedOxcCodeShape = normalizeOxcCodeShape(config.oxc_code_shape);
-  const codeOptions = useMemo(
+  const targetOptions = useMemo(
     () =>
       Object.values(configs)
         .flatMap((item) => {
+          if (config.validator_type === "json" || config.validator_type === "markdown") {
+            if (
+              item.kind === "llm" ||
+              item.kind === "expression" ||
+              item.kind === "sampler"
+            ) {
+              return [{ name: item.name, codeLang: config.code_lang }];
+            }
+            return [];
+          }
           if (!(item.kind === "llm" && item.llm_type === "code")) {
             return [];
           }
@@ -95,7 +105,7 @@ export function ValidatorDialog({
         })
         .filter((item) => item.name.trim())
         .sort((a, b) => a.name.localeCompare(b.name)),
-    [configs],
+    [config.code_lang, config.validator_type, configs],
   );
   const currentTarget = config.target_columns[0] ?? "";
 
@@ -109,9 +119,17 @@ export function ValidatorDialog({
       />
       <div className="grid gap-1.5">
         <FieldLabel
-          label="Code to check"
+          label={config.validator_type === "json" || config.validator_type === "markdown"
+            ? "Field to check"
+            : "Code to check"}
           htmlFor={targetColumnId}
-          hint="Choose the AI code step this check should review."
+          hint={
+            config.validator_type === "json"
+              ? "Choose the column that should contain valid JSON."
+              : config.validator_type === "markdown"
+                ? "Choose the column that should contain valid markdown."
+                : "Choose the AI code step this check should review."
+          }
         />
         <Select
           value={currentTarget || NONE_VALUE}
@@ -123,7 +141,7 @@ export function ValidatorDialog({
               });
               return;
             }
-            const targetConfig = codeOptions.find((item) => item.name === value);
+            const targetConfig = targetOptions.find((item) => item.name === value);
             const nextCodeLang = targetConfig?.codeLang?.trim();
             onUpdate({
               // biome-ignore lint/style/useNamingConvention: api schema
@@ -141,16 +159,20 @@ export function ValidatorDialog({
           </SelectTrigger>
           <SelectContent>
             <SelectItem value={NONE_VALUE}>None</SelectItem>
-            {codeOptions.map((item) => (
+            {targetOptions.map((item) => (
               <SelectItem key={item.name} value={item.name}>
                 {item.name}
               </SelectItem>
             ))}
           </SelectContent>
         </Select>
-        {codeOptions.length === 0 && (
+        {targetOptions.length === 0 && (
               <p className="text-xs text-muted-foreground">
-                {config.validator_type === "oxc"
+                {config.validator_type === "json"
+                  ? "Add a generation step that outputs JSON first."
+                  : config.validator_type === "markdown"
+                    ? "Add a generation step that outputs markdown first."
+                    : config.validator_type === "oxc"
                   ? "Add an AI code step that generates JavaScript or TypeScript first."
                   : "Add an AI code step first."}
               </p>

--- a/studio/frontend/src/features/recipe-studio/stores/helpers/edge-sync.ts
+++ b/studio/frontend/src/features/recipe-studio/stores/helpers/edge-sync.ts
@@ -13,6 +13,18 @@ import { applyRecipeConnection } from "../../utils/graph";
 import { isCategoryConfig, isSubcategoryConfig } from "../../utils";
 import { HANDLE_IDS } from "../../utils/handles";
 
+function isJsonMarkdownValidator(validator: ValidatorConfig): boolean {
+  return validator.validator_type === "json" || validator.validator_type === "markdown";
+}
+
+function isJsonMarkdownValidatorTarget(config: NodeConfig): boolean {
+  return (
+    config.kind === "llm" ||
+    config.kind === "expression" ||
+    config.kind === "sampler"
+  );
+}
+
 function findNodeIdByName(
   configs: Record<string, NodeConfig>,
   name: string,
@@ -238,6 +250,8 @@ export function syncEdgesForConfigPatch(
     "target_columns",
   );
   if (current.kind === "validator" && hasValidatorTargetsPatch) {
+    const validator = current;
+    const isTextFormatValidator = isJsonMarkdownValidator(validator);
     const nextTargets =
       ((patch as Partial<ValidatorConfig>).target_columns ?? [])
         .map((value) => value.trim())
@@ -248,23 +262,28 @@ export function syncEdgesForConfigPatch(
       }
       const otherId = edge.source === current.id ? edge.target : edge.source;
       const other = configs[otherId];
-      return !(
-        other &&
-        other.kind === "llm" &&
-        other.llm_type === "code"
-      );
+      if (!other) {
+        return true;
+      }
+      if (isTextFormatValidator) {
+        return !isJsonMarkdownValidatorTarget(other);
+      }
+      return !(other.kind === "llm" && other.llm_type === "code");
     });
     const nextTargetName = nextTargets[0];
     if (nextTargetName) {
       const targetId = findNodeIdByName(configs, nextTargetName);
       const target = targetId ? configs[targetId] : null;
-      if (
-        targetId &&
-        target &&
-        target.kind === "llm" &&
-        target.llm_type === "code"
-      ) {
-        nextEdges = addValidatorSemanticEdge(nextEdges, targetId, current.id);
+      if (targetId && target) {
+        if (isTextFormatValidator && isJsonMarkdownValidatorTarget(target)) {
+          nextEdges = addValidatorSemanticEdge(nextEdges, targetId, current.id);
+        } else if (
+          !isTextFormatValidator &&
+          target.kind === "llm" &&
+          target.llm_type === "code"
+        ) {
+          nextEdges = addValidatorSemanticEdge(nextEdges, targetId, current.id);
+        }
       }
     }
   }

--- a/studio/frontend/src/features/recipe-studio/types/index.ts
+++ b/studio/frontend/src/features/recipe-studio/types/index.ts
@@ -22,13 +22,15 @@ export type ValidatorCodeLang =
   | "jsx"
   | "tsx"
   | "python"
+  | "json"
+  | "markdown"
   | "sql:sqlite"
   | "sql:postgres"
   | "sql:mysql"
   | "sql:tsql"
   | "sql:bigquery"
   | "sql:ansi";
-export type ValidatorType = "code" | "oxc";
+export type ValidatorType = "code" | "oxc" | "json" | "markdown";
 export type OxcValidationMode = "syntax" | "lint" | "syntax+lint";
 export type OxcCodeShape = "auto" | "module" | "snippet";
 
@@ -68,6 +70,8 @@ export type RecipeNodeData = {
     | "validator_python"
     | "validator_sql"
     | "validator_oxc"
+    | "validator_json"
+    | "validator_markdown"
     | "expression"
     | "seed"
     | "markdown_note"

--- a/studio/frontend/src/features/recipe-studio/utils/config-factories.ts
+++ b/studio/frontend/src/features/recipe-studio/utils/config-factories.ts
@@ -353,11 +353,17 @@ export function makeValidatorConfig(
 ): ValidatorConfig {
   const isSql = validatorType === "code" && codeLang.startsWith("sql:");
   const isOxc = validatorType === "oxc";
+  const isJson = validatorType === "json";
+  const isMarkdown = validatorType === "markdown";
   let namePrefix = "validator_python";
   if (isSql) {
     namePrefix = "validator_sql";
   } else if (isOxc) {
     namePrefix = "validator_oxc";
+  } else if (isJson) {
+    namePrefix = "validator_json";
+  } else if (isMarkdown) {
+    namePrefix = "validator_markdown";
   }
   return {
     id,

--- a/studio/frontend/src/features/recipe-studio/utils/graph/recipe-graph-connection.ts
+++ b/studio/frontend/src/features/recipe-studio/utils/graph/recipe-graph-connection.ts
@@ -92,6 +92,27 @@ type SingleRefRelation =
   | "subcategory_parent"
   | "validator_target_columns";
 
+function isJsonMarkdownValidator(
+  validator: NodeConfig,
+): validator is Extract<NodeConfig, { kind: "validator" }> {
+  return (
+    validator.kind === "validator" &&
+    (validator.validator_type === "json" || validator.validator_type === "markdown")
+  );
+}
+
+function isJsonMarkdownValidatorSource(source: NodeConfig): boolean {
+  return (
+    source.kind === "llm" ||
+    source.kind === "expression" ||
+    source.kind === "sampler"
+  );
+}
+
+function isCodeValidatorSource(source: NodeConfig): boolean {
+  return source.kind === "llm" && source.llm_type === "code";
+}
+
 function getSingleRefRelation(
   source: NodeConfig,
   target: NodeConfig,
@@ -116,12 +137,13 @@ function getSingleRefRelation(
   if (isCategoryConfig(source) && isSubcategoryConfig(target)) {
     return "subcategory_parent";
   }
-  if (
-    source.kind === "llm" &&
-    source.llm_type === "code" &&
-    target.kind === "validator"
-  ) {
-    return "validator_target_columns";
+  if (target.kind === "validator") {
+    if (isJsonMarkdownValidator(target) && isJsonMarkdownValidatorSource(source)) {
+      return "validator_target_columns";
+    }
+    if (isCodeValidatorSource(source)) {
+      return "validator_target_columns";
+    }
   }
   return null;
 }
@@ -152,7 +174,11 @@ function isCompetingIncomingEdge(
     return isCategoryConfig(source);
   }
   if (relation === "validator_target_columns") {
-    return source.kind === "llm" && source.llm_type === "code";
+    const target = configs[targetId];
+    if (target && isJsonMarkdownValidator(target)) {
+      return isJsonMarkdownValidatorSource(source);
+    }
+    return isCodeValidatorSource(source);
   }
   return source.kind === "sampler" && source.sampler_type === "datetime";
 }
@@ -290,6 +316,19 @@ function normalizeValidatorSemanticConnection(
 ): Connection {
   if (
     source.kind === "validator" &&
+    isJsonMarkdownValidator(source) &&
+    isJsonMarkdownValidatorSource(target)
+  ) {
+    return {
+      ...connection,
+      source: target.id,
+      target: source.id,
+      sourceHandle: HANDLE_IDS.dataOut,
+      targetHandle: HANDLE_IDS.dataIn,
+    };
+  }
+  if (
+    source.kind === "validator" &&
     target.kind === "llm" &&
     target.llm_type === "code"
   ) {
@@ -387,9 +426,10 @@ export function applyRecipeConnection(
     nextBaseEdges,
   );
   if (source.kind === "model_provider" && target.kind === "model_config") {
-    // Keep model_config.provider in sync when a drag changes the link. Local providers need an
-    // explicit load id; don't synthesize the legacy "local" placeholder. External relinks clear
-    // local-only GGUF metadata; legacy placeholders normalize back to empty.
+    // Keep model_config.provider in sync when a drag changes the link.
+    // Local providers need an explicit load id; don't synthesize the legacy
+    // "local" placeholder. External relinks clear local-only GGUF metadata;
+    // legacy placeholders normalize back to empty.
     const isSourceLocal = source.is_local === true;
     const isLegacyLocalPlaceholder =
       target.model.trim().toLowerCase() === "local";
@@ -436,6 +476,17 @@ export function applyRecipeConnection(
       ...target,
       // biome-ignore lint/style/useNamingConvention: api schema
       reference_column_name: source.name,
+    };
+    return { edges: nextEdges, configs: { ...configs, [target.id]: next } };
+  }
+  if (target.kind === "validator" && isJsonMarkdownValidator(target)) {
+    if (!isJsonMarkdownValidatorSource(source)) {
+      return { edges: nextEdges };
+    }
+    const next = {
+      ...target,
+      // biome-ignore lint/style/useNamingConvention: api schema
+      target_columns: [source.name],
     };
     return { edges: nextEdges, configs: { ...configs, [target.id]: next } };
   }

--- a/studio/frontend/src/features/recipe-studio/utils/import/parsers/validator-parser.ts
+++ b/studio/frontend/src/features/recipe-studio/utils/import/parsers/validator-parser.ts
@@ -8,6 +8,8 @@ import { normalizeOxcCodeShape } from "../../validators/oxc-code-shape";
 import { normalizeOxcValidationMode } from "../../validators/oxc-mode";
 
 const OXC_VALIDATION_FN_MARKER = "unsloth_oxc_validator";
+const JSON_VALIDATION_FN_MARKER = "unsloth_json_validator";
+const MARKDOWN_VALIDATION_FN_MARKER = "unsloth_markdown_validator";
 
 function parseOxcValidationMarker(
   validationFunctionRaw: string,
@@ -50,12 +52,24 @@ export function parseValidator(
     typeof params.validation_function === "string"
       ? params.validation_function.trim()
       : "";
+  const isLocalCallable =
+    String(column.validator_type ?? "").trim() === "local_callable";
   const isOxc =
-    String(column.validator_type ?? "").trim() === "local_callable" &&
-    validationFunctionRaw.startsWith(OXC_VALIDATION_FN_MARKER);
+    isLocalCallable && validationFunctionRaw.startsWith(OXC_VALIDATION_FN_MARKER);
+  const isJson =
+    isLocalCallable && validationFunctionRaw === JSON_VALIDATION_FN_MARKER;
+  const isMarkdown =
+    isLocalCallable && validationFunctionRaw === MARKDOWN_VALIDATION_FN_MARKER;
   const marker = isOxc
     ? parseOxcValidationMarker(validationFunctionRaw)
     : { codeLang: "", mode: "syntax", codeShape: "auto" };
+  const validatorType = isJson
+    ? "json"
+    : isMarkdown
+      ? "markdown"
+      : isOxc
+        ? "oxc"
+        : "code";
   return {
     id,
     kind: "validator",
@@ -63,10 +77,16 @@ export function parseValidator(
     drop: column.drop === true,
     // biome-ignore lint/style/useNamingConvention: api schema
     target_columns: targetColumns,
-    validator_type: isOxc ? "oxc" : "code",
+    validator_type: validatorType,
     // biome-ignore lint/style/useNamingConvention: api schema
     code_lang: normalizeValidatorCodeLang(
-      isOxc ? marker.codeLang || "javascript" : params.code_lang,
+      isJson
+        ? "json"
+        : isMarkdown
+          ? "markdown"
+          : isOxc
+            ? marker.codeLang || "javascript"
+            : params.code_lang,
     ),
     oxc_validation_mode: isOxc
       ? normalizeOxcValidationMode(marker.mode)

--- a/studio/frontend/src/features/recipe-studio/utils/node-data.ts
+++ b/studio/frontend/src/features/recipe-studio/utils/node-data.ts
@@ -34,10 +34,18 @@ export function nodeDataFromConfig(
   }
   if (config.kind === "validator") {
     const isOxc = config.validator_type === "oxc";
+    const isJson = config.validator_type === "json";
+    const isMarkdown = config.validator_type === "markdown";
     const isSql = config.code_lang.startsWith("sql:");
     let subtype = "Python";
     let blockType: RecipeNodeData["blockType"] = "validator_python";
-    if (isOxc) {
+    if (isJson) {
+      subtype = "JSON";
+      blockType = "validator_json";
+    } else if (isMarkdown) {
+      subtype = "Markdown";
+      blockType = "validator_markdown";
+    } else if (isOxc) {
       subtype = "OXC";
       blockType = "validator_oxc";
     } else if (isSql) {

--- a/studio/frontend/src/features/recipe-studio/utils/payload/builders-validator.ts
+++ b/studio/frontend/src/features/recipe-studio/utils/payload/builders-validator.ts
@@ -5,6 +5,8 @@ import type { NodeConfig, ValidatorConfig } from "../../types";
 import { isValidatorCodeLang } from "../validators/code-lang";
 
 const OXC_VALIDATION_FN_MARKER = "unsloth_oxc_validator";
+const JSON_VALIDATION_FN_MARKER = "unsloth_json_validator";
+const MARKDOWN_VALIDATION_FN_MARKER = "unsloth_markdown_validator";
 
 function parseBatchSize(value: string): number {
   const parsed = Number.parseInt(value, 10);
@@ -23,7 +25,45 @@ export function buildValidatorColumn(
     .map((value) => value.trim())
     .filter(Boolean);
   if (targetColumns.length === 0) {
-    errors.push(`Validator ${config.name}: target code column required.`);
+    errors.push(`Validator ${config.name}: target column required.`);
+  }
+  if (config.validator_type === "json") {
+    return {
+      // biome-ignore lint/style/useNamingConvention: api schema
+      column_type: "validation",
+      name: config.name,
+      drop: config.drop ?? false,
+      // biome-ignore lint/style/useNamingConvention: api schema
+      target_columns: targetColumns,
+      // biome-ignore lint/style/useNamingConvention: api schema
+      validator_type: "local_callable",
+      // biome-ignore lint/style/useNamingConvention: api schema
+      validator_params: {
+        // biome-ignore lint/style/useNamingConvention: api schema
+        validation_function: JSON_VALIDATION_FN_MARKER,
+      },
+      // biome-ignore lint/style/useNamingConvention: api schema
+      batch_size: parseBatchSize(config.batch_size),
+    };
+  }
+  if (config.validator_type === "markdown") {
+    return {
+      // biome-ignore lint/style/useNamingConvention: api schema
+      column_type: "validation",
+      name: config.name,
+      drop: config.drop ?? false,
+      // biome-ignore lint/style/useNamingConvention: api schema
+      target_columns: targetColumns,
+      // biome-ignore lint/style/useNamingConvention: api schema
+      validator_type: "local_callable",
+      // biome-ignore lint/style/useNamingConvention: api schema
+      validator_params: {
+        // biome-ignore lint/style/useNamingConvention: api schema
+        validation_function: MARKDOWN_VALIDATION_FN_MARKER,
+      },
+      // biome-ignore lint/style/useNamingConvention: api schema
+      batch_size: parseBatchSize(config.batch_size),
+    };
   }
   if (config.validator_type === "oxc") {
     const targetName = targetColumns[0] ?? "";

--- a/studio/frontend/src/features/recipe-studio/utils/payload/validate.ts
+++ b/studio/frontend/src/features/recipe-studio/utils/payload/validate.ts
@@ -165,6 +165,21 @@ export function validateValidatorConfigs(
       errors.push(`Validator ${config.name}: target '${target}' not found.`);
       continue;
     }
+    if (
+      config.validator_type === "json" ||
+      config.validator_type === "markdown"
+    ) {
+      if (
+        targetConfig.kind !== "llm" &&
+        targetConfig.kind !== "expression" &&
+        targetConfig.kind !== "sampler"
+      ) {
+        errors.push(
+          `Validator ${config.name}: target '${target}' must be a generated field.`,
+        );
+      }
+      continue;
+    }
     if (targetConfig.kind !== "llm" || targetConfig.llm_type !== "code") {
       errors.push(
         `Validator ${config.name}: target '${target}' must be LLM Code.`,

--- a/studio/frontend/src/features/recipe-studio/utils/validation.ts
+++ b/studio/frontend/src/features/recipe-studio/utils/validation.ts
@@ -242,11 +242,14 @@ export function getConfigErrors(config: NodeConfig | null): string[] {
       .map((value) => value.trim())
       .filter(Boolean);
     if (targets.length === 0) {
-      errors.push("Choose the code step to check.");
+      errors.push("Choose the field to check.");
     }
     const batch = parseIntNumber(config.batch_size);
     if (batch === null || batch < 1) {
       errors.push("Batch size must be an integer >= 1.");
+    }
+    if (config.validator_type === "json" || config.validator_type === "markdown") {
+      return errors;
     }
     if (!config.code_lang.trim()) {
       errors.push("Choose a code language for this check.");

--- a/studio/frontend/src/features/recipe-studio/utils/validators/code-lang.ts
+++ b/studio/frontend/src/features/recipe-studio/utils/validators/code-lang.ts
@@ -22,6 +22,8 @@ export const VALIDATOR_SQL_CODE_LANGS: ValidatorCodeLang[] = [
 const VALIDATOR_CODE_LANG_SET = new Set<ValidatorCodeLang>([
   ...VALIDATOR_OXC_CODE_LANGS,
   "python",
+  "json",
+  "markdown",
   ...VALIDATOR_SQL_CODE_LANGS,
 ]);
 
@@ -41,6 +43,12 @@ export function normalizeValidatorCodeLang(
   }
   if (raw === "python") {
     return "python";
+  }
+  if (raw === "json") {
+    return "json";
+  }
+  if (raw === "markdown") {
+    return "markdown";
   }
   if (raw.startsWith("sql:")) {
     if (VALIDATOR_SQL_CODE_LANGS.includes(raw as ValidatorCodeLang)) {


### PR DESCRIPTION
Follow-up to #10637 / #10708.

Adds **JSON check** and **Markdown check** validator blocks under Checks in Recipe Studio.

- Target any generated field (AI text/structured, formula, sampler)
- Backend registers local validators via `unsloth_json_validator` and `unsloth_markdown_validator`
- Graph connection plumbing and unit tests included

**Split for review** (same original umbrella work, separate PRs):
- **This PR** — JSON & Markdown validators
- #10736 — Models top-level block group in picker
- #10737 — Live dataset preview during active runs

Pairs with #10708 (download button) — no overlap.