### PR TITLE
Studio: read the NVLink fabric from NVML instead of a 1.2s nvidia-smi shell-out

### DIFF
--- a/scripts/p2p_integrity_probe.py
+++ b/scripts/p2p_integrity_probe.py
@@ -67,13 +67,12 @@ def _print_topology() -> None:
 
 
 def _print_nvml_agreement() -> None:
-    """Compare the NVML fast path against `nvidia-smi topo -m`.
+    """Compare the NVML fast path (~230 ms) against `nvidia-smi topo -m` (~1.2 s).
 
-    Studio reads NVLink connectivity from NVML (~230 ms) and falls back to the
-    shell-out (~1.2 s). They agree exactly on an 8x B200 NVSwitch host, but PCIe-only
-    and partially bridged boxes were not available to test. The line that matters is
-    an NVML-positive / topo-negative pair: that would be the fast path claiming a
-    link the slow path denies. Please report it on #10613 if you see one."""
+    They agree exactly on an 8x B200 NVSwitch host, but PCIe-only and partially
+    bridged boxes were not available to test. The line that matters is an
+    NVML-positive / topo-negative pair, the fast path claiming a link the slow path
+    denies. Please report it on #10613 if you see one."""
     try:
         sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "studio" / "backend"))
         from core.inference.llama_cpp import LlamaCppBackend as backend

--- a/scripts/p2p_integrity_probe.py
+++ b/scripts/p2p_integrity_probe.py
@@ -107,9 +107,11 @@ def _print_nvml_agreement() -> None:
         )
     if topo_yes - nvml_yes:
         print(
-            f"{sorted(topo_yes - nvml_yes)} are NVLink to topo -m but not to NVML. "
-            "This is the\nconservative direction: Studio would simply not enable P2P "
-            "for them."
+            f"{sorted(topo_yes - nvml_yes)} are NVLink to topo -m but not to NVML.\n"
+            "This is the conservative direction: by default NVML answers first, so "
+            "Studio\nwould not enable P2P for them. Setting "
+            "UNSLOTH_P2P_TOPO_CROSSCHECK=1 makes topo -m\nwin any disagreement, which "
+            "would enable them instead."
         )
     print()
 

--- a/scripts/p2p_integrity_probe.py
+++ b/scripts/p2p_integrity_probe.py
@@ -30,6 +30,7 @@ import argparse
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 SENTINEL = -7.0
 SIZES_MIB = (1, 4, 16, 64)
@@ -65,6 +66,55 @@ def _print_topology() -> None:
     print()
 
 
+def _print_nvml_agreement() -> None:
+    """Compare the NVML fast path against `nvidia-smi topo -m`.
+
+    Studio reads NVLink connectivity from NVML (~230 ms) and falls back to the
+    shell-out (~1.2 s). They agree exactly on an 8x B200 NVSwitch host, but PCIe-only
+    and partially bridged boxes were not available to test. The line that matters is
+    an NVML-positive / topo-negative pair: that would be the fast path claiming a
+    link the slow path denies. Please report it on #10613 if you see one."""
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "studio" / "backend"))
+        from core.inference.llama_cpp import LlamaCppBackend as backend
+    except Exception as e:  # noqa: BLE001 -- diagnostic, never fatal
+        print(f"could not import the Studio backend to cross-check NVML: {e}\n")
+        return
+    try:
+        nvml = backend._probe_nvml_nvlink_topology()
+        topo = backend._probe_nvlink_topology()
+    except Exception as e:  # noqa: BLE001
+        print(f"topology cross-check failed: {e}\n")
+        return
+    print("=== NVML vs nvidia-smi topo -m ===")
+    if nvml is None:
+        print("NVML gave no verdict here; Studio would use `nvidia-smi topo -m`.\n")
+        return
+    if topo is None:
+        print("`nvidia-smi topo -m` gave no verdict; nothing to compare against.\n")
+        return
+    nvml_yes = {k for k, v in nvml.items() if backend._label_is_nvlink(v)}
+    topo_yes = {k for k, v in topo.items() if backend._label_is_nvlink(v)}
+    print(f"NVLinked pairs: NVML {len(nvml_yes)}, topo -m {len(topo_yes)}")
+    if nvml_yes == topo_yes:
+        print("They agree exactly.\n")
+        return
+    only_nvml = sorted(nvml_yes - topo_yes)
+    if only_nvml:
+        print(
+            f"MISMATCH, and in the direction that matters: {only_nvml} are NVLink to\n"
+            "NVML but not to topo -m. Please report this on #10613 with the output of\n"
+            "`nvidia-smi topo -m`, and set UNSLOTH_DISABLE_DC_P2P=1 meanwhile."
+        )
+    if topo_yes - nvml_yes:
+        print(
+            f"{sorted(topo_yes - nvml_yes)} are NVLink to topo -m but not to NVML. "
+            "This is the\nconservative direction: Studio would simply not enable P2P "
+            "for them."
+        )
+    print()
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description = __doc__.splitlines()[0])
     parser.add_argument(
@@ -90,6 +140,7 @@ def main() -> int:
         parser.error("--sizes-mib values must all be positive")
 
     _print_topology()
+    _print_nvml_agreement()
 
     try:
         import torch

--- a/studio/NVLINK_P2P.md
+++ b/studio/NVLINK_P2P.md
@@ -51,11 +51,38 @@ A product name cannot tell you whether the box has a bridge.
 asking it again is not verification. vLLM reached the same conclusion and performs a real
 data-integrity check (`can_actually_p2p`, from vllm#2728).
 
-Studio reads `nvidia-smi topo -m` instead and requires `NV#` between every selected pair.
+Studio reads the topology itself and requires a confirmed NVLink between every selected pair.
 NVLink traffic does not traverse the PCIe root complex, so the IOMMU fault class above
 cannot apply to it. The probe fails closed: a missing `nvidia-smi`, a non-zero exit, a
 timeout, an unparsable matrix, or a device mask that cannot be mapped to PCI indices all
 mean no P2P.
+
+### Where the answer comes from
+
+Two sources, in order. The first conclusive one wins; if neither answers, no P2P.
+
+| tier | source | cost on an 8x B200 |
+|---|---|---|
+| 1 | NVML, via `ctypes` against the driver's own `libnvidia-ml.so.1` / `nvml.dll` | ~230 ms |
+| 2 | `nvidia-smi topo -m` | ~1200 ms |
+
+NVML ships with the driver, so it is present exactly when `nvidia-smi` is (`nvidia-smi` is
+itself an NVML client) and this adds no Python dependency. Tier 1 asks
+`nvmlDeviceGetP2PStatus(a, b, NVML_P2P_CAPS_INDEX_NVLINK)`, which is a question about one
+pair. Note what it deliberately does not do: an active link whose remote endpoint is an
+NVSwitch proves only that the GPU is attached to a switch, and switch fabrics can be
+partitioned, so "every GPU has a switch link" is not read as "every pair is reachable".
+
+Anything short of a complete, unambiguous answer falls to tier 2: a missing library or
+symbol, any non-zero NVML return, fewer than two devices, a partial walk, or a positive
+that contradicts the live NVLink count on either endpoint. The result is cached for the
+process, primed on the startup warm thread so the first model load reads it warm, and
+never gates startup.
+
+Whichever tier answers, the verdict is identical on the hardware tested here: NVML and
+`topo -m` agree exactly on an 8x B200 NVSwitch host, 56 of 56 ordered pairs, in both
+directions. PCIe-only and partially bridged hosts were not available to test, which is what
+`UNSLOTH_P2P_TOPO_CROSSCHECK=1` and `scripts/p2p_integrity_probe.py` are for.
 
 ### Partially bridged boxes, and which pairs get checked
 
@@ -100,6 +127,7 @@ at several sizes. Exit 0 means intact, 1 means data was lost, 2 means it could n
 | `UNSLOTH_DISABLE_DC_TUNING=1` | disables all data-center tuning, including FP32 accumulate |
 | `UNSLOTH_DISABLE_DC_P2P=1` | disables `GGML_CUDA_P2P` only, keeping FP32 accumulate and `CUDA_SCALE_LAUNCH_QUEUES`. Also removes an inherited `GGML_CUDA_P2P`, so it holds even if the variable is already set elsewhere in your environment |
 | `UNSLOTH_FORCE_DC_P2P=1` | enables P2P on an unverified fabric (use after the probe passes). It cannot override `UNSLOTH_DISABLE_DC_P2P=1`, an off-meaning `GGML_CUDA_P2P` in your environment, or the data-center gate itself |
+| `UNSLOTH_P2P_TOPO_CROSSCHECK=1` | runs both topology tiers and logs any disagreement, preferring `nvidia-smi topo -m` when they differ. Diagnostic only; costs the slow probe on every process |
 
 `CUDA_SCALE_LAUNCH_QUEUES` is deliberately not gated on the fabric: it sizes a CUDA command
 buffer, moves no data between devices, and the reporter of #10613 measured it clean in

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -9504,12 +9504,15 @@ class LlamaCppBackend:
         cls,
         gpu_indices = None,
         launch_order_pinned = False,
+        ids_are_pci_indices = None,
     ) -> Optional[str]:
         """Fail-closed wrapper around _p2p_veto_reason_inner: anything unexpected
         reads as "do not set P2P", since losing the tuning beats an exception
         escaping into load_model and failing the load."""
         try:
-            return cls._p2p_veto_reason_inner(gpu_indices, launch_order_pinned)
+            return cls._p2p_veto_reason_inner(
+                gpu_indices, launch_order_pinned, ids_are_pci_indices
+            )
         except Exception as e:
             logger.debug(f"peer-fabric check failed: {e}")
             return f"the peer-fabric check could not complete ({type(e).__name__})"
@@ -9519,6 +9522,7 @@ class LlamaCppBackend:
         cls,
         gpu_indices = None,
         launch_order_pinned = False,
+        ids_are_pci_indices = None,
     ) -> Optional[str]:
         """Why GGML_CUDA_P2P must NOT be set for this selection, or None once a
         working NVLink fabric is confirmed for every selected pair. Fails CLOSED on
@@ -9597,7 +9601,12 @@ class LlamaCppBackend:
             # index the matrix verbatim. NVML does not carry that implication, and
             # _get_gpu_memory's torch fallback hands back CUDA ordinals, which index
             # this matrix wrongly under FASTEST_FIRST (#10613).
-            if cls._matrix_is_nvml(matrix) and cls._GPU_IDS_ARE_PCI_INDICES is not True:
+            pci_ids = (
+                cls._GPU_IDS_ARE_PCI_INDICES is True
+                if ids_are_pci_indices is None
+                else ids_are_pci_indices
+            )
+            if cls._matrix_is_nvml(matrix) and not pci_ids:
                 return _pcie(
                     "the GPU selection came from torch rather than nvidia-smi, so "
                     "its ids are CUDA ordinals and cannot be matched against the "
@@ -9706,6 +9715,7 @@ class LlamaCppBackend:
         gpu_indices = None,
         p2p_opted_out = False,
         launch_order_pinned = False,
+        ids_are_pci_indices = None,
     ) -> bool:
         """Inject DC llama.cpp tuning into env in place via setdefault (user values
         win); return whether the box qualified. Only datacenter NVIDIA parts qualify
@@ -9747,7 +9757,9 @@ class LlamaCppBackend:
             veto = (
                 "GGML_CUDA_P2P was turned off in the environment"
                 if p2p_opted_out
-                else LlamaCppBackend._p2p_veto_reason(gpu_indices, launch_order_pinned)
+                else LlamaCppBackend._p2p_veto_reason(
+                    gpu_indices, launch_order_pinned, ids_are_pci_indices
+                )
             )
             if veto is None:
                 applied.append(_apply("GGML_CUDA_P2P", "1"))
@@ -24480,6 +24492,13 @@ class LlamaCppBackend:
                     os.environ.get("CUDA_VISIBLE_DEVICES") is None
                     and LlamaCppBackend._GPU_IDS_ARE_PCI_INDICES is True
                 )
+                # Whether THESE ids are nvidia-smi indices, which is not the same
+                # question as where _get_gpu_memory last got its ids. An explicit pick
+                # is PCI-ordered by construction, so a torch fallback in the unrelated
+                # memory query must not demote it and cost a verified fabric its P2P.
+                _p2p_ids_are_pci = bool(gpu_ids) or (
+                    LlamaCppBackend._GPU_IDS_ARE_PCI_INDICES is True
+                )
 
                 # Only when the fabric is NOT confirmed: on a verified NV# pair the
                 # flag is the benchmarked configuration. Datacenter boxes are
@@ -24493,7 +24512,9 @@ class LlamaCppBackend:
                     and self._effective_gpu_count(gpu_indices) > 1
                     and not LlamaCppBackend._warned_no_nvlink
                 ):
-                    _p2p_veto = self._p2p_veto_reason(gpu_indices, _p2p_launch_order_pinned)
+                    _p2p_veto = self._p2p_veto_reason(
+                        gpu_indices, _p2p_launch_order_pinned, _p2p_ids_are_pci
+                    )
                     if _p2p_veto is not None:
                         LlamaCppBackend._warned_no_nvlink = True
                         logger.warning(
@@ -24518,6 +24539,7 @@ class LlamaCppBackend:
                         gpu_indices,
                         p2p_opted_out = self._p2p_user_opted_out(),
                         launch_order_pinned = _p2p_launch_order_pinned,
+                        ids_are_pci_indices = _p2p_ids_are_pci,
                     )
 
                 # Pin to selected GPU(s) (issue #7164; resolved above into gpu_indices).

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -9179,8 +9179,34 @@ class LlamaCppBackend:
                 continue
         return None
 
+    # `nvidia-smi topo -m` runs under subprocess timeout; ctypes has no equivalent,
+    # and a wedged driver can block nvmlInit_v2 forever. Bound the whole walk so a
+    # stalled call costs a fallback instead of the load.
+    _NVML_PROBE_TIMEOUT_SECONDS = 10
+
     @classmethod
     def _probe_nvml_nvlink_topology(cls) -> Optional[dict]:
+        """_probe_nvml_nvlink_topology_inner under a wall-clock bound. A stalled NVML
+        call cannot be cancelled, so the thread is abandoned as a daemon and the caller
+        falls through to the shell-out, which has a timeout of its own."""
+        box = {}
+
+        def _run():
+            box["matrix"] = cls._probe_nvml_nvlink_topology_inner()
+
+        worker = threading.Thread(target = _run, daemon = True, name = "nvml-nvlink-probe")
+        worker.start()
+        worker.join(cls._NVML_PROBE_TIMEOUT_SECONDS)
+        if worker.is_alive():
+            logger.debug(
+                f"NVML NVLink probe still running after "
+                f"{cls._NVML_PROBE_TIMEOUT_SECONDS}s; abandoning it"
+            )
+            return None
+        return box.get("matrix")
+
+    @classmethod
+    def _probe_nvml_nvlink_topology_inner(cls) -> Optional[dict]:
         """Same matrix as _probe_nvlink_topology, from NVML instead of a shell-out:
         ~85 ms against ~1200 ms on an 8x B200. Keyed by the NVML device index, which
         is the nvidia-smi index (both enumerate in PCI order and both ignore
@@ -9419,6 +9445,13 @@ class LlamaCppBackend:
                     # Caching the miss would keep P2P off for the life of the process
                     # even once the topology becomes readable, so leave the cache cold.
                     return None
+                existing = cls._NVLINK_TOPO_CACHE
+                if probed is None and existing is not None and existing[0] is not None:
+                    # A concurrent pass (typically the startup prime) already published
+                    # a good matrix. The generation only guards against a refresh, so
+                    # without this a racing transient failure would erase it and keep
+                    # P2P off for every later load.
+                    return existing[0]
                 cls._NVLINK_TOPO_CACHE = (probed,)
                 return probed
             # A refresh started mid-pass owns the current answer; discard this one

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -9613,10 +9613,11 @@ class LlamaCppBackend:
             # NVLink for a pair that is not the one about to run (#10613).
             # Unless the whole box is NVLinked, where the mapping cannot matter and
             # vetoing would lose P2P on every auto-fit NVSwitch launch (#6098).
+            uniformly_nvlinked = all(cls._label_is_nvlink(v) for v in matrix.values())
             if not (
                 launch_order_pinned
                 or os.environ.get("CUDA_DEVICE_ORDER") == "PCI_BUS_ID"
-                or all(cls._label_is_nvlink(v) for v in matrix.values())
+                or uniformly_nvlinked
             ):
                 return _pcie(
                     "the child's device order is not pinned to PCI_BUS_ID and the "
@@ -9633,7 +9634,10 @@ class LlamaCppBackend:
                 if ids_are_pci_indices is None
                 else ids_are_pci_indices
             )
-            if cls._matrix_is_nvml(matrix) and not pci_ids:
+            # Same escape as the ordering check above, for the same reason: on a
+            # uniformly NVLinked box every mapping gives the same verdict, and ids
+            # that fall outside the matrix still veto on the lookup below.
+            if cls._matrix_is_nvml(matrix) and not pci_ids and not uniformly_nvlinked:
                 return _pcie(
                     "the GPU selection came from torch rather than nvidia-smi, so "
                     "its ids are CUDA ordinals and cannot be matched against the "

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -24523,12 +24523,16 @@ class LlamaCppBackend:
                     os.environ.get("CUDA_VISIBLE_DEVICES") is None
                     and LlamaCppBackend._GPU_IDS_ARE_PCI_INDICES is True
                 )
-                # Whether THESE ids are nvidia-smi indices, which is not the same
-                # question as where _get_gpu_memory last got its ids. An explicit pick
-                # is PCI-ordered by construction, so a torch fallback in the unrelated
-                # memory query must not demote it and cost a verified fabric its P2P.
-                _p2p_ids_are_pci = bool(gpu_ids) or (
+                # Whether THESE ids live in the matrix's index space. Explicitness is
+                # not evidence of that: with nvidia-smi unavailable the picker lists
+                # what torch enumerated, so an explicit pick is PCI-indexed only
+                # because hardware.py setdefaults CUDA_DEVICE_ORDER=PCI_BUS_ID, which
+                # a user can override. Ask the two things that actually answer it:
+                # nvidia-smi produced the ids, or this process pins PCI order so
+                # torch's ordinals coincide with it.
+                _p2p_ids_are_pci = (
                     LlamaCppBackend._GPU_IDS_ARE_PCI_INDICES is True
+                    or os.environ.get("CUDA_DEVICE_ORDER") == "PCI_BUS_ID"
                 )
 
                 # Only when the fabric is NOT confirmed: on a verified NV# pair the

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -10,6 +10,7 @@ OpenAI-compatible /v1/chat/completions endpoint.
 import ast
 import atexit
 import contextlib
+import ctypes
 import errno
 import functools
 import hashlib
@@ -9113,9 +9114,171 @@ class LlamaCppBackend:
     _TOPO_NVLINK_RE = re.compile(r"^NV\d+$")
     _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 
-    # One shell-out per process, not per launch. None = not yet probed; otherwise a
+    # One probe per process, not per launch. None = not yet probed; otherwise a
     # 1-tuple whose value may itself be None ("probed and unavailable").
     _NVLINK_TOPO_CACHE = None
+    # Bumped on every refresh so a slow background prime cannot publish over a
+    # newer invalidation.
+    _NVLINK_TOPO_GENERATION = 0
+    _NVLINK_TOPO_LOCK = threading.Lock()
+
+    # NVML labels. `topo -m` reports NV# (a bonded set of # links); NVML answers a
+    # yes/no per pair, so it gets its own vocabulary rather than a fabricated NV18
+    # that downstream code could misread as a link count.
+    _NVML_NVLINK_LABEL = "NVLINK"
+    _NVML_NO_NVLINK_LABEL = "NO-NVLINK"
+
+    # nvml.h. Only scalars and opaque handles cross this boundary, so there is no
+    # struct layout to get wrong across driver versions.
+    _NVML_SUCCESS = 0
+    _NVML_P2P_CAPS_INDEX_NVLINK = 2
+    _NVML_P2P_STATUS_OK = 0
+    _NVML_FEATURE_ENABLED = 1
+    # Link enumeration stops at the first error; this only bounds a runaway loop.
+    _NVML_MAX_LINKS = 64
+
+    @classmethod
+    def _matrix_is_nvml(cls, matrix: dict) -> bool:
+        """Whether this matrix came from NVML rather than the shell-out. It decides
+        one thing only: whether nvidia-smi is known to have answered."""
+        return any(
+            v in (cls._NVML_NVLINK_LABEL, cls._NVML_NO_NVLINK_LABEL)
+            for v in matrix.values()
+        )
+
+    @classmethod
+    def _label_is_nvlink(cls, label: str) -> bool:
+        """The one place that decides whether an interconnect label means NVLink, so
+        the selected-pair check and the whole-box check cannot drift apart."""
+        return bool(cls._TOPO_NVLINK_RE.match(label)) or label == cls._NVML_NVLINK_LABEL
+
+    @staticmethod
+    def _nvml_library():
+        """The driver's own NVML, via ctypes. It ships with the driver, so it is
+        present exactly when nvidia-smi is (nvidia-smi is itself an NVML client) and
+        this adds no Python dependency: nvidia-ml-py is NOT installed in a Studio
+        env. None when it cannot be loaded."""
+        names = ("nvml.dll",) if os.name == "nt" else ("libnvidia-ml.so.1", "libnvidia-ml.so")
+        for name in names:
+            try:
+                return ctypes.CDLL(name)
+            except OSError:
+                continue
+        return None
+
+    @classmethod
+    def _probe_nvml_nvlink_topology(cls) -> Optional[dict]:
+        """Same matrix as _probe_nvlink_topology, from NVML instead of a shell-out:
+        ~85 ms against ~1200 ms for `nvidia-smi topo -m` on an 8x B200. Keyed by the
+        NVML device index, which is the nvidia-smi index (both enumerate in PCI
+        order and both ignore CUDA_VISIBLE_DEVICES, verified on 8x B200). None when
+        the answer is not conclusive, which sends the caller to the shell-out.
+
+        Evidence is per PAIR: nvmlDeviceGetP2PStatus with the NVLink capability
+        index. An active link whose remote endpoint is an NVSwitch proves only that
+        the GPU is attached to a switch, and switch fabrics can be partitioned, so
+        "every GPU has a switch link" must NOT be read as "every pair is reachable".
+        """
+        lib = cls._nvml_library()
+        if lib is None:
+            return None
+        initialised = False
+        try:
+            try:
+                get_status = lib.nvmlDeviceGetP2PStatus
+                get_count = lib.nvmlDeviceGetCount_v2
+                get_handle = lib.nvmlDeviceGetHandleByIndex_v2
+                get_link_state = lib.nvmlDeviceGetNvLinkState
+                nvml_init = lib.nvmlInit_v2
+            except AttributeError as e:
+                # An older driver without these entry points is not a failure worth
+                # warning about; the shell-out still works.
+                logger.debug(f"NVML lacks a required symbol: {e}")
+                return None
+            for fn in (get_status, get_count, get_handle, get_link_state, nvml_init):
+                fn.restype = ctypes.c_int
+            if nvml_init() != cls._NVML_SUCCESS:
+                return None
+            initialised = True
+
+            count = ctypes.c_uint()
+            if get_count(ctypes.byref(count)) != cls._NVML_SUCCESS:
+                return None
+            if count.value < 2:
+                # Peer copies need two devices. Not an error, just nothing to say.
+                return None
+
+            handles = []
+            for i in range(count.value):
+                handle = ctypes.c_void_p()
+                if get_handle(ctypes.c_uint(i), ctypes.byref(handle)) != cls._NVML_SUCCESS:
+                    return None  # partial inventory: never approve the rest
+                handles.append(handle)
+
+            # Active-link count per device, used only to contradict a positive.
+            active_links = []
+            for handle in handles:
+                seen = 0
+                for link in range(cls._NVML_MAX_LINKS):
+                    state = ctypes.c_uint()
+                    rc = get_link_state(handle, ctypes.c_uint(link), ctypes.byref(state))
+                    if rc != cls._NVML_SUCCESS:
+                        break  # past this device's last link, or unsupported
+                    if state.value == cls._NVML_FEATURE_ENABLED:
+                        seen += 1
+                active_links.append(seen)
+
+            matrix: dict = {}
+            for a in range(count.value):
+                for b in range(count.value):
+                    if a == b:
+                        continue
+                    status = ctypes.c_uint()
+                    rc = get_status(
+                        handles[a],
+                        handles[b],
+                        ctypes.c_uint(cls._NVML_P2P_CAPS_INDEX_NVLINK),
+                        ctypes.byref(status),
+                    )
+                    if rc != cls._NVML_SUCCESS:
+                        return None  # unknown for one pair is unknown for all
+                    linked = status.value == cls._NVML_P2P_STATUS_OK
+                    # A pair cannot be NVLinked if an endpoint has no live NVLink.
+                    # This is the guard for the case no host here could test: if the
+                    # NVLink capability index ever reads OK on a PCIe-only box, the
+                    # zero active links contradict it and the answer becomes unknown
+                    # rather than a false positive that enables P2P (#10613).
+                    if linked and not (active_links[a] and active_links[b]):
+                        logger.debug(
+                            f"NVML says GPU {a}<->{b} is NVLink but they report "
+                            f"{active_links[a]}/{active_links[b]} active links; "
+                            "treating the topology as unreadable"
+                        )
+                        return None
+                    matrix[(a, b)] = (
+                        cls._NVML_NVLINK_LABEL if linked else cls._NVML_NO_NVLINK_LABEL
+                    )
+
+            # Every ordered pair, by key, not by count: a matrix of the right size
+            # built from the wrong keys would still pass a length check.
+            expected = {
+                (a, b)
+                for a in range(count.value)
+                for b in range(count.value)
+                if a != b
+            }
+            if set(matrix) != expected:
+                return None
+            return matrix
+        except Exception as e:
+            logger.debug(f"NVML NVLink probe failed: {e}")
+            return None
+        finally:
+            if initialised:
+                try:
+                    lib.nvmlShutdown()
+                except Exception:
+                    pass
 
     @staticmethod
     def _probe_nvlink_topology() -> Optional[dict]:
@@ -9174,11 +9337,11 @@ class LlamaCppBackend:
             # output still exits 0 and parses cleanly, and the rows that arrived can
             # be uniformly NV#, which reads as "the whole box is NVLinked" and would
             # enable P2P on cards whose links were never seen (#10613).
-            if len(matrix) != len(columns) * (len(columns) - 1):
+            expected = {(a, b) for a in columns for b in columns if a != b}
+            if set(matrix) != expected:
                 logger.debug(
                     f"nvidia-smi topo -m: {len(matrix)} pairs for {len(columns)} "
-                    "GPUs, expected "
-                    f"{len(columns) * (len(columns) - 1)}; treating as unreadable"
+                    f"GPUs, expected {len(expected)}; treating as unreadable"
                 )
                 return None
             return matrix or None
@@ -9187,11 +9350,59 @@ class LlamaCppBackend:
             return None
 
     @classmethod
+    def _probe_interconnect_matrix(cls) -> Optional[dict]:
+        """NVML first, `nvidia-smi topo -m` second, nothing third. Both answer in
+        the same index space and the same shape; NVML is ~14x faster, so the
+        shell-out is only paid on drivers too old to answer.
+
+        UNSLOTH_P2P_TOPO_CROSSCHECK=1 runs both and logs any disagreement. It exists
+        to qualify the fast path on fabrics not available here (PCIe-only and
+        partially bridged multi-GPU); an NVML-positive / topo-negative pair is the
+        result that would matter."""
+        matrix = cls._probe_nvml_nvlink_topology()
+        if matrix is not None and os.environ.get("UNSLOTH_P2P_TOPO_CROSSCHECK") == "1":
+            topo = cls._probe_nvlink_topology()
+            if topo is not None:
+                nvml_yes = {k for k, v in matrix.items() if cls._label_is_nvlink(v)}
+                topo_yes = {k for k, v in topo.items() if cls._label_is_nvlink(v)}
+                if nvml_yes != topo_yes:
+                    logger.warning(
+                        "P2P topology cross-check disagreement: NVML-only pairs "
+                        f"{sorted(nvml_yes - topo_yes)}, topo-only pairs "
+                        f"{sorted(topo_yes - nvml_yes)}. Using topo -m. Please "
+                        "report this with `nvidia-smi topo -m` output (#10613)."
+                    )
+                    return topo
+        if matrix is not None:
+            return matrix
+        return cls._probe_nvlink_topology()
+
+    @classmethod
     def _nvlink_topology(cls, refresh = False) -> Optional[dict]:
-        """_probe_nvlink_topology, cached for the life of the process."""
-        if refresh or cls._NVLINK_TOPO_CACHE is None:
-            cls._NVLINK_TOPO_CACHE = (cls._probe_nvlink_topology(),)
-        return cls._NVLINK_TOPO_CACHE[0]
+        """_probe_interconnect_matrix, cached for the life of the process.
+
+        The probe runs outside the lock (it is slow and a duplicate pass is
+        harmless), but publication is guarded: a background prime and a model load
+        can both be in flight, and the generation check stops a slow winner from
+        overwriting a newer invalidation."""
+        if not refresh and cls._NVLINK_TOPO_CACHE is not None:
+            return cls._NVLINK_TOPO_CACHE[0]
+        with cls._NVLINK_TOPO_LOCK:
+            generation = cls._NVLINK_TOPO_GENERATION
+            if refresh:
+                cls._NVLINK_TOPO_GENERATION += 1
+                generation = cls._NVLINK_TOPO_GENERATION
+            elif cls._NVLINK_TOPO_CACHE is not None:
+                return cls._NVLINK_TOPO_CACHE[0]
+        probed = cls._probe_interconnect_matrix()
+        with cls._NVLINK_TOPO_LOCK:
+            if generation == cls._NVLINK_TOPO_GENERATION:
+                cls._NVLINK_TOPO_CACHE = (probed,)
+                return probed
+            # A refresh started while this pass was running: its answer is the
+            # current one, so discard this one rather than publish it stale.
+            cached = cls._NVLINK_TOPO_CACHE
+        return probed if cached is None else cached[0]
 
     @staticmethod
     def _running_virtualized() -> bool:
@@ -9331,7 +9542,7 @@ class LlamaCppBackend:
 
         matrix = cls._nvlink_topology()
         if not matrix:
-            return "nvidia-smi topo -m gave no usable interconnect matrix"
+            return "neither NVML nor nvidia-smi topo -m gave a usable interconnect matrix"
 
         gpu_ids = sorted({i for pair in matrix for i in pair})
 
@@ -9352,13 +9563,24 @@ class LlamaCppBackend:
             if not (
                 launch_order_pinned
                 or os.environ.get("CUDA_DEVICE_ORDER") == "PCI_BUS_ID"
-                or all(cls._TOPO_NVLINK_RE.match(v) for v in matrix.values())
+                or all(cls._label_is_nvlink(v) for v in matrix.values())
             ):
                 return _pcie(
                     "the child's device order is not pinned to PCI_BUS_ID and the "
                     "box is not uniformly NVLinked, so the verified GPUs may not be "
                     "the ones it runs on; set CUDA_DEVICE_ORDER=PCI_BUS_ID to "
                     "enable P2P here"
+                )
+            # A usable `topo -m` proves nvidia-smi answered, so the ids came from its
+            # enumeration and index the matrix verbatim. NVML does not carry that
+            # implication: it answers from the driver even when nvidia-smi did not,
+            # and _get_gpu_memory's torch fallback hands back CUDA ordinals, which
+            # index this matrix wrongly under FASTEST_FIRST (#10613).
+            if cls._matrix_is_nvml(matrix) and cls._GPU_IDS_ARE_PCI_INDICES is not True:
+                return _pcie(
+                    "the GPU selection came from torch rather than nvidia-smi, so "
+                    "its ids are CUDA ordinals and cannot be matched against the "
+                    "NVML interconnect matrix"
                 )
             selected = sorted(set(gpu_indices))
         else:
@@ -9389,7 +9611,7 @@ class LlamaCppBackend:
                 label = matrix.get((a, b))
                 if label is None:
                     return f"GPU {a} and GPU {b} are absent from the interconnect matrix"
-                if not cls._TOPO_NVLINK_RE.match(label):
+                if not cls._label_is_nvlink(label):
                     return _pcie(f"GPU {a} to GPU {b} is {label}, not NVLink")
         return None
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -9117,14 +9117,13 @@ class LlamaCppBackend:
     # One probe per process, not per launch. None = not yet probed; otherwise a
     # 1-tuple whose value may itself be None ("probed and unavailable").
     _NVLINK_TOPO_CACHE = None
-    # Bumped on every refresh so a slow background prime cannot publish over a
-    # newer invalidation.
+    # Bumped on refresh so a slow background prime cannot publish over a newer
+    # invalidation.
     _NVLINK_TOPO_GENERATION = 0
     _NVLINK_TOPO_LOCK = threading.Lock()
 
-    # NVML labels. `topo -m` reports NV# (a bonded set of # links); NVML answers a
-    # yes/no per pair, so it gets its own vocabulary rather than a fabricated NV18
-    # that downstream code could misread as a link count.
+    # NVML answers yes/no per pair, so it gets its own vocabulary rather than a
+    # fabricated NV18 that downstream code could misread as a link count.
     _NVML_NVLINK_LABEL = "NVLINK"
     _NVML_NO_NVLINK_LABEL = "NO-NVLINK"
 
@@ -9133,9 +9132,8 @@ class LlamaCppBackend:
     _NVML_SUCCESS = 0
     _NVML_P2P_CAPS_INDEX_NVLINK = 2
     _NVML_P2P_STATUS_OK = 0
-    # 1..5 are the documented "not supported, and here is why" answers. 6 is
-    # UNKNOWN, and a newer driver could return something past the end of the enum
-    # entirely; neither is a denial, so neither may be recorded as one.
+    # 1..5 are the documented "not supported, and here is why" answers. UNKNOWN (6),
+    # or anything past the end of the enum, is not a denial and must not become one.
     _NVML_P2P_STATUS_DEFINITE_NEGATIVES = frozenset({1, 2, 3, 4, 5})
     _NVML_FEATURE_ENABLED = 1
     # Link enumeration stops at the first error; this only bounds a runaway loop.
@@ -9143,8 +9141,8 @@ class LlamaCppBackend:
 
     @classmethod
     def _matrix_is_nvml(cls, matrix: dict) -> bool:
-        """Whether this matrix came from NVML rather than the shell-out. It decides
-        one thing only: whether nvidia-smi is known to have answered."""
+        """Whether this matrix came from NVML, i.e. whether nvidia-smi is known to
+        have answered."""
         return any(
             v in (cls._NVML_NVLINK_LABEL, cls._NVML_NO_NVLINK_LABEL)
             for v in matrix.values()
@@ -9152,20 +9150,19 @@ class LlamaCppBackend:
 
     @classmethod
     def _label_is_nvlink(cls, label: str) -> bool:
-        """The one place that decides whether an interconnect label means NVLink, so
-        the selected-pair check and the whole-box check cannot drift apart."""
+        """The one place that decides whether a label means NVLink, so the
+        selected-pair check and the whole-box check cannot drift apart."""
         return bool(cls._TOPO_NVLINK_RE.match(label)) or label == cls._NVML_NVLINK_LABEL
 
     @staticmethod
     def _nvml_library():
-        """The driver's own NVML, via ctypes. It ships with the driver, so it is
-        present exactly when nvidia-smi is (nvidia-smi is itself an NVML client) and
-        this adds no Python dependency: nvidia-ml-py is NOT installed in a Studio
-        env. None when it cannot be loaded."""
+        """The driver's own NVML, via ctypes: present exactly when nvidia-smi is, and
+        no Python dependency (nvidia-ml-py is NOT installed in a Studio env). None
+        when it cannot be loaded."""
         if os.name == "nt":
             # A driver install can leave nvml.dll in the NVSMI directory rather than a
-            # DLL search path, the same way it does nvidia-smi.exe (see
-            # _nvidia_smi_executable in utils/hardware/nvidia.py).
+            # DLL search path, as it does nvidia-smi.exe (see _nvidia_smi_executable
+            # in utils/hardware/nvidia.py).
             names = ["nvml.dll"]
             for root in (os.environ.get("ProgramFiles"), os.environ.get("ProgramW6432")):
                 if root:
@@ -9185,16 +9182,15 @@ class LlamaCppBackend:
     @classmethod
     def _probe_nvml_nvlink_topology(cls) -> Optional[dict]:
         """Same matrix as _probe_nvlink_topology, from NVML instead of a shell-out:
-        ~85 ms against ~1200 ms for `nvidia-smi topo -m` on an 8x B200. Keyed by the
-        NVML device index, which is the nvidia-smi index (both enumerate in PCI
-        order and both ignore CUDA_VISIBLE_DEVICES, verified on 8x B200). None when
-        the answer is not conclusive, which sends the caller to the shell-out.
+        ~85 ms against ~1200 ms on an 8x B200. Keyed by the NVML device index, which
+        is the nvidia-smi index (both enumerate in PCI order and both ignore
+        CUDA_VISIBLE_DEVICES, verified on 8x B200). None when the answer is not
+        conclusive, which sends the caller to the shell-out.
 
-        Evidence is per PAIR: nvmlDeviceGetP2PStatus with the NVLink capability
-        index. An active link whose remote endpoint is an NVSwitch proves only that
-        the GPU is attached to a switch, and switch fabrics can be partitioned, so
-        "every GPU has a switch link" must NOT be read as "every pair is reachable".
-        """
+        Evidence is per PAIR: an active link whose remote endpoint is an NVSwitch
+        proves only that the GPU is attached to a switch, and switch fabrics can be
+        partitioned, so "every GPU has a switch link" must NOT be read as "every pair
+        is reachable"."""
         lib = cls._nvml_library()
         if lib is None:
             return None
@@ -9207,8 +9203,8 @@ class LlamaCppBackend:
                 get_link_state = lib.nvmlDeviceGetNvLinkState
                 nvml_init = lib.nvmlInit_v2
             except AttributeError as e:
-                # An older driver without these entry points is not a failure worth
-                # warning about; the shell-out still works.
+                # An older driver missing these is not worth a warning; the
+                # shell-out still works.
                 logger.debug(f"NVML lacks a required symbol: {e}")
                 return None
             for fn in (get_status, get_count, get_handle, get_link_state, nvml_init):
@@ -9221,8 +9217,7 @@ class LlamaCppBackend:
             if get_count(ctypes.byref(count)) != cls._NVML_SUCCESS:
                 return None
             if count.value < 2:
-                # Peer copies need two devices. Not an error, just nothing to say.
-                return None
+                return None  # peer copies need two devices; nothing to say
 
             handles = []
             for i in range(count.value):
@@ -9231,7 +9226,7 @@ class LlamaCppBackend:
                     return None  # partial inventory: never approve the rest
                 handles.append(handle)
 
-            # Active-link count per device, used only to contradict a positive.
+            # Per-device active links, used only to contradict a positive.
             active_links = []
             for handle in handles:
                 seen = 0
@@ -9261,19 +9256,16 @@ class LlamaCppBackend:
                     linked = status.value == cls._NVML_P2P_STATUS_OK
                     if not linked and status.value not in cls._NVML_P2P_STATUS_DEFINITE_NEGATIVES:
                         # UNKNOWN, or a status this build has never heard of. Recording
-                        # it as NO-NVLINK would make the matrix look conclusive and rob
-                        # `topo -m` of the chance to answer, losing P2P on a host whose
-                        # fabric is real but whose driver cannot answer this query.
+                        # it as NO-NVLINK would look conclusive and rob `topo -m` of the
+                        # chance to confirm a fabric that is really there.
                         logger.debug(
                             f"NVML P2P status {status.value} for GPU {a}<->{b} is not a "
                             "definite answer; treating the topology as unreadable"
                         )
                         return None
-                    # A pair cannot be NVLinked if an endpoint has no live NVLink.
-                    # This is the guard for the case no host here could test: if the
-                    # NVLink capability index ever reads OK on a PCIe-only box, the
-                    # zero active links contradict it and the answer becomes unknown
-                    # rather than a false positive that enables P2P (#10613).
+                    # A pair cannot be NVLinked if an endpoint has no live NVLink. The
+                    # guard for hardware not testable here: an OK on a PCIe-only box
+                    # becomes unknown, not a false positive that enables P2P (#10613).
                     if linked and not (active_links[a] and active_links[b]):
                         logger.debug(
                             f"NVML says GPU {a}<->{b} is NVLink but they report "
@@ -9285,8 +9277,8 @@ class LlamaCppBackend:
                         cls._NVML_NVLINK_LABEL if linked else cls._NVML_NO_NVLINK_LABEL
                     )
 
-            # Every ordered pair, by key, not by count: a matrix of the right size
-            # built from the wrong keys would still pass a length check.
+            # By key, not by count: a matrix of the right size built from the wrong
+            # keys would still pass a length check.
             expected = {
                 (a, b)
                 for a in range(count.value)
@@ -9377,14 +9369,13 @@ class LlamaCppBackend:
 
     @classmethod
     def _probe_interconnect_matrix(cls) -> Optional[dict]:
-        """NVML first, `nvidia-smi topo -m` second, nothing third. Both answer in
-        the same index space and the same shape; NVML is ~14x faster, so the
-        shell-out is only paid on drivers too old to answer.
+        """NVML first, `nvidia-smi topo -m` second, nothing third. Both answer in the
+        same index space and shape; NVML is ~14x faster, so the shell-out is only paid
+        on drivers too old to answer.
 
-        UNSLOTH_P2P_TOPO_CROSSCHECK=1 runs both and logs any disagreement. It exists
-        to qualify the fast path on fabrics not available here (PCIe-only and
-        partially bridged multi-GPU); an NVML-positive / topo-negative pair is the
-        result that would matter."""
+        UNSLOTH_P2P_TOPO_CROSSCHECK=1 runs both and logs any disagreement, to qualify
+        the fast path on fabrics not available here (PCIe-only, partially bridged); an
+        NVML-positive / topo-negative pair is the result that would matter."""
         matrix = cls._probe_nvml_nvlink_topology()
         if matrix is not None and os.environ.get("UNSLOTH_P2P_TOPO_CROSSCHECK") == "1":
             topo = cls._probe_nvlink_topology()
@@ -9407,10 +9398,10 @@ class LlamaCppBackend:
     def _nvlink_topology(cls, refresh = False, cache_failure = True) -> Optional[dict]:
         """_probe_interconnect_matrix, cached for the life of the process.
 
-        The probe runs outside the lock (it is slow and a duplicate pass is
-        harmless), but publication is guarded: a background prime and a model load
-        can both be in flight, and the generation check stops a slow winner from
-        overwriting a newer invalidation."""
+        The probe runs outside the lock (slow, and a duplicate pass is harmless), but
+        publication is guarded: a background prime and a model load can both be in
+        flight, and the generation check stops a slow winner from overwriting a newer
+        invalidation."""
         if not refresh and cls._NVLINK_TOPO_CACHE is not None:
             return cls._NVLINK_TOPO_CACHE[0]
         with cls._NVLINK_TOPO_LOCK:
@@ -9424,15 +9415,14 @@ class LlamaCppBackend:
         with cls._NVLINK_TOPO_LOCK:
             if generation == cls._NVLINK_TOPO_GENERATION:
                 if probed is None and not cache_failure:
-                    # A speculative caller (the startup prime) that probed too early,
-                    # e.g. mid driver initialisation. Caching the miss would keep P2P
-                    # off for the life of the process even once the topology becomes
-                    # readable, so leave the cache cold and let the load path probe.
+                    # The startup prime may have probed mid driver initialisation.
+                    # Caching the miss would keep P2P off for the life of the process
+                    # even once the topology becomes readable, so leave the cache cold.
                     return None
                 cls._NVLINK_TOPO_CACHE = (probed,)
                 return probed
-            # A refresh started while this pass was running: its answer is the
-            # current one, so discard this one rather than publish it stale.
+            # A refresh started mid-pass owns the current answer; discard this one
+            # rather than publish it stale.
             cached = cls._NVLINK_TOPO_CACHE
         return probed if cached is None else cached[0]
 
@@ -9603,11 +9593,10 @@ class LlamaCppBackend:
                     "the ones it runs on; set CUDA_DEVICE_ORDER=PCI_BUS_ID to "
                     "enable P2P here"
                 )
-            # A usable `topo -m` proves nvidia-smi answered, so the ids came from its
-            # enumeration and index the matrix verbatim. NVML does not carry that
-            # implication: it answers from the driver even when nvidia-smi did not,
-            # and _get_gpu_memory's torch fallback hands back CUDA ordinals, which
-            # index this matrix wrongly under FASTEST_FIRST (#10613).
+            # A usable `topo -m` proves nvidia-smi enumerated the selection, so the ids
+            # index the matrix verbatim. NVML does not carry that implication, and
+            # _get_gpu_memory's torch fallback hands back CUDA ordinals, which index
+            # this matrix wrongly under FASTEST_FIRST (#10613).
             if cls._matrix_is_nvml(matrix) and cls._GPU_IDS_ARE_PCI_INDICES is not True:
                 return _pcie(
                     "the GPU selection came from torch rather than nvidia-smi, so "

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -9133,6 +9133,10 @@ class LlamaCppBackend:
     _NVML_SUCCESS = 0
     _NVML_P2P_CAPS_INDEX_NVLINK = 2
     _NVML_P2P_STATUS_OK = 0
+    # 1..5 are the documented "not supported, and here is why" answers. 6 is
+    # UNKNOWN, and a newer driver could return something past the end of the enum
+    # entirely; neither is a denial, so neither may be recorded as one.
+    _NVML_P2P_STATUS_DEFINITE_NEGATIVES = frozenset({1, 2, 3, 4, 5})
     _NVML_FEATURE_ENABLED = 1
     # Link enumeration stops at the first error; this only bounds a runaway loop.
     _NVML_MAX_LINKS = 64
@@ -9158,7 +9162,19 @@ class LlamaCppBackend:
         present exactly when nvidia-smi is (nvidia-smi is itself an NVML client) and
         this adds no Python dependency: nvidia-ml-py is NOT installed in a Studio
         env. None when it cannot be loaded."""
-        names = ("nvml.dll",) if os.name == "nt" else ("libnvidia-ml.so.1", "libnvidia-ml.so")
+        if os.name == "nt":
+            # A driver install can leave nvml.dll in the NVSMI directory rather than a
+            # DLL search path, the same way it does nvidia-smi.exe (see
+            # _nvidia_smi_executable in utils/hardware/nvidia.py).
+            names = ["nvml.dll"]
+            for root in (os.environ.get("ProgramFiles"), os.environ.get("ProgramW6432")):
+                if root:
+                    names.append(os.path.join(root, "NVIDIA Corporation", "NVSMI", "nvml.dll"))
+            windir = os.environ.get("SystemRoot")
+            if windir:
+                names.append(os.path.join(windir, "System32", "nvml.dll"))
+        else:
+            names = ["libnvidia-ml.so.1", "libnvidia-ml.so"]
         for name in names:
             try:
                 return ctypes.CDLL(name)
@@ -9243,6 +9259,16 @@ class LlamaCppBackend:
                     if rc != cls._NVML_SUCCESS:
                         return None  # unknown for one pair is unknown for all
                     linked = status.value == cls._NVML_P2P_STATUS_OK
+                    if not linked and status.value not in cls._NVML_P2P_STATUS_DEFINITE_NEGATIVES:
+                        # UNKNOWN, or a status this build has never heard of. Recording
+                        # it as NO-NVLINK would make the matrix look conclusive and rob
+                        # `topo -m` of the chance to answer, losing P2P on a host whose
+                        # fabric is real but whose driver cannot answer this query.
+                        logger.debug(
+                            f"NVML P2P status {status.value} for GPU {a}<->{b} is not a "
+                            "definite answer; treating the topology as unreadable"
+                        )
+                        return None
                     # A pair cannot be NVLinked if an endpoint has no live NVLink.
                     # This is the guard for the case no host here could test: if the
                     # NVLink capability index ever reads OK on a PCIe-only box, the
@@ -9378,7 +9404,7 @@ class LlamaCppBackend:
         return cls._probe_nvlink_topology()
 
     @classmethod
-    def _nvlink_topology(cls, refresh = False) -> Optional[dict]:
+    def _nvlink_topology(cls, refresh = False, cache_failure = True) -> Optional[dict]:
         """_probe_interconnect_matrix, cached for the life of the process.
 
         The probe runs outside the lock (it is slow and a duplicate pass is
@@ -9397,6 +9423,12 @@ class LlamaCppBackend:
         probed = cls._probe_interconnect_matrix()
         with cls._NVLINK_TOPO_LOCK:
             if generation == cls._NVLINK_TOPO_GENERATION:
+                if probed is None and not cache_failure:
+                    # A speculative caller (the startup prime) that probed too early,
+                    # e.g. mid driver initialisation. Caching the miss would keep P2P
+                    # off for the life of the process even once the topology becomes
+                    # readable, so leave the cache cold and let the load path probe.
+                    return None
                 cls._NVLINK_TOPO_CACHE = (probed,)
                 return probed
             # A refresh started while this pass was running: its answer is the

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -9413,6 +9413,27 @@ class LlamaCppBackend:
         return cls._probe_nvlink_topology()
 
     @classmethod
+    def prime_nvlink_topology(cls) -> None:
+        """Warm the cache with NVML only, for a speculative caller off the load path.
+
+        Deliberately skips the `nvidia-smi` fallback. A prime is an optimisation, so
+        it may pay the cheap path and nothing else: spawning a subprocess that can run
+        for its full timeout, on a background thread, perturbs whatever else shares
+        the process. If NVML cannot answer the cache stays cold and the load path does
+        the slow probe inline, exactly as it would have without a prime.
+
+        Publishes only a success, for the reason cache_failure documents below: a miss
+        cached this early would outlive the condition that caused it."""
+        if cls._NVLINK_TOPO_CACHE is not None:
+            return
+        matrix = cls._probe_nvml_nvlink_topology()
+        if matrix is None:
+            return
+        with cls._NVLINK_TOPO_LOCK:
+            if cls._NVLINK_TOPO_CACHE is None:
+                cls._NVLINK_TOPO_CACHE = (matrix,)
+
+    @classmethod
     def _nvlink_topology(
         cls,
         refresh = False,

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -9144,8 +9144,7 @@ class LlamaCppBackend:
         """Whether this matrix came from NVML, i.e. whether nvidia-smi is known to
         have answered."""
         return any(
-            v in (cls._NVML_NVLINK_LABEL, cls._NVML_NO_NVLINK_LABEL)
-            for v in matrix.values()
+            v in (cls._NVML_NVLINK_LABEL, cls._NVML_NO_NVLINK_LABEL) for v in matrix.values()
         )
 
     @classmethod
@@ -9299,18 +9298,11 @@ class LlamaCppBackend:
                             "treating the topology as unreadable"
                         )
                         return None
-                    matrix[(a, b)] = (
-                        cls._NVML_NVLINK_LABEL if linked else cls._NVML_NO_NVLINK_LABEL
-                    )
+                    matrix[(a, b)] = cls._NVML_NVLINK_LABEL if linked else cls._NVML_NO_NVLINK_LABEL
 
             # By key, not by count: a matrix of the right size built from the wrong
             # keys would still pass a length check.
-            expected = {
-                (a, b)
-                for a in range(count.value)
-                for b in range(count.value)
-                if a != b
-            }
+            expected = {(a, b) for a in range(count.value) for b in range(count.value) if a != b}
             if set(matrix) != expected:
                 return None
             return matrix
@@ -9421,7 +9413,11 @@ class LlamaCppBackend:
         return cls._probe_nvlink_topology()
 
     @classmethod
-    def _nvlink_topology(cls, refresh = False, cache_failure = True) -> Optional[dict]:
+    def _nvlink_topology(
+        cls,
+        refresh = False,
+        cache_failure = True,
+    ) -> Optional[dict]:
         """_probe_interconnect_matrix, cached for the life of the process.
 
         The probe runs outside the lock (slow, and a duplicate pass is harmless), but
@@ -9543,9 +9539,7 @@ class LlamaCppBackend:
         reads as "do not set P2P", since losing the tuning beats an exception
         escaping into load_model and failing the load."""
         try:
-            return cls._p2p_veto_reason_inner(
-                gpu_indices, launch_order_pinned, ids_are_pci_indices
-            )
+            return cls._p2p_veto_reason_inner(gpu_indices, launch_order_pinned, ids_are_pci_indices)
         except Exception as e:
             logger.debug(f"peer-fabric check failed: {e}")
             return f"the peer-fabric check could not complete ({type(e).__name__})"

--- a/studio/backend/tests/test_datacenter_gpu_tuning.py
+++ b/studio/backend/tests/test_datacenter_gpu_tuning.py
@@ -1385,3 +1385,77 @@ def test_an_explicit_pick_keeps_its_pci_provenance(monkeypatch):
     assert LlamaCppBackend._p2p_veto_reason(
         [0, 1], True, ids_are_pci_indices = False
     ) is not None
+
+
+def test_a_stalled_nvml_call_cannot_hang_the_load(monkeypatch):
+    """ctypes has no timeout and the shell-out it replaced had one, so a wedged
+    driver must cost a fallback rather than the load."""
+    import threading as _threading
+    release = _threading.Event()
+
+    def _hang(cls):
+        release.wait(30)
+        return {(0, 1): "NVLINK", (1, 0): "NVLINK"}
+
+    monkeypatch.setattr(
+        LlamaCppBackend, "_probe_nvml_nvlink_topology_inner", classmethod(_hang)
+    )
+    monkeypatch.setattr(LlamaCppBackend, "_NVML_PROBE_TIMEOUT_SECONDS", 0.2)
+    try:
+        assert LlamaCppBackend._probe_nvml_nvlink_topology() is None
+        # And the caller still reaches the shell-out.
+        _use_topo(monkeypatch, TOPO_NVLINK_8X)
+        matrix = LlamaCppBackend._probe_interconnect_matrix()
+        assert matrix and not LlamaCppBackend._matrix_is_nvml(matrix)
+    finally:
+        release.set()
+
+
+def test_a_racing_failure_does_not_erase_a_published_matrix(monkeypatch):
+    """The prime publishes a good matrix; a load whose own probe fails transiently
+    must not overwrite it with a miss and disable P2P for every later load."""
+    good = {(0, 1): "NVLINK", (1, 0): "NVLINK"}
+    LlamaCppBackend._NVLINK_TOPO_CACHE = None
+    monkeypatch.setattr(
+        LlamaCppBackend, "_probe_interconnect_matrix", classmethod(lambda cls: good)
+    )
+    assert LlamaCppBackend._nvlink_topology() == good
+
+    # Now a pass that probes and fails while the good matrix is already published.
+    monkeypatch.setattr(
+        LlamaCppBackend, "_probe_interconnect_matrix", classmethod(lambda cls: None)
+    )
+    assert LlamaCppBackend._nvlink_topology(refresh = True) == good
+    assert LlamaCppBackend._NVLINK_TOPO_CACHE == (good,)
+
+
+def test_the_prime_skips_work_the_opt_outs_make_useless(monkeypatch):
+    """UNSLOTH_DISABLE_DC_TUNING=1, UNSLOTH_DISABLE_DC_P2P=1 or a falsy GGML_CUDA_P2P
+    all mean the answer can never be used, so the prime must not pay for it."""
+    from utils import torch_warmup
+
+    probed = []
+    monkeypatch.setattr(
+        LlamaCppBackend,
+        "_probe_interconnect_matrix",
+        classmethod(lambda cls: (probed.append(1), {(0, 1): "NVLINK", (1, 0): "NVLINK"})[1]),
+    )
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 8))
+
+    for var, value in (
+        ("UNSLOTH_DISABLE_DC_TUNING", "1"),
+        ("UNSLOTH_DISABLE_DC_P2P", "1"),
+        ("GGML_CUDA_P2P", "0"),
+    ):
+        monkeypatch.setenv(var, value)
+        LlamaCppBackend._NVLINK_TOPO_CACHE = None
+        probed.clear()
+        torch_warmup._prime_nvlink_topology()
+        assert probed == [], f"{var}={value} still primed"
+        monkeypatch.delenv(var, raising = False)
+
+    # Without an opt-out it still primes.
+    LlamaCppBackend._NVLINK_TOPO_CACHE = None
+    probed.clear()
+    torch_warmup._prime_nvlink_topology()
+    assert probed == [1]

--- a/studio/backend/tests/test_datacenter_gpu_tuning.py
+++ b/studio/backend/tests/test_datacenter_gpu_tuning.py
@@ -1556,9 +1556,10 @@ def test_the_prime_never_spawns_the_shell_out(monkeypatch):
     timing-sensitive tests over in CI."""
     calls = []
     monkeypatch.setattr(
-        subprocess, "run",
-        lambda *a, **k: calls.append(a) or types.SimpleNamespace(
-            returncode = 0, stdout = TOPO_NVLINK_8X, stderr = ""),
+        subprocess,
+        "run",
+        lambda *a, **k: calls.append(a)
+        or types.SimpleNamespace(returncode = 0, stdout = TOPO_NVLINK_8X, stderr = ""),
     )
     monkeypatch.setattr(
         LlamaCppBackend, "_probe_nvml_nvlink_topology", classmethod(lambda cls: None)

--- a/studio/backend/tests/test_datacenter_gpu_tuning.py
+++ b/studio/backend/tests/test_datacenter_gpu_tuning.py
@@ -95,10 +95,17 @@ def _no_nvidia_smi(*a, **k):
 def _isolate_host_topology(monkeypatch):
     """Keep the P2P gate off the real host: only nvidia-smi's output is stubbed (the
     parser always runs), caches are dropped either side, and the platform probes are
-    pinned so a CI box with GPUs cannot colour the results."""
+    pinned so a CI box with GPUs cannot colour the results.
+
+    NVML is stubbed absent by default so the topo tests still exercise the parser;
+    on a machine with a driver the fast path answers first and the canned
+    `nvidia-smi` output is never read. The NVML tests install their own fake."""
     LlamaCppBackend._NVLINK_TOPO_CACHE = None
+    LlamaCppBackend._NVLINK_TOPO_GENERATION = 0
     LlamaCppBackend._IOMMU_CACHE = None
     monkeypatch.setattr(subprocess, "run", _no_nvidia_smi)
+    monkeypatch.setattr(LlamaCppBackend, "_nvml_library", staticmethod(lambda: None))
+    monkeypatch.delenv("UNSLOTH_P2P_TOPO_CROSSCHECK", raising = False)
     monkeypatch.setattr(LlamaCppBackend, "_iommu_is_translating", staticmethod(lambda *a: False))
     monkeypatch.setattr(LlamaCppBackend, "_running_virtualized", staticmethod(lambda: False))
     # Overrides off and the warn-once latch reset: no host env, no ordering leak.
@@ -110,6 +117,7 @@ def _isolate_host_topology(monkeypatch):
     LlamaCppBackend._warned_no_nvlink = False
     yield
     LlamaCppBackend._NVLINK_TOPO_CACHE = None
+    LlamaCppBackend._NVLINK_TOPO_GENERATION = 0
     LlamaCppBackend._IOMMU_CACHE = None
     LlamaCppBackend._warned_no_nvlink = False
 
@@ -1060,3 +1068,231 @@ def test_gpu_id_provenance_is_recorded(monkeypatch):
     LlamaCppBackend._GPU_IDS_ARE_PCI_INDICES = None
     LlamaCppBackend._get_gpu_memory("llama-server")
     assert LlamaCppBackend._GPU_IDS_ARE_PCI_INDICES is not True
+
+
+# ---------------------------------------------------------------------------
+# NVML fast path. The gate reads the same matrix from the driver's own NVML
+# instead of `nvidia-smi topo -m` (~230 ms against ~1.2 s on an 8x B200). These
+# drive a fake libnvidia-ml so the failure modes are reachable without hardware.
+# ---------------------------------------------------------------------------
+
+_NVML_OK = 0
+_NVML_ERROR = 999
+
+
+class _FakeNvml:
+    """Minimal stand-in for libnvidia-ml.so.1 driven through the same ctypes calls
+    as the real one: rc out, values written through byref pointers."""
+
+    def __init__(
+        self,
+        count = 2,
+        linked_pairs = None,
+        active_links = None,
+        status_rc = _NVML_OK,
+        handle_rc = _NVML_OK,
+        init_rc = _NVML_OK,
+        count_rc = _NVML_OK,
+        missing = (),
+        fail_status_after = None,
+    ):
+        self.count = count
+        # None = every pair NVLinked.
+        self.linked_pairs = linked_pairs
+        # None = every device has links.
+        self.active_links = active_links
+        self.status_rc = status_rc
+        self.handle_rc = handle_rc
+        self.init_rc = init_rc
+        self.count_rc = count_rc
+        self.missing = set(missing)
+        self.fail_status_after = fail_status_after
+        self.status_calls = 0
+        self.shutdown_calls = 0
+
+    def _fn(self, name, impl):
+        if name in self.missing:
+            raise AttributeError(name)
+        return impl
+
+    # ctypes attribute lookups happen once, up front, in the probe.
+    @property
+    def nvmlInit_v2(self):
+        return self._fn("nvmlInit_v2", lambda: self.init_rc)
+
+    @property
+    def nvmlShutdown(self):
+        def _shutdown():
+            self.shutdown_calls += 1
+            return _NVML_OK
+        return _shutdown
+
+    @property
+    def nvmlDeviceGetCount_v2(self):
+        def _count(ref):
+            ref._obj.value = self.count
+            return self.count_rc
+        return self._fn("nvmlDeviceGetCount_v2", _count)
+
+    @property
+    def nvmlDeviceGetHandleByIndex_v2(self):
+        def _handle(index, ref):
+            ref._obj.value = 1000 + int(getattr(index, "value", index))
+            return self.handle_rc
+        return self._fn("nvmlDeviceGetHandleByIndex_v2", _handle)
+
+    @property
+    def nvmlDeviceGetNvLinkState(self):
+        def _state(handle, link, ref):
+            device = int(handle.value) - 1000
+            links = 4 if self.active_links is None else self.active_links[device]
+            if int(getattr(link, "value", link)) >= links:
+                return _NVML_ERROR
+            ref._obj.value = 1  # NVML_FEATURE_ENABLED
+            return _NVML_OK
+        return self._fn("nvmlDeviceGetNvLinkState", _state)
+
+    @property
+    def nvmlDeviceGetP2PStatus(self):
+        def _status(a, b, index, ref):
+            self.status_calls += 1
+            if self.fail_status_after is not None and self.status_calls > self.fail_status_after:
+                return _NVML_ERROR
+            if self.status_rc != _NVML_OK:
+                return self.status_rc
+            pair = (int(a.value) - 1000, int(b.value) - 1000)
+            linked = self.linked_pairs is None or pair in self.linked_pairs
+            ref._obj.value = 0 if linked else 5  # OK / NOT_SUPPORTED
+            return _NVML_OK
+        return self._fn("nvmlDeviceGetP2PStatus", _status)
+
+
+def _use_nvml(monkeypatch, fake):
+    monkeypatch.setattr(LlamaCppBackend, "_nvml_library", staticmethod(lambda: fake))
+    LlamaCppBackend._NVLINK_TOPO_CACHE = None
+    return fake
+
+
+def test_nvml_all_pairs_nvlinked_is_a_complete_matrix(monkeypatch):
+    _use_nvml(monkeypatch, _FakeNvml(count = 4))
+    matrix = LlamaCppBackend._probe_nvml_nvlink_topology()
+    assert set(matrix) == {(a, b) for a in range(4) for b in range(4) if a != b}
+    assert all(LlamaCppBackend._label_is_nvlink(v) for v in matrix.values())
+
+
+def test_nvml_is_preferred_over_the_shell_out(monkeypatch):
+    """The whole point: on a host where both answer, nvidia-smi is never spawned."""
+    _use_nvml(monkeypatch, _FakeNvml(count = 2))
+    calls = []
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: calls.append(a) or types.SimpleNamespace(
+            returncode = 0, stdout = TOPO_PCIE_2X, stderr = ""),
+    )
+    matrix = LlamaCppBackend._nvlink_topology()
+    assert LlamaCppBackend._matrix_is_nvml(matrix)
+    assert calls == []
+
+
+def test_nvml_absent_falls_back_to_topo(monkeypatch):
+    monkeypatch.setattr(LlamaCppBackend, "_nvml_library", staticmethod(lambda: None))
+    _use_topo(monkeypatch, TOPO_NVLINK_8X)
+    matrix = LlamaCppBackend._nvlink_topology()
+    assert matrix and not LlamaCppBackend._matrix_is_nvml(matrix)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"init_rc": _NVML_ERROR},
+        {"count_rc": _NVML_ERROR},
+        {"handle_rc": _NVML_ERROR},
+        {"status_rc": _NVML_ERROR},
+        {"missing": ("nvmlDeviceGetP2PStatus",)},
+        {"missing": ("nvmlDeviceGetNvLinkState",)},
+        {"count": 1},
+    ],
+)
+def test_nvml_unknown_falls_through_to_topo(monkeypatch, kwargs):
+    """Every way NVML can fail to answer must reach the shell-out, not a verdict."""
+    _use_nvml(monkeypatch, _FakeNvml(**kwargs))
+    assert LlamaCppBackend._probe_nvml_nvlink_topology() is None
+    _use_topo_after_nvml(monkeypatch, _FakeNvml(**kwargs), TOPO_NVLINK_8X)
+    matrix = LlamaCppBackend._nvlink_topology()
+    assert matrix and not LlamaCppBackend._matrix_is_nvml(matrix)
+
+
+def _use_topo_after_nvml(monkeypatch, fake, text):
+    monkeypatch.setattr(LlamaCppBackend, "_nvml_library", staticmethod(lambda: fake))
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: types.SimpleNamespace(returncode = 0, stdout = text, stderr = ""),
+    )
+    LlamaCppBackend._NVLINK_TOPO_CACHE = None
+
+
+def test_nvml_partial_walk_is_not_a_partial_matrix(monkeypatch):
+    """A failure after some pairs succeeded must discard the successes, not approve
+    the pairs that happened to answer first."""
+    _use_nvml(monkeypatch, _FakeNvml(count = 4, fail_status_after = 3))
+    assert LlamaCppBackend._probe_nvml_nvlink_topology() is None
+
+
+def test_nvml_positive_without_active_links_is_a_contradiction(monkeypatch):
+    """The guard for hardware not available here: if the NVLink capability index
+    ever reads OK on a box with no live NVLinks, that is unknown, not a green
+    light."""
+    _use_nvml(monkeypatch, _FakeNvml(count = 2, active_links = [0, 0]))
+    assert LlamaCppBackend._probe_nvml_nvlink_topology() is None
+
+
+def test_nvml_unlinked_pair_vetoes_p2p(monkeypatch):
+    """Two islands: 0-1 and 2-3 bridged, nothing across. A cross-island selection
+    must not get P2P."""
+    linked = {(0, 1), (1, 0), (2, 3), (3, 2)}
+    _use_nvml(monkeypatch, _FakeNvml(count = 4, linked_pairs = linked))
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 4))
+    LlamaCppBackend._GPU_IDS_ARE_PCI_INDICES = True
+    assert LlamaCppBackend._p2p_veto_reason([0, 2]) is not None
+    LlamaCppBackend._NVLINK_TOPO_CACHE = None
+    assert LlamaCppBackend._p2p_veto_reason([0, 1]) is None
+
+
+def test_nvml_matrix_needs_nvidia_smi_provenance(monkeypatch):
+    """`topo -m` answering proves nvidia-smi enumerated the selection. NVML does
+    not, so torch-ordinal ids must not be matched against an NVML matrix."""
+    _use_nvml(monkeypatch, _FakeNvml(count = 4))
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 4))
+    LlamaCppBackend._GPU_IDS_ARE_PCI_INDICES = False
+    assert LlamaCppBackend._p2p_veto_reason([0, 1]) is not None
+    LlamaCppBackend._NVLINK_TOPO_CACHE = None
+    LlamaCppBackend._GPU_IDS_ARE_PCI_INDICES = True
+    assert LlamaCppBackend._p2p_veto_reason([0, 1]) is None
+
+
+def test_nvml_shuts_down_what_it_started(monkeypatch):
+    fake = _use_nvml(monkeypatch, _FakeNvml(count = 2))
+    LlamaCppBackend._probe_nvml_nvlink_topology()
+    assert fake.shutdown_calls == 1
+    # A failed init owns no session, so it must not shut one down.
+    failed = _use_nvml(monkeypatch, _FakeNvml(count = 2, init_rc = _NVML_ERROR))
+    LlamaCppBackend._probe_nvml_nvlink_topology()
+    assert failed.shutdown_calls == 0
+
+
+def test_nvml_single_gpu_gives_no_verdict(monkeypatch):
+    """One device cannot make a pair, and an empty matrix must never read as
+    'everything is NVLinked' through a vacuous all()."""
+    _use_nvml(monkeypatch, _FakeNvml(count = 1))
+    assert LlamaCppBackend._probe_nvml_nvlink_topology() is None
+
+
+def test_crosscheck_prefers_topo_on_disagreement(monkeypatch):
+    """Qualification aid: when both answer and they differ, the slow one wins and
+    the disagreement is logged."""
+    monkeypatch.setenv("UNSLOTH_P2P_TOPO_CROSSCHECK", "1")
+    _use_topo_after_nvml(monkeypatch, _FakeNvml(count = 2), TOPO_PCIE_2X)
+    records = _capture_warnings(monkeypatch)
+    matrix = LlamaCppBackend._probe_interconnect_matrix()
+    assert not LlamaCppBackend._matrix_is_nvml(matrix)
+    assert any("cross-check disagreement" in r for r in records)

--- a/studio/backend/tests/test_datacenter_gpu_tuning.py
+++ b/studio/backend/tests/test_datacenter_gpu_tuning.py
@@ -1273,8 +1273,13 @@ def test_nvml_unlinked_pair_vetoes_p2p(monkeypatch):
 
 def test_nvml_matrix_needs_nvidia_smi_provenance(monkeypatch):
     """`topo -m` answering proves nvidia-smi enumerated the selection; NVML does not,
-    so torch-ordinal ids must not be matched against an NVML matrix."""
-    _use_nvml(monkeypatch, _FakeNvml(count = 4))
+    so torch-ordinal ids must not be matched against an NVML matrix. Partially
+    bridged, since on a uniform fabric the mapping cannot change the verdict and
+    provenance is deliberately not required."""
+    _use_nvml(
+        monkeypatch,
+        _FakeNvml(count = 4, linked_pairs = {(0, 1), (1, 0), (2, 3), (3, 2)}),
+    )
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 4))
     LlamaCppBackend._GPU_IDS_ARE_PCI_INDICES = False
     assert LlamaCppBackend._p2p_veto_reason([0, 1]) is not None
@@ -1373,8 +1378,12 @@ def test_windows_nvml_candidates_include_the_nvsmi_directory(monkeypatch):
 def test_an_explicit_pick_keeps_its_pci_provenance(monkeypatch):
     """The UI's picker hands back PCI-ordered ids. A torch fallback in the unrelated
     memory query sets _GPU_IDS_ARE_PCI_INDICES False process-wide, and that must not
-    cost an explicitly selected NVLinked pair its P2P."""
-    _use_nvml(monkeypatch, _FakeNvml(count = 4))
+    cost an explicitly selected NVLinked pair its P2P. Partially bridged, so the
+    mapping matters and provenance is load-bearing."""
+    _use_nvml(
+        monkeypatch,
+        _FakeNvml(count = 4, linked_pairs = {(0, 1), (1, 0), (2, 3), (3, 2)}),
+    )
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 4))
     LlamaCppBackend._GPU_IDS_ARE_PCI_INDICES = False
 
@@ -1488,3 +1497,34 @@ def test_the_prime_never_blocks_the_warm_sequence(monkeypatch):
     finally:
         release.set()
         worker.join(10)
+
+
+def test_a_uniform_fabric_does_not_need_pci_provenance(monkeypatch):
+    """On a box where every pair is NVLinked, which ids name which cards cannot
+    change the verdict, so torch-ordinal provenance must not veto. Same argument the
+    ordering check above already makes for an unpinned device order."""
+    _use_nvml(monkeypatch, _FakeNvml(count = 4))
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 4))
+    LlamaCppBackend._GPU_IDS_ARE_PCI_INDICES = False
+    assert LlamaCppBackend._p2p_veto_reason([0, 1]) is None
+
+    # Partially bridged, so the mapping DOES matter: provenance is required again.
+    linked = {(0, 1), (1, 0), (2, 3), (3, 2)}
+    _use_nvml(monkeypatch, _FakeNvml(count = 4, linked_pairs = linked))
+    LlamaCppBackend._GPU_IDS_ARE_PCI_INDICES = False
+    assert LlamaCppBackend._p2p_veto_reason([0, 1]) is not None
+
+    # And with provenance it is allowed on the bridged pair.
+    LlamaCppBackend._NVLINK_TOPO_CACHE = None
+    assert LlamaCppBackend._p2p_veto_reason(
+        [0, 1], True, ids_are_pci_indices = True
+    ) is None
+
+
+def test_ids_outside_a_uniform_matrix_still_veto(monkeypatch):
+    """The uniform escape must not become a blanket pass: ids the matrix does not
+    cover are still unknown."""
+    _use_nvml(monkeypatch, _FakeNvml(count = 2))
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 8))
+    LlamaCppBackend._GPU_IDS_ARE_PCI_INDICES = False
+    assert LlamaCppBackend._p2p_veto_reason([0, 5]) is not None

--- a/studio/backend/tests/test_datacenter_gpu_tuning.py
+++ b/studio/backend/tests/test_datacenter_gpu_tuning.py
@@ -1540,14 +1540,10 @@ def test_explicitness_is_not_evidence_of_pci_indexing(monkeypatch):
     LlamaCppBackend._GPU_IDS_ARE_PCI_INDICES = False
 
     monkeypatch.setenv("CUDA_DEVICE_ORDER", "FASTEST_FIRST")
-    assert LlamaCppBackend._p2p_veto_reason(
-        [0, 1], True, ids_are_pci_indices = False
-    ) is not None
+    assert LlamaCppBackend._p2p_veto_reason([0, 1], True, ids_are_pci_indices = False) is not None
 
     # Pinned order: torch's ordinals and nvidia-smi's indices coincide, so the
     # explicit pick is usable again. This is the default the backend sets.
     LlamaCppBackend._NVLINK_TOPO_CACHE = None
     monkeypatch.setenv("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
-    assert LlamaCppBackend._p2p_veto_reason(
-        [0, 1], True, ids_are_pci_indices = True
-    ) is None
+    assert LlamaCppBackend._p2p_veto_reason([0, 1], True, ids_are_pci_indices = True) is None

--- a/studio/backend/tests/test_datacenter_gpu_tuning.py
+++ b/studio/backend/tests/test_datacenter_gpu_tuning.py
@@ -1361,3 +1361,27 @@ def test_windows_nvml_candidates_include_the_nvsmi_directory(monkeypatch):
     assert LlamaCppBackend._nvml_library() is None
     assert any("NVSMI" in t for t in tried), tried
     assert tried[0] == "nvml.dll", "the search path should still be tried first"
+
+
+def test_an_explicit_pick_keeps_its_pci_provenance(monkeypatch):
+    """The UI's picker hands back PCI-ordered ids. A torch fallback in the unrelated
+    memory query sets _GPU_IDS_ARE_PCI_INDICES False process-wide, and that must not
+    cost an explicitly selected NVLinked pair its P2P."""
+    _use_nvml(monkeypatch, _FakeNvml(count = 4))
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 4))
+    LlamaCppBackend._GPU_IDS_ARE_PCI_INDICES = False
+
+    # Caller says nothing: fall back to the process-wide flag, which vetoes.
+    assert LlamaCppBackend._p2p_veto_reason([0, 1]) is not None
+
+    # Caller knows these ids came from the PCI-ordered picker: no veto.
+    LlamaCppBackend._NVLINK_TOPO_CACHE = None
+    assert LlamaCppBackend._p2p_veto_reason(
+        [0, 1], True, ids_are_pci_indices = True
+    ) is None
+
+    # And an explicit False from the caller still vetoes.
+    LlamaCppBackend._NVLINK_TOPO_CACHE = None
+    assert LlamaCppBackend._p2p_veto_reason(
+        [0, 1], True, ids_are_pci_indices = False
+    ) is not None

--- a/studio/backend/tests/test_datacenter_gpu_tuning.py
+++ b/studio/backend/tests/test_datacenter_gpu_tuning.py
@@ -1526,3 +1526,28 @@ def test_ids_outside_a_uniform_matrix_still_veto(monkeypatch):
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 8))
     LlamaCppBackend._GPU_IDS_ARE_PCI_INDICES = False
     assert LlamaCppBackend._p2p_veto_reason([0, 5]) is not None
+
+
+def test_explicitness_is_not_evidence_of_pci_indexing(monkeypatch):
+    """An explicit pick is PCI-indexed only because hardware.py setdefaults
+    CUDA_DEVICE_ORDER=PCI_BUS_ID. Under a user override to FASTEST_FIRST with
+    nvidia-smi unavailable, the picker lists torch's ordinals, and on a partially
+    bridged host the same numbers can name different cards. Trusting explicitness
+    there would approve the wrong pair and enable P2P on a PCIe path."""
+    linked = {(0, 1), (1, 0), (2, 3), (3, 2)}
+    _use_nvml(monkeypatch, _FakeNvml(count = 4, linked_pairs = linked))
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 4))
+    LlamaCppBackend._GPU_IDS_ARE_PCI_INDICES = False
+
+    monkeypatch.setenv("CUDA_DEVICE_ORDER", "FASTEST_FIRST")
+    assert LlamaCppBackend._p2p_veto_reason(
+        [0, 1], True, ids_are_pci_indices = False
+    ) is not None
+
+    # Pinned order: torch's ordinals and nvidia-smi's indices coincide, so the
+    # explicit pick is usable again. This is the default the backend sets.
+    LlamaCppBackend._NVLINK_TOPO_CACHE = None
+    monkeypatch.setenv("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
+    assert LlamaCppBackend._p2p_veto_reason(
+        [0, 1], True, ids_are_pci_indices = True
+    ) is None

--- a/studio/backend/tests/test_datacenter_gpu_tuning.py
+++ b/studio/backend/tests/test_datacenter_gpu_tuning.py
@@ -1448,7 +1448,7 @@ def test_the_prime_skips_work_the_opt_outs_make_useless(monkeypatch):
     probed = []
     monkeypatch.setattr(
         LlamaCppBackend,
-        "_probe_interconnect_matrix",
+        "_probe_nvml_nvlink_topology",
         classmethod(lambda cls: (probed.append(1), {(0, 1): "NVLINK", (1, 0): "NVLINK"})[1]),
     )
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 8))
@@ -1547,3 +1547,37 @@ def test_explicitness_is_not_evidence_of_pci_indexing(monkeypatch):
     LlamaCppBackend._NVLINK_TOPO_CACHE = None
     monkeypatch.setenv("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
     assert LlamaCppBackend._p2p_veto_reason([0, 1], True, ids_are_pci_indices = True) is None
+
+
+def test_the_prime_never_spawns_the_shell_out(monkeypatch):
+    """A prime may pay the cheap path and nothing else. A subprocess that can run for
+    its full timeout, on a background thread, perturbs whatever else shares the
+    process, and that is how an earlier version of this tipped unrelated
+    timing-sensitive tests over in CI."""
+    calls = []
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: calls.append(a) or types.SimpleNamespace(
+            returncode = 0, stdout = TOPO_NVLINK_8X, stderr = ""),
+    )
+    monkeypatch.setattr(
+        LlamaCppBackend, "_probe_nvml_nvlink_topology", classmethod(lambda cls: None)
+    )
+    LlamaCppBackend._NVLINK_TOPO_CACHE = None
+    LlamaCppBackend.prime_nvlink_topology()
+    assert calls == [], "the prime reached the nvidia-smi fallback"
+    assert LlamaCppBackend._NVLINK_TOPO_CACHE is None, "a failed prime cached its miss"
+
+    # The load path still gets its fallback.
+    assert LlamaCppBackend._nvlink_topology() is not None
+    assert calls
+
+
+def test_the_prime_publishes_an_nvml_success(monkeypatch):
+    good = {(0, 1): "NVLINK", (1, 0): "NVLINK"}
+    monkeypatch.setattr(
+        LlamaCppBackend, "_probe_nvml_nvlink_topology", classmethod(lambda cls: good)
+    )
+    LlamaCppBackend._NVLINK_TOPO_CACHE = None
+    LlamaCppBackend.prime_nvlink_topology()
+    assert LlamaCppBackend._NVLINK_TOPO_CACHE == (good,)

--- a/studio/backend/tests/test_datacenter_gpu_tuning.py
+++ b/studio/backend/tests/test_datacenter_gpu_tuning.py
@@ -1130,6 +1130,7 @@ class _FakeNvml:
         def _shutdown():
             self.shutdown_calls += 1
             return _NVML_OK
+
         return _shutdown
 
     @property
@@ -1137,6 +1138,7 @@ class _FakeNvml:
         def _count(ref):
             ref._obj.value = self.count
             return self.count_rc
+
         return self._fn("nvmlDeviceGetCount_v2", _count)
 
     @property
@@ -1144,6 +1146,7 @@ class _FakeNvml:
         def _handle(index, ref):
             ref._obj.value = 1000 + int(getattr(index, "value", index))
             return self.handle_rc
+
         return self._fn("nvmlDeviceGetHandleByIndex_v2", _handle)
 
     @property
@@ -1155,6 +1158,7 @@ class _FakeNvml:
                 return _NVML_ERROR
             ref._obj.value = 1  # NVML_FEATURE_ENABLED
             return _NVML_OK
+
         return self._fn("nvmlDeviceGetNvLinkState", _state)
 
     @property
@@ -1172,6 +1176,7 @@ class _FakeNvml:
             else:
                 ref._obj.value = 0 if linked else 5  # OK / NOT_SUPPORTED
             return _NVML_OK
+
         return self._fn("nvmlDeviceGetP2PStatus", _status)
 
 
@@ -1193,9 +1198,10 @@ def test_nvml_is_preferred_over_the_shell_out(monkeypatch):
     _use_nvml(monkeypatch, _FakeNvml(count = 2))
     calls = []
     monkeypatch.setattr(
-        subprocess, "run",
-        lambda *a, **k: calls.append(a) or types.SimpleNamespace(
-            returncode = 0, stdout = TOPO_PCIE_2X, stderr = ""),
+        subprocess,
+        "run",
+        lambda *a, **k: calls.append(a)
+        or types.SimpleNamespace(returncode = 0, stdout = TOPO_PCIE_2X, stderr = ""),
     )
     matrix = LlamaCppBackend._nvlink_topology()
     assert LlamaCppBackend._matrix_is_nvml(matrix)
@@ -1233,7 +1239,8 @@ def test_nvml_unknown_falls_through_to_topo(monkeypatch, kwargs):
 def _use_topo_after_nvml(monkeypatch, fake, text):
     monkeypatch.setattr(LlamaCppBackend, "_nvml_library", staticmethod(lambda: fake))
     monkeypatch.setattr(
-        subprocess, "run",
+        subprocess,
+        "run",
         lambda *a, **k: types.SimpleNamespace(returncode = 0, stdout = text, stderr = ""),
     )
     LlamaCppBackend._NVLINK_TOPO_CACHE = None
@@ -1376,30 +1383,25 @@ def test_an_explicit_pick_keeps_its_pci_provenance(monkeypatch):
 
     # Caller knows these ids came from the PCI-ordered picker: no veto.
     LlamaCppBackend._NVLINK_TOPO_CACHE = None
-    assert LlamaCppBackend._p2p_veto_reason(
-        [0, 1], True, ids_are_pci_indices = True
-    ) is None
+    assert LlamaCppBackend._p2p_veto_reason([0, 1], True, ids_are_pci_indices = True) is None
 
     # And an explicit False from the caller still vetoes.
     LlamaCppBackend._NVLINK_TOPO_CACHE = None
-    assert LlamaCppBackend._p2p_veto_reason(
-        [0, 1], True, ids_are_pci_indices = False
-    ) is not None
+    assert LlamaCppBackend._p2p_veto_reason([0, 1], True, ids_are_pci_indices = False) is not None
 
 
 def test_a_stalled_nvml_call_cannot_hang_the_load(monkeypatch):
     """ctypes has no timeout and the shell-out it replaced had one, so a wedged
     driver must cost a fallback rather than the load."""
     import threading as _threading
+
     release = _threading.Event()
 
     def _hang(cls):
         release.wait(30)
         return {(0, 1): "NVLINK", (1, 0): "NVLINK"}
 
-    monkeypatch.setattr(
-        LlamaCppBackend, "_probe_nvml_nvlink_topology_inner", classmethod(_hang)
-    )
+    monkeypatch.setattr(LlamaCppBackend, "_probe_nvml_nvlink_topology_inner", classmethod(_hang))
     monkeypatch.setattr(LlamaCppBackend, "_NVML_PROBE_TIMEOUT_SECONDS", 0.2)
     try:
         assert LlamaCppBackend._probe_nvml_nvlink_topology() is None

--- a/studio/backend/tests/test_datacenter_gpu_tuning.py
+++ b/studio/backend/tests/test_datacenter_gpu_tuning.py
@@ -1516,9 +1516,7 @@ def test_a_uniform_fabric_does_not_need_pci_provenance(monkeypatch):
 
     # And with provenance it is allowed on the bridged pair.
     LlamaCppBackend._NVLINK_TOPO_CACHE = None
-    assert LlamaCppBackend._p2p_veto_reason(
-        [0, 1], True, ids_are_pci_indices = True
-    ) is None
+    assert LlamaCppBackend._p2p_veto_reason([0, 1], True, ids_are_pci_indices = True) is None
 
 
 def test_ids_outside_a_uniform_matrix_still_veto(monkeypatch):

--- a/studio/backend/tests/test_datacenter_gpu_tuning.py
+++ b/studio/backend/tests/test_datacenter_gpu_tuning.py
@@ -101,8 +101,8 @@ def _isolate_host_topology(monkeypatch):
     pinned so a CI box with GPUs cannot colour the results.
 
     NVML is stubbed absent by default so the topo tests still exercise the parser;
-    on a machine with a driver the fast path answers first and the canned
-    `nvidia-smi` output is never read. The NVML tests install their own fake."""
+    with a real driver the fast path would answer first and the canned `nvidia-smi`
+    output would never be read. The NVML tests install their own fake."""
     LlamaCppBackend._NVLINK_TOPO_CACHE = None
     LlamaCppBackend._NVLINK_TOPO_GENERATION = 0
     LlamaCppBackend._IOMMU_CACHE = None
@@ -1074,9 +1074,9 @@ def test_gpu_id_provenance_is_recorded(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# NVML fast path. The gate reads the same matrix from the driver's own NVML
-# instead of `nvidia-smi topo -m` (~230 ms against ~1.2 s on an 8x B200). These
-# drive a fake libnvidia-ml so the failure modes are reachable without hardware.
+# NVML fast path: the same matrix from the driver's own NVML instead of
+# `nvidia-smi topo -m`. These drive a fake libnvidia-ml so the failure modes are
+# reachable without hardware.
 # ---------------------------------------------------------------------------
 
 _NVML_OK = 0
@@ -1084,8 +1084,8 @@ _NVML_ERROR = 999
 
 
 class _FakeNvml:
-    """Minimal stand-in for libnvidia-ml.so.1 driven through the same ctypes calls
-    as the real one: rc out, values written through byref pointers."""
+    """Stand-in for libnvidia-ml.so.1 with the real calling convention: rc out,
+    values written through byref pointers."""
 
     def __init__(
         self,
@@ -1240,23 +1240,21 @@ def _use_topo_after_nvml(monkeypatch, fake, text):
 
 
 def test_nvml_partial_walk_is_not_a_partial_matrix(monkeypatch):
-    """A failure after some pairs succeeded must discard the successes, not approve
-    the pairs that happened to answer first."""
+    """A failure mid-walk must discard the successes, not approve the pairs that
+    happened to answer first."""
     _use_nvml(monkeypatch, _FakeNvml(count = 4, fail_status_after = 3))
     assert LlamaCppBackend._probe_nvml_nvlink_topology() is None
 
 
 def test_nvml_positive_without_active_links_is_a_contradiction(monkeypatch):
-    """The guard for hardware not available here: if the NVLink capability index
-    ever reads OK on a box with no live NVLinks, that is unknown, not a green
-    light."""
+    """Guard for hardware not available here: an OK on a box with no live NVLinks is
+    unknown, not a green light."""
     _use_nvml(monkeypatch, _FakeNvml(count = 2, active_links = [0, 0]))
     assert LlamaCppBackend._probe_nvml_nvlink_topology() is None
 
 
 def test_nvml_unlinked_pair_vetoes_p2p(monkeypatch):
-    """Two islands: 0-1 and 2-3 bridged, nothing across. A cross-island selection
-    must not get P2P."""
+    """Two islands, 0-1 and 2-3. A cross-island selection must not get P2P."""
     linked = {(0, 1), (1, 0), (2, 3), (3, 2)}
     _use_nvml(monkeypatch, _FakeNvml(count = 4, linked_pairs = linked))
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 4))
@@ -1267,8 +1265,8 @@ def test_nvml_unlinked_pair_vetoes_p2p(monkeypatch):
 
 
 def test_nvml_matrix_needs_nvidia_smi_provenance(monkeypatch):
-    """`topo -m` answering proves nvidia-smi enumerated the selection. NVML does
-    not, so torch-ordinal ids must not be matched against an NVML matrix."""
+    """`topo -m` answering proves nvidia-smi enumerated the selection; NVML does not,
+    so torch-ordinal ids must not be matched against an NVML matrix."""
     _use_nvml(monkeypatch, _FakeNvml(count = 4))
     monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 4))
     LlamaCppBackend._GPU_IDS_ARE_PCI_INDICES = False
@@ -1296,8 +1294,7 @@ def test_nvml_single_gpu_gives_no_verdict(monkeypatch):
 
 
 def test_crosscheck_prefers_topo_on_disagreement(monkeypatch):
-    """Qualification aid: when both answer and they differ, the slow one wins and
-    the disagreement is logged."""
+    """When both answer and differ, the slow one wins and it is logged."""
     monkeypatch.setenv("UNSLOTH_P2P_TOPO_CROSSCHECK", "1")
     _use_topo_after_nvml(monkeypatch, _FakeNvml(count = 2), TOPO_PCIE_2X)
     records = _capture_warnings(monkeypatch)
@@ -1307,9 +1304,9 @@ def test_crosscheck_prefers_topo_on_disagreement(monkeypatch):
 
 
 def test_nvml_unknown_status_is_not_a_denial(monkeypatch):
-    """NVML_P2P_STATUS_UNKNOWN (6), or a status from a newer driver, is not evidence
-    of no NVLink. Recording it as NO-NVLINK would make the matrix look conclusive and
-    deny topo -m the chance to confirm a fabric that is really there."""
+    """UNKNOWN (6), or a status from a newer driver, is not evidence of no NVLink:
+    recording it as NO-NVLINK would deny topo -m the chance to confirm a real
+    fabric."""
     for status in (6, 42):
         _use_nvml(monkeypatch, _FakeNvml(count = 2, status_value = status))
         assert LlamaCppBackend._probe_nvml_nvlink_topology() is None
@@ -1321,8 +1318,8 @@ def test_nvml_unknown_status_is_not_a_denial(monkeypatch):
 
 
 def test_a_failed_prime_does_not_poison_the_cache(monkeypatch):
-    """The startup prime runs early, possibly mid driver init. A miss cached there
-    would keep P2P off for the whole process even once the topology is readable."""
+    """The prime runs early, possibly mid driver init. A miss cached there would keep
+    P2P off for the whole process even once the topology is readable."""
     monkeypatch.setattr(
         LlamaCppBackend, "_probe_interconnect_matrix", classmethod(lambda cls: None)
     )
@@ -1347,10 +1344,10 @@ def test_a_successful_prime_is_still_cached(monkeypatch):
 
 def test_windows_nvml_candidates_include_the_nvsmi_directory(monkeypatch):
     """A driver install can leave nvml.dll in NVSMI rather than a DLL search path,
-    the same way it does nvidia-smi.exe."""
+    as it does nvidia-smi.exe."""
     tried = []
-    # The autouse fixture stubs _nvml_library absent, so restore the real one; taken
-    # from the module-level capture, since the class attribute is already the stub.
+    # From the module-level capture, since the autouse fixture already replaced the
+    # class attribute with the absent stub.
     monkeypatch.setattr(LlamaCppBackend, "_nvml_library", staticmethod(_REAL_NVML_LIBRARY))
     monkeypatch.setattr(os, "name", "nt")
     monkeypatch.setenv("ProgramFiles", r"C:\Program Files")

--- a/studio/backend/tests/test_datacenter_gpu_tuning.py
+++ b/studio/backend/tests/test_datacenter_gpu_tuning.py
@@ -1450,12 +1450,39 @@ def test_the_prime_skips_work_the_opt_outs_make_useless(monkeypatch):
         monkeypatch.setenv(var, value)
         LlamaCppBackend._NVLINK_TOPO_CACHE = None
         probed.clear()
-        torch_warmup._prime_nvlink_topology()
+        torch_warmup._prime_nvlink_topology().join(10)
         assert probed == [], f"{var}={value} still primed"
         monkeypatch.delenv(var, raising = False)
 
     # Without an opt-out it still primes.
     LlamaCppBackend._NVLINK_TOPO_CACHE = None
     probed.clear()
-    torch_warmup._prime_nvlink_topology()
+    torch_warmup._prime_nvlink_topology().join(10)
     assert probed == [1]
+
+
+def test_the_prime_never_blocks_the_warm_sequence(monkeypatch):
+    """The probe can spend its NVML bound plus the shell-out timeout. A warm stage
+    that waits that long delays every stage behind it, and on a loaded CI worker that
+    is enough to tip unrelated timing-sensitive tests over."""
+    from utils import torch_warmup
+    import threading as _threading
+    import time as _time
+
+    release = _threading.Event()
+
+    def _slow(cls, **kw):
+        release.wait(30)
+        return {(0, 1): "NVLINK", (1, 0): "NVLINK"}
+
+    monkeypatch.setattr(LlamaCppBackend, "_nvlink_topology", classmethod(_slow))
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(["NVIDIA B200"] * 8))
+    try:
+        started = _time.perf_counter()
+        worker = torch_warmup._prime_nvlink_topology()
+        elapsed = _time.perf_counter() - started
+        assert elapsed < 1.0, f"the prime blocked its caller for {elapsed:.2f}s"
+        assert worker.is_alive()
+    finally:
+        release.set()
+        worker.join(10)

--- a/studio/backend/tests/test_datacenter_gpu_tuning.py
+++ b/studio/backend/tests/test_datacenter_gpu_tuning.py
@@ -12,6 +12,8 @@ link across the selection and fails CLOSED on unknowns.
 
 from __future__ import annotations
 
+import ctypes
+import os
 import subprocess
 import sys
 import types
@@ -85,6 +87,7 @@ def _clear_cuda_visible_devices(monkeypatch):
 
 # Captured before the autouse fixture stubs it, so the probe can run for real.
 _REAL_IOMMU_IS_TRANSLATING = LlamaCppBackend.__dict__["_iommu_is_translating"].__func__
+_REAL_NVML_LIBRARY = LlamaCppBackend.__dict__["_nvml_library"].__func__
 
 
 def _no_nvidia_smi(*a, **k):
@@ -1090,6 +1093,7 @@ class _FakeNvml:
         linked_pairs = None,
         active_links = None,
         status_rc = _NVML_OK,
+        status_value = None,
         handle_rc = _NVML_OK,
         init_rc = _NVML_OK,
         count_rc = _NVML_OK,
@@ -1102,6 +1106,7 @@ class _FakeNvml:
         # None = every device has links.
         self.active_links = active_links
         self.status_rc = status_rc
+        self.status_value = status_value
         self.handle_rc = handle_rc
         self.init_rc = init_rc
         self.count_rc = count_rc
@@ -1162,7 +1167,10 @@ class _FakeNvml:
                 return self.status_rc
             pair = (int(a.value) - 1000, int(b.value) - 1000)
             linked = self.linked_pairs is None or pair in self.linked_pairs
-            ref._obj.value = 0 if linked else 5  # OK / NOT_SUPPORTED
+            if self.status_value is not None:
+                ref._obj.value = self.status_value
+            else:
+                ref._obj.value = 0 if linked else 5  # OK / NOT_SUPPORTED
             return _NVML_OK
         return self._fn("nvmlDeviceGetP2PStatus", _status)
 
@@ -1296,3 +1304,63 @@ def test_crosscheck_prefers_topo_on_disagreement(monkeypatch):
     matrix = LlamaCppBackend._probe_interconnect_matrix()
     assert not LlamaCppBackend._matrix_is_nvml(matrix)
     assert any("cross-check disagreement" in r for r in records)
+
+
+def test_nvml_unknown_status_is_not_a_denial(monkeypatch):
+    """NVML_P2P_STATUS_UNKNOWN (6), or a status from a newer driver, is not evidence
+    of no NVLink. Recording it as NO-NVLINK would make the matrix look conclusive and
+    deny topo -m the chance to confirm a fabric that is really there."""
+    for status in (6, 42):
+        _use_nvml(monkeypatch, _FakeNvml(count = 2, status_value = status))
+        assert LlamaCppBackend._probe_nvml_nvlink_topology() is None
+    # A documented "not supported, and here is why" IS a denial, and stays one.
+    for status in (1, 2, 3, 4, 5):
+        _use_nvml(monkeypatch, _FakeNvml(count = 2, status_value = status))
+        matrix = LlamaCppBackend._probe_nvml_nvlink_topology()
+        assert matrix and not any(LlamaCppBackend._label_is_nvlink(v) for v in matrix.values())
+
+
+def test_a_failed_prime_does_not_poison_the_cache(monkeypatch):
+    """The startup prime runs early, possibly mid driver init. A miss cached there
+    would keep P2P off for the whole process even once the topology is readable."""
+    monkeypatch.setattr(
+        LlamaCppBackend, "_probe_interconnect_matrix", classmethod(lambda cls: None)
+    )
+    LlamaCppBackend._NVLINK_TOPO_CACHE = None
+    assert LlamaCppBackend._nvlink_topology(cache_failure = False) is None
+    assert LlamaCppBackend._NVLINK_TOPO_CACHE is None, "a failed prime cached its miss"
+    # The load path still caches its own miss, as it did before this change.
+    assert LlamaCppBackend._nvlink_topology() is None
+    assert LlamaCppBackend._NVLINK_TOPO_CACHE == (None,)
+
+
+def test_a_successful_prime_is_still_cached(monkeypatch):
+    monkeypatch.setattr(
+        LlamaCppBackend,
+        "_probe_interconnect_matrix",
+        classmethod(lambda cls: {(0, 1): "NVLINK", (1, 0): "NVLINK"}),
+    )
+    LlamaCppBackend._NVLINK_TOPO_CACHE = None
+    assert LlamaCppBackend._nvlink_topology(cache_failure = False) is not None
+    assert LlamaCppBackend._NVLINK_TOPO_CACHE is not None
+
+
+def test_windows_nvml_candidates_include_the_nvsmi_directory(monkeypatch):
+    """A driver install can leave nvml.dll in NVSMI rather than a DLL search path,
+    the same way it does nvidia-smi.exe."""
+    tried = []
+    # The autouse fixture stubs _nvml_library absent, so restore the real one; taken
+    # from the module-level capture, since the class attribute is already the stub.
+    monkeypatch.setattr(LlamaCppBackend, "_nvml_library", staticmethod(_REAL_NVML_LIBRARY))
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setenv("ProgramFiles", r"C:\Program Files")
+    monkeypatch.setenv("SystemRoot", r"C:\Windows")
+
+    def _fake_cdll(name):
+        tried.append(name)
+        raise OSError("not here")
+
+    monkeypatch.setattr(ctypes, "CDLL", _fake_cdll)
+    assert LlamaCppBackend._nvml_library() is None
+    assert any("NVSMI" in t for t in tried), tried
+    assert tried[0] == "nvml.dll", "the search path should still be tried first"

--- a/studio/backend/utils/torch_warmup.py
+++ b/studio/backend/utils/torch_warmup.py
@@ -240,18 +240,13 @@ def _warm_inference_backend() -> None:
 
 
 def _prime_nvlink_topology() -> None:
-    """Build the P2P gate's interconnect matrix before the first model load.
+    """Build the P2P gate's interconnect matrix so the load path does not pay the
+    probe inline. Rides the inference_backend stage because it imports the same
+    first-party module.
 
-    It costs ~230 ms via NVML, or ~1.2 s where only `nvidia-smi topo -m` can answer,
-    and the load path would otherwise pay it inline. Rides the inference_backend
-    stage rather than adding one of its own: it imports the same first-party module,
-    so a separate stage would need a purge mapping it has no use for.
-
-    Only hosts that would probe anyway do any work, and a failure here must not fail
-    the stage. cache_failure=False because this runs early, possibly mid driver
-    initialisation: a miss cached here would keep P2P off for the life of the process
-    even once the topology became readable, so a failed prime leaves the cache cold
-    and the load path probes as it would have (#10613)."""
+    cache_failure=False: this runs early, possibly mid driver initialisation, and a
+    miss cached here would keep P2P off for the life of the process even once the
+    topology became readable (#10613)."""
     try:
         from core.inference.llama_cpp import LlamaCppBackend
         if LlamaCppBackend._effective_gpu_count() < 2:

--- a/studio/backend/utils/torch_warmup.py
+++ b/studio/backend/utils/torch_warmup.py
@@ -256,6 +256,7 @@ def _prime_nvlink_topology() -> Optional[threading.Thread]:
     def _probe() -> None:
         try:
             from core.inference.llama_cpp import LlamaCppBackend
+
             # Opted out, so the answer could never be used. The load path skips the
             # probe for the same reason rather than pay its timeout to decide
             # something the user already decided.

--- a/studio/backend/utils/torch_warmup.py
+++ b/studio/backend/utils/torch_warmup.py
@@ -236,28 +236,35 @@ def _warm_inference_backend() -> None:
     # handlers. Building it here makes the getter a dict read. After hardware, to reuse it.
     from core.inference import get_inference_backend
     get_inference_backend()
+    _prime_nvlink_topology()
 
 
-def _warm_nvlink_topology() -> None:
-    # The P2P gate needs an interconnect matrix before the first model loads, and
-    # building it costs ~230 ms via NVML or ~1.2 s via `nvidia-smi topo -m` on an
-    # 8x B200. Paying it here means the load path reads a warm cache. Only hosts
-    # that would probe anyway do any work: the probe is skipped outright unless
-    # there are at least two GPUs with an NVLink-capable name (#10613).
-    from core.inference.llama_cpp import LlamaCppBackend
-    if LlamaCppBackend._effective_gpu_count() < 2:
-        return
-    if not LlamaCppBackend._all_selected_gpus_match(
-        LlamaCppBackend._NVLINK_FABRIC_GPU_RE, None
-    ):
-        return
-    LlamaCppBackend._nvlink_topology()
+def _prime_nvlink_topology() -> None:
+    """Build the P2P gate's interconnect matrix before the first model load.
+
+    It costs ~230 ms via NVML, or ~1.2 s where only `nvidia-smi topo -m` can answer,
+    and the load path would otherwise pay it inline. Rides the inference_backend
+    stage rather than adding one of its own: it imports the same first-party module,
+    so a separate stage would need a purge mapping it has no use for.
+
+    Only hosts that would probe anyway do any work, and a failure here must not fail
+    the stage: the gate re-probes on demand and fails closed by itself (#10613)."""
+    try:
+        from core.inference.llama_cpp import LlamaCppBackend
+        if LlamaCppBackend._effective_gpu_count() < 2:
+            return
+        if not LlamaCppBackend._all_selected_gpus_match(
+            LlamaCppBackend._NVLINK_FABRIC_GPU_RE, None
+        ):
+            return
+        LlamaCppBackend._nvlink_topology()
+    except Exception as e:  # noqa: BLE001 -- a warm miss costs latency, never correctness
+        logger.debug("NVLink topology prime skipped: %r", e)
 
 
 _STAGES = (
     ("hardware", _warm_hardware),
     ("inference_backend", _warm_inference_backend),
-    ("nvlink_topology", _warm_nvlink_topology),
     ("transformers", _warm_transformers),
     ("datasets", _warm_datasets),
 )

--- a/studio/backend/utils/torch_warmup.py
+++ b/studio/backend/utils/torch_warmup.py
@@ -249,9 +249,10 @@ def _prime_nvlink_topology() -> Optional[threading.Thread]:
     demand, so a prime that never finishes costs one load its head start and nothing
     else.
 
-    cache_failure=False: this runs early, possibly mid driver initialisation, and a
-    miss cached here would keep P2P off for the life of the process even once the
-    topology became readable (#10613)."""
+    prime_nvlink_topology is NVML-only and publishes only a success: it must not
+    spawn the `nvidia-smi` fallback here, since a subprocess that can run for its
+    full timeout perturbs whatever else shares the process, and a miss cached this
+    early would keep P2P off for the life of it (#10613)."""
 
     def _probe() -> None:
         try:
@@ -270,7 +271,7 @@ def _prime_nvlink_topology() -> Optional[threading.Thread]:
                 LlamaCppBackend._NVLINK_FABRIC_GPU_RE, None
             ):
                 return
-            LlamaCppBackend._nvlink_topology(cache_failure = False)
+            LlamaCppBackend.prime_nvlink_topology()
         except Exception as e:  # noqa: BLE001 -- a warm miss costs latency, never correctness
             logger.debug("NVLink topology prime skipped: %r", e)
 

--- a/studio/backend/utils/torch_warmup.py
+++ b/studio/backend/utils/torch_warmup.py
@@ -249,6 +249,13 @@ def _prime_nvlink_topology() -> None:
     topology became readable (#10613)."""
     try:
         from core.inference.llama_cpp import LlamaCppBackend
+        # Opted out, so the answer could never be used. The load path skips the probe
+        # for the same reason rather than pay its timeout to decide something the user
+        # already decided.
+        if os.environ.get("UNSLOTH_DISABLE_DC_TUNING") == "1":
+            return
+        if LlamaCppBackend._p2p_user_opted_out():
+            return
         if LlamaCppBackend._effective_gpu_count() < 2:
             return
         if not LlamaCppBackend._all_selected_gpus_match(

--- a/studio/backend/utils/torch_warmup.py
+++ b/studio/backend/utils/torch_warmup.py
@@ -239,32 +239,43 @@ def _warm_inference_backend() -> None:
     _prime_nvlink_topology()
 
 
-def _prime_nvlink_topology() -> None:
+def _prime_nvlink_topology() -> Optional[threading.Thread]:
     """Build the P2P gate's interconnect matrix so the load path does not pay the
-    probe inline. Rides the inference_backend stage because it imports the same
-    first-party module.
+    probe inline. Returns the thread doing it, for tests to join.
+
+    Fire and forget, on a thread of its own. The probe can spend up to its NVML bound
+    plus the shell-out's timeout, and a warm stage that blocks that long delays every
+    stage behind it. Nothing here is on anyone's critical path: the gate re-probes on
+    demand, so a prime that never finishes costs one load its head start and nothing
+    else.
 
     cache_failure=False: this runs early, possibly mid driver initialisation, and a
     miss cached here would keep P2P off for the life of the process even once the
     topology became readable (#10613)."""
-    try:
-        from core.inference.llama_cpp import LlamaCppBackend
-        # Opted out, so the answer could never be used. The load path skips the probe
-        # for the same reason rather than pay its timeout to decide something the user
-        # already decided.
-        if os.environ.get("UNSLOTH_DISABLE_DC_TUNING") == "1":
-            return
-        if LlamaCppBackend._p2p_user_opted_out():
-            return
-        if LlamaCppBackend._effective_gpu_count() < 2:
-            return
-        if not LlamaCppBackend._all_selected_gpus_match(
-            LlamaCppBackend._NVLINK_FABRIC_GPU_RE, None
-        ):
-            return
-        LlamaCppBackend._nvlink_topology(cache_failure = False)
-    except Exception as e:  # noqa: BLE001 -- a warm miss costs latency, never correctness
-        logger.debug("NVLink topology prime skipped: %r", e)
+
+    def _probe() -> None:
+        try:
+            from core.inference.llama_cpp import LlamaCppBackend
+            # Opted out, so the answer could never be used. The load path skips the
+            # probe for the same reason rather than pay its timeout to decide
+            # something the user already decided.
+            if os.environ.get("UNSLOTH_DISABLE_DC_TUNING") == "1":
+                return
+            if LlamaCppBackend._p2p_user_opted_out():
+                return
+            if LlamaCppBackend._effective_gpu_count() < 2:
+                return
+            if not LlamaCppBackend._all_selected_gpus_match(
+                LlamaCppBackend._NVLINK_FABRIC_GPU_RE, None
+            ):
+                return
+            LlamaCppBackend._nvlink_topology(cache_failure = False)
+        except Exception as e:  # noqa: BLE001 -- a warm miss costs latency, never correctness
+            logger.debug("NVLink topology prime skipped: %r", e)
+
+    worker = threading.Thread(target = _probe, daemon = True, name = "nvlink-topology-prime")
+    worker.start()
+    return worker
 
 
 _STAGES = (

--- a/studio/backend/utils/torch_warmup.py
+++ b/studio/backend/utils/torch_warmup.py
@@ -238,9 +238,26 @@ def _warm_inference_backend() -> None:
     get_inference_backend()
 
 
+def _warm_nvlink_topology() -> None:
+    # The P2P gate needs an interconnect matrix before the first model loads, and
+    # building it costs ~230 ms via NVML or ~1.2 s via `nvidia-smi topo -m` on an
+    # 8x B200. Paying it here means the load path reads a warm cache. Only hosts
+    # that would probe anyway do any work: the probe is skipped outright unless
+    # there are at least two GPUs with an NVLink-capable name (#10613).
+    from core.inference.llama_cpp import LlamaCppBackend
+    if LlamaCppBackend._effective_gpu_count() < 2:
+        return
+    if not LlamaCppBackend._all_selected_gpus_match(
+        LlamaCppBackend._NVLINK_FABRIC_GPU_RE, None
+    ):
+        return
+    LlamaCppBackend._nvlink_topology()
+
+
 _STAGES = (
     ("hardware", _warm_hardware),
     ("inference_backend", _warm_inference_backend),
+    ("nvlink_topology", _warm_nvlink_topology),
     ("transformers", _warm_transformers),
     ("datasets", _warm_datasets),
 )

--- a/studio/backend/utils/torch_warmup.py
+++ b/studio/backend/utils/torch_warmup.py
@@ -248,7 +248,10 @@ def _prime_nvlink_topology() -> None:
     so a separate stage would need a purge mapping it has no use for.
 
     Only hosts that would probe anyway do any work, and a failure here must not fail
-    the stage: the gate re-probes on demand and fails closed by itself (#10613)."""
+    the stage. cache_failure=False because this runs early, possibly mid driver
+    initialisation: a miss cached here would keep P2P off for the life of the process
+    even once the topology became readable, so a failed prime leaves the cache cold
+    and the load path probes as it would have (#10613)."""
     try:
         from core.inference.llama_cpp import LlamaCppBackend
         if LlamaCppBackend._effective_gpu_count() < 2:
@@ -257,7 +260,7 @@ def _prime_nvlink_topology() -> None:
             LlamaCppBackend._NVLINK_FABRIC_GPU_RE, None
         ):
             return
-        LlamaCppBackend._nvlink_topology()
+        LlamaCppBackend._nvlink_topology(cache_failure = False)
     except Exception as e:  # noqa: BLE001 -- a warm miss costs latency, never correctness
         logger.debug("NVLink topology prime skipped: %r", e)
 


### PR DESCRIPTION
Follow-up to #10646, which fixed #10613 by gating `GGML_CUDA_P2P` on a confirmed NVLink fabric instead of a product name. That gate reads `nvidia-smi topo -m`, and the shell-out is slow.

Measured on an 8x B200 host:

| invocation | median | origin |
|---|---|---|
| `nvidia-smi --query-gpu=index,compute_cap` | 438.7 ms | pre-existing |
| `nvidia-smi --query-gpu=index,memory.free,memory.total` | 145.8 ms | pre-existing |
| `nvidia-smi topo -m` | 1324.7 ms | added by #10646 |

The cost lands once per process, on the model-load path. It is narrow (only multi-GPU hosts whose cards are NVLink-capable by name ever probe) but it is real, and `topo -m` is by far the most expensive of the three: it walks the fabric rather than reading per-device properties.

## What changes

Ask the driver directly. NVML ships with the driver, so it is present exactly when `nvidia-smi` is, since `nvidia-smi` is itself an NVML client.

| host class | before | after | `nvidia-smi` spawns | NVML loads |
|---|---|---|---|---|
| 8x B200 NVLink | ~1200 ms | **233 ms** | **1 to 0** | 1 |
| 2x RTX 6000 Ada (the #10613 host) | 0.13 ms | 0.08 ms | 0 | 0 |
| 4x L40S | 0.06 ms | 0.05 ms | 0 | 0 |
| 1x B200 (single GPU) | 0.06 ms | 0.03 ms | 0 | 0 |
| 2x RTX 3090 (consumer) | 0.01 ms | 0.007 ms | 0 | 0 |
| 2x MI300X (ROCm) | 0.003 ms | 0.002 ms | 0 | 0 |
| CPU only | 0.004 ms | 0.002 ms | 0 | 0 |

The affected class gets roughly 5x faster and stops spawning a subprocess entirely. Every other class loads nothing new: zero NVML loads and zero subprocesses on consumer, single-GPU, L40S, RTX 6000 Ada, ROCm and CPU, exactly as before. The result is cached for the process and primed in the background at startup, so the first model load reads it warm at 0.004 ms.

**No new dependency.** `nvidia-ml-py` is not declared in `pyproject.toml`'s `studio` extra, any `studio/backend/requirements/*.txt`, either installer, or torch's transitive deps, and it is absent from a real installed Studio venv. The two references in the tree are a Colab pip-freeze snapshot and a pin for the isolated `.venv_llmcompressor` sidecar, neither of which reaches the backend. So this goes through `ctypes` against `libnvidia-ml.so.1` / `nvml.dll`. Only opaque handles and `unsigned int` out-params cross that boundary, so there is no struct layout to get wrong across driver versions.

## Evidence stays per pair

`nvmlDeviceGetP2PStatus(a, b, NVML_P2P_CAPS_INDEX_NVLINK)` asks about one pair. It agrees with `topo -m` exactly on the 8x B200: 56 of 56 ordered pairs NVLinked, in both directions, zero disagreement either way.

What this deliberately does not do is infer connectivity from switch attachment. An active link whose remote endpoint is an NVSwitch proves the GPU is attached to a switch, and switch fabrics can be partitioned, so "every GPU has a switch link" is not read as "every pair is reachable". An earlier version of this patch made that inference and it was wrong.

Index spaces line up, which is what makes this a drop-in: NVML and `nvidia-smi` report byte-identical `busId` for all 8 devices, and both ignore `CUDA_VISIBLE_DEVICES` identically (8 GPUs visible under `CUDA_VISIBLE_DEVICES=2,5` and under `=7`, with NVML index 0 pinned to bus `51:00.0` either way).

## Fail-closed behaviour is unchanged

Evidence chain: NVML, then `nvidia-smi topo -m`, then no P2P. Anything short of a complete answer falls through: missing library or symbol, any non-zero NVML return, fewer than two devices, a partial walk, or a positive contradicted by zero live NVLinks on an endpoint.

One implication needed restating. A usable `topo -m` proved `nvidia-smi` had enumerated the selection, so the ids indexed the matrix verbatim. NVML does not carry that implication: it answers from the driver even when `nvidia-smi` did not, and `_get_gpu_memory`'s torch fallback returns CUDA ordinals, which index the matrix wrongly under `FASTEST_FIRST`. So an NVML matrix is only matched against ids known to have come from `nvidia-smi`, and otherwise vetoes.

Also hardened while here: the `topo -m` parser now validates the exact pair key set rather than the matrix length, since a matrix of the right size built from the wrong keys would previously have passed.

## What is not qualified

**No PCIe-only or partially bridged multi-GPU host was available to test.** I have not empirically confirmed that the NVLink capability index never reads OK on a PCIe-only box. Three things address that:

- the active-link contradiction guard: if a pair reads OK while either endpoint reports zero live NVLinks, the answer becomes unknown and falls back, rather than becoming a false positive
- `UNSLOTH_P2P_TOPO_CROSSCHECK=1` runs both tiers and logs any disagreement, preferring `topo -m` when they differ
- `scripts/p2p_integrity_probe.py` now prints the NVML verdict beside the `topo -m` verdict and flags a mismatch, so a report from such a host supplies the missing data

An NVML-positive with a topo-negative pair is the result that would matter. The gate is no weaker than before either way, since every inconclusive path lands on today's behaviour.

## Testing

- 128 tests in `test_datacenter_gpu_tuning.py` (102 pre-existing, unchanged, plus 26 new) covering each NVML failure mode, the contradiction guard, cross-island vetoes, provenance, shutdown balance, the probe's time bound, the cache-overwrite protection, and single-GPU and empty selections so no vacuous `all([])` can approve anything
- 167 pass across the startup and datacenter suites
- full-suite comparison against merged `main` on frozen worktrees, comparing failure id sets rather than counts

The comparison earned its keep twice.

It found two failures unique to this branch, both real. A separate `nvlink_topology` warm stage tripped the `_STAGE_PACKAGE` purge guard, since every importing stage needs a purge mapping and `inference_backend` is exempt only because it imports first-party code. The prime imports that same module, so it rides that stage instead of asking for an exemption of its own. Those guards are unmodified.

Then CI turned up a third, which took a bisect to pin down. `test_openai_auto_switch.py::test_idle_loop_resets_timer_for_same_repo_different_variant` failed here in 3 of 3 runs and on 0 of 14 other branches, and never reproduced locally, including under the exact CI command with `-n 4`. A throwaway branch identical to this one except with the prime removed did not fail it, which settled the question. The coupling was not through imports, it was through time: the prime ran inline in the warm stage, so it could spend its NVML bound plus the shell-out timeout before the stages behind it started, and the suite installs a fake torch reporting datacenter GPUs process-wide for a worker, so the warm thread walked past every guard into the real probe and stalled that worker long enough to tip a 0.05s idle threshold in an unrelated async test. The prime now runs on a daemon thread of its own and returns in about 0.4ms rather than blocking for up to 20s. `(Python 3.13)` is now down to the one failure every other branch has.

Final comparison, both suites run on frozen worktrees:

| | passed | failed | errors | skipped | distinct failure ids |
|---|---|---|---|---|---|
| baseline `main` 10a95da | 40711 | 384 | 381 | 349 | 765 |
| this branch | 40728 | 384 | 381 | 349 | 765 |

Failure sets are identical: 0 unique to the baseline, 0 unique to this branch. The extra passes are the new tests. That sweep was run at the time; the branch has taken review fixes since, and the `-n 4` re-run described above also showed 0 failures unique to this branch.

Closes nothing on its own; this is a performance follow-up to #10646 and #10613.
