### PR TITLE
Refuse to format when ruff cannot run, and stop the fixed-point guard skipping itself away in CI

### DIFF
--- a/scripts/run_ruff_format.py
+++ b/scripts/run_ruff_format.py
@@ -49,12 +49,32 @@ def installed_ruff_version(python: str = sys.executable) -> str | None:
     return match.group(1) if match else None
 
 
+def ruff_unavailable_reason(python: str = sys.executable) -> str | None:
+    """Why `python -m ruff` cannot run here, or None when it can.
+
+    Separate from the version question because the answers differ. A ruff that
+    runs but reports a version this cannot parse is survivable; a ruff that does
+    not run at all is not, and the pre-pass below has already rewritten every
+    file it was given by the time `ruff format` says so.
+    """
+    try:
+        out = subprocess.run(
+            [python, "-m", "ruff", "--version"], capture_output = True, text = True, timeout = 60
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return f"{type(exc).__name__}: {exc}"
+    if out.returncode != 0:
+        return (out.stderr or out.stdout).strip() or f"`ruff --version` exited {out.returncode}"
+    return None
+
+
 def version_mismatch(pinned: str | None, installed: str | None) -> bool:
     """Whether running this ruff would produce formatting the hook then undoes.
 
-    An unreadable pin or an unreadable ruff is not a mismatch: the format below
-    fails loudly enough on its own, and refusing on a question we could not ask
-    would break the hook wherever the config moves.
+    An unreadable pin or an unreadable version string is not a mismatch:
+    refusing on a question we could not ask would break the hook wherever the
+    config moves. A ruff that cannot run at all is caught before this, by
+    ruff_unavailable_reason.
     """
     return bool(pinned and installed and pinned != installed)
 
@@ -97,12 +117,30 @@ def main(argv: list[str]) -> int:
         print(f"run_ruff_format: {error}", file = sys.stderr)
         return 2
 
-    # Checked before anything is rewritten. ruff's own formatting is not stable
-    # across releases -- 0.9 changed which half of an `assert cond, "msg"` gets
-    # wrapped -- so running this with a newer ruff silently produces a style the
-    # pinned hook reformats back, and the commit fails pre-commit on files that
-    # are otherwise correct. It reached main twice before this check existed.
     pinned = pinned_ruff_version(CONFIG.read_text(encoding = "utf-8")) if CONFIG.exists() else None
+
+    # Both checks are made before anything is rewritten, because the pre-pass is
+    # itself a rewrite. Without this first one, a missing or broken ruff let the
+    # pre-pass strip every magic comma it was given and only then die on `ruff
+    # format`, leaving files in a shape the hook rejects -- the opposite of what
+    # a full run produces, and blamed on the next person to touch them. The
+    # override below is deliberately not honoured here: no ruff formats nothing.
+    unavailable = ruff_unavailable_reason()
+    if unavailable is not None:
+        print(
+            f"run_ruff_format: cannot run `python -m ruff` ({unavailable}).\n"
+            f"  Refusing before rewriting anything: the passes either side of ruff would "
+            f"leave the files half-formatted.\n"
+            f"  Fix: pip install ruff=={pinned or '<the pin in .pre-commit-config.yaml>'}",
+            file = sys.stderr,
+        )
+        return 1
+
+    # ruff's own formatting is not stable across releases -- 0.9 changed which
+    # half of an `assert cond, "msg"` gets wrapped -- so running this with a newer
+    # ruff silently produces a style the pinned hook reformats back, and the
+    # commit fails pre-commit on files that are otherwise correct. It reached main
+    # twice before this check existed.
     installed = installed_ruff_version()
     if version_mismatch(pinned, installed) and not os.environ.get(ANY_VERSION_ENV):
         print(

--- a/tests/test_formatter_fixed_point.py
+++ b/tests/test_formatter_fixed_point.py
@@ -17,6 +17,7 @@ run reports the drift instead of quietly fixing it.
 
 from __future__ import annotations
 
+import os
 import re
 import shutil
 import subprocess
@@ -120,6 +121,32 @@ def _pinned_ruff_reason() -> str | None:
     return None
 
 
+def guard_verdict(ruff_reason: str | None, in_ci: bool) -> str:
+    """`run`, `skip` or `fail`.
+
+    Skipping is for a contributor who has not installed the pinned ruff; making
+    them install one to run the rest of the suite would be rude. In CI it is the
+    wrong answer: the runner installs the pin in a step of its own, so a missing
+    ruff there means that step moved, was renamed, or a new job started calling
+    `pytest tests/` without it, and the guard would go green having checked
+    nothing. That is the failure this whole file exists to stop, applied to
+    itself, and it costs nothing to notice.
+    """
+    if ruff_reason is None:
+        return "run"
+    return "fail" if in_ci else "skip"
+
+
+def running_in_ci(environ: dict[str, str] | None = None) -> bool:
+    """GitHub Actions sets both; `CI` alone covers the other providers."""
+    env = os.environ if environ is None else environ
+    return bool(env.get("GITHUB_ACTIONS") or env.get("CI"))
+
+
+_RUFF_REASON = _pinned_ruff_reason()
+_VERDICT = guard_verdict(_RUFF_REASON, running_in_ci())
+
+
 class TestTheExcludeComesFromTheConfig:
     """The filter has to track the hook, not a copy of it made once."""
 
@@ -171,9 +198,41 @@ class TestTheExcludeComesFromTheConfig:
         assert "scripts/run_ruff_format.py" in names
 
 
-@pytest.mark.skipif(_pinned_ruff_reason() is not None, reason = _pinned_ruff_reason() or "")
+class TestTheGuardCannotGoGreenHavingCheckedNothing:
+    """A skip is a pass to everything that reads CI, so CI may not be allowed one."""
+
+    def test_a_usable_ruff_runs_the_check(self):
+        assert guard_verdict(None, in_ci = False) == "run"
+        assert guard_verdict(None, in_ci = True) == "run"
+
+    def test_a_contributor_without_the_pin_is_only_skipped(self):
+        assert guard_verdict("ruff is not installed here", in_ci = False) == "skip"
+
+    def test_the_same_gap_in_ci_is_a_failure(self):
+        # Whichever reason it is: no ruff means the guard checked nothing, and a
+        # mismatched ruff means the workflow drifted off the pin it installs.
+        assert guard_verdict("ruff is not installed here", in_ci = True) == "fail"
+        assert guard_verdict("the repo is formatted with ruff 0.6.9", in_ci = True) == "fail"
+
+    def test_ci_is_detected_from_either_variable(self):
+        assert running_in_ci({"GITHUB_ACTIONS": "true"}) is True
+        assert running_in_ci({"CI": "true"}) is True
+        assert running_in_ci({}) is False
+        # Unset-but-present is how some runners spell "not CI".
+        assert running_in_ci({"CI": ""}) is False
+
+
+@pytest.mark.skipif(_VERDICT == "skip", reason = _RUFF_REASON or "")
 def test_every_tracked_python_file_is_already_formatted(tmp_path):
     """Run the hook over copies of the whole tracked set and expect no rewrite."""
+    if _VERDICT == "fail":
+        pytest.fail(
+            f"this guard cannot run in CI: {_RUFF_REASON}.\n"
+            "  The runner installs the pinned ruff in its own step (see the "
+            "'Install the pinned ruff (formatter fixed-point guard)' step in "
+            ".github/workflows/studio-backend-ci.yml).\n"
+            "  Skipping here would report a green formatting guard that checked no files."
+        )
     names = eligible_files(_ROOT)
     assert len(names) > 1000, f"only {len(names)} files matched; the file list has gone vacuous"
 

--- a/tests/test_run_ruff_format_pin.py
+++ b/tests/test_run_ruff_format_pin.py
@@ -23,6 +23,7 @@ _SCRIPTS = str(_ROOT / "scripts")
 if _SCRIPTS not in sys.path:
     sys.path.insert(0, _SCRIPTS)
 
+import run_ruff_format  # noqa: E402
 from run_ruff_format import (  # noqa: E402
     ANY_VERSION_ENV,
     CONFIG,
@@ -74,10 +75,97 @@ class TestTheMismatchRule:
     def test_the_pinned_ruff_is_not(self):
         assert version_mismatch("0.6.9", "0.6.9") is False
 
-    def test_an_unreadable_ruff_is_not(self):
-        # `python -m ruff --version` failing means the format below fails too, and
-        # loudly. Refusing here would only replace one error with a worse one.
+    def test_an_unreadable_version_string_is_not(self):
+        # A ruff that runs but names itself in a shape this cannot parse is a
+        # question we could not ask, not a mismatch. A ruff that does not run at
+        # all is a different matter and is refused earlier, by
+        # ruff_unavailable_reason -- see TestRuffHasToBeRunnableFirst.
         assert version_mismatch("0.6.9", None) is False
+
+
+class TestRuffHasToBeRunnableFirst:
+    """No ruff means no run at all, decided before the first file is rewritten.
+
+    The version gate already refused before touching anything, but only when it
+    could read a version. With ruff missing or broken the script used to fall
+    through: the pre-pass stripped every magic comma it was given, `ruff format`
+    then died, and the post-pass never ran. What is left is neither the original
+    nor the formatted result, and the magic commas the pre-pass removes are ones
+    a full run puts back, so the files come out in the exact shape the hook
+    rejects. Observed on a `uv run --with ruff==...` whose ruff wheel carried no
+    binary: three signatures in one kernel lost their trailing commas and had to
+    be restored by hand.
+    """
+
+    def test_a_binary_that_is_not_there_is_reported_not_raised(self, tmp_path):
+        reason = run_ruff_format.ruff_unavailable_reason(str(tmp_path / "no-such-python"))
+        assert reason is not None
+        # The exception type is in the message: "cannot run ruff" without the
+        # underlying error sends people to reinstall a ruff that is already fine.
+        assert "Error" in reason or "error" in reason
+
+    def test_a_ruff_that_exits_nonzero_is_unavailable(self, monkeypatch):
+        monkeypatch.setattr(
+            run_ruff_format.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(a[0], 1, "", "No module named ruff"),
+        )
+        assert run_ruff_format.ruff_unavailable_reason() == "No module named ruff"
+
+    def test_a_silent_failure_still_says_something(self, monkeypatch):
+        # A non-zero exit with nothing on either stream would otherwise produce an
+        # empty parenthesis in the error and read like a bug in the check.
+        monkeypatch.setattr(
+            run_ruff_format.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(a[0], 3, "", ""),
+        )
+        reason = run_ruff_format.ruff_unavailable_reason()
+        assert reason and "3" in reason
+
+    def test_a_working_ruff_is_available(self, monkeypatch):
+        monkeypatch.setattr(
+            run_ruff_format.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(a[0], 0, "ruff 0.6.9\n", ""),
+        )
+        assert run_ruff_format.ruff_unavailable_reason() is None
+
+    def test_the_magic_commas_survive_a_run_with_no_ruff(self, tmp_path, monkeypatch):
+        # The regression itself, in the shape it was found: a signature whose
+        # trailing comma the pre-pass strips and ruff puts back.
+        target = tmp_path / "kernel.py"
+        original = "def f(\n    a,\n    b,\n):\n    return a\n"
+        target.write_text(original, encoding = "utf-8")
+        monkeypatch.setattr(
+            "run_ruff_format.ruff_unavailable_reason", lambda *a, **k: "No module named ruff"
+        )
+        assert main([str(target)]) == 1
+        assert target.read_text(encoding = "utf-8") == original
+
+    def test_the_override_does_not_buy_a_run_without_ruff(self, tmp_path, monkeypatch):
+        # ANY_VERSION_ENV waives "this is the wrong ruff". It cannot waive "there
+        # is no ruff", which is not a version question.
+        target = tmp_path / "sample.py"
+        original = "x = f(a=1)\n"
+        target.write_text(original, encoding = "utf-8")
+        monkeypatch.setattr(
+            "run_ruff_format.ruff_unavailable_reason", lambda *a, **k: "No module named ruff"
+        )
+        monkeypatch.setenv(ANY_VERSION_ENV, "1")
+        assert main([str(target)]) == 1
+        assert target.read_text(encoding = "utf-8") == original
+
+    def test_the_message_names_the_pin_to_install(self, tmp_path, monkeypatch, capsys):
+        target = tmp_path / "sample.py"
+        target.write_text("x = 1\n", encoding = "utf-8")
+        monkeypatch.setattr(
+            "run_ruff_format.ruff_unavailable_reason", lambda *a, **k: "No module named ruff"
+        )
+        assert main([str(target)]) == 1
+        err = capsys.readouterr().err
+        assert "pip install ruff==" in err
+        assert pinned_ruff_version(CONFIG.read_text(encoding = "utf-8")) in err
 
 
 class TestRefusing:


### PR DESCRIPTION
Follow-up to #10715, which re-formats the two lines that are currently failing `pre-commit.ci` on `main`. This is about why they reached main at all.

## What actually happened

The formatting guard is not broken and neither are the two PRs. `tests/test_formatter_fixed_point.py` caught #10711 exactly as designed, named the file and printed the fix command:

```
AssertionError: these tracked files are not a fixed point of the ruff-format-with-kwargs hook
    tests/studio/test_installer_av_shapes.py
    Fix: python scripts/run_ruff_format.py tests/studio/test_installer_av_shapes.py
1 failed, 18248 passed, 376 skipped in 1389.33s
```

That job takes about 23 minutes. #10711 was merged while it was still running, and #10703 the same way an hour later, so both drifts landed on `main` and every open PR inherited a red `pre-commit.ci`. Nothing in this PR changes that; it is a merge-timing matter. What it does change is two places where the guard can fail open, both of which were hit while diagnosing this.

## 1. The formatter rewrites files before checking it can run

`run_ruff_format.py` is `enforce_kwargs_spacing --pre`, then `ruff format`, then `enforce_kwargs_spacing`. The version gate refuses before touching anything, but only when it can read a version: `installed_ruff_version()` returns `None` for a ruff that will not run at all, and `version_mismatch(pin, None)` is `False`, so the run proceeds. The pre-pass then strips every magic comma it was given and `ruff format` dies.

Reproduced on a venv with no ruff, against `unsloth/kernels/rms_layernorm.py`:

```
Adjusted kwarg spacing in kern.py
python: No module named ruff
EXIT=1
33c33
<     BLOCK_SIZE: tl.constexpr,
---
>     BLOCK_SIZE: tl.constexpr
```

Three signatures lost their trailing commas, which a full run puts back, so the file ends up in the exact shape the hook rejects. The same interpreter and the same file after this change:

```
run_ruff_format: cannot run `python -m ruff` (No module named ruff).
  Refusing before rewriting anything: the passes either side of ruff would leave the files half-formatted.
  Fix: pip install ruff==0.6.9
EXIT=1
before=88ed494ae41b7be79bf2bca978295f74 after=88ed494ae41b7be79bf2bca978295f74
```

`UNSLOTH_RUFF_FORMAT_ANY_VERSION` deliberately does not waive this. It answers "this is the wrong ruff", not "there is no ruff".

## 2. The fixed-point guard skips itself away when ruff is missing

The guard is `skipif` on the pinned ruff being absent, which is right for a contributor and wrong on the runner, where `Install the pinned ruff (formatter fixed-point guard)` exists precisely to make it run. If that step is renamed or moved, or a new job calls `pytest tests/` without it, the guard goes green having checked no files, which is the failure mode the file was written to stop, applied to itself.

In CI a missing or mismatched ruff is now a failure that names the step. Locally it still skips. Verified both ways against a ruff-less interpreter:

```
CI=true   -> Failed: this guard cannot run in CI: ruff is not installed here ...
no CI     -> SKIPPED: ruff is not installed here, and the formatter cannot run without it
```

## Tests

Seven new cases for the runnable-ruff refusal, including the regression in the shape it was found (a signature whose magic comma survives a run with no ruff), and that the override does not buy a run without ruff. Four for the skip/fail verdict, split into a pure `guard_verdict()` so it is testable without touching the environment. `101 passed` across the three formatter suites, and `tests/test_formatter_fixed_point.py` is `10 passed` once #10715's two lines are applied.

Its `Repo tests (CPU)` job will stay red here until #10715 merges. That is the guard correctly reporting the drift already on `main`, not a defect in this change.