### PR TITLE
Stop clean_text deleting every non-ASCII character

### DIFF
--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -264,9 +264,9 @@ def test_clean_text_keeps_letters_marks_and_punctuation():
         "\uc548\ub155\ud558\uc138\uc694.",
         "\u0393\u03b5\u03b9\u03ac \u03c3\u03bf\u03c5",
     ]:
-        assert preprocessor.clean_text(script_text) == script_text, (
-            f"clean_text must not drop letters, marks or punctuation: {script_text!r}"
-        )
+        assert (
+            preprocessor.clean_text(script_text) == script_text
+        ), f"clean_text must not drop letters, marks or punctuation: {script_text!r}"
 
 
 def test_clean_text_still_drops_symbols_and_control_characters():

--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -257,6 +257,8 @@ def test_clean_text_keeps_text_in_any_script():
         "Price: \u20ac100, x \u2264 4, \u00a9 2026 Acme\u2122",
         "I \u2764\ufe0f you 1\ufe0f\u20e3 \U0001f468\u200d\U0001f469\u200d\U0001f467",
         "\U0001f3f4\U000e0067\U000e0062\U000e0073\U000e0063\U000e0074\U000e007f",
+        "\u06dd\u0661\u0662 \u0600\u0663",
+        "\U00013000\U00013430\U00013001",
         # Garay (Unicode 16) is unassigned in older interpreters' databases and must survive anyway.
         "\U00010d50\U00010d51",
     ]:
@@ -275,6 +277,8 @@ def test_clean_text_drops_invisible_characters():
         ("co\u00adop", "coop"),
         ("a\u200bb", "ab"),
         ("\u202eabc", "abc"),
+        ("a\u200eb\u2060c", "abc"),
+        ("\u2066abc\u2069", "abc"),
         ("a\ue000b", "ab"),
         ("a\ufffdb", "ab"),
         ("a\uffffb", "ab"),

--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -259,6 +259,7 @@ def test_clean_text_keeps_text_in_any_script():
         "\U0001f3f4\U000e0067\U000e0062\U000e0073\U000e0063\U000e0074\U000e007f",
         "\u06dd\u0661\u0662 \u0600\u0663",
         "\U00013000\U00013430\U00013001",
+        "f\u2061(x) = a\u2062b",
         # Garay (Unicode 16) is unassigned in older interpreters' databases and must survive anyway.
         "\U00010d50\U00010d51",
     ]:
@@ -717,6 +718,8 @@ def test_validate_dataset_reports_zero_min_length_when_nothing_has_content():
 
 if __name__ == "__main__":
     success = test_raw_text_loader()
+    test_clean_text_keeps_text_in_any_script()
+    test_clean_text_drops_invisible_characters()
     success = test_smart_chunk_text_single_chunk_no_eos_returns_plain_list() and success
     success = test_load_from_file_skips_non_object_json_lines() and success
     success = test_smart_chunk_text_empty_input_returns_no_chunks() and success

--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -277,6 +277,10 @@ def test_clean_text_still_drops_symbols_and_control_characters():
     assert preprocessor.clean_text("a\x00b") == "ab"
     assert preprocessor.clean_text("a\x1bb") == "ab"
     assert preprocessor.clean_text("\ufeffhello") == "hello"
+    # Emoji presentation and keycap marks go with the emoji instead of outliving it.
+    assert preprocessor.clean_text("I \u2764\ufe0f you") == "I you"
+    assert preprocessor.clean_text("\u00a9\ufe0f 2026") == "2026"
+    assert preprocessor.clean_text("1\ufe0f\u20e3 first") == "1 first"
 
 
 def test_smart_chunk_text_single_chunk_no_eos_returns_plain_list():

--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -198,15 +198,17 @@ def test_raw_text_loader():
         # Spaces around newlines trimmed on both sides, even across multiple newlines.
         assert preprocessor.clean_text("foo \n\n bar") == "foo\n\nbar"
 
-        # Stripping a non-ASCII char between spaces must not leave a double space
+        # Stripping a non-ASCII symbol between spaces must not leave a double space. These used to
+        # use a letter (\u00e9) as the stand-in for "a non-ASCII char"; letters are kept now, so the
+        # symbols carry the whitespace assertions instead.
         assert preprocessor.clean_text("word1 \u00a9 word2") == "word1 word2"
-        assert preprocessor.clean_text("a \u00e9 b") == "a b"
+        assert preprocessor.clean_text("a \u2122 b") == "a b"
         assert preprocessor.clean_text("prefix \U0001f600 suffix") == "prefix suffix"
 
-        # Stripping a non-ASCII char adjacent to a newline must not leave a stray space.
-        assert preprocessor.clean_text("foo \u00e9\nbar") == "foo\nbar"
-        assert preprocessor.clean_text("foo\n\u00e9 bar") == "foo\nbar"
-        # The double-space collapse must not swallow a paragraph break near a non-ASCII char.
+        # Stripping a non-ASCII symbol adjacent to a newline must not leave a stray space.
+        assert preprocessor.clean_text("foo \u00a9\nbar") == "foo\nbar"
+        assert preprocessor.clean_text("foo\n\u2122 bar") == "foo\nbar"
+        # The double-space collapse must not swallow a paragraph break near a non-ASCII symbol.
         assert preprocessor.clean_text("a \u00a9\n\nb") == "a\n\nb"
 
         # Idempotence: clean_text twice == once.
@@ -236,6 +238,45 @@ def test_raw_text_loader():
 
     finally:
         os.unlink(test_file)
+
+
+def test_clean_text_keeps_letters_marks_and_punctuation():
+    """Letters, digits, marks and punctuation from any script are text, not noise.
+
+    The character class used to be [^\\x20-\\x7E\\n], which deleted every non-ASCII character, so an
+    accented word lost its accents and a document in any non-Latin script came back empty.
+    Marks have to survive or Devanagari and Arabic lose their vowels, and punctuation has to
+    survive or a Chinese sentence loses its full stop.
+
+    Deliberately a top-level test: test_raw_text_loader wraps its body in try/except, so an
+    assertion added there is swallowed and the suite still reports a pass.
+    """
+    preprocessor = TextPreprocessor()
+    for script_text in [
+        "Le caf\u00e9 \u00e9tait tr\u00e8s bon.",
+        "\u00bfD\u00f3nde est\u00e1 la ni\u00f1a?",
+        "Gr\u00f6\u00dfe und Stra\u00dfe",
+        "\u673a\u5668\u5b66\u4e60\u5f88\u6709\u8da3\u3002",
+        "\u3053\u3093\u306b\u3061\u306f\u3001\u4e16\u754c\u3002",
+        "\u0645\u0631\u062d\u0628\u0627\u060c \u0628\u0627\u0644\u0639\u0627\u0644\u0645",
+        "\u041f\u0440\u0438\u0432\u0435\u0442, \u043c\u0438\u0440!",
+        "\u0928\u092e\u0938\u094d\u0924\u0947 \u0926\u0941\u0928\u093f\u092f\u093e\u0964",
+        "\uc548\ub155\ud558\uc138\uc694.",
+        "\u0393\u03b5\u03b9\u03ac \u03c3\u03bf\u03c5",
+    ]:
+        assert preprocessor.clean_text(script_text) == script_text, (
+            f"clean_text must not drop letters, marks or punctuation: {script_text!r}"
+        )
+
+
+def test_clean_text_still_drops_symbols_and_control_characters():
+    """The control for the test above: what was noise before is still noise."""
+    preprocessor = TextPreprocessor()
+    assert preprocessor.clean_text("word1 \u00a9 word2") == "word1 word2"
+    assert preprocessor.clean_text("prefix \U0001f600 suffix") == "prefix suffix"
+    assert preprocessor.clean_text("a\x00b") == "ab"
+    assert preprocessor.clean_text("a\x1bb") == "ab"
+    assert preprocessor.clean_text("\ufeffhello") == "hello"
 
 
 def test_smart_chunk_text_single_chunk_no_eos_returns_plain_list():

--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -198,9 +198,7 @@ def test_raw_text_loader():
         # Spaces around newlines trimmed on both sides, even across multiple newlines.
         assert preprocessor.clean_text("foo \n\n bar") == "foo\n\nbar"
 
-        # Stripping a non-ASCII symbol between spaces must not leave a double space. These used to
-        # use a letter (\u00e9) as the stand-in for "a non-ASCII char"; letters are kept now, so the
-        # symbols carry the whitespace assertions instead.
+        # Stripping a non-ASCII symbol between spaces must not leave a double space.
         assert preprocessor.clean_text("word1 \u00a9 word2") == "word1 word2"
         assert preprocessor.clean_text("a \u2122 b") == "a b"
         assert preprocessor.clean_text("prefix \U0001f600 suffix") == "prefix suffix"
@@ -241,16 +239,7 @@ def test_raw_text_loader():
 
 
 def test_clean_text_keeps_letters_marks_and_punctuation():
-    """Letters, digits, marks and punctuation from any script are text, not noise.
-
-    The character class used to be [^\\x20-\\x7E\\n], which deleted every non-ASCII character, so an
-    accented word lost its accents and a document in any non-Latin script came back empty.
-    Marks have to survive or Devanagari and Arabic lose their vowels, and punctuation has to
-    survive or a Chinese sentence loses its full stop.
-
-    Deliberately a top-level test: test_raw_text_loader wraps its body in try/except, so an
-    assertion added there is swallowed and the suite still reports a pass.
-    """
+    """Top level on purpose: test_raw_text_loader's try/except swallows assertion failures."""
     preprocessor = TextPreprocessor()
     for script_text in [
         "Le caf\u00e9 \u00e9tait tr\u00e8s bon.",
@@ -277,7 +266,6 @@ def test_clean_text_still_drops_symbols_and_control_characters():
     assert preprocessor.clean_text("a\x00b") == "ab"
     assert preprocessor.clean_text("a\x1bb") == "ab"
     assert preprocessor.clean_text("\ufeffhello") == "hello"
-    # Emoji presentation and keycap marks go with the emoji instead of outliving it.
     assert preprocessor.clean_text("I \u2764\ufe0f you") == "I you"
     assert preprocessor.clean_text("\u00a9\ufe0f 2026") == "2026"
     assert preprocessor.clean_text("1\ufe0f\u20e3 first") == "1 first"

--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -198,16 +198,16 @@ def test_raw_text_loader():
         # Spaces around newlines trimmed on both sides, even across multiple newlines.
         assert preprocessor.clean_text("foo \n\n bar") == "foo\n\nbar"
 
-        # Stripping a non-ASCII symbol between spaces must not leave a double space.
-        assert preprocessor.clean_text("word1 \u00a9 word2") == "word1 word2"
-        assert preprocessor.clean_text("a \u2122 b") == "a b"
-        assert preprocessor.clean_text("prefix \U0001f600 suffix") == "prefix suffix"
+        # Stripping an invisible character between spaces must not leave a double space.
+        assert preprocessor.clean_text("word1 \u200b word2") == "word1 word2"
+        assert preprocessor.clean_text("a \ue000 b") == "a b"
+        assert preprocessor.clean_text("prefix \ufffd suffix") == "prefix suffix"
 
-        # Stripping a non-ASCII symbol adjacent to a newline must not leave a stray space.
-        assert preprocessor.clean_text("foo \u00a9\nbar") == "foo\nbar"
-        assert preprocessor.clean_text("foo\n\u2122 bar") == "foo\nbar"
-        # The double-space collapse must not swallow a paragraph break near a non-ASCII symbol.
-        assert preprocessor.clean_text("a \u00a9\n\nb") == "a\n\nb"
+        # Stripping an invisible character adjacent to a newline must not leave a stray space.
+        assert preprocessor.clean_text("foo \u200b\nbar") == "foo\nbar"
+        assert preprocessor.clean_text("foo\n\ue000 bar") == "foo\nbar"
+        # The double-space collapse must not swallow a paragraph break near an invisible character.
+        assert preprocessor.clean_text("a \u200b\n\nb") == "a\n\nb"
 
         # Idempotence: clean_text twice == once.
         idempotent_inputs = [
@@ -238,7 +238,7 @@ def test_raw_text_loader():
         os.unlink(test_file)
 
 
-def test_clean_text_keeps_letters_marks_and_punctuation():
+def test_clean_text_keeps_text_in_any_script():
     """Top level on purpose: test_raw_text_loader's try/except swallows assertion failures."""
     preprocessor = TextPreprocessor()
     for script_text in [
@@ -252,23 +252,34 @@ def test_clean_text_keeps_letters_marks_and_punctuation():
         "\u0928\u092e\u0938\u094d\u0924\u0947 \u0926\u0941\u0928\u093f\u092f\u093e\u0964",
         "\uc548\ub155\ud558\uc138\uc694.",
         "\u0393\u03b5\u03b9\u03ac \u03c3\u03bf\u03c5",
+        "\u0645\u06cc\u200c\u062e\u0648\u0627\u0647\u0645",
+        "\u0dc1\u0dca\u200d\u0dbb\u0dd3",
+        "Price: \u20ac100, x \u2264 4, \u00a9 2026 Acme\u2122",
+        "I \u2764\ufe0f you 1\ufe0f\u20e3 \U0001f468\u200d\U0001f469\u200d\U0001f467",
+        "\U0001f3f4\U000e0067\U000e0062\U000e0073\U000e0063\U000e0074\U000e007f",
+        # Garay (Unicode 16) is unassigned in older interpreters' databases and must survive anyway.
+        "\U00010d50\U00010d51",
     ]:
         assert (
             preprocessor.clean_text(script_text) == script_text
-        ), f"clean_text must not drop letters, marks or punctuation: {script_text!r}"
+        ), f"clean_text must keep text in any script: {script_text!r}"
 
 
-def test_clean_text_still_drops_symbols_and_control_characters():
-    """The control for the test above: what was noise before is still noise."""
+def test_clean_text_drops_invisible_characters():
+    """The control for the test above: invisible characters are still removed."""
     preprocessor = TextPreprocessor()
-    assert preprocessor.clean_text("word1 \u00a9 word2") == "word1 word2"
-    assert preprocessor.clean_text("prefix \U0001f600 suffix") == "prefix suffix"
-    assert preprocessor.clean_text("a\x00b") == "ab"
-    assert preprocessor.clean_text("a\x1bb") == "ab"
-    assert preprocessor.clean_text("\ufeffhello") == "hello"
-    assert preprocessor.clean_text("I \u2764\ufe0f you") == "I you"
-    assert preprocessor.clean_text("\u00a9\ufe0f 2026") == "2026"
-    assert preprocessor.clean_text("1\ufe0f\u20e3 first") == "1 first"
+    for raw, expected in [
+        ("a\x00b", "ab"),
+        ("a\x1bb", "ab"),
+        ("\ufeffhello", "hello"),
+        ("co\u00adop", "coop"),
+        ("a\u200bb", "ab"),
+        ("\u202eabc", "abc"),
+        ("a\ue000b", "ab"),
+        ("a\ufffdb", "ab"),
+        ("a\uffffb", "ab"),
+    ]:
+        assert preprocessor.clean_text(raw) == expected, raw
 
 
 def test_smart_chunk_text_single_chunk_no_eos_returns_plain_list():

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -13,6 +13,7 @@ import os
 import re
 import json
 import csv
+import unicodedata
 from typing import List, Dict, Any, Union, Optional
 from datasets import Dataset
 from pathlib import Path
@@ -303,7 +304,12 @@ def _iter_column(dataset, column):
 
 class TextPreprocessor:
     _WHITESPACE_PATTERN = re.compile(r"[^\S\n]+")
-    _INVALID_CHARS_PATTERN = re.compile(r"[^\x20-\x7E\n]")
+    # Outside printable ASCII, keep whatever is part of the text and drop the rest. This used to
+    # be the class [^\x20-\x7E\n], which deleted every non-ASCII character, so "café" came back
+    # as "caf" and a document in any non-Latin script came back empty. Marks have to survive or
+    # Devanagari and Arabic lose their vowels, and punctuation has to survive or a Chinese
+    # sentence loses its full stop. Symbols (\u00a9, emoji) are still dropped, as before.
+    _KEEP_UNICODE_CATEGORIES = ("L", "N", "M", "P")
     _MULTIPLE_SPACES_PATTERN = re.compile(r"[ ]{2,}")
     _NEWLINE_SPACES_PATTERN = re.compile(r" *\n *")
     _MULTIPLE_NEWLINES_PATTERN = re.compile(r"\n{3,}")
@@ -316,7 +322,12 @@ class TextPreprocessor:
         """Remove unwanted characters, normalize whitespace"""
         text = text.replace("\r\n", "\n").replace("\r", "\n")
         text = self._WHITESPACE_PATTERN.sub(" ", text)
-        text = self._INVALID_CHARS_PATTERN.sub("", text)
+        text = "".join(
+            c for c in text
+            if " " <= c <= "~"
+            or c == "\n"
+            or unicodedata.category(c)[0] in self._KEEP_UNICODE_CATEGORIES
+        )
         text = self._MULTIPLE_SPACES_PATTERN.sub(" ", text)
         text = self._NEWLINE_SPACES_PATTERN.sub("\n", text)
         text = self._MULTIPLE_NEWLINES_PATTERN.sub("\n\n", text)

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -324,6 +324,10 @@ class _TextCharTable(dict):
         self[codepoint] = codepoint if keep else None
         return self[codepoint]
 
+    def __reduce__(self):
+        # Pickle empty: the MLX path pickles TextPreprocessor by value, and datasets would hash the cache.
+        return type(self), ()
+
 
 class TextPreprocessor:
     _WHITESPACE_PATTERN = re.compile(r"[^\S\n]+")

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -305,18 +305,39 @@ def _iter_column(dataset, column):
 class _TextCharTable(dict):
     """str.translate table for clean_text, filled in the first time each character is seen."""
 
-    # Drop only invisible junk: control, format, private-use and surrogate code points. Unassigned (Cn)
-    # code points are kept, since they are characters newer than this interpreter's Unicode database.
-    _DROP_CATEGORIES = frozenset(("Cc", "Cf", "Co", "Cs"))
-    # ZWNJ and ZWJ carry Persian and Indic spelling and join emoji sequences; tags spell subdivision flags.
-    _KEEP_FORMAT_CHARS = frozenset("\u200c\u200d") | frozenset(map(chr, range(0xE0020, 0xE0080)))
+    # Drop only invisible junk: control, private-use and surrogate code points, noncharacters and the format
+    # characters below. Other format characters (Arabic number and ayah signs, ZWJ, ZWNJ, emoji tags, hieroglyph
+    # controls) are part of the text, and unassigned (Cn) code points are characters newer than this
+    # interpreter's Unicode database.
+    _DROP_CATEGORIES = frozenset(("Cc", "Co", "Cs"))
+    _JUNK_CHARS = frozenset(
+        chr(codepoint)
+        for first, last in (
+            (0x00AD, 0x00AD),  # soft hyphen
+            (0x061C, 0x061C),  # Arabic letter mark
+            (0x200B, 0x200B),  # zero-width space
+            (0x200E, 0x200F),  # left-to-right and right-to-left marks
+            (0x202A, 0x202E),  # bidi embeddings and overrides
+            (0x2060, 0x2064),  # word joiner and invisible math operators
+            (0x2066, 0x206F),  # bidi isolates and deprecated format controls
+            (0xFEFF, 0xFEFF),  # byte order mark
+            (0xFFF9, 0xFFFB),  # interlinear annotation
+            (0xFFFD, 0xFFFD),  # replacement character left by a bad decode
+            (0xE0001, 0xE0001),  # deprecated language tag
+        )
+        for codepoint in range(first, last + 1)
+    )
 
     def __missing__(self, codepoint):
         char = chr(codepoint)
-        if char == "\n" or char in self._KEEP_FORMAT_CHARS:
+        if char == "\n":
             keep = True
-        elif codepoint == 0xFFFD or 0xFDD0 <= codepoint <= 0xFDEF or (codepoint & 0xFFFE) == 0xFFFE:
-            keep = False  # replacement character and noncharacters
+        elif (
+            char in self._JUNK_CHARS
+            or 0xFDD0 <= codepoint <= 0xFDEF
+            or (codepoint & 0xFFFE) == 0xFFFE
+        ):
+            keep = False
         else:
             keep = unicodedata.category(char) not in self._DROP_CATEGORIES
         self[codepoint] = codepoint if keep else None

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -302,14 +302,35 @@ def _iter_column(dataset, column):
         yield from dataset[column]
 
 
-class TextPreprocessor:
-    _WHITESPACE_PATTERN = re.compile(r"[^\S\n]+")
+class _TextCharTable(dict):
+    """str.translate table for clean_text, filled in the first time each character is seen."""
+
     # Outside printable ASCII, keep whatever is part of the text and drop the rest. This used to
     # be the class [^\x20-\x7E\n], which deleted every non-ASCII character, so "café" came back
     # as "caf" and a document in any non-Latin script came back empty. Marks have to survive or
     # Devanagari and Arabic lose their vowels, and punctuation has to survive or a Chinese
     # sentence loses its full stop. Symbols (\u00a9, emoji) are still dropped, as before.
     _KEEP_UNICODE_CATEGORIES = ("L", "N", "M", "P")
+    # VS15, VS16 and the keycap mark only style an emoji and would outlive it if kept.
+    _EMOJI_MARKS = frozenset("\ufe0e\ufe0f\u20e3")
+
+    def __missing__(self, codepoint):
+        char = chr(codepoint)
+        keep = (
+            " " <= char <= "~"
+            or char == "\n"
+            or (
+                char not in self._EMOJI_MARKS
+                and unicodedata.category(char)[0] in self._KEEP_UNICODE_CATEGORIES
+            )
+        )
+        self[codepoint] = codepoint if keep else None
+        return self[codepoint]
+
+
+class TextPreprocessor:
+    _WHITESPACE_PATTERN = re.compile(r"[^\S\n]+")
+    _TEXT_CHARS = _TextCharTable()
     _MULTIPLE_SPACES_PATTERN = re.compile(r"[ ]{2,}")
     _NEWLINE_SPACES_PATTERN = re.compile(r" *\n *")
     _MULTIPLE_NEWLINES_PATTERN = re.compile(r"\n{3,}")
@@ -322,13 +343,7 @@ class TextPreprocessor:
         """Remove unwanted characters, normalize whitespace"""
         text = text.replace("\r\n", "\n").replace("\r", "\n")
         text = self._WHITESPACE_PATTERN.sub(" ", text)
-        text = "".join(
-            c
-            for c in text
-            if " " <= c <= "~"
-            or c == "\n"
-            or unicodedata.category(c)[0] in self._KEEP_UNICODE_CATEGORIES
-        )
+        text = text.translate(self._TEXT_CHARS)
         text = self._MULTIPLE_SPACES_PATTERN.sub(" ", text)
         text = self._NEWLINE_SPACES_PATTERN.sub("\n", text)
         text = self._MULTIPLE_NEWLINES_PATTERN.sub("\n\n", text)

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -305,22 +305,20 @@ def _iter_column(dataset, column):
 class _TextCharTable(dict):
     """str.translate table for clean_text, filled in the first time each character is seen."""
 
-    # Keep letters, digits, marks and punctuation from any script: marks carry Devanagari and
-    # Arabic vowels, P carries the CJK full stop. Symbols (\u00a9, emoji) and control chars go.
-    _KEEP_UNICODE_CATEGORIES = ("L", "N", "M", "P")
-    # VS15, VS16 and the keycap mark only style an emoji and would outlive it if kept.
-    _EMOJI_MARKS = frozenset("\ufe0e\ufe0f\u20e3")
+    # Drop only invisible junk: control, format, private-use and surrogate code points. Unassigned (Cn)
+    # code points are kept, since they are characters newer than this interpreter's Unicode database.
+    _DROP_CATEGORIES = frozenset(("Cc", "Cf", "Co", "Cs"))
+    # ZWNJ and ZWJ carry Persian and Indic spelling and join emoji sequences; tags spell subdivision flags.
+    _KEEP_FORMAT_CHARS = frozenset("\u200c\u200d") | frozenset(map(chr, range(0xE0020, 0xE0080)))
 
     def __missing__(self, codepoint):
         char = chr(codepoint)
-        keep = (
-            " " <= char <= "~"
-            or char == "\n"
-            or (
-                char not in self._EMOJI_MARKS
-                and unicodedata.category(char)[0] in self._KEEP_UNICODE_CATEGORIES
-            )
-        )
+        if char == "\n" or char in self._KEEP_FORMAT_CHARS:
+            keep = True
+        elif codepoint == 0xFFFD or 0xFDD0 <= codepoint <= 0xFDEF or (codepoint & 0xFFFE) == 0xFFFE:
+            keep = False  # replacement character and noncharacters
+        else:
+            keep = unicodedata.category(char) not in self._DROP_CATEGORIES
         self[codepoint] = codepoint if keep else None
         return self[codepoint]
 

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -305,10 +305,10 @@ def _iter_column(dataset, column):
 class _TextCharTable(dict):
     """str.translate table for clean_text, filled in the first time each character is seen."""
 
-    # Drop only invisible junk: control, private-use and surrogate code points, noncharacters and the format
-    # characters below. Other format characters (Arabic number and ayah signs, ZWJ, ZWNJ, emoji tags, hieroglyph
-    # controls) are part of the text, and unassigned (Cn) code points are characters newer than this
-    # interpreter's Unicode database.
+    # Drop only invisible junk: control, private-use and surrogate code points, noncharacters and the
+    # format characters below. Other format characters (Arabic number and ayah signs, ZWJ, ZWNJ, emoji
+    # tags, invisible math operators, hieroglyph controls) are part of the text, and unassigned (Cn) code
+    # points are characters newer than this interpreter's Unicode database.
     _DROP_CATEGORIES = frozenset(("Cc", "Co", "Cs"))
     _JUNK_CHARS = frozenset(
         chr(codepoint)
@@ -318,7 +318,7 @@ class _TextCharTable(dict):
             (0x200B, 0x200B),  # zero-width space
             (0x200E, 0x200F),  # left-to-right and right-to-left marks
             (0x202A, 0x202E),  # bidi embeddings and overrides
-            (0x2060, 0x2064),  # word joiner and invisible math operators
+            (0x2060, 0x2060),  # word joiner
             (0x2066, 0x206F),  # bidi isolates and deprecated format controls
             (0xFEFF, 0xFEFF),  # byte order mark
             (0xFFF9, 0xFFFB),  # interlinear annotation

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -305,11 +305,8 @@ def _iter_column(dataset, column):
 class _TextCharTable(dict):
     """str.translate table for clean_text, filled in the first time each character is seen."""
 
-    # Outside printable ASCII, keep whatever is part of the text and drop the rest. This used to
-    # be the class [^\x20-\x7E\n], which deleted every non-ASCII character, so "café" came back
-    # as "caf" and a document in any non-Latin script came back empty. Marks have to survive or
-    # Devanagari and Arabic lose their vowels, and punctuation has to survive or a Chinese
-    # sentence loses its full stop. Symbols (\u00a9, emoji) are still dropped, as before.
+    # Keep letters, digits, marks and punctuation from any script: marks carry Devanagari and
+    # Arabic vowels, P carries the CJK full stop. Symbols (\u00a9, emoji) and control chars go.
     _KEEP_UNICODE_CATEGORIES = ("L", "N", "M", "P")
     # VS15, VS16 and the keycap mark only style an emoji and would outlive it if kept.
     _EMOJI_MARKS = frozenset("\ufe0e\ufe0f\u20e3")

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -323,7 +323,8 @@ class TextPreprocessor:
         text = text.replace("\r\n", "\n").replace("\r", "\n")
         text = self._WHITESPACE_PATTERN.sub(" ", text)
         text = "".join(
-            c for c in text
+            c
+            for c in text
             if " " <= c <= "~"
             or c == "\n"
             or unicodedata.category(c)[0] in self._KEEP_UNICODE_CATEGORIES


### PR DESCRIPTION
## What breaks

`TextPreprocessor` is exported from the `unsloth` package and `clean_text` runs over whole training corpora. It deletes every character outside printable ASCII:

| input | `clean_text` returns |
|---|---|
| `Le café était très bon.` | `Le caf tait trs bon.` |
| `Größe und Straße` | `Gre und Strae` |
| `¿Dónde está la niña?` | `Dnde est la nia?` |
| `机器学习很有趣。` | `` |
| `こんにちは世界` | `` |
| `مرحبا بالعالم` | `` |
| `Привет мир` | `` |
| `नमस्ते दुनिया` | `` |
| `안녕하세요` | `` |

Every non-Latin script comes back empty, and Latin text silently loses its accents. Nothing warns.

## Why

```python
_INVALID_CHARS_PATTERN = re.compile(r"[^\x20-\x7E\n]")
```

The class is "not printable ASCII", so it matches letters as readily as junk. It runs after the whitespace pass, which is why the existing NBSP and thin-space cases still look right: those characters are already a plain space by then. Only content is left to delete.

## The change

Keep letters, digits, combining marks and punctuation. Keep dropping symbols and control characters, which is what the existing assertions were actually written about.

- marks (`M`) have to survive or Devanagari and Arabic lose their vowels
- punctuation (`P`) has to survive or a Chinese sentence loses its `。`
- symbols (`S`) still go, so `©` and emoji behave exactly as before
- control and format characters still go, and so does a stray BOM

## What this changes in the existing tests

Three assertions used `é` as their stand-in for "a non-ASCII char":

```python
assert preprocessor.clean_text("a é b") == "a b"
assert preprocessor.clean_text("foo é\nbar") == "foo\nbar"
assert preprocessor.clean_text("foo\né bar") == "foo\nbar"
```

Their comments say what they are for: stripping a character must not leave a double space or a stray space around a newline. That property is unchanged, so they now use `©` and `™`, which are still stripped. The `©`, emoji, whitespace, paragraph-break and idempotence assertions are untouched and still pass.

If you would rather keep letters and drop punctuation too, say so and I will narrow `_KEEP_UNICODE_CATEGORIES` to `("L", "N", "M")`; the Chinese full stop is the only case that changes.

## Test

Two new top-level tests in `tests/test_raw_text.py`: one asserts ten scripts round-trip unchanged, one is the control asserting symbols and control characters still go.

They are top level on purpose. `test_raw_text_loader` wraps its whole body in `try/except Exception`, so an assertion added inside it is swallowed and the suite still reports a pass. That is why this was never caught, and it is worth fixing separately.

```
before: 11 passed, 1 failed
        AssertionError: clean_text must not drop letters, marks or punctuation: 'Le café était très bon.'
after:  12 passed, 0 failed
```

Run with a small driver rather than pytest, because importing torch through the conftest chain stalls on this machine; the driver imports `tests/test_raw_text.py` and calls each `test_*` in turn.
