### PR TITLE
Fix Studio text/CPT branches passing TRL 0.20-removed kwargs (max_seq_length, tokenizer)

### DIFF
--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -3532,7 +3532,7 @@ class UnslothTrainer:
 
         try:
             text_field = config_args.get("dataset_text_field", "text") or "text"
-            max_length = int(config_args.get("max_seq_length") or 2048)
+            max_length = int(config_args.get("max_length") or 2048)
             # The generated __init__ clamps max_seq_length to the model's cap and derives max_length from it, but runs
             # after this: apply the same cap here or the transform truncates wider than the eager map it replaces.
             model_cap = getattr(self.model, "max_seq_length", None)
@@ -4005,7 +4005,8 @@ class UnslothTrainer:
                     1 if (self.is_audio or self.is_audio_vlm or self._cuda_audio_used) else None,
                     serial_as_none = False,
                 ),
-                "max_seq_length": training_args.get("max_seq_length", 2048),
+                # TRL >=0.20 renamed SFTConfig.max_seq_length -> max_length.
+                "max_length": training_args.get("max_seq_length", 2048),
             }
             if training_args.get("enable_tensorboard", False):
                 config_args["logging_dir"] = str(
@@ -4226,7 +4227,7 @@ class UnslothTrainer:
                         logger.info("CPT packing strategy: wrapped\n")
                     trainer_kwargs = {
                         "model": self.model,
-                        "tokenizer": sft_tokenizer,
+                        "processing_class": sft_tokenizer,
                         "train_dataset": dataset["dataset"],
                         "data_collator": data_collator,
                         "args": cpt_args,
@@ -4237,7 +4238,7 @@ class UnslothTrainer:
                 else:
                     trainer_kwargs = {
                         "model": self.model,
-                        "tokenizer": sft_tokenizer,
+                        "processing_class": sft_tokenizer,
                         "train_dataset": dataset["dataset"],
                         "data_collator": data_collator,
                         "args": SFTConfig(**config_args),


### PR DESCRIPTION
## Problem

Starting a Studio run with any text model fails immediately on `trl >= 0.20`:

```
TypeError: SFTConfig.__init__() got an unexpected keyword argument 'max_seq_length'
```

and once that is resolved, the next failure is:

```
TypeError: SFTTrainer.__init__() got an unexpected keyword argument 'tokenizer'
```

TRL 0.20.0 removed both names: `SFTConfig.max_seq_length` -> `max_length`, and
`Trainer/SFTTrainer.tokenizer` -> `processing_class`.

## Root cause

This is a **half-finished migration**, not untested code: the VLM branches already use
`processing_class` / `max_length`, but the **text** and **CPT** branches were missed.

## Changes

Four sites in `studio/backend/core/training/trainer.py`:

1. **L4008** — base config dict: `"max_seq_length"` -> `"max_length"`.
   This dict is splatted into every branch's `SFTConfig`, so renaming at the source fixes
   all three `SFTConfig(**config_args)` construction sites at once.
2. **L3535** — online-tokenization read-back: `config_args.get("max_seq_length")` ->
   `get("max_length")`.
   **Silent failure**: without this the key is absent, so it falls back to `2048` and the
   configured context length is ignored — no error, wrong behaviour.
3. **L4240** — text `SFTTrainer`: `tokenizer` -> `processing_class`.
4. **L4229** — CPT `UnslothTrainer`: `tokenizer` -> `processing_class`.
   `_UnslothCPTTrainer` subclasses TRL's `SFTTrainer`, so it inherits the rename.

Deliberately **not** changed: `DataCollatorForSeq2Seq(tokenizer=...)` and friends — the
collator API is unchanged; Whisper / CSM / SNAC paths go through HF `Trainer` and are
unaffected.

## Environment

- unsloth 2026.9.2 / trl 0.24.0 / transformers 5.16.1 / peft 0.20.0
- Official Docker image `unsloth/unsloth`, 2x RTX 4090 D
- Model: Qwen3-32B, QLoRA, max_seq_length 2048

## Open question for maintainers

`unsloth` still declares `trl >= 0.18.2, <= 0.24.0`, and on `trl < 0.20` the new names do
not exist, so a plain rename drops support for those versions. Two options:

- (a) raise the `trl` floor to `>= 0.20` and keep this rename unconditional; or
- (b) keep the old floor and branch on the installed TRL version.

I went with the unconditional rename since `0.24.0` is the current default in the official
image, but happy to switch to (b) if you want to keep supporting older TRL.