### PR TITLE
perf(studio): share MLX array storage when copying prompt caches

### DIFF
--- a/studio/backend/core/inference/mlx_inference.py
+++ b/studio/backend/core/inference/mlx_inference.py
@@ -78,7 +78,7 @@ def _is_opaque_cache(value):
 
 def _copy_value(value, mx):
     if isinstance(value, mx.array):
-        return value + 0
+        return copy.copy(value)
     if isinstance(value, list):
         return [_copy_value(item, mx) for item in value]
     if isinstance(value, tuple):
@@ -131,7 +131,7 @@ def release_cache_entries(entries):
 
 
 def copy_cache_entries(entries):
-    """Copies, object-shallow and array-deep, evaluated so they own their data."""
+    """Copy cache containers and array handles; MLX isolates subsequent writes."""
     import mlx.core as mx
 
     for entry in entries:

--- a/studio/backend/tests/test_mlx_vlm_prompt_cache_metal.py
+++ b/studio/backend/tests/test_mlx_vlm_prompt_cache_metal.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+pytestmark = pytest.mark.skipif(not mx.metal.is_available(), reason = "Requires Metal")
+
+from mlx_vlm.models.cache import ArraysCache, KVCache, RotatingKVCache
+from core.inference.mlx_inference import copy_cache_entries
+
+
+def _bits(value):
+    return np.array(value.view(mx.uint8)).tobytes()
+
+
+@pytest.mark.parametrize("factory", [KVCache, lambda: RotatingKVCache(max_size = 8, keep = 2)])
+def test_snapshot_isolated_from_cache_growth_and_rotating_overwrites(factory):
+    cache = factory()
+    data = mx.arange(16, dtype = mx.float32).reshape(1, 2, 1, 8)
+    for i in range(8):
+        cache.update_and_fetch(data + i, data + 100 + i)
+    mx.eval(cache.state)
+    saved = copy_cache_entries([cache])[0]
+    original = [_bits(value) for value in saved.state]
+    for i in range(12):
+        cache.update_and_fetch(data + i, data + 200 + i)
+        mx.eval(cache.state)
+    assert [_bits(value) for value in saved.state] == original
+    advanced = [_bits(value) for value in cache.state]
+    for i in range(10):
+        saved.update_and_fetch(data + 1000 + i, data + 2000 + i)
+        mx.eval(saved.state)
+    assert [_bits(value) for value in cache.state] == advanced
+
+
+def test_recurrent_snapshot_shares_storage_but_isolates_both_state_slots():
+    cache = ArraysCache(2)
+    cache[0] = mx.arange(1 << 20, dtype = mx.float32).reshape(1024, 1024)
+    cache[1] = cache[0] * 2
+    mx.eval(cache.state)
+    expected = [_bits(value) for value in cache.state]
+    before = mx.get_active_memory()
+    saved = copy_cache_entries([cache])[0]
+    assert mx.get_active_memory() - before < cache[0].nbytes // 10
+    for i in (1, 0):
+        cache[i][1:, 1::2] += 7
+        mx.eval(cache[i])
+    assert [_bits(value) for value in saved.state] == expected
+    advanced = [_bits(value) for value in cache.state]
+    for i in (0, 1):
+        saved[i] = saved[i] * 1.25
+        saved[i][2:, ::2] -= 3
+        mx.eval(saved[i])
+    assert [_bits(value) for value in cache.state] == advanced
+
+
+def test_snapshot_preserves_signed_zero_and_nan_payloads():
+    cache = ArraysCache(2)
+    bits = mx.array([0x80000000, 0, 0x7FC00123, 0xFFC00456], dtype = mx.uint32)
+    cache[0] = bits.view(mx.float32)
+    cache[1] = mx.roll(bits, 1).view(mx.float32)
+    saved = copy_cache_entries([cache])[0]
+    assert [_bits(value) for value in saved.state] == [_bits(value) for value in cache.state]


### PR DESCRIPTION
Prompt-cache snapshots currently copy MLX arrays by adding zero. That schedules unnecessary arithmetic and allocates new array storage even when a snapshot only needs an independent array handle. Use `copy.copy` for MLX arrays while retaining recursive cache/container copying. MLX array updates replace the handle's value, so later cache growth and rotating overwrites remain isolated in both directions. This also preserves signed-zero and NaN payload bits that arithmetic copying can change.

Native Metal tests cover regular and rotating KV caches, both recurrent state slots, modifications in both directions, shared-storage memory use, and exact special-value bits. Four native tests passed on the rebased branch.

```bash
python -m pytest studio/backend/tests/test_mlx_vlm_prompt_cache_metal.py -q
```

### HTTP benchmark

Six fixed paired repetitions per case, balanced AB/BA; 512 generated tokens, greedy seed 42, identical snapshot/native context and unquantized KV within pairs. M3 Max / 128 GiB, MLX 0.32.2, mlx-lm 0.31.3, mlx-vlm 0.7.0, Transformers 5.5.0. Loading, unloading and generation all use HTTP. Warmups and conditioning are excluded; MoE variants load one at a time. Qwen 0.8B is BF16, Gemma E2B mixed 4/8-bit QAT, both large MoEs 8-bit.

| Case | Metric | Valid pairs | Median baseline → candidate | Paired change (95% CI) | CV baseline / candidate | Result |
|---|---|---:|---:|---:|---:|---|
| copy-gemmae2 | ttft (ms) | 6/6 | 112.09 → 111.01 | -1.57% (-5.55% to 2.58%) | 10.65% / 12.85% | Inconclusive: repeatability gate not met |
| copy-qwen08 | ttft (ms) | 6/6 | 130.43 → 129.15 | -1.30% (-8.72% to 6.71%) | 9.11% / 7.30% | Inconclusive: repeatability gate not met |

Changes are geometric mean paired speed ratios with Student-t 95% intervals on paired log ratios. Stable requires ≥4 valid pairs and both variant CV ≤1%; improvement additionally requires a positive lower confidence bound. No throughput-based rejection or adaptive extension. Intervals describe this session, not cross-day reproducibility.

Physical checks: nominal OS thermal pressure, ≤75°C admission and ≤3°C paired start difference, zero new global pageouts/swapouts, equal output text/token counts. Prefill and decode independently require phase-clock matching/drift ≤1% and telemetry coverage ≥90%. Prefill telemetry includes HTTP/CPU/first-token overhead. Warm TTFT is too short for reliable per-phase clock sampling and uses shared checks only. Matching GPU clocks does not prove an otherwise idle system.

Copy uses an 8K reused prefix; its primary metric is warm TTFT (positive speed ratio means faster, not the same percentage as latency reduction). Prefill/MoE/integration use 4K cold prompts (the explicitly labelled Gemma 8K prefill case is a separate longer-window experiment); recurrent decode 1K. Zoo comparisons hold Studio integration constant, with only the named Zoo optimization present. Integration alone uses baseline Zoo; Gemma E2B decode is a no-op control. Gains are not additive.

<details>
<summary>All measured primary-metric pairs and exclusions</summary>


| Case / metric | A→B values (tokens/s; TTFT in seconds) | Accepted | Reasons |
|---|---|---|---|
| copy-gemmae2 / ttft / 1 (AB) | 0.1416 → 0.1508 | yes | — |
| copy-gemmae2 / ttft / 2 (BA) | 0.1050 → 0.1097 | yes | — |
| copy-gemmae2 / ttft / 3 (AB) | 0.1131 → 0.1110 | yes | — |
| copy-gemmae2 / ttft / 4 (BA) | 0.1110 → 0.1112 | yes | — |
| copy-gemmae2 / ttft / 5 (AB) | 0.1065 → 0.1111 | yes | — |
| copy-gemmae2 / ttft / 6 (BA) | 0.1133 → 0.1093 | yes | — |

copy-gemmae2 ttft: all-pair estimate -1.57% (95% CI -5.55% to 2.58%; baseline/candidate CV 10.65% / 12.85%); accepted AB -2.80%, BA -0.33%.


| Case / metric | A→B values (tokens/s; TTFT in seconds) | Accepted | Reasons |
|---|---|---|---|
| copy-qwen08 / ttft / 1 (AB) | 0.1053 → 0.1052 | yes | — |
| copy-qwen08 / ttft / 2 (BA) | 0.1331 → 0.1279 | yes | — |
| copy-qwen08 / ttft / 3 (AB) | 0.1305 → 0.1277 | yes | — |
| copy-qwen08 / ttft / 4 (BA) | 0.1113 → 0.1308 | yes | — |
| copy-qwen08 / ttft / 5 (AB) | 0.1304 → 0.1304 | yes | — |
| copy-qwen08 / ttft / 6 (BA) | 0.1333 → 0.1305 | yes | — |

copy-qwen08 ttft: all-pair estimate -1.30% (95% CI -8.72% to 6.71%; baseline/candidate CV 9.11% / 7.30%); accepted AB 0.73%, BA -3.30%.


</details>

<details>
<summary>Checkpoint revisions and context limits</summary>

| Alias | Model | Revision | Checkpoint dtype | Context |
|---|---|---|---|---:|
| gemmae2 | mlx-community/gemma-4-E2B-it-qat-4bit | `42f62737af7a9fd8c1d55d79666c1a217be4e2e2` | QAT mixed 4/8-bit | 131072 |
| qwen08 | Qwen/Qwen3.5-0.8B | `2fc06364715b967f1860aea9cf38778875588b17` | BF16/F32 native | 262144 |

</details>

Measured candidate `9d99e361fb721a767de92c3b8c926fc39686ab23` against `57b1d758b82ab8e3839f3069cfed0c79e087bd8a`.


Published head `b792ab38b997f989f7c00ffb3ef60b6541bf7e80` is rebased onto `d0dbe9059efa443c6ad8bd1d51af7e2d9276a2bc`. The MLX inference implementation and feature tests are AST-identical to the measured revision after ignoring docstrings; targeted tests passed again. Intervening API changes handle tool history and do not activate for the measured tools-disabled, single-user requests. The timings above retain their original measured revision.
