### PR TITLE
Re-format the two lines that drifted, so pre-commit stops failing on main

### DIFF
--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -5211,9 +5211,7 @@ def _reconcile_cuda_integrated_memory(
             dev["vram_used_gb"] = pool_used_gb
         if dev.get("vram_utilization_pct") is None:
             dev["vram_utilization_pct"] = (
-                round((min(pool_used_gb, total_gb) / total_gb) * 100, 1)
-                if total_gb > 0
-                else None
+                round((min(pool_used_gb, total_gb) / total_gb) * 100, 1) if total_gb > 0 else None
             )
 
 

--- a/tests/studio/test_installer_av_shapes.py
+++ b/tests/studio/test_installer_av_shapes.py
@@ -414,7 +414,7 @@ def _run_watch(tmp_path, action: str) -> tuple[str, list[str]]:
     )
     assert result.returncode == 0, result.stderr + result.stdout
     libraries = [
-        line[len("LIB:"):] for line in result.stdout.splitlines() if line.startswith("LIB:")
+        line[len("LIB:") :] for line in result.stdout.splitlines() if line.startswith("LIB:")
     ]
     return result.stdout, libraries
 


### PR DESCRIPTION
`pre-commit.ci` has been red on `main` since #10711 (`a167f284f`), and every open PR inherits the failure. The `ruff-format-with-kwargs` hook reports `files were modified by this hook`.

The cause is one line. #10711 added a slice at `tests/studio/test_installer_av_shapes.py:417` written as `line[len("LIB:"):]`; the pinned `ruff==0.6.9` formatter wants `line[len("LIB:") :]`.

Running the repo's own `scripts/run_ruff_format.py` over a clean checkout of `main` modifies seven files, and six of them (`unsloth/chat_templates.py`, `studio/backend/core/inference/chat_templates.py`, the four `studio/backend/vendor/truststore/*`) are excluded by the hook's own `exclude` pattern. `tests/studio/test_installer_av_shapes.py` is the only in-scope file that drifts, so this one line is the whole failure.

This is the formatter's own output, nothing hand-written.