### PR TITLE
Windows No Compiler CI: see the intermediates the compiler cleaned up

### DIFF
--- a/.github/scripts/Watch-ForCompiler.ps1
+++ b/.github/scripts/Watch-ForCompiler.ps1
@@ -18,8 +18,17 @@ is not the code under test:
   2. New *.dll, *.cmdline, *.rsp and *.?.cs files under every temporary directory
      in play. The artefact half of the same shape, and it survives auditing being
      silently overridden by machine policy. csc.exe writes the source and the
-     response file next to the assembly, so those names are watched too: an
-     assembly cleaned up leaves nothing to show, and a .cmdline still names it.
+     response file next to the assembly, so those names are watched too.
+
+     Watched live, with a FileSystemWatcher, and not only by comparing a listing
+     taken before the action against one taken after. CodeDom deletes its whole
+     intermediate directory once the assembly is loaded, so on a hosted runner the
+     before-and-after diff saw nothing at all while 4688 recorded
+
+         csc.exe /noconfig /fullpaths @"...\Temp\vpmyd5eq\vpmyd5eq.cmdline"
+
+     which is a compile this half missed entirely. The two are unioned: the listing
+     catches what was left behind, the watcher catches what was cleaned up.
 
 Both are reported. The positive control requires both to fire, and the real
 measurement requires neither to.
@@ -70,6 +79,82 @@ function Get-StudioTempArtifacts {
     # caller casts this into a HashSet whose two-argument constructor rejects null.
     # On a clean runner that killed the watcher before the positive control ran.
     return ,[string[]]$found
+}
+
+$script:ArtifactPattern = '\.(dll|cmdline|rsp|cs|err|out)$'
+$script:LibraryPattern = '\.(dll|cmdline|rsp)$'
+
+function Start-StudioTempWatch {
+    <#
+    .SYNOPSIS
+    Begin recording file creations under every temp root, and return the handles.
+    .DESCRIPTION
+    Register-ObjectEvent without an -Action: the events queue in the session's event
+    manager as they are raised, and Stop-StudioTempWatch drains them afterwards. An
+    -Action block would have to run for anything to be recorded, and there is nothing
+    to run it while a synchronous installer holds the pipeline.
+
+    A root that cannot be watched is skipped rather than fatal. The listing half still
+    covers it, and on a machine where none of them can be watched the positive control
+    is what says so.
+    #>
+    $handles = @()
+    foreach ($root in (Get-StudioTempRoots)) {
+        try {
+            $watcher = New-Object System.IO.FileSystemWatcher
+            $watcher.Path = $root
+            $watcher.IncludeSubdirectories = $true
+            $watcher.NotifyFilter = [System.IO.NotifyFilters]::FileName
+            # The default 8 KB buffer overflows on a busy temp directory, and an
+            # overflow drops events silently, which here reads as a clean run.
+            $watcher.InternalBufferSize = 65536
+            $identifier = "StudioTempWatch-" + [guid]::NewGuid().ToString('N')
+            $null = Register-ObjectEvent -InputObject $watcher -EventName Created `
+                -SourceIdentifier $identifier
+            $watcher.EnableRaisingEvents = $true
+            $handles += [pscustomobject]@{
+                Watcher          = $watcher
+                SourceIdentifier = $identifier
+                Root             = $root
+            }
+        } catch {
+            continue
+        }
+    }
+    return ,[object[]]$handles
+}
+
+function Stop-StudioTempWatch {
+    <#
+    .SYNOPSIS
+    Stop recording and return every path created while the handles were live.
+    .DESCRIPTION
+    Always unregisters and disposes, including on a path that saw nothing: a leaked
+    subscription keeps firing into the next measurement's queue.
+    #>
+    param([Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$Handle)
+
+    # Delivery is asynchronous, so the last few creations before the action returned may
+    # still be in flight. Settle first, then stop raising: draining immediately dropped
+    # exactly the events that matter, the ones from the end of a compile.
+    Start-Sleep -Milliseconds 750
+
+    $seen = @()
+    foreach ($entry in $Handle) {
+        try { $entry.Watcher.EnableRaisingEvents = $false } catch { }
+        try {
+            foreach ($record in @(Get-Event -SourceIdentifier $entry.SourceIdentifier `
+                    -ErrorAction SilentlyContinue)) {
+                $path = ''
+                try { $path = [string]$record.SourceEventArgs.FullPath } catch { }
+                if (-not [string]::IsNullOrWhiteSpace($path)) { $seen += $path }
+                Remove-Event -EventIdentifier $record.EventIdentifier -ErrorAction SilentlyContinue
+            }
+        } catch { }
+        Unregister-Event -SourceIdentifier $entry.SourceIdentifier -ErrorAction SilentlyContinue
+        try { $entry.Watcher.Dispose() } catch { }
+    }
+    return ,[string[]]$seen
 }
 
 function Get-StudioProcessImageName {
@@ -212,8 +297,12 @@ function Invoke-WithCompilerWatch {
     # of the sweep above, so a compiler started in that second is counted: a deliberate
     # trade towards a loud false alarm rather than a dropped real compile.
     $since = (Get-Date).AddSeconds(-1)
+    # Opened here, with the 4688 window, and not before the baseline: a file the
+    # machine creates during that recursive sweep predates the action.
+    $watch = Start-StudioTempWatch
 
     $failure = $null
+    $live = @()
     try {
         # Out-Host, not the success stream. The installer action tees its log, and those
         # lines would be emitted as function output ahead of the result hashtable, making
@@ -224,6 +313,9 @@ function Invoke-WithCompilerWatch {
         # Recorded and re-thrown below. The detectors still report, because "the
         # installer died AND spawned a compiler" beats either half alone.
         $failure = $_
+    } finally {
+        # In the finally, so an action that threw still closes its subscriptions.
+        $live = @(Stop-StudioTempWatch -Handle $watch)
     }
 
     # Closed before the temp sweep, which can take seconds: anything the machine
@@ -232,8 +324,16 @@ function Invoke-WithCompilerWatch {
     $compilers = @(Get-StudioCompilerEvents -Since $since -Until $until)
 
     $after = Get-StudioTempArtifacts
-    $newArtifacts = @($after | Where-Object { -not $before.Contains($_) })
-    $newLibraries = @($newArtifacts | Where-Object { $_ -match '\.(dll|cmdline|rsp)$' })
+    $left = @($after | Where-Object { -not $before.Contains($_) })
+    # Only the names the compiler writes, because the watcher reports every creation
+    # under temp and most of them are nobody's business.
+    $transient = @($live | Where-Object { $_ -match $script:ArtifactPattern })
+    $union = New-Object 'System.Collections.Generic.HashSet[string]' ([StringComparer]::OrdinalIgnoreCase)
+    $newArtifacts = @()
+    foreach ($path in ($left + $transient)) {
+        if ($union.Add($path)) { $newArtifacts += $path }
+    }
+    $newLibraries = @($newArtifacts | Where-Object { $_ -match $script:LibraryPattern })
 
     $stem = Join-Path $EvidenceRoot $Name
     $compilers | Out-File -FilePath "$stem-compilers.txt" -Encoding utf8

--- a/.github/workflows/windows-no-compiler-ci.yml
+++ b/.github/workflows/windows-no-compiler-ci.yml
@@ -162,8 +162,9 @@ jobs:
           }
           if ($seen.TempLibraries) {
               $seen.TempLibraries | ForEach-Object { Write-Host "TEMP DLL: $_" }
-              throw ("the installer left {0} DLL(s) in a temporary directory. Even without a " +
-                     "compiler process this is the artefact half of the same shape." -f `
+              throw ("the installer wrote {0} DLL(s) into a temporary directory. Even without a " +
+                     "compiler process this is the artefact half of the same shape. Cleaning one " +
+                     "up does not clear it: the watcher records the creation." -f `
                      $seen.TempLibraries.Count)
           }
           Write-Host "no compiler, no temporary DLL"
@@ -232,7 +233,7 @@ jobs:
           }
           if ($seen.TempLibraries) {
               $seen.TempLibraries | ForEach-Object { Write-Host "TEMP DLL: $_" }
-              throw "the desktop-mode installer left $($seen.TempLibraries.Count) DLL(s) in a temporary directory."
+              throw "the desktop-mode installer wrote $($seen.TempLibraries.Count) DLL(s) into a temporary directory."
           }
           Write-Host "desktop mode: no compiler, no temporary DLL"
 

--- a/tests/studio/test_installer_av_shapes.py
+++ b/tests/studio/test_installer_av_shapes.py
@@ -373,6 +373,106 @@ def test_the_watcher_scores_the_image_that_ran_not_the_words_in_the_message(
     assert f"HITS:{expected}" in result.stdout, result.stdout
 
 
+_FAKE_WINEVENT = r"""
+function Get-WinEvent {
+    # Off Windows there is no such cmdlet, so this resolves the call. Empty rather than
+    # throwing: this exercises the artefact half, and the 4688 half has its own tests.
+    param([Parameter(ValueFromRemainingArguments = $true)]$Rest)
+    return @()
+}
+"""
+
+
+def _run_watch(tmp_path, action: str) -> tuple[str, list[str]]:
+    """Drive the real Invoke-WithCompilerWatch over $Action, with TEMP pointed at tmp_path."""
+    temp_root = tmp_path / "temp"
+    temp_root.mkdir()
+    evidence = tmp_path / "evidence"
+    script = tmp_path / "probe.ps1"
+    script.write_text(
+        "\n".join(
+            [
+                '$ErrorActionPreference = "Stop"',
+                f'$env:TEMP = "{temp_root.as_posix()}"',
+                f'$env:TMP = "{temp_root.as_posix()}"',
+                _FAKE_WINEVENT,
+                f'. "{_WATCHER}"',
+                f"$action = {{ {action} }}",
+                "$seen = Invoke-WithCompilerWatch -Name 'probe' -Action $action "
+                f'-EvidenceRoot "{evidence.as_posix()}"',
+                'foreach ($lib in $seen.TempLibraries) { Write-Output "LIB:$lib" }',
+                'Write-Output "COUNT:$($seen.TempLibraries.Count)"',
+            ]
+        ),
+        encoding = "utf-8",
+    )
+    result = subprocess.run(
+        ["pwsh", "-NoProfile", "-NonInteractive", "-File", str(script)],
+        capture_output = True,
+        text = True,
+        timeout = 300,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    libraries = [
+        line[len("LIB:"):] for line in result.stdout.splitlines() if line.startswith("LIB:")
+    ]
+    return result.stdout, libraries
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason = "needs PowerShell")
+def test_the_watcher_sees_intermediates_the_compiler_cleaned_up(tmp_path) -> None:
+    """The failure this replaces: the positive control compiled a type, 4688 recorded
+
+        csc.exe /noconfig /fullpaths @"...\\Temp\\vpmyd5eq\\vpmyd5eq.cmdline"
+
+    and the artefact half reported nothing, because CodeDom deletes its intermediate
+    directory once the assembly is loaded. Comparing a listing taken before against one
+    taken after cannot see a file that no longer exists, so the job failed as a broken
+    detector on every run since it was added.
+    """
+    action = (
+        '$dir = Join-Path $env:TEMP "abcd1234"; '
+        "New-Item -ItemType Directory -Force -Path $dir | Out-Null; "
+        'Set-Content -LiteralPath (Join-Path $dir "abcd1234.cmdline") -Value "/noconfig"; '
+        'Set-Content -LiteralPath (Join-Path $dir "abcd1234.dll") -Value "MZ"; '
+        "Start-Sleep -Milliseconds 400; "
+        # The whole point: gone before the action returns, exactly as CodeDom leaves it.
+        "Remove-Item -LiteralPath $dir -Recurse -Force"
+    )
+    stdout, libraries = _run_watch(tmp_path, action)
+    assert libraries, f"a compile that cleaned up after itself was missed again: {stdout}"
+    assert any(lib.endswith(".cmdline") for lib in libraries), libraries
+    assert any(lib.endswith(".dll") for lib in libraries), libraries
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason = "needs PowerShell")
+def test_the_watcher_still_reports_intermediates_that_were_left_behind(tmp_path) -> None:
+    """The listing half must keep working; the watcher is added to it, not swapped for it."""
+    action = (
+        '$dir = Join-Path $env:TEMP "leftover"; '
+        "New-Item -ItemType Directory -Force -Path $dir | Out-Null; "
+        'Set-Content -LiteralPath (Join-Path $dir "leftover.dll") -Value "MZ"'
+    )
+    _, libraries = _run_watch(tmp_path, action)
+    assert any(lib.endswith("leftover.dll") for lib in libraries), libraries
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason = "needs PowerShell")
+def test_an_action_that_compiles_nothing_reports_nothing(tmp_path) -> None:
+    """Otherwise the real measurement, which requires neither detector to fire, can never pass.
+
+    A text file is written so the action is not a no-op: the watcher sees the creation and
+    must still discard it, because the extension is not one a compiler writes.
+    """
+    action = (
+        'Set-Content -LiteralPath (Join-Path $env:TEMP "notes.txt") -Value "hello"; '
+        "Start-Sleep -Milliseconds 400"
+    )
+    stdout, libraries = _run_watch(tmp_path, action)
+    assert "COUNT:0" in stdout, stdout
+    assert not libraries, libraries
+
+
 def test_an_unreadable_security_log_is_void_rather_than_clean() -> None:
     """Get-WinEvent throws both for "nothing matched" and for "could not read".
 


### PR DESCRIPTION
`Windows No Compiler CI` has failed on every run since it was added: 45 completed runs, 0 successes, on main and on every branch. It never fails in the measurement, it fails in the positive control, so the lane has never actually measured the installer.

### What the runner's own evidence says

From the artifact of the run on main at `89b7ff00`:

`positive-control-compilers.txt`

```
csc.exe /noconfig /fullpaths @"C:\Users\runneradmin\AppData\Local\Temp\vpmyd5eq\vpmyd5eq.cmdline"
```

`positive-control-temp-artifacts.txt`

```
(empty)
```

So 4688 saw the compile, named the response file, and the artefact half reported nothing at all. CodeDom deletes its whole intermediate directory once the assembly is loaded, and `Invoke-WithCompilerWatch` compares a listing taken before the action against one taken after. A file that no longer exists cannot appear in that diff, so the control throws "the temporary-directory half of the detector is broken", which it was.

This is not specific to the control. Any compile that cleans up after itself is invisible to that half today, including one the installer might perform, which is the thing the lane exists to catch.

### The change

Watch the temp roots live with a `FileSystemWatcher` while the action runs, and union that with the existing before-and-after listing. The listing catches what was left behind, the watcher catches what was cleaned up.

- Subscriptions are registered with `Register-ObjectEvent` and no `-Action` block. An action block needs the engine to run it, and there is nothing to run one while a synchronous installer holds the pipeline. The events queue in the session's event manager and are drained afterwards.
- `InternalBufferSize` is raised to 64 KB. The default 8 KB overflows on a busy temp directory, and an overflow drops events silently, which here would read as a clean run.
- The watcher opens with the 4688 window and not before the baseline sweep, so a file the machine creates during that recursive walk is not scored against the action.
- Draining settles for 750 ms first. Delivery is asynchronous, and the events that matter are the ones from the end of a compile.
- Stopping happens in a `finally`, so an action that threw does not leak subscriptions into the next measurement.
- A temp root that cannot be watched is skipped rather than fatal. The listing half still covers it, and if none of them can be watched the positive control is what says so.

### Tests

Three new tests in `tests/studio/test_installer_av_shapes.py`, driving the real `Invoke-WithCompilerWatch` under pwsh with `TEMP` pointed at a tmp dir. They follow the existing idiom in that file for exercising this script off a Windows runner.

- `test_the_watcher_sees_intermediates_the_compiler_cleaned_up` writes a `.cmdline` and a `.dll` and deletes them before the action returns, which is what CodeDom does. It fails on the current script with the same empty result the runner produced, and passes with this change.
- `test_the_watcher_still_reports_intermediates_that_were_left_behind` keeps the listing half honest. The watcher is added to it, not swapped for it.
- `test_an_action_that_compiles_nothing_reports_nothing` writes a `.txt` so the action is not a no-op, and requires it to be discarded. Without this the real measurement, which requires neither detector to fire, could never pass.

Verified locally: 47 passed in `tests/studio/test_installer_av_shapes.py`, `Watch-ForCompiler.ps1` parses, workflow YAML parses, ruff and codespell clean.

### One thing to expect

With the control passing, the two real legs will run to completion for the first time. They now fail on a DLL that was created and cleaned up, not only on one still sitting in temp, so they may surface something that was always there and never observed. Both legs print every offending path before throwing, and the evidence artifact keeps the full list, so triage is immediate. I would rather have that than a lane that cannot see a compile which tidies up.

The two throw messages now say "wrote into" rather than "left in", which is what the check actually means after this.
