### PR TITLE
fix(studio): give downloaded code blocks and HTML artifacts meaningful filenames

### DIFF
--- a/studio/frontend/src/components/assistant-ui/markdown-text.tsx
+++ b/studio/frontend/src/components/assistant-ui/markdown-text.tsx
@@ -5,6 +5,7 @@
 
 import {
   ArtifactCard,
+  getCodeFilename,
   useChatProjectScope,
   useChatRuntimeStore,
 } from "@/features/chat";
@@ -300,39 +301,6 @@ function getMermaidSource(blockContent: string): string | null {
   return source && source.length > 0 ? source : null;
 }
 
-function getCodeFilename(language: string | null) {
-  const extByLanguage: Record<string, string> = {
-    bash: "sh",
-    "c++": "cpp",
-    csharp: "cs",
-    javascript: "js",
-    js: "js",
-    json: "json",
-    jsx: "jsx",
-    markdown: "md",
-    md: "md",
-    python: "py",
-    py: "py",
-    ruby: "rb",
-    rust: "rs",
-    shell: "sh",
-    sh: "sh",
-    sql: "sql",
-    ts: "ts",
-    tsx: "tsx",
-    typescript: "ts",
-    svg: "svg",
-    yaml: "yml",
-    yml: "yml",
-  };
-
-  const normalized = language?.toLowerCase();
-  const fallbackExt = normalized?.replace(/[^a-z0-9]+/g, "-");
-  const ext = normalized
-    ? extByLanguage[normalized] || fallbackExt || "txt"
-    : "txt";
-  return `snippet.${ext}`;
-}
 
 const UNSAFE_SVG_RE =
   /<script[\s>]|on\w+\s*=|javascript:|<foreignObject[\s>]|<iframe[\s>]|<embed[\s>]|<object[\s>]/i;

--- a/studio/frontend/src/features/chat/artifacts/types.ts
+++ b/studio/frontend/src/features/chat/artifacts/types.ts
@@ -80,10 +80,21 @@ export function createChatArtifact(input: ChatArtifactInput): ChatArtifact {
   };
 }
 
+/*
+ * The page's own <title>, when it has one. A fence-sourced artifact is titled
+ * "HTML preview" by the card that opens it -- a UI label, not a name for the
+ * document -- so without this every generated page downloads as
+ * `html-preview.html`, whatever the page calls itself. Cheap regex rather than
+ * DOMParser: the artifact may still be streaming, and a half-written document
+ * should degrade to the card title, not throw.
+ */
+const DOCUMENT_TITLE_RE = /<title[^>]*>([^<]*)<\/title>/i;
+
 export function getArtifactFilename(
-  artifact: Pick<ChatArtifact, "title">,
+  artifact: Pick<ChatArtifact, "title" | "code">,
 ): string {
-  const slug = artifact.title
+  const documentTitle = artifact.code.match(DOCUMENT_TITLE_RE)?.[1]?.trim();
+  const slug = (documentTitle || artifact.title)
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")

--- a/studio/frontend/src/features/chat/index.ts
+++ b/studio/frontend/src/features/chat/index.ts
@@ -172,6 +172,7 @@ export {
 } from "./utils/prompt-queue-user-stop";
 export { chatHistoryClearBoundary } from "./utils/chat-history-clear-boundary";
 export { rangeBetween, toggleSelected } from "./utils/row-selection";
+export { getCodeFilename } from "./utils/code-filename";
 export {
   addQueuedChatRunSettingsThreadIds,
   consumeQueuedChatRunSettings,

--- a/studio/frontend/src/features/chat/utils/code-filename.ts
+++ b/studio/frontend/src/features/chat/utils/code-filename.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+const EXT_BY_LANGUAGE: Record<string, string> = {
+  bash: "sh",
+  "c++": "cpp",
+  csharp: "cs",
+  javascript: "js",
+  js: "js",
+  json: "json",
+  jsx: "jsx",
+  markdown: "md",
+  md: "md",
+  python: "py",
+  py: "py",
+  ruby: "rb",
+  rust: "rs",
+  shell: "sh",
+  sh: "sh",
+  sql: "sql",
+  ts: "ts",
+  tsx: "tsx",
+  typescript: "ts",
+  svg: "svg",
+  yaml: "yml",
+  yml: "yml",
+};
+
+/*
+ * A filename offered by the model, not a path. Anchored, so a separator anywhere
+ * rejects the whole token: the info string is model output, and `download` on an
+ * anchor is the one place a traversal-shaped name would be worth attempting. The
+ * leading class also rejects a bare ".." and any dotfile, and the length bound
+ * keeps a pathological fence from naming a 4KB file.
+ */
+const OFFERED_FILENAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}\.[A-Za-z0-9]{1,10}$/;
+
+/**
+ * Name the file a fence downloads as.
+ *
+ * Markdown treats everything after the first word of the info string as metadata,
+ * so ```html index.html arrives here whole. A model writing a multi-file answer
+ * puts the name it wants there, and it is the only place it can: the download had
+ * no other channel for it, and every block landed on `snippet.<ext>` regardless.
+ *
+ * @param info Raw fence info string ("html", "html index.html", "python startLine=10").
+ * @returns The offered filename when the info string carries one, else `snippet.<ext>`
+ *   derived from the language token, else `snippet.txt`.
+ */
+export function getCodeFilename(info: string | null): string {
+  const [languageToken, ...metadata] = (info ?? "").trim().split(/\s+/);
+
+  const offered = metadata.find((token) => OFFERED_FILENAME_RE.test(token));
+  if (offered) {
+    return offered;
+  }
+
+  // From the language TOKEN, not the whole info string: a fence carrying metadata
+  // used to slug the lot, so ```html index.html downloaded as
+  // `snippet.html-index-html`.
+  const normalized = languageToken?.toLowerCase();
+  const fallbackExt = normalized?.replace(/[^a-z0-9]+/g, "-");
+  const ext = normalized
+    ? EXT_BY_LANGUAGE[normalized] || fallbackExt || "txt"
+    : "txt";
+  return `snippet.${ext}`;
+}

--- a/studio/frontend/tests/artifact-filename.test.ts
+++ b/studio/frontend/tests/artifact-filename.test.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getArtifactFilename } from "../src/features/chat/artifacts/types.ts";
+
+test("the page's own title names the download", () => {
+  // A fence-sourced card is titled "HTML preview" by the UI, so without reading
+  // the document every generated page downloaded as `html-preview.html`.
+  assert.equal(
+    getArtifactFilename({
+      title: "HTML preview",
+      code: "<html><head><title>Snake Game</title></head><body></body></html>",
+    }),
+    "snake-game.html",
+  );
+});
+
+test("the card title carries a document with no title", () => {
+  assert.equal(
+    getArtifactFilename({ title: "HTML canvas", code: "<div>hi</div>" }),
+    "html-canvas.html",
+  );
+});
+
+test("a still-streaming document degrades to the card title", () => {
+  assert.equal(
+    getArtifactFilename({ title: "HTML preview", code: "<html><head><tit" }),
+    "html-preview.html",
+  );
+});
+
+test("an empty title falls back to canvas", () => {
+  assert.equal(getArtifactFilename({ title: "   ", code: "" }), "canvas.html");
+});
+
+test("the slug stays clipped at 48 characters", () => {
+  const long = "a".repeat(80);
+  const name = getArtifactFilename({
+    title: "ignored",
+    code: `<title>${long}</title>`,
+  });
+  assert.equal(name, `${"a".repeat(48)}.html`);
+});

--- a/studio/frontend/tests/code-filename.test.ts
+++ b/studio/frontend/tests/code-filename.test.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getCodeFilename } from "../src/features/chat/utils/code-filename.ts";
+
+test("a bare language keeps the snippet name", () => {
+  assert.equal(getCodeFilename("python"), "snippet.py");
+  assert.equal(getCodeFilename("html"), "snippet.html");
+});
+
+test("an unknown language slugs into the extension", () => {
+  assert.equal(getCodeFilename("brainfuck"), "snippet.brainfuck");
+});
+
+test("no info string falls back to text", () => {
+  assert.equal(getCodeFilename(null), "snippet.txt");
+  assert.equal(getCodeFilename(""), "snippet.txt");
+});
+
+test("a filename in the info string names the download", () => {
+  // The multi-file case: three fences that have to agree on names, because the
+  // generated index.html references the other two by name.
+  assert.equal(getCodeFilename("html index.html"), "index.html");
+  assert.equal(getCodeFilename("css style.css"), "style.css");
+  assert.equal(getCodeFilename("javascript script.js"), "script.js");
+});
+
+test("non-filename metadata does not leak into the extension", () => {
+  // Regression: the whole info string used to be slugged, so this downloaded as
+  // `snippet.python-startline-10`.
+  assert.equal(getCodeFilename("python startLine=10"), "snippet.py");
+});
+
+test("a path-shaped token is refused, not sanitised", () => {
+  // Model output; an anchor's `download` is where a traversal name would be tried.
+  assert.equal(getCodeFilename("html ../../etc/passwd"), "snippet.html");
+  assert.equal(getCodeFilename("html /tmp/evil.html"), "snippet.html");
+  assert.equal(getCodeFilename("html ..hidden.js"), "snippet.html");
+});
+
+test("an overlong offered name is refused", () => {
+  const long = `${"a".repeat(80)}.html`;
+  assert.equal(getCodeFilename(`html ${long}`), "snippet.html");
+});


### PR DESCRIPTION
## Problem

Ask a local model to build a small static site. It emits three fences and tells you to
save them as `index.html`, `style.css`, `script.js` and open `index.html`. Neither
download path in Studio can produce those names, so the saved site is broken on arrival
and every file has to be renamed by hand.

| Path | Saved as |
|---|---|
| Code-block download button | `snippet.html`, `snippet.css`, `snippet.js` |
| HTML preview / artifact card | `html-preview.html` |

Two separate causes, one theme: no download path consults the content for a name.

## Cause and fix

**1. Code fences — `getCodeFilename` ignored the info string.**

Markdown treats everything after the first word of a fence info string as metadata, so
a model naming its file writes ` ```html index.html ` and that whole string arrives as
`language`. The basename was the literal `snippet`, so the name was dropped.

Now: an offered filename in the info string is used when present, otherwise the previous
`snippet.<ext>` is returned unchanged.

This also fixes a smaller bug on the same line. Because the *whole* info string was
slugged for the extension, a fence carrying metadata was mangled:

```
```python startLine=10   →  snippet.python-startline-10   (before)
                         →  snippet.py                    (after)
```

The offered name is model output, so it is matched against an anchored pattern rather
than sanitised — a separator anywhere rejects the token, as does a leading dot or
anything past 64 characters. Anything unusable falls back to `snippet.<ext>`.

**2. HTML artifacts — the filename was a slug of a UI label.**

A fence-sourced card is opened as `<ArtifactCard ... title="HTML preview" source="fence" />`,
and `getArtifactFilename` slugs that title. `"HTML preview"` → `html-preview.html`, for
every page, whatever the page calls itself.

Now: prefer the document's own `<title>` when it has one, falling back to the card title.
Matched with a regex rather than `DOMParser` because the artifact may still be streaming —
a half-written document degrades to the card title instead of throwing. The `title` field
and its existing `|| "canvas"` fallback already looked designed to carry a real name; the
fence path just never supplied one.

The visible card header is unchanged — this only affects the download name.

## Notes on the shape of the diff

`getCodeFilename` was module-local in `markdown-text.tsx`, which imports React and
Streamdown and so cannot be pulled into a `node --test` run. It moved to a leaf module in
`features/chat/utils/` and is re-exported from the feature barrel, so the component keeps
importing from `@/features/chat` and no new `no-restricted-imports` violation is added.
Behavior of the extracted function is otherwise identical.

`getArtifactFilename`'s parameter widened from `Pick<ChatArtifact, "title">` to
`Pick<ChatArtifact, "title" | "code">`. Its single caller already passes the whole
artifact, so no call sites changed.

## Verification

- `node --experimental-strip-types --test "tests/**/*.test.ts"` — **7296 passing, 0 failing**
- `npx tsc --noEmit -p tsconfig.app.json` — no errors in the changed files
- `npx eslint` on `markdown-text.tsx` — 15 problems before, 15 after (all pre-existing;
  no new violations introduced)
- 12 new tests across `tests/code-filename.test.ts` and `tests/artifact-filename.test.ts`,
  covering the multi-file case, the metadata regression, path-shaped and overlong names,
  a streaming half-document, and the existing 48-character slug clip

## Related

#10425 covers a different gap in the same area — files written by the Code tool are hidden
behind the collapsed tool card, with no preview for a sandbox `.html`. That issue notes the
same two card titles (`HTML preview` for a fence, `HTML canvas` for `render_html`). Together
they suggest the delivery path a model happens to choose decides both whether the user sees
the file and what it is called. This PR only addresses the naming half.

## Environment where this was found

Unsloth desktop app 0.1.807-beta, studio package 2026.9.3, macOS 27.0 (Apple M5 Pro),
local model via the llama.cpp provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
