### PR TITLE
fix(dataprep): don't append EOS to full-size mid-stride chunks

### DIFF
--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -293,11 +293,7 @@ def test_smart_chunk_text_single_chunk_no_eos_returns_plain_list():
 
 
 def test_smart_chunk_text_no_eos_on_intermediate_full_chunks():
-    """A full-size chunk produced mid-stride still has real continuation tokens in
-    the very next chunk (that is the point of the stride overlap), so it must not
-    get an EOS appended. Only the chunk that actually reaches the end of the text
-    may end with EOS, and every other chunk must stay exactly chunk_size long.
-    Covers both the tokenized and text output branches of the same loop."""
+    """Only the final chunk gets EOS; mid-stride chunks stay exactly chunk_size long."""
 
     class WordTokenizer:
         def __init__(self):

--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -292,6 +292,66 @@ def test_smart_chunk_text_single_chunk_no_eos_returns_plain_list():
     return True
 
 
+def test_smart_chunk_text_no_eos_on_intermediate_full_chunks():
+    """A full-size chunk produced mid-stride still has real continuation tokens in
+    the very next chunk (that is the point of the stride overlap), so it must not
+    get an EOS appended. Only the chunk that actually reaches the end of the text
+    may end with EOS, and every other chunk must stay exactly chunk_size long.
+    Covers both the tokenized and text output branches of the same loop."""
+
+    class WordTokenizer:
+        def __init__(self):
+            self.eos_token = "</s>"
+            self.eos_token_id = -1
+
+        def __call__(
+            self,
+            text,
+            return_tensors = None,
+            add_special_tokens = False,
+        ):
+            token_ids = list(range(len(text.split())))
+            if return_tensors == "pt":
+                return {"input_ids": [token_ids]}
+            return {"input_ids": token_ids}
+
+        def decode(
+            self,
+            token_ids,
+            skip_special_tokens = False,
+        ):
+            return " ".join(f"word_{i}" for i in token_ids)
+
+    text = " ".join(f"w{i}" for i in range(37))  # 37 tokens: several full chunks + a short tail
+    loader = RawTextDataLoader(WordTokenizer(), chunk_size = 10, stride = 3)
+
+    tokenized_chunks = loader.chunk_text(text, return_tokenized = True)
+    assert len(tokenized_chunks) > 2, "test needs several chunks to cover the intermediate case"
+    for i, chunk in enumerate(tokenized_chunks):
+        ids = chunk["input_ids"]
+        is_last = i == len(tokenized_chunks) - 1
+        if is_last:
+            assert ids[-1] == -1, f"last chunk should end with eos_token_id, got {ids}"
+        else:
+            assert (
+                len(ids) == 10
+            ), f"chunk {i} should stay exactly chunk_size (10), got {len(ids)}: {ids}"
+            assert (
+                ids[-1] != -1
+            ), f"chunk {i} is not the last chunk but ends with eos_token_id: {ids}"
+
+    text_chunks = loader.chunk_text(text, return_tokenized = False)
+    assert len(text_chunks) > 2
+    for i, chunk in enumerate(text_chunks):
+        is_last = i == len(text_chunks) - 1
+        assert (
+            chunk.endswith("</s>") == is_last
+        ), f"chunk {i} (last={is_last}) eos suffix mismatch: {chunk!r}"
+
+    print("✅ test_smart_chunk_text_no_eos_on_intermediate_full_chunks passed!")
+    return True
+
+
 def test_load_from_file_skips_non_object_json_lines():
     """Non-object .jsonl lines (valid JSON, not dicts) are skipped, not fatal."""
     # "context" contains "text", ["text"] holds it, 42 isn't iterable -- each
@@ -670,6 +730,7 @@ def test_validate_dataset_reports_zero_min_length_when_nothing_has_content():
 if __name__ == "__main__":
     success = test_raw_text_loader()
     success = test_smart_chunk_text_single_chunk_no_eos_returns_plain_list() and success
+    success = test_smart_chunk_text_no_eos_on_intermediate_full_chunks() and success
     success = test_load_from_file_skips_non_object_json_lines() and success
     success = test_smart_chunk_text_empty_input_returns_no_chunks() and success
     success = test_load_from_files_all_empty_raises() and success

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -188,10 +188,7 @@ class RawTextDataLoader:
                     chunk_tokens.tolist() if hasattr(chunk_tokens, "tolist") else list(chunk_tokens)
                 )
 
-                # Append EOS only on the chunk that actually reaches the end of the text: a
-                # full-size chunk mid-stride still has real continuation tokens in the next
-                # chunk, so marking it as sequence-end would train a false stop signal into
-                # every overlap boundary.
+                # EOS only at the true end: a full chunk mid-stride continues in the next chunk.
                 if end_idx == len(tokens):
                     eos_token_id = getattr(self.tokenizer, "eos_token_id", None)
                     if eos_token_id is not None:
@@ -203,8 +200,6 @@ class RawTextDataLoader:
             else:
                 chunk_text = self.tokenizer.decode(chunk_tokens, skip_special_tokens = True)
 
-                # Append EOS only on the chunk that actually reaches the end of the text; see the
-                # tokenized branch above for why a full-size mid-stride chunk must not get one.
                 if end_idx == len(tokens):
                     eos_token = self.tokenizer.eos_token if self.tokenizer.eos_token else ""
                     chunk_text += eos_token

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -188,8 +188,11 @@ class RawTextDataLoader:
                     chunk_tokens.tolist() if hasattr(chunk_tokens, "tolist") else list(chunk_tokens)
                 )
 
-                # Append EOS on the last or a full chunk.
-                if end_idx == len(tokens) or len(chunk_tokens_list) == chunk_size:
+                # Append EOS only on the chunk that actually reaches the end of the text: a
+                # full-size chunk mid-stride still has real continuation tokens in the next
+                # chunk, so marking it as sequence-end would train a false stop signal into
+                # every overlap boundary.
+                if end_idx == len(tokens):
                     eos_token_id = getattr(self.tokenizer, "eos_token_id", None)
                     if eos_token_id is not None:
                         chunk_tokens_list.append(eos_token_id)
@@ -200,8 +203,9 @@ class RawTextDataLoader:
             else:
                 chunk_text = self.tokenizer.decode(chunk_tokens, skip_special_tokens = True)
 
-                # Append EOS on the last or a full chunk.
-                if end_idx == len(tokens) or len(chunk_tokens) == chunk_size:
+                # Append EOS only on the chunk that actually reaches the end of the text; see the
+                # tokenized branch above for why a full-size mid-stride chunk must not get one.
+                if end_idx == len(tokens):
                     eos_token = self.tokenizer.eos_token if self.tokenizer.eos_token else ""
                     chunk_text += eos_token
 


### PR DESCRIPTION
`RawTextDataLoader.smart_chunk_text()` appends an EOS token to any chunk that reaches `chunk_size`, not only the chunk that reaches the actual end of the text:

```python
if end_idx == len(tokens) or len(chunk_tokens_list) == chunk_size:
    ...
    chunk_tokens_list.append(eos_token_id)
```

With `chunk_size=32, stride=8` and a real gpt2 tokenizer over a 265-token document, 8 of 9 chunks get `<|endoftext|>` appended. Chunk 0 decodes to `...lazy dog. The quick<|endoftext|>`, and chunk 1 immediately continues with ` jumps over the lazy dog.`, same sentence, split across a fabricated document boundary. `create_causal_dataset()` sets `labels = input_ids`, so the model is trained to predict end-of-sequence at every stride boundary of continuous text, not just at genuine document ends. The same condition also grows every non-final chunk to `chunk_size + 1` tokens.

Reachable through `RawTextDataLoader(tokenizer, chunk_size, stride).chunk_text(text)` / `.load_from_file()`, the class's documented public API for "maintains context with stride overlap."

Fix: append EOS only when `end_idx == len(tokens)`, in both the tokenized and text branches.

Added `test_smart_chunk_text_no_eos_on_intermediate_full_chunks`. It fails on the unfixed code (`chunk 0 should stay exactly chunk_size (10), got 11`) and passes after the fix.

Test commands and results:
- `python3 tests/test_raw_text.py`: 10/10 passed
- `python3 -m pytest tests/test_raw_text_json_loading.py`: 8/8 passed
- `ruff check unsloth/dataprep/raw_text.py tests/test_raw_text.py`: clean
- `python3 scripts/run_ruff_format.py unsloth/dataprep/raw_text.py tests/test_raw_text.py`: clean

hit this while working on a project of mine. drafted with claude opus / fable 5.1. i tested this myself before submitting (see commands above). reviewed by muse spark 1.3 and glm 5.3 as judges.
