### PR TITLE
Studio: top-level Models block group in picker

### DIFF
--- a/studio/frontend/src/features/recipe-studio/components/block-sheet.tsx
+++ b/studio/frontend/src/features/recipe-studio/components/block-sheet.tsx
@@ -352,15 +352,24 @@ export function BlockSheet({
         if (group.kind === "processor") {
           return matchesSearch(PROCESSOR_TITLE, PROCESSOR_DESCRIPTION);
         }
-        return getBlocksForKind(group.kind).some((item) =>
+        const blockKind = VIEW_KIND[group.kind];
+        if (!blockKind) {
+          return false;
+        }
+        return getBlocksForKind(blockKind).some((item) =>
           matchesSearch(item.title, item.description),
         );
       }),
     ];
   }, [hasSearch, matchesSearch]);
+  const visibleScopedBlocks =
+    sheetView === "model" ? modelSetupBlocks : scopedBlocks;
   const showNoMatches =
-    (isRootView && hasSearch && rootSearchBlocks.length === 0) ||
-    (isScopedBlockView && scopedBlocks.length === 0) ||
+    (isRootView &&
+      hasSearch &&
+      rootSearchBlocks.length === 0 &&
+      rootGroups.length === 0) ||
+    (isScopedBlockView && visibleScopedBlocks.length === 0) ||
     (isProcessorView &&
       hasSearch &&
       !matchesSearch(PROCESSOR_TITLE, PROCESSOR_DESCRIPTION));
@@ -527,7 +536,6 @@ export function BlockSheet({
                   />
                 ))}
               {isRootView &&
-                !hasSearch &&
                 rootGroups.map((item) => (
                   <BlockSheetButton
                     key={item.kind}

--- a/studio/frontend/src/features/recipe-studio/components/block-sheet.tsx
+++ b/studio/frontend/src/features/recipe-studio/components/block-sheet.tsx
@@ -19,6 +19,7 @@ import {
   DocumentAttachmentIcon,
   PlusSignIcon,
   Search01Icon,
+  Settings02Icon,
   Upload01Icon,
 } from "@hugeicons/core-free-icons";
 import {
@@ -52,6 +53,7 @@ type SheetView =
   | "sampler"
   | "seed"
   | "llm"
+  | "model"
   | "validator"
   | "expression"
   | "note"
@@ -122,6 +124,9 @@ function getSheetTitle(sheetView: SheetView): string {
   if (sheetView === "processor") {
     return "Processor blocks";
   }
+  if (sheetView === "model") {
+    return "Models";
+  }
   return "AI generation";
 }
 
@@ -130,6 +135,7 @@ const VIEW_KIND: Record<SheetView, SheetKind | null> = {
   sampler: "sampler",
   seed: "seed",
   llm: "llm",
+  model: "llm",
   validator: "validator",
   expression: "expression",
   note: "note",
@@ -157,6 +163,13 @@ const LLM_SETUP_TYPES = new Set<BlockType>([
   "model_config",
   "tool_config",
 ]);
+const MODEL_SETUP_TYPES = new Set<BlockType>(["model_provider", "model_config"]);
+const MODEL_ROOT_GROUP = {
+  kind: "model" as SheetView,
+  title: "Models",
+  description: "Connect a provider and pick which model powers your AI steps.",
+  icon: Settings02Icon,
+};
 
 function BlockSheetButton({
   icon,
@@ -309,6 +322,10 @@ export function BlockSheet({
     sheetView === "llm"
       ? scopedBlocks.filter((item) => LLM_SETUP_TYPES.has(item.type))
       : [];
+  const modelSetupBlocks =
+    sheetView === "model"
+      ? scopedBlocks.filter((item) => MODEL_SETUP_TYPES.has(item.type))
+      : [];
   const featuredSeedBlock =
     sheetView === "seed" && !hasSearch
       ? scopedBlocks.find((item) => item.type === "seed_unstructured") ?? null
@@ -320,19 +337,26 @@ export function BlockSheet({
 
   const rootGroups = useMemo(() => {
     if (!hasSearch) {
-      return ROOT_GROUPS_WITH_SEED_FIRST;
+      const seedFirst = ROOT_GROUPS_WITH_SEED_FIRST.filter((group) => group.kind === "seed");
+      const rest = ROOT_GROUPS_WITH_SEED_FIRST.filter((group) => group.kind !== "seed");
+      return [...seedFirst, MODEL_ROOT_GROUP, ...rest];
     }
-    return ROOT_GROUPS.filter((group) => {
-      if (matchesSearch(group.title, group.description)) {
-        return true;
-      }
-      if (group.kind === "processor") {
-        return matchesSearch(PROCESSOR_TITLE, PROCESSOR_DESCRIPTION);
-      }
-      return getBlocksForKind(group.kind).some((item) =>
-        matchesSearch(item.title, item.description),
-      );
-    });
+    return [
+      ...(matchesSearch(MODEL_ROOT_GROUP.title, MODEL_ROOT_GROUP.description)
+        ? [MODEL_ROOT_GROUP]
+        : []),
+      ...ROOT_GROUPS.filter((group) => {
+        if (matchesSearch(group.title, group.description)) {
+          return true;
+        }
+        if (group.kind === "processor") {
+          return matchesSearch(PROCESSOR_TITLE, PROCESSOR_DESCRIPTION);
+        }
+        return getBlocksForKind(group.kind).some((item) =>
+          matchesSearch(item.title, item.description),
+        );
+      }),
+    ];
   }, [hasSearch, matchesSearch]);
   const showNoMatches =
     (isRootView && hasSearch && rootSearchBlocks.length === 0) ||
@@ -524,6 +548,10 @@ export function BlockSheet({
                         : "chevron"
                     }
                     onClick={() => {
+                      if (item.kind === "model") {
+                        onViewChange("model");
+                        return;
+                      }
                       if (item.kind === "seed" && seedBlocks.length === 1) {
                         setSheetOpen(false);
                         onAddSeed(seedBlocks[0].type as SeedBlockType);
@@ -654,6 +682,20 @@ export function BlockSheet({
                   />
                 ))}
               {isScopedBlockView &&
+                sheetView === "model" &&
+                modelSetupBlocks.map((item) => (
+                  <BlockSheetButton
+                    key={item.type}
+                    icon={item.icon}
+                    title={item.title}
+                    description={item.description}
+                    draggable={true}
+                    onDragStart={buildDragStart(item.kind, item.type)}
+                    trailing={getTrailing()}
+                    onClick={() => onBlockClick(item.kind, item.type)}
+                  />
+                ))}
+              {isScopedBlockView &&
                 sheetView === "seed" &&
                 otherSeedBlocks.map((item) => (
                   <BlockSheetButton
@@ -670,6 +712,7 @@ export function BlockSheet({
               {isScopedBlockView &&
                 sheetView !== "llm" &&
                 sheetView !== "seed" &&
+                sheetView !== "model" &&
                 scopedBlocks.map(
                   (item) => (
                     <BlockSheetButton

--- a/studio/frontend/src/features/recipe-studio/stores/recipe-studio.ts
+++ b/studio/frontend/src/features/recipe-studio/stores/recipe-studio.ts
@@ -56,6 +56,7 @@ type SheetView =
   | "sampler"
   | "seed"
   | "llm"
+  | "model"
   | "validator"
   | "expression"
   | "note"


### PR DESCRIPTION
Split from #10710 per review feedback.

Adds a top-level **Models** step group in the block picker (provider connection + model preset). Same blocks as before — just easier to find without digging into AI generation → Setup.

Related: #10637, #10708
Supersedes the Models picker portion of #10710.