### PR TITLE
Studio: live dataset preview during active runs

### DIFF
--- a/studio/backend/core/data_recipe/jobs/manager.py
+++ b/studio/backend/core/data_recipe/jobs/manager.py
@@ -280,6 +280,7 @@ class JobManager:
         return self.get_status(job_id)
 
     def get_current_job_id(self) -> str | None:
+        """Return current job_id (or None)."""
         with self._lock:
             return None if self._job is None else self._job.job_id
 
@@ -318,7 +319,9 @@ class JobManager:
             base_dataset_path = Path(artifact_path)
             parquet_dir = base_dataset_path / "parquet-files"
             if not parquet_dir.exists():
-                return {"error": f"dataset path missing: {parquet_dir}"}
+                if job_status in {"completed", "error", "cancelled"}:
+                    return {"error": f"dataset path missing: {parquet_dir}"}
+                return None
 
             return self._load_dataset_page(parquet_dir = parquet_dir, limit = limit, offset = offset)
         except Exception as exc:
@@ -544,6 +547,12 @@ class JobManager:
                 return
             if et == EVENT_JOB_STARTED:
                 self._job.status = "active"
+                artifact_path = event.get("artifact_path")
+                if isinstance(artifact_path, str) and artifact_path.strip():
+                    self._job.artifact_path = artifact_path.strip()
+                execution_type = event.get("execution_type")
+                if isinstance(execution_type, str) and execution_type.strip():
+                    self._job.execution_type = execution_type.strip()
             if et == EVENT_JOB_COMPLETED:
                 self._job.status = "completed"
                 self._job.finished_at = time.time()

--- a/studio/backend/core/data_recipe/jobs/worker.py
+++ b/studio/backend/core/data_recipe/jobs/worker.py
@@ -95,8 +95,6 @@ def run_job_process(*, event_queue, recipe: dict[str, Any], run: dict[str, Any])
         env = os.getenv("ENVIRONMENT_TYPE", "production"),
     )
 
-    event_queue.put({"type": EVENT_JOB_STARTED, "ts": time.time()})
-
     try:
         from data_designer.config.run_config import RunConfig
 
@@ -114,6 +112,18 @@ def run_job_process(*, event_queue, recipe: dict[str, Any], run: dict[str, Any])
         merge_batches = bool(run.get("merge_batches"))
         ensure_dir(_ARTIFACT_ROOT)
         run_config_raw = run.get("run_config") or {}
+        execution_type = str(run.get("execution_type") or "full").strip().lower()
+        planned_artifact_path = (
+            str(_ARTIFACT_ROOT / dataset_name) if execution_type != "preview" else None
+        )
+        event_queue.put(
+            {
+                "type": EVENT_JOB_STARTED,
+                "ts": time.time(),
+                "artifact_path": planned_artifact_path,
+                "execution_type": execution_type,
+            }
+        )
 
         builder = build_config_builder(recipe)
         designer = create_data_designer(recipe, artifact_path = str(_ARTIFACT_ROOT))
@@ -136,7 +146,6 @@ def run_job_process(*, event_queue, recipe: dict[str, Any], run: dict[str, Any])
         if run_config_raw:
             designer.set_run_config(RunConfig.model_validate(run_config_raw))
 
-        execution_type = str(run.get("execution_type") or "full").strip().lower()
         if execution_type == "preview":
             results = designer.preview(builder, num_records = rows)
             analysis = (

--- a/studio/frontend/src/features/recipe-studio/components/executions/execution-data-tab.tsx
+++ b/studio/frontend/src/features/recipe-studio/components/executions/execution-data-tab.tsx
@@ -177,7 +177,14 @@ export function ExecutionDataTab({
   return (
     <div className="mt-3">
       <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-        <p className="text-sm font-semibold">Dataset sample</p>
+        <div className="space-y-0.5">
+          <p className="text-sm font-semibold">Dataset sample</p>
+          {isExecutionInProgress(execution.status) && execution.dataset.length > 0 && (
+            <p className="text-xs text-muted-foreground">
+              Live preview — new rows appear here as the run progresses.
+            </p>
+          )}
+        </div>
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           {datasetColumnNames.length > 0 && (
             <DropdownMenu>
@@ -219,9 +226,7 @@ export function ExecutionDataTab({
                 type="button"
                 size="sm"
                 variant="outline"
-                disabled={
-                  isExecutionInProgress(execution.status) || currentDatasetPage <= 1
-                }
+                disabled={currentDatasetPage <= 1}
                 onClick={onPrevPage}
               >
                 Prev
@@ -230,10 +235,7 @@ export function ExecutionDataTab({
                 type="button"
                 size="sm"
                 variant="outline"
-                disabled={
-                  isExecutionInProgress(execution.status) ||
-                  currentDatasetPage >= totalPages
-                }
+                disabled={currentDatasetPage >= totalPages}
                 onClick={onNextPage}
               >
                 Next

--- a/studio/frontend/src/features/recipe-studio/components/executions/executions-view.tsx
+++ b/studio/frontend/src/features/recipe-studio/components/executions/executions-view.tsx
@@ -223,7 +223,9 @@ export function ExecutionsView({
       : Math.max(1, Math.ceil(datasetTotal / datasetPageSize));
   const canPageDataset =
     selectedExecution?.kind === "preview" ||
-    (selectedExecution?.kind === "full" && Boolean(selectedExecution.jobId));
+    (selectedExecution?.kind === "full" &&
+      Boolean(selectedExecution.jobId) &&
+      !isExecutionInProgress(selectedExecution.status));
   const datasetRowsForTable = useMemo(() => {
     if (!selectedExecution) {
       return [];

--- a/studio/frontend/src/features/recipe-studio/executions/tracker.ts
+++ b/studio/frontend/src/features/recipe-studio/executions/tracker.ts
@@ -104,6 +104,7 @@ export async function trackRecipeExecution({
   let lastStatus: RecipeExecutionStatus = initialExecution.status;
   let completedEventPayload: Record<string, unknown> | null = null;
   let latestExecution: RecipeExecutionRecord = initialExecution;
+  let lastDatasetPollAt = 0;
 
   const eventsAbortController = new AbortController();
   void streamRecipeJobEvents({
@@ -220,6 +221,35 @@ export async function trackRecipeExecution({
       onUpsert(latestExecution);
 
       done = isTerminalStatus(mappedStatus);
+      if (!done && Date.now() - lastDatasetPollAt >= 2500) {
+        lastDatasetPollAt = Date.now();
+        try {
+          const datasetPage = Math.max(1, latestExecution.datasetPage ?? 1);
+          const datasetPageSize =
+            latestExecution.datasetPageSize ?? DATASET_PAGE_SIZE;
+          const datasetResponse = await getRecipeJobDataset(jobId, {
+            limit: datasetPageSize,
+            offset: (datasetPage - 1) * datasetPageSize,
+          });
+          const dataset = normalizeDatasetRows(datasetResponse.dataset);
+          const datasetTotal =
+            typeof datasetResponse.total === "number"
+              ? datasetResponse.total
+              : dataset.length;
+          if (dataset.length > 0 || datasetTotal > 0) {
+            latestExecution = {
+              ...latestExecution,
+              dataset,
+              datasetTotal,
+              datasetPage,
+              datasetPageSize,
+            };
+            onUpsert(latestExecution);
+          }
+        } catch {
+          // Dataset pages can lag behind status while a run is still warming up.
+        }
+      }
       if (!done) {
         await delay(1200);
       }


### PR DESCRIPTION
Split from #10710 per review feedback.

**Live dataset preview**
- Data tab refreshes every ~2.5s while a run is active
- Rows show up before the run finishes
- Pagination stays disabled during in-progress full runs; re-enabled after completion
- Backend publishes the planned artifact path at job start so polling can read partial parquet output

Related: #10637, #10708
Supersedes the live preview portion of #10710.