### PR TITLE
Use live PyTorch streams for bitsandbytes native calls

### DIFF
--- a/tests/python/test_bnb_current_stream.py
+++ b/tests/python/test_bnb_current_stream.py
@@ -35,10 +35,12 @@ class _Tensor:
         shape,
         dtype,
         device = None,
+        storage = None,
     ):
         self.shape = (shape,) if isinstance(shape, int) else tuple(shape)
         self.dtype = dtype
         self.device = device or SimpleNamespace(type = "cuda", index = DEVICE_INDEX)
+        self.storage = storage if storage is not None else object()
 
     def numel(self):
         total = 1
@@ -49,8 +51,21 @@ class _Tensor:
     def __iadd__(self, _other):
         return self
 
+    def __getitem__(self, item):
+        assert isinstance(item, slice)
+        start = 0 if item.start is None else item.start
+        stop = self.numel() if item.stop is None else item.stop
+        return _Tensor((max(0, stop - start),), self.dtype, self.device, self.storage)
+
+    def resize_(self, size):
+        self.shape = (size,) if isinstance(size, int) else tuple(size)
+        return self
+
     def t(self):
         return self
+
+    def view(self, shape):
+        return _Tensor(shape, self.dtype, self.device, self.storage)
 
 
 def _production_functions(name: str) -> dict[str, ast.FunctionDef]:
@@ -75,7 +90,11 @@ def _load_function(name: str, backend: str, namespace: dict):
     return namespace[name]
 
 
-def _mock_namespace(backend: str, stream_values = LIVE_STREAMS):
+def _mock_namespace(
+    backend: str,
+    stream_values = LIVE_STREAMS,
+    cached_stream = CACHED_STREAM,
+):
     device_type = "xpu" if backend == "xpu" else "cpu" if backend == "fallback" else backend
     device = SimpleNamespace(type = device_type, index = DEVICE_INDEX)
     fp8_dtype = object()
@@ -83,6 +102,7 @@ def _mock_namespace(backend: str, stream_values = LIVE_STREAMS):
     bfloat16 = object()
     native_calls = []
     stream_lookups = []
+    device_contexts = []
     matmul_result = object()
     fp8_result = object()
     streams = iter(stream_values)
@@ -107,7 +127,8 @@ def _mock_namespace(backend: str, stream_values = LIVE_STREAMS):
 
     @contextlib.contextmanager
     def torch_gpu_device(selected_device):
-        assert selected_device is device
+        assert selected_device.type == device.type
+        device_contexts.append(selected_device.index)
         yield
 
     def torch_matmul(*_args, **_kwargs):
@@ -119,7 +140,7 @@ def _mock_namespace(backend: str, stream_values = LIVE_STREAMS):
     namespace = {
         "DEVICE_TYPE": device_type,
         "Float8Tensor": _Float8Tensor,
-        "torch": SimpleNamespace(float8_e4m3fn = fp8_dtype),
+        "torch": SimpleNamespace(float8_e4m3fn = fp8_dtype, float32 = object()),
         "torch_float16": float16,
         "torch_bfloat16": bfloat16,
         "torch_float32": object(),
@@ -136,11 +157,11 @@ def _mock_namespace(backend: str, stream_values = LIVE_STREAMS):
         "cdequantize_blockwise_bf16_nf4": record("nf4_bf16"),
         "cgemm_4bit_inference_naive_fp16": record("gemv_fp16"),
         "cgemm_4bit_inference_naive_bf16": record("gemv_bf16"),
-        # Deliberately valid-looking snapshots: production execution must ignore them.
-        "CUDA_STREAMS": tuple(ctypes.c_void_p(CACHED_STREAM) for _ in range(DEVICE_INDEX + 1)),
-        "XPU_STREAMS": tuple(ctypes.c_void_p(CACHED_STREAM) for _ in range(DEVICE_INDEX + 1)),
-        "WEIGHT_BUFFERS": [None] * (DEVICE_INDEX + 1),
-        "ABSMAX_BUFFERS": [None] * (DEVICE_INDEX + 1),
+        # Snapshots gate scratch ownership but must not select native execution streams.
+        "CUDA_STREAMS": tuple(ctypes.c_void_p(cached_stream) for _ in range(DEVICE_INDEX + 2)),
+        "XPU_STREAMS": tuple(ctypes.c_void_p(cached_stream) for _ in range(DEVICE_INDEX + 2)),
+        "WEIGHT_BUFFERS": [None] * (DEVICE_INDEX + 2),
+        "ABSMAX_BUFFERS": [None] * (DEVICE_INDEX + 2),
     }
     controls = SimpleNamespace(
         device = device,
@@ -149,6 +170,7 @@ def _mock_namespace(backend: str, stream_values = LIVE_STREAMS):
         bfloat16 = bfloat16,
         native_calls = native_calls,
         stream_lookups = stream_lookups,
+        device_contexts = device_contexts,
         matmul_result = matmul_result,
         fp8_result = fp8_result,
     )
@@ -179,10 +201,18 @@ def _quant_state(controls, representation: str, dtype):
     return [absmax, shape, dtype, blocksize, [offset, state2], "nf4", stats]
 
 
-def _invoke(name: str, function, controls, quant_state):
-    weight = _Tensor((4, 3), object(), controls.device)
+def _invoke(
+    name: str,
+    function,
+    controls,
+    quant_state,
+    use_global_buffer = False,
+    device = None,
+):
+    device = controls.device if device is None else device
+    weight = _Tensor((4, 3), object(), device)
     if name == "fast_dequantize":
-        return function(weight, quant_state)
+        return function(weight, quant_state, use_global_buffer = use_global_buffer)
     activation = _Tensor(
         (1, 1, 6),
         quant_state.dtype if hasattr(quant_state, "dtype") else quant_state[2],
@@ -264,6 +294,120 @@ def test_quant_state_formats_and_dtype_specific_native_symbols(
         final_name,
     ]
     assert _stream_values(controls.native_calls) == list(LIVE_STREAMS)
+
+
+@pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
+def test_global_scratch_reuses_same_device_and_stream(backend):
+    owner_stream = LIVE_STREAMS[0]
+    namespace, controls = _mock_namespace(
+        backend,
+        (owner_stream,) * 6,
+        cached_stream = owner_stream,
+    )
+    function = _load_function("fast_dequantize", backend, namespace)
+    state = _quant_state(controls, "object", controls.float16)
+
+    first = _invoke("fast_dequantize", function, controls, state, use_global_buffer = True)
+    second = _invoke("fast_dequantize", function, controls, state, use_global_buffer = True)
+
+    assert first.storage is second.storage
+    nested_calls = [call for call in controls.native_calls if call[0] == "nested_absmax"]
+    assert nested_calls[0][1][3].storage is nested_calls[1][1][3].storage
+    assert namespace["WEIGHT_BUFFERS"][DEVICE_INDEX].storage is first.storage
+    assert namespace["ABSMAX_BUFFERS"][DEVICE_INDEX].storage is nested_calls[0][1][3].storage
+    assert _stream_values(controls.native_calls) == [owner_stream] * 4
+
+
+@pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
+def test_cached_snapshot_only_gates_scratch_not_native_stream_selection(backend):
+    owner_stream = LIVE_STREAMS[0]
+    nested_stream = LIVE_STREAMS[1]
+    final_stream = CACHED_STREAM
+    namespace, controls = _mock_namespace(
+        backend,
+        (owner_stream, nested_stream, final_stream),
+        cached_stream = owner_stream,
+    )
+    function = _load_function("fast_dequantize", backend, namespace)
+    state = _quant_state(controls, "object", controls.float16)
+
+    _invoke("fast_dequantize", function, controls, state, use_global_buffer = True)
+
+    assert namespace["WEIGHT_BUFFERS"][DEVICE_INDEX] is not None
+    assert namespace["ABSMAX_BUFFERS"][DEVICE_INDEX] is not None
+    assert _stream_values(controls.native_calls) == [nested_stream, final_stream]
+
+
+@pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
+def test_global_scratch_is_bypassed_for_nonowning_streams(backend):
+    stream_a, stream_b = LIVE_STREAMS
+    namespace, controls = _mock_namespace(
+        backend,
+        (stream_a, stream_a, stream_a, stream_b, stream_b, stream_b),
+        cached_stream = CACHED_STREAM,
+    )
+    function = _load_function("fast_dequantize", backend, namespace)
+    state = _quant_state(controls, "object", controls.float16)
+
+    first = _invoke("fast_dequantize", function, controls, state, use_global_buffer = True)
+    second = _invoke("fast_dequantize", function, controls, state, use_global_buffer = True)
+
+    assert first.storage is not second.storage
+    nested_calls = [call for call in controls.native_calls if call[0] == "nested_absmax"]
+    assert nested_calls[0][1][3].storage is not nested_calls[1][1][3].storage
+    final_calls = [call for call in controls.native_calls if call[0].startswith("nf4_")]
+    assert final_calls[0][1][3].storage is not final_calls[1][1][3].storage
+    assert namespace["WEIGHT_BUFFERS"][DEVICE_INDEX] is None
+    assert namespace["ABSMAX_BUFFERS"][DEVICE_INDEX] is None
+    assert _stream_values(controls.native_calls) == [stream_a, stream_a, stream_b, stream_b]
+
+
+@pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
+def test_global_scratch_isolated_by_device_even_for_same_stream(backend):
+    stream = LIVE_STREAMS[0]
+    namespace, controls = _mock_namespace(backend, (stream,) * 6, cached_stream = stream)
+    function = _load_function("fast_dequantize", backend, namespace)
+    state = _quant_state(controls, "object", controls.float16)
+    other_device = SimpleNamespace(type = controls.device.type, index = DEVICE_INDEX + 1)
+
+    first = _invoke("fast_dequantize", function, controls, state, use_global_buffer = True)
+    second = _invoke(
+        "fast_dequantize",
+        function,
+        controls,
+        state,
+        use_global_buffer = True,
+        device = other_device,
+    )
+
+    assert first.storage is not second.storage
+    nested_calls = [call for call in controls.native_calls if call[0] == "nested_absmax"]
+    assert nested_calls[0][1][3].storage is not nested_calls[1][1][3].storage
+    assert (
+        namespace["WEIGHT_BUFFERS"][DEVICE_INDEX].storage
+        is not namespace["WEIGHT_BUFFERS"][DEVICE_INDEX + 1].storage
+    )
+    assert (
+        namespace["ABSMAX_BUFFERS"][DEVICE_INDEX].storage
+        is not namespace["ABSMAX_BUFFERS"][DEVICE_INDEX + 1].storage
+    )
+    assert controls.stream_lookups == [DEVICE_INDEX] * 3 + [DEVICE_INDEX + 1] * 3
+    assert controls.device_contexts == [DEVICE_INDEX, DEVICE_INDEX + 1]
+
+
+@pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
+def test_default_stream_zero_is_a_reusable_scratch_key(backend):
+    namespace, controls = _mock_namespace(backend, (0,) * 6, cached_stream = 0)
+    function = _load_function("fast_dequantize", backend, namespace)
+    state = _quant_state(controls, "object", controls.bfloat16)
+
+    first = _invoke("fast_dequantize", function, controls, state, use_global_buffer = True)
+    second = _invoke("fast_dequantize", function, controls, state, use_global_buffer = True)
+
+    assert first.storage is second.storage
+    assert namespace["WEIGHT_BUFFERS"][DEVICE_INDEX].storage is first.storage
+    nested_calls = [call for call in controls.native_calls if call[0] == "nested_absmax"]
+    assert namespace["ABSMAX_BUFFERS"][DEVICE_INDEX].storage is nested_calls[0][1][3].storage
 
 
 @pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
@@ -360,6 +504,9 @@ def test_xpu_and_cuda_hip_native_symbol_bindings_remain_distinct():
 def test_accelerator_paths_ignore_cached_snapshots_and_add_no_coordination():
     assert "CUDA_STREAMS = tuple(CUDA_STREAMS)" in UTILS_SOURCE
     assert "XPU_STREAMS = tuple(XPU_STREAMS)" in UTILS_SOURCE
+    assert UTILS_SOURCE.count("WEIGHT_BUFFERS = [None] *") == 2
+    assert UTILS_SOURCE.count("ABSMAX_BUFFERS = [None] *") == 2
+    assert ".get(stream_key)" not in UTILS_SOURCE
     forbidden_calls = {
         "Event",
         "record_event",
@@ -367,6 +514,9 @@ def test_accelerator_paths_ignore_cached_snapshots_and_add_no_coordination():
         "synchronize",
         "wait_event",
         "wait_stream",
+        "Lock",
+        "RLock",
+        "sleep",
     }
     for name in ("fast_dequantize", "fast_gemv"):
         for backend in ("xpu", "cuda"):
@@ -402,6 +552,16 @@ def test_accelerator_paths_ignore_cached_snapshots_and_add_no_coordination():
                 assert len(stream_argument.args) == 1
                 assert isinstance(stream_argument.args[0], ast.Name)
                 assert stream_argument.args[0].id == "W"
-            assert names.isdisjoint({"CUDA_STREAMS", "XPU_STREAMS"})
+                native_names = {
+                    node.id for node in ast.walk(native_call) if isinstance(node, ast.Name)
+                }
+                assert native_names.isdisjoint({"CUDA_STREAMS", "XPU_STREAMS"})
+            if name == "fast_dequantize":
+                expected_snapshot = "XPU_STREAMS" if backend == "xpu" else "CUDA_STREAMS"
+                other_snapshot = "CUDA_STREAMS" if backend == "xpu" else "XPU_STREAMS"
+                assert expected_snapshot in names
+                assert other_snapshot not in names
+            else:
+                assert names.isdisjoint({"CUDA_STREAMS", "XPU_STREAMS"})
             assert attributes.isdisjoint(forbidden_calls)
             assert calls.isdisjoint(forbidden_calls)

--- a/tests/python/test_bnb_current_stream.py
+++ b/tests/python/test_bnb_current_stream.py
@@ -1,32 +1,28 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
-"""CPU/mock coverage for live PyTorch streams in direct BNB native calls."""
+"""CPU/mock behavioral coverage for live streams in direct BNB native calls."""
 
 from __future__ import annotations
 
-import ast
-import contextlib
-import copy
-import ctypes
+import importlib.util
+import sys
+from importlib.machinery import ModuleSpec
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
+import torch
+import triton.language as tl
+from packaging.version import Version
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 UTILS_PATH = REPO_ROOT / "unsloth" / "kernels" / "utils.py"
-UTILS_SOURCE = UTILS_PATH.read_text(encoding = "utf-8")
-UTILS_TREE = ast.parse(UTILS_SOURCE)
 
 DEVICE_INDEX = 5
 CACHED_STREAM = 0xCA11ED
 LIVE_STREAMS = (0xA11CE, 0xB0B)
-
-
-class _Float8Tensor:
-    pass
 
 
 class _Tensor:
@@ -68,54 +64,144 @@ class _Tensor:
         return _Tensor(shape, self.dtype, self.device, self.storage)
 
 
-def _production_functions(name: str) -> dict[str, ast.FunctionDef]:
-    functions = sorted(
-        (
-            node
-            for node in ast.walk(UTILS_TREE)
-            if isinstance(node, ast.FunctionDef) and node.name == name
-        ),
-        key = lambda node: node.lineno,
-    )
-    assert len(functions) == 3, f"expected XPU, CUDA/HIP, and fallback {name} variants"
-    return dict(zip(("xpu", "cuda", "fallback"), functions))
+def _install_module(monkeypatch, name: str, module: ModuleType):
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
 
 
-def _load_function(name: str, backend: str, namespace: dict):
-    variant = "xpu" if backend == "xpu" else "fallback" if backend == "fallback" else "cuda"
-    function = copy.deepcopy(_production_functions(name)[variant])
-    function.decorator_list = []
-    module = ast.fix_missing_locations(ast.Module(body = [function], type_ignores = []))
-    exec(compile(module, str(UTILS_PATH), "exec"), namespace)
-    return namespace[name]
-
-
-def _mock_namespace(
+def _load_utils(
+    monkeypatch,
     backend: str,
     stream_values = LIVE_STREAMS,
     cached_stream = CACHED_STREAM,
 ):
-    device_type = "xpu" if backend == "xpu" else "cpu" if backend == "fallback" else backend
+    device_type = "xpu" if backend == "xpu" else backend
     device = SimpleNamespace(type = device_type, index = DEVICE_INDEX)
-    fp8_dtype = object()
-    float16 = object()
-    bfloat16 = object()
-    native_calls = []
-    stream_lookups = []
-    device_contexts = []
-    matmul_result = object()
-    fp8_result = object()
+    controls = SimpleNamespace(
+        device = device,
+        native_calls = [],
+        snapshot_calls = [],
+        stream_lookups = [],
+        import_phase = True,
+        matmul_result = object(),
+        fp8_result = object(),
+    )
     streams = iter(stream_values)
+    expected_route = "xpu" if backend == "xpu" else "cuda"
 
-    def record(name):
+    def snapshot_getter(route):
+        def get_current_raw_stream(index):
+            if controls.import_phase:
+                controls.snapshot_calls.append((route, index))
+                return cached_stream if route == expected_route else CACHED_STREAM + 1
+            if route != expected_route:
+                raise AssertionError(f"unexpected live stream route: {route}")
+            controls.stream_lookups.append(index)
+            return next(streams)
+
+        return get_current_raw_stream
+
+    monkeypatch.setattr(
+        torch._C,
+        "_cuda_getCurrentRawStream",
+        snapshot_getter("cuda"),
+        raising = False,
+    )
+    monkeypatch.setattr(
+        torch._C,
+        "_xpu_getCurrentRawStream",
+        snapshot_getter("xpu"),
+        raising = False,
+    )
+
+    def device_factory(_index):
+        return SimpleNamespace(idx = DEVICE_INDEX)
+
+    monkeypatch.setattr(torch.cuda, "device", device_factory)
+    monkeypatch.setattr(torch.xpu, "device", device_factory)
+    if backend == "xpu" and not hasattr(tl.extra, "intel"):
+        monkeypatch.setattr(
+            tl.extra,
+            "intel",
+            SimpleNamespace(libdevice = SimpleNamespace(tanh = lambda value: value)),
+            raising = False,
+        )
+
+    package_name = f"_bnb_stream_test_{backend}"
+    package = ModuleType(package_name)
+    package.__path__ = []
+    kernels_package = ModuleType(f"{package_name}.kernels")
+    kernels_package.__path__ = []
+    _install_module(monkeypatch, package_name, package)
+    _install_module(monkeypatch, f"{package_name}.kernels", kernels_package)
+
+    device_module = ModuleType(f"{package_name}.device_type")
+    device_module.is_hip = lambda: backend == "hip"
+    device_module.get_device_type = lambda: device_type
+    device_module.DEVICE_TYPE = device_type
+    device_module.DEVICE_TYPE_TORCH = device_type
+    device_module.DEVICE_COUNT = 0 if backend == "fallback" else 1
+    device_module.ALLOW_PREQUANTIZED_MODELS = True
+    _install_module(monkeypatch, device_module.__name__, device_module)
+
+    availability_module = ModuleType(f"{package_name}.bnb_availability")
+    availability_module.native_kernels_ready = lambda *_args, **_kwargs: True
+    _install_module(monkeypatch, availability_module.__name__, availability_module)
+
+    fp8_module = ModuleType(f"{package_name}.kernels.fp8")
+    fp8_module.weight_dequant = lambda *_args, **_kwargs: controls.fp8_result
+    fp8_module.fp8_linear = lambda *_args, **_kwargs: controls.fp8_result
+    _install_module(monkeypatch, fp8_module.__name__, fp8_module)
+
+    zoo_package = ModuleType("unsloth_zoo")
+    zoo_package.__path__ = []
+    zoo_utils = ModuleType("unsloth_zoo.utils")
+    zoo_utils.Version = Version
+    _install_module(monkeypatch, "unsloth_zoo", zoo_package)
+    _install_module(monkeypatch, "unsloth_zoo.utils", zoo_utils)
+
+    torchao_package = ModuleType("torchao")
+    torchao_package.__path__ = []
+    torchao_package.__spec__ = ModuleSpec("torchao", loader = None)
+    torchao_quantization = ModuleType("torchao.quantization")
+    torchao_quantization.__spec__ = ModuleSpec("torchao.quantization", loader = None)
+    torchao_quantization.Float8Tensor = type("Float8Tensor", (), {})
+    _install_module(monkeypatch, "torchao", torchao_package)
+    _install_module(monkeypatch, "torchao.quantization", torchao_quantization)
+
+    def record_native_call(name):
         def native_call(*args):
-            native_calls.append((name, args))
+            controls.native_calls.append((name, args))
 
         return native_call
 
-    def get_tensor_stream(tensor):
-        stream_lookups.append(tensor.device.index)
-        return ctypes.c_void_p(next(streams))
+    functional_module = ModuleType("bitsandbytes.functional")
+    functional_module.get_ptr = lambda value: value
+    functional_module.lib = SimpleNamespace()
+    for symbol in (
+        "cdequantize_blockwise_fp32",
+        "cdequantize_blockwise_fp16_nf4",
+        "cdequantize_blockwise_bf16_nf4",
+        "cgemv_4bit_inference_fp16",
+        "cgemv_4bit_inference_bf16",
+        "cgemm_4bit_inference_naive_fp16",
+        "cgemm_4bit_inference_naive_bf16",
+    ):
+        setattr(functional_module.lib, symbol, record_native_call(symbol))
+    functional_module.__spec__ = ModuleSpec("bitsandbytes.functional", loader = None)
+    bnb_package = ModuleType("bitsandbytes")
+    bnb_package.__path__ = []
+    bnb_package.__version__ = "0.45.0"
+    bnb_package.functional = functional_module
+    bnb_package.__spec__ = ModuleSpec("bitsandbytes", loader = None)
+    _install_module(monkeypatch, "bitsandbytes", bnb_package)
+    _install_module(monkeypatch, "bitsandbytes.functional", functional_module)
+
+    module_name = f"{package_name}.kernels.utils"
+    spec = importlib.util.spec_from_file_location(module_name, UTILS_PATH)
+    module = importlib.util.module_from_spec(spec)
+    _install_module(monkeypatch, module_name, module)
+    spec.loader.exec_module(module)
 
     def torch_empty(
         shape,
@@ -125,443 +211,152 @@ def _mock_namespace(
     ):
         return _Tensor(shape, dtype, device)
 
-    @contextlib.contextmanager
-    def torch_gpu_device(selected_device):
-        assert selected_device.type == device.type
-        device_contexts.append(selected_device.index)
-        yield
-
-    def torch_matmul(*_args, **_kwargs):
-        return matmul_result
-
-    def weight_dequant(*_args, **_kwargs):
-        return fp8_result
-
-    namespace = {
-        "DEVICE_TYPE": device_type,
-        "Float8Tensor": _Float8Tensor,
-        "torch": SimpleNamespace(float8_e4m3fn = fp8_dtype, float32 = object()),
-        "torch_float16": float16,
-        "torch_bfloat16": bfloat16,
-        "torch_float32": object(),
-        "torch_empty": torch_empty,
-        "torch_gpu_device": torch_gpu_device,
-        "torch_matmul": torch_matmul,
-        "weight_dequant": weight_dequant,
-        "get_ptr": lambda value: value,
-        "ctypes_c_int": ctypes.c_int,
-        "ctypes_c_int32": ctypes.c_int32,
-        "_get_tensor_stream": get_tensor_stream,
-        "cdequantize_blockwise_fp32": record("nested_absmax"),
-        "cdequantize_blockwise_fp16_nf4": record("nf4_fp16"),
-        "cdequantize_blockwise_bf16_nf4": record("nf4_bf16"),
-        "cgemm_4bit_inference_naive_fp16": record("gemv_fp16"),
-        "cgemm_4bit_inference_naive_bf16": record("gemv_bf16"),
-        # Snapshots gate scratch ownership but must not select native execution streams.
-        "CUDA_STREAMS": tuple(ctypes.c_void_p(cached_stream) for _ in range(DEVICE_INDEX + 2)),
-        "XPU_STREAMS": tuple(ctypes.c_void_p(cached_stream) for _ in range(DEVICE_INDEX + 2)),
-        "WEIGHT_BUFFERS": [None] * (DEVICE_INDEX + 2),
-        "ABSMAX_BUFFERS": [None] * (DEVICE_INDEX + 2),
-    }
-    controls = SimpleNamespace(
-        device = device,
-        fp8_dtype = fp8_dtype,
-        float16 = float16,
-        bfloat16 = bfloat16,
-        native_calls = native_calls,
-        stream_lookups = stream_lookups,
-        device_contexts = device_contexts,
-        matmul_result = matmul_result,
-        fp8_result = fp8_result,
-    )
-    return namespace, controls
+    controls.import_phase = False
+    module.torch_empty = torch_empty
+    module.torch_matmul = lambda *_args, **_kwargs: controls.matmul_result
+    controls.float16 = module.torch_float16
+    controls.bfloat16 = module.torch_bfloat16
+    controls.fp8_dtype = module.torch.float8_e4m3fn
+    return module, controls
 
 
-def _quant_state(controls, representation: str, dtype):
+def _quant_state(controls, dtype):
     absmax = _Tensor((2,), controls.float16, controls.device)
     absmax2 = _Tensor((1,), controls.float16, controls.device)
-    code2 = object()
-    stats = object()
-    shape = (4, 6)
-    blocksize = 64
-    blocksize2 = 256
-    offset = 0.25
-    if representation == "object":
-        state2 = SimpleNamespace(absmax = absmax2, code = code2, blocksize = blocksize2)
-        return SimpleNamespace(
-            absmax = absmax,
-            shape = shape,
-            dtype = dtype,
-            blocksize = blocksize,
-            code = stats,
-            offset = offset,
-            state2 = state2,
-        )
-    state2 = [absmax2, code2, blocksize2, None, None, None, None]
-    return [absmax, shape, dtype, blocksize, [offset, state2], "nf4", stats]
+    return SimpleNamespace(
+        absmax = absmax,
+        shape = (4, 6),
+        dtype = dtype,
+        blocksize = 64,
+        code = object(),
+        offset = 0.25,
+        state2 = SimpleNamespace(absmax = absmax2, code = object(), blocksize = 256),
+    )
 
 
 def _invoke(
-    name: str,
-    function,
+    name,
+    module,
     controls,
     quant_state,
     use_global_buffer = False,
-    device = None,
 ):
-    device = controls.device if device is None else device
-    weight = _Tensor((4, 3), object(), device)
+    weight = _Tensor((4, 3), object(), controls.device)
     if name == "fast_dequantize":
-        return function(weight, quant_state, use_global_buffer = use_global_buffer)
-    activation = _Tensor(
-        (1, 1, 6),
-        quant_state.dtype if hasattr(quant_state, "dtype") else quant_state[2],
-        controls.device,
-    )
-    return function(activation, weight, quant_state)
+        return module.fast_dequantize(weight, quant_state, use_global_buffer = use_global_buffer)
+    activation = _Tensor((1, 1, 6), quant_state.dtype, controls.device)
+    return module.fast_gemv(activation, weight, quant_state)
 
 
 def _stream_values(calls):
-    return [args[-1].value for _name, args in calls]
-
-
-def test_get_tensor_stream_invokes_the_bound_getter_at_call_time():
-    helper = copy.deepcopy(
-        next(
-            node
-            for node in UTILS_TREE.body
-            if isinstance(node, ast.FunctionDef) and node.name == "_get_tensor_stream"
-        )
-    )
-    values = iter(LIVE_STREAMS)
-    device_indices = []
-
-    def current_raw_stream(device_index):
-        device_indices.append(device_index)
-        return next(values)
-
-    namespace = {
-        "torch_Tensor": object,
-        "c_void_p": ctypes.c_void_p,
-        "_gpu_getCurrentRawStream": current_raw_stream,
-    }
-    exec(
-        compile(
-            ast.fix_missing_locations(ast.Module(body = [helper], type_ignores = [])),
-            str(UTILS_PATH),
-            "exec",
-        ),
-        namespace,
-    )
-    tensor = _Tensor((1,), object(), SimpleNamespace(type = "cuda", index = DEVICE_INDEX))
-
-    assert namespace["_get_tensor_stream"](tensor).value == LIVE_STREAMS[0]
-    assert namespace["_get_tensor_stream"](tensor).value == LIVE_STREAMS[1]
-    assert device_indices == [DEVICE_INDEX, DEVICE_INDEX]
+    return [0 if args[-1].value is None else args[-1].value for _name, args in calls]
 
 
 @pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
 @pytest.mark.parametrize("name", ("fast_dequantize", "fast_gemv"))
-def test_each_native_call_observes_its_own_live_stream(backend, name):
-    namespace, controls = _mock_namespace(backend)
-    function = _load_function(name, backend, namespace)
-    state = _quant_state(controls, "object", controls.float16)
-
-    _invoke(name, function, controls, state)
+def test_native_calls_use_the_live_stream_at_each_invocation(monkeypatch, backend, name):
+    module, controls = _load_utils(monkeypatch, backend)
+    _invoke(name, module, controls, _quant_state(controls, controls.float16))
 
     assert controls.stream_lookups == [DEVICE_INDEX, DEVICE_INDEX]
     assert _stream_values(controls.native_calls) == list(LIVE_STREAMS)
     assert CACHED_STREAM not in _stream_values(controls.native_calls)
 
 
-@pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
-@pytest.mark.parametrize("name", ("fast_dequantize", "fast_gemv"))
-@pytest.mark.parametrize("representation", ("object", "list"))
-@pytest.mark.parametrize("dtype_name", ("float16", "bfloat16"))
-def test_quant_state_formats_and_dtype_specific_native_symbols(
-    backend, name, representation, dtype_name
-):
-    namespace, controls = _mock_namespace(backend)
-    function = _load_function(name, backend, namespace)
-    dtype = getattr(controls, dtype_name)
+@pytest.mark.parametrize(
+    ("backend", "expected_route"),
+    (("cuda", "cuda"), ("hip", "cuda"), ("xpu", "xpu")),
+)
+def test_backend_current_stream_getter_route(monkeypatch, backend, expected_route):
+    _module, controls = _load_utils(monkeypatch, backend, stream_values = ())
 
-    _invoke(name, function, controls, _quant_state(controls, representation, dtype))
-
-    suffix = "fp16" if dtype_name == "float16" else "bf16"
-    final_name = f"nf4_{suffix}" if name == "fast_dequantize" else f"gemv_{suffix}"
-    assert [call_name for call_name, _args in controls.native_calls] == [
-        "nested_absmax",
-        final_name,
-    ]
-    assert _stream_values(controls.native_calls) == list(LIVE_STREAMS)
+    assert controls.snapshot_calls
+    assert {route for route, _index in controls.snapshot_calls} == {expected_route}
+    assert {index for _route, index in controls.snapshot_calls} == {DEVICE_INDEX}
 
 
 @pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
-def test_global_scratch_reuses_same_device_and_stream(backend):
-    owner_stream = LIVE_STREAMS[0]
-    namespace, controls = _mock_namespace(
+@pytest.mark.parametrize("owner_stream", (LIVE_STREAMS[0], 0))
+def test_owner_stream_reuses_per_device_scratch(monkeypatch, backend, owner_stream):
+    module, controls = _load_utils(
+        monkeypatch,
         backend,
-        (owner_stream,) * 6,
+        stream_values = (owner_stream,) * 6,
         cached_stream = owner_stream,
     )
-    function = _load_function("fast_dequantize", backend, namespace)
-    state = _quant_state(controls, "object", controls.float16)
+    state = _quant_state(controls, controls.float16)
 
-    first = _invoke("fast_dequantize", function, controls, state, use_global_buffer = True)
-    second = _invoke("fast_dequantize", function, controls, state, use_global_buffer = True)
+    first = _invoke("fast_dequantize", module, controls, state, use_global_buffer = True)
+    second = _invoke("fast_dequantize", module, controls, state, use_global_buffer = True)
 
+    nested_calls = [controls.native_calls[index] for index in (0, 2)]
     assert first.storage is second.storage
-    nested_calls = [call for call in controls.native_calls if call[0] == "nested_absmax"]
     assert nested_calls[0][1][3].storage is nested_calls[1][1][3].storage
-    assert namespace["WEIGHT_BUFFERS"][DEVICE_INDEX].storage is first.storage
-    assert namespace["ABSMAX_BUFFERS"][DEVICE_INDEX].storage is nested_calls[0][1][3].storage
+    assert module.WEIGHT_BUFFERS[DEVICE_INDEX].storage is first.storage
+    assert module.ABSMAX_BUFFERS[DEVICE_INDEX].storage is nested_calls[0][1][3].storage
     assert _stream_values(controls.native_calls) == [owner_stream] * 4
 
 
 @pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
-def test_cached_snapshot_only_gates_scratch_not_native_stream_selection(backend):
+def test_nonowner_streams_use_call_local_scratch(monkeypatch, backend):
     owner_stream = LIVE_STREAMS[0]
-    nested_stream = LIVE_STREAMS[1]
-    final_stream = CACHED_STREAM
-    namespace, controls = _mock_namespace(
+    alternate_a, alternate_b = LIVE_STREAMS[1], CACHED_STREAM
+    module, controls = _load_utils(
+        monkeypatch,
         backend,
-        (owner_stream, nested_stream, final_stream),
+        stream_values = (alternate_a,) * 6 + (alternate_b,) * 3,
         cached_stream = owner_stream,
     )
-    function = _load_function("fast_dequantize", backend, namespace)
-    state = _quant_state(controls, "object", controls.float16)
+    state = _quant_state(controls, controls.float16)
 
-    _invoke("fast_dequantize", function, controls, state, use_global_buffer = True)
+    outputs = [
+        _invoke("fast_dequantize", module, controls, state, use_global_buffer = True)
+        for _ in range(3)
+    ]
+    nested_scratch = [controls.native_calls[index][1][3] for index in (0, 2, 4)]
+    final_outputs = [controls.native_calls[index][1][3] for index in (1, 3, 5)]
 
-    assert namespace["WEIGHT_BUFFERS"][DEVICE_INDEX] is not None
-    assert namespace["ABSMAX_BUFFERS"][DEVICE_INDEX] is not None
+    assert len({output.storage for output in outputs}) == 3
+    assert len({scratch.storage for scratch in nested_scratch}) == 3
+    assert len({output.storage for output in final_outputs}) == 3
+    assert module.WEIGHT_BUFFERS[DEVICE_INDEX] is None
+    assert module.ABSMAX_BUFFERS[DEVICE_INDEX] is None
+    assert _stream_values(controls.native_calls) == [alternate_a] * 4 + [alternate_b] * 2
+
+
+@pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
+def test_cached_snapshot_only_gates_scratch_eligibility(monkeypatch, backend):
+    owner_stream = LIVE_STREAMS[0]
+    nested_stream, final_stream = LIVE_STREAMS[1], CACHED_STREAM
+    module, controls = _load_utils(
+        monkeypatch,
+        backend,
+        stream_values = (owner_stream, nested_stream, final_stream),
+        cached_stream = owner_stream,
+    )
+
+    _invoke(
+        "fast_dequantize",
+        module,
+        controls,
+        _quant_state(controls, controls.float16),
+        use_global_buffer = True,
+    )
+
+    assert module.WEIGHT_BUFFERS[DEVICE_INDEX] is not None
+    assert module.ABSMAX_BUFFERS[DEVICE_INDEX] is not None
     assert _stream_values(controls.native_calls) == [nested_stream, final_stream]
 
 
 @pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
-def test_global_scratch_is_bypassed_for_nonowning_streams(backend):
-    stream_a, stream_b = LIVE_STREAMS
-    namespace, controls = _mock_namespace(
-        backend,
-        (stream_a, stream_a, stream_a, stream_b, stream_b, stream_b),
-        cached_stream = CACHED_STREAM,
-    )
-    function = _load_function("fast_dequantize", backend, namespace)
-    state = _quant_state(controls, "object", controls.float16)
-
-    first = _invoke("fast_dequantize", function, controls, state, use_global_buffer = True)
-    second = _invoke("fast_dequantize", function, controls, state, use_global_buffer = True)
-
-    assert first.storage is not second.storage
-    nested_calls = [call for call in controls.native_calls if call[0] == "nested_absmax"]
-    assert nested_calls[0][1][3].storage is not nested_calls[1][1][3].storage
-    final_calls = [call for call in controls.native_calls if call[0].startswith("nf4_")]
-    assert final_calls[0][1][3].storage is not final_calls[1][1][3].storage
-    assert namespace["WEIGHT_BUFFERS"][DEVICE_INDEX] is None
-    assert namespace["ABSMAX_BUFFERS"][DEVICE_INDEX] is None
-    assert _stream_values(controls.native_calls) == [stream_a, stream_a, stream_b, stream_b]
-
-
-@pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
-def test_global_scratch_isolated_by_device_even_for_same_stream(backend):
-    stream = LIVE_STREAMS[0]
-    namespace, controls = _mock_namespace(backend, (stream,) * 6, cached_stream = stream)
-    function = _load_function("fast_dequantize", backend, namespace)
-    state = _quant_state(controls, "object", controls.float16)
-    other_device = SimpleNamespace(type = controls.device.type, index = DEVICE_INDEX + 1)
-
-    first = _invoke("fast_dequantize", function, controls, state, use_global_buffer = True)
-    second = _invoke(
-        "fast_dequantize",
-        function,
-        controls,
-        state,
-        use_global_buffer = True,
-        device = other_device,
-    )
-
-    assert first.storage is not second.storage
-    nested_calls = [call for call in controls.native_calls if call[0] == "nested_absmax"]
-    assert nested_calls[0][1][3].storage is not nested_calls[1][1][3].storage
-    assert (
-        namespace["WEIGHT_BUFFERS"][DEVICE_INDEX].storage
-        is not namespace["WEIGHT_BUFFERS"][DEVICE_INDEX + 1].storage
-    )
-    assert (
-        namespace["ABSMAX_BUFFERS"][DEVICE_INDEX].storage
-        is not namespace["ABSMAX_BUFFERS"][DEVICE_INDEX + 1].storage
-    )
-    assert controls.stream_lookups == [DEVICE_INDEX] * 3 + [DEVICE_INDEX + 1] * 3
-    assert controls.device_contexts == [DEVICE_INDEX, DEVICE_INDEX + 1]
-
-
-@pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
-def test_default_stream_zero_is_a_reusable_scratch_key(backend):
-    namespace, controls = _mock_namespace(backend, (0,) * 6, cached_stream = 0)
-    function = _load_function("fast_dequantize", backend, namespace)
-    state = _quant_state(controls, "object", controls.bfloat16)
-
-    first = _invoke("fast_dequantize", function, controls, state, use_global_buffer = True)
-    second = _invoke("fast_dequantize", function, controls, state, use_global_buffer = True)
-
-    assert first.storage is second.storage
-    assert namespace["WEIGHT_BUFFERS"][DEVICE_INDEX].storage is first.storage
-    nested_calls = [call for call in controls.native_calls if call[0] == "nested_absmax"]
-    assert namespace["ABSMAX_BUFFERS"][DEVICE_INDEX].storage is nested_calls[0][1][3].storage
-
-
-@pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
-def test_gemv_preserves_backend_specific_dimension_abi(backend):
-    namespace, controls = _mock_namespace(backend)
-    function = _load_function("fast_gemv", backend, namespace)
-
-    _invoke("fast_gemv", function, controls, _quant_state(controls, "object", controls.float16))
-
-    _call_name, args = controls.native_calls[-1]
-    expected_mn = (1, 4) if backend == "xpu" else (4, 1)
-    assert (args[0].value, args[1].value) == expected_mn
-    assert len(args) == 13
-
-
-@pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
-def test_unquantized_and_fp8_early_returns_do_not_look_up_a_stream(backend):
-    namespace, controls = _mock_namespace(backend, ())
-    dequantize = _load_function("fast_dequantize", backend, namespace)
-    gemv = _load_function("fast_gemv", backend, namespace)
+def test_early_returns_do_not_query_a_stream(monkeypatch, backend):
+    module, controls = _load_utils(monkeypatch, backend, stream_values = ())
     weight = _Tensor((4, 3), object(), controls.device)
     activation = _Tensor((1, 1, 6), controls.float16, controls.device)
 
-    assert dequantize(weight, None) is weight
-    assert gemv(activation, weight, None) is controls.matmul_result
-
+    assert module.fast_dequantize(weight, None) is weight
+    assert module.fast_gemv(activation, weight, None) is controls.matmul_result
     weight.dtype = controls.fp8_dtype
-    assert dequantize(weight, object()) is controls.fp8_result
+    assert module.fast_dequantize(weight, object()) is controls.fp8_result
     assert controls.stream_lookups == []
     assert controls.native_calls == []
-
-
-@pytest.mark.parametrize("name", ("fast_dequantize", "fast_gemv"))
-def test_legacy_no_stream_fallback_keeps_native_abi_without_stream_argument(name):
-    namespace, controls = _mock_namespace("fallback", ())
-    function = _load_function(name, "fallback", namespace)
-
-    _invoke(name, function, controls, _quant_state(controls, "list", controls.bfloat16))
-
-    assert controls.stream_lookups == []
-    assert [len(args) for _call_name, args in controls.native_calls] == (
-        [6, 6] if name == "fast_dequantize" else [6, 12]
-    )
-
-
-@pytest.mark.parametrize(
-    ("backend", "expected_getter"),
-    (("cuda", "cuda"), ("hip", "cuda"), ("xpu", "xpu")),
-)
-def test_backend_binds_the_expected_current_stream_getter(backend, expected_getter):
-    binding = next(
-        node
-        for node in UTILS_TREE.body
-        if isinstance(node, ast.If)
-        and any(
-            isinstance(target, ast.Name) and target.id == "_gpu_getCurrentRawStream"
-            for assignment in ast.walk(node)
-            if isinstance(assignment, ast.Assign)
-            for target in assignment.targets
-        )
-    )
-    cuda_getter = object()
-    xpu_getter = object()
-    namespace = {
-        "DEVICE_TYPE": backend,
-        "torch": SimpleNamespace(
-            _C = SimpleNamespace(
-                _cuda_getCurrentRawStream = cuda_getter,
-                _xpu_getCurrentRawStream = xpu_getter,
-            )
-        ),
-    }
-
-    exec(
-        compile(
-            ast.fix_missing_locations(ast.Module(body = [copy.deepcopy(binding)], type_ignores = [])),
-            str(UTILS_PATH),
-            "exec",
-        ),
-        namespace,
-    )
-
-    expected = cuda_getter if expected_getter == "cuda" else xpu_getter
-    assert namespace["_gpu_getCurrentRawStream"] is expected
-
-
-def test_xpu_and_cuda_hip_native_symbol_bindings_remain_distinct():
-    assert "bnb_functional.lib.cgemv_4bit_inference_fp16" in UTILS_SOURCE
-    assert "bnb_functional.lib.cgemv_4bit_inference_bf16" in UTILS_SOURCE
-    assert "bnb_functional.lib.cgemm_4bit_inference_naive_fp16" in UTILS_SOURCE
-    assert "bnb_functional.lib.cgemm_4bit_inference_naive_bf16" in UTILS_SOURCE
-
-
-def test_accelerator_paths_ignore_cached_snapshots_and_add_no_coordination():
-    assert "CUDA_STREAMS = tuple(CUDA_STREAMS)" in UTILS_SOURCE
-    assert "XPU_STREAMS = tuple(XPU_STREAMS)" in UTILS_SOURCE
-    assert UTILS_SOURCE.count("WEIGHT_BUFFERS = [None] *") == 2
-    assert UTILS_SOURCE.count("ABSMAX_BUFFERS = [None] *") == 2
-    assert ".get(stream_key)" not in UTILS_SOURCE
-    forbidden_calls = {
-        "Event",
-        "record_event",
-        "record_stream",
-        "synchronize",
-        "wait_event",
-        "wait_stream",
-        "Lock",
-        "RLock",
-        "sleep",
-    }
-    for name in ("fast_dequantize", "fast_gemv"):
-        for backend in ("xpu", "cuda"):
-            function = _production_functions(name)[backend]
-            names = {node.id for node in ast.walk(function) if isinstance(node, ast.Name)}
-            attributes = {
-                node.attr for node in ast.walk(function) if isinstance(node, ast.Attribute)
-            }
-            calls = {
-                node.func.id
-                for node in ast.walk(function)
-                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
-            }
-            native_calls = [
-                node
-                for node in ast.walk(function)
-                if isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Name)
-                and node.func.id
-                in {
-                    "cdequantize_blockwise_fp32",
-                    "cdequantize_blockwise_fp16_nf4",
-                    "cdequantize_blockwise_bf16_nf4",
-                    "fx",
-                }
-            ]
-            assert len(native_calls) == 2
-            for native_call in native_calls:
-                stream_argument = native_call.args[-1]
-                assert isinstance(stream_argument, ast.Call)
-                assert isinstance(stream_argument.func, ast.Name)
-                assert stream_argument.func.id == "_get_tensor_stream"
-                assert len(stream_argument.args) == 1
-                assert isinstance(stream_argument.args[0], ast.Name)
-                assert stream_argument.args[0].id == "W"
-                native_names = {
-                    node.id for node in ast.walk(native_call) if isinstance(node, ast.Name)
-                }
-                assert native_names.isdisjoint({"CUDA_STREAMS", "XPU_STREAMS"})
-            if name == "fast_dequantize":
-                expected_snapshot = "XPU_STREAMS" if backend == "xpu" else "CUDA_STREAMS"
-                other_snapshot = "CUDA_STREAMS" if backend == "xpu" else "XPU_STREAMS"
-                assert expected_snapshot in names
-                assert other_snapshot not in names
-            else:
-                assert names.isdisjoint({"CUDA_STREAMS", "XPU_STREAMS"})
-            assert attributes.isdisjoint(forbidden_calls)
-            assert calls.isdisjoint(forbidden_calls)

--- a/tests/python/test_bnb_current_stream.py
+++ b/tests/python/test_bnb_current_stream.py
@@ -1,0 +1,407 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""CPU/mock coverage for live PyTorch streams in direct BNB native calls."""
+
+from __future__ import annotations
+
+import ast
+import contextlib
+import copy
+import ctypes
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UTILS_PATH = REPO_ROOT / "unsloth" / "kernels" / "utils.py"
+UTILS_SOURCE = UTILS_PATH.read_text(encoding = "utf-8")
+UTILS_TREE = ast.parse(UTILS_SOURCE)
+
+DEVICE_INDEX = 5
+CACHED_STREAM = 0xCA11ED
+LIVE_STREAMS = (0xA11CE, 0xB0B)
+
+
+class _Float8Tensor:
+    pass
+
+
+class _Tensor:
+    def __init__(
+        self,
+        shape,
+        dtype,
+        device = None,
+    ):
+        self.shape = (shape,) if isinstance(shape, int) else tuple(shape)
+        self.dtype = dtype
+        self.device = device or SimpleNamespace(type = "cuda", index = DEVICE_INDEX)
+
+    def numel(self):
+        total = 1
+        for dimension in self.shape:
+            total *= dimension
+        return total
+
+    def __iadd__(self, _other):
+        return self
+
+    def t(self):
+        return self
+
+
+def _production_functions(name: str) -> dict[str, ast.FunctionDef]:
+    functions = sorted(
+        (
+            node
+            for node in ast.walk(UTILS_TREE)
+            if isinstance(node, ast.FunctionDef) and node.name == name
+        ),
+        key = lambda node: node.lineno,
+    )
+    assert len(functions) == 3, f"expected XPU, CUDA/HIP, and fallback {name} variants"
+    return dict(zip(("xpu", "cuda", "fallback"), functions))
+
+
+def _load_function(name: str, backend: str, namespace: dict):
+    variant = "xpu" if backend == "xpu" else "fallback" if backend == "fallback" else "cuda"
+    function = copy.deepcopy(_production_functions(name)[variant])
+    function.decorator_list = []
+    module = ast.fix_missing_locations(ast.Module(body = [function], type_ignores = []))
+    exec(compile(module, str(UTILS_PATH), "exec"), namespace)
+    return namespace[name]
+
+
+def _mock_namespace(backend: str, stream_values = LIVE_STREAMS):
+    device_type = "xpu" if backend == "xpu" else "cpu" if backend == "fallback" else backend
+    device = SimpleNamespace(type = device_type, index = DEVICE_INDEX)
+    fp8_dtype = object()
+    float16 = object()
+    bfloat16 = object()
+    native_calls = []
+    stream_lookups = []
+    matmul_result = object()
+    fp8_result = object()
+    streams = iter(stream_values)
+
+    def record(name):
+        def native_call(*args):
+            native_calls.append((name, args))
+
+        return native_call
+
+    def get_tensor_stream(tensor):
+        stream_lookups.append(tensor.device.index)
+        return ctypes.c_void_p(next(streams))
+
+    def torch_empty(
+        shape,
+        dtype = None,
+        device = None,
+        **_kwargs,
+    ):
+        return _Tensor(shape, dtype, device)
+
+    @contextlib.contextmanager
+    def torch_gpu_device(selected_device):
+        assert selected_device is device
+        yield
+
+    def torch_matmul(*_args, **_kwargs):
+        return matmul_result
+
+    def weight_dequant(*_args, **_kwargs):
+        return fp8_result
+
+    namespace = {
+        "DEVICE_TYPE": device_type,
+        "Float8Tensor": _Float8Tensor,
+        "torch": SimpleNamespace(float8_e4m3fn = fp8_dtype),
+        "torch_float16": float16,
+        "torch_bfloat16": bfloat16,
+        "torch_float32": object(),
+        "torch_empty": torch_empty,
+        "torch_gpu_device": torch_gpu_device,
+        "torch_matmul": torch_matmul,
+        "weight_dequant": weight_dequant,
+        "get_ptr": lambda value: value,
+        "ctypes_c_int": ctypes.c_int,
+        "ctypes_c_int32": ctypes.c_int32,
+        "_get_tensor_stream": get_tensor_stream,
+        "cdequantize_blockwise_fp32": record("nested_absmax"),
+        "cdequantize_blockwise_fp16_nf4": record("nf4_fp16"),
+        "cdequantize_blockwise_bf16_nf4": record("nf4_bf16"),
+        "cgemm_4bit_inference_naive_fp16": record("gemv_fp16"),
+        "cgemm_4bit_inference_naive_bf16": record("gemv_bf16"),
+        # Deliberately valid-looking snapshots: production execution must ignore them.
+        "CUDA_STREAMS": tuple(ctypes.c_void_p(CACHED_STREAM) for _ in range(DEVICE_INDEX + 1)),
+        "XPU_STREAMS": tuple(ctypes.c_void_p(CACHED_STREAM) for _ in range(DEVICE_INDEX + 1)),
+        "WEIGHT_BUFFERS": [None] * (DEVICE_INDEX + 1),
+        "ABSMAX_BUFFERS": [None] * (DEVICE_INDEX + 1),
+    }
+    controls = SimpleNamespace(
+        device = device,
+        fp8_dtype = fp8_dtype,
+        float16 = float16,
+        bfloat16 = bfloat16,
+        native_calls = native_calls,
+        stream_lookups = stream_lookups,
+        matmul_result = matmul_result,
+        fp8_result = fp8_result,
+    )
+    return namespace, controls
+
+
+def _quant_state(controls, representation: str, dtype):
+    absmax = _Tensor((2,), controls.float16, controls.device)
+    absmax2 = _Tensor((1,), controls.float16, controls.device)
+    code2 = object()
+    stats = object()
+    shape = (4, 6)
+    blocksize = 64
+    blocksize2 = 256
+    offset = 0.25
+    if representation == "object":
+        state2 = SimpleNamespace(absmax = absmax2, code = code2, blocksize = blocksize2)
+        return SimpleNamespace(
+            absmax = absmax,
+            shape = shape,
+            dtype = dtype,
+            blocksize = blocksize,
+            code = stats,
+            offset = offset,
+            state2 = state2,
+        )
+    state2 = [absmax2, code2, blocksize2, None, None, None, None]
+    return [absmax, shape, dtype, blocksize, [offset, state2], "nf4", stats]
+
+
+def _invoke(name: str, function, controls, quant_state):
+    weight = _Tensor((4, 3), object(), controls.device)
+    if name == "fast_dequantize":
+        return function(weight, quant_state)
+    activation = _Tensor(
+        (1, 1, 6),
+        quant_state.dtype if hasattr(quant_state, "dtype") else quant_state[2],
+        controls.device,
+    )
+    return function(activation, weight, quant_state)
+
+
+def _stream_values(calls):
+    return [args[-1].value for _name, args in calls]
+
+
+def test_get_tensor_stream_invokes_the_bound_getter_at_call_time():
+    helper = copy.deepcopy(
+        next(
+            node
+            for node in UTILS_TREE.body
+            if isinstance(node, ast.FunctionDef) and node.name == "_get_tensor_stream"
+        )
+    )
+    values = iter(LIVE_STREAMS)
+    device_indices = []
+
+    def current_raw_stream(device_index):
+        device_indices.append(device_index)
+        return next(values)
+
+    namespace = {
+        "torch_Tensor": object,
+        "c_void_p": ctypes.c_void_p,
+        "_gpu_getCurrentRawStream": current_raw_stream,
+    }
+    exec(
+        compile(
+            ast.fix_missing_locations(ast.Module(body = [helper], type_ignores = [])),
+            str(UTILS_PATH),
+            "exec",
+        ),
+        namespace,
+    )
+    tensor = _Tensor((1,), object(), SimpleNamespace(type = "cuda", index = DEVICE_INDEX))
+
+    assert namespace["_get_tensor_stream"](tensor).value == LIVE_STREAMS[0]
+    assert namespace["_get_tensor_stream"](tensor).value == LIVE_STREAMS[1]
+    assert device_indices == [DEVICE_INDEX, DEVICE_INDEX]
+
+
+@pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
+@pytest.mark.parametrize("name", ("fast_dequantize", "fast_gemv"))
+def test_each_native_call_observes_its_own_live_stream(backend, name):
+    namespace, controls = _mock_namespace(backend)
+    function = _load_function(name, backend, namespace)
+    state = _quant_state(controls, "object", controls.float16)
+
+    _invoke(name, function, controls, state)
+
+    assert controls.stream_lookups == [DEVICE_INDEX, DEVICE_INDEX]
+    assert _stream_values(controls.native_calls) == list(LIVE_STREAMS)
+    assert CACHED_STREAM not in _stream_values(controls.native_calls)
+
+
+@pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
+@pytest.mark.parametrize("name", ("fast_dequantize", "fast_gemv"))
+@pytest.mark.parametrize("representation", ("object", "list"))
+@pytest.mark.parametrize("dtype_name", ("float16", "bfloat16"))
+def test_quant_state_formats_and_dtype_specific_native_symbols(
+    backend, name, representation, dtype_name
+):
+    namespace, controls = _mock_namespace(backend)
+    function = _load_function(name, backend, namespace)
+    dtype = getattr(controls, dtype_name)
+
+    _invoke(name, function, controls, _quant_state(controls, representation, dtype))
+
+    suffix = "fp16" if dtype_name == "float16" else "bf16"
+    final_name = f"nf4_{suffix}" if name == "fast_dequantize" else f"gemv_{suffix}"
+    assert [call_name for call_name, _args in controls.native_calls] == [
+        "nested_absmax",
+        final_name,
+    ]
+    assert _stream_values(controls.native_calls) == list(LIVE_STREAMS)
+
+
+@pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
+def test_gemv_preserves_backend_specific_dimension_abi(backend):
+    namespace, controls = _mock_namespace(backend)
+    function = _load_function("fast_gemv", backend, namespace)
+
+    _invoke("fast_gemv", function, controls, _quant_state(controls, "object", controls.float16))
+
+    _call_name, args = controls.native_calls[-1]
+    expected_mn = (1, 4) if backend == "xpu" else (4, 1)
+    assert (args[0].value, args[1].value) == expected_mn
+    assert len(args) == 13
+
+
+@pytest.mark.parametrize("backend", ("cuda", "hip", "xpu"))
+def test_unquantized_and_fp8_early_returns_do_not_look_up_a_stream(backend):
+    namespace, controls = _mock_namespace(backend, ())
+    dequantize = _load_function("fast_dequantize", backend, namespace)
+    gemv = _load_function("fast_gemv", backend, namespace)
+    weight = _Tensor((4, 3), object(), controls.device)
+    activation = _Tensor((1, 1, 6), controls.float16, controls.device)
+
+    assert dequantize(weight, None) is weight
+    assert gemv(activation, weight, None) is controls.matmul_result
+
+    weight.dtype = controls.fp8_dtype
+    assert dequantize(weight, object()) is controls.fp8_result
+    assert controls.stream_lookups == []
+    assert controls.native_calls == []
+
+
+@pytest.mark.parametrize("name", ("fast_dequantize", "fast_gemv"))
+def test_legacy_no_stream_fallback_keeps_native_abi_without_stream_argument(name):
+    namespace, controls = _mock_namespace("fallback", ())
+    function = _load_function(name, "fallback", namespace)
+
+    _invoke(name, function, controls, _quant_state(controls, "list", controls.bfloat16))
+
+    assert controls.stream_lookups == []
+    assert [len(args) for _call_name, args in controls.native_calls] == (
+        [6, 6] if name == "fast_dequantize" else [6, 12]
+    )
+
+
+@pytest.mark.parametrize(
+    ("backend", "expected_getter"),
+    (("cuda", "cuda"), ("hip", "cuda"), ("xpu", "xpu")),
+)
+def test_backend_binds_the_expected_current_stream_getter(backend, expected_getter):
+    binding = next(
+        node
+        for node in UTILS_TREE.body
+        if isinstance(node, ast.If)
+        and any(
+            isinstance(target, ast.Name) and target.id == "_gpu_getCurrentRawStream"
+            for assignment in ast.walk(node)
+            if isinstance(assignment, ast.Assign)
+            for target in assignment.targets
+        )
+    )
+    cuda_getter = object()
+    xpu_getter = object()
+    namespace = {
+        "DEVICE_TYPE": backend,
+        "torch": SimpleNamespace(
+            _C = SimpleNamespace(
+                _cuda_getCurrentRawStream = cuda_getter,
+                _xpu_getCurrentRawStream = xpu_getter,
+            )
+        ),
+    }
+
+    exec(
+        compile(
+            ast.fix_missing_locations(ast.Module(body = [copy.deepcopy(binding)], type_ignores = [])),
+            str(UTILS_PATH),
+            "exec",
+        ),
+        namespace,
+    )
+
+    expected = cuda_getter if expected_getter == "cuda" else xpu_getter
+    assert namespace["_gpu_getCurrentRawStream"] is expected
+
+
+def test_xpu_and_cuda_hip_native_symbol_bindings_remain_distinct():
+    assert "bnb_functional.lib.cgemv_4bit_inference_fp16" in UTILS_SOURCE
+    assert "bnb_functional.lib.cgemv_4bit_inference_bf16" in UTILS_SOURCE
+    assert "bnb_functional.lib.cgemm_4bit_inference_naive_fp16" in UTILS_SOURCE
+    assert "bnb_functional.lib.cgemm_4bit_inference_naive_bf16" in UTILS_SOURCE
+
+
+def test_accelerator_paths_ignore_cached_snapshots_and_add_no_coordination():
+    assert "CUDA_STREAMS = tuple(CUDA_STREAMS)" in UTILS_SOURCE
+    assert "XPU_STREAMS = tuple(XPU_STREAMS)" in UTILS_SOURCE
+    forbidden_calls = {
+        "Event",
+        "record_event",
+        "record_stream",
+        "synchronize",
+        "wait_event",
+        "wait_stream",
+    }
+    for name in ("fast_dequantize", "fast_gemv"):
+        for backend in ("xpu", "cuda"):
+            function = _production_functions(name)[backend]
+            names = {node.id for node in ast.walk(function) if isinstance(node, ast.Name)}
+            attributes = {
+                node.attr for node in ast.walk(function) if isinstance(node, ast.Attribute)
+            }
+            calls = {
+                node.func.id
+                for node in ast.walk(function)
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+            }
+            native_calls = [
+                node
+                for node in ast.walk(function)
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id
+                in {
+                    "cdequantize_blockwise_fp32",
+                    "cdequantize_blockwise_fp16_nf4",
+                    "cdequantize_blockwise_bf16_nf4",
+                    "fx",
+                }
+            ]
+            assert len(native_calls) == 2
+            for native_call in native_calls:
+                stream_argument = native_call.args[-1]
+                assert isinstance(stream_argument, ast.Call)
+                assert isinstance(stream_argument.func, ast.Name)
+                assert stream_argument.func.id == "_get_tensor_stream"
+                assert len(stream_argument.args) == 1
+                assert isinstance(stream_argument.args[0], ast.Name)
+                assert stream_argument.args[0].id == "W"
+            assert names.isdisjoint({"CUDA_STREAMS", "XPU_STREAMS"})
+            assert attributes.isdisjoint(forbidden_calls)
+            assert calls.isdisjoint(forbidden_calls)

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -204,8 +204,9 @@ global XPU_STREAMS
 global WEIGHT_BUFFERS
 global ABSMAX_BUFFERS
 
-# These snapshots remain coupled to global-buffer initialization. Native BNB
-# execution paths obtain the live PyTorch stream with _get_tensor_stream instead.
+# These snapshots remain coupled to global-buffer initialization. They only gate
+# reuse of the per-device scratch pair; native BNB execution paths obtain the
+# live PyTorch stream with _get_tensor_stream instead.
 # DEVICE_COUNT == 0 means no visible accelerator (CPU-only CI runner).
 if DEVICE_TYPE == "xpu":
     if DEVICE_COUNT > 0:
@@ -468,7 +469,14 @@ if DEVICE_TYPE == "xpu" and HAS_XPU_STREAM:
 
         n_elements_absmax = absmax.numel()
         if use_global_buffer:
-            # Use same buffers for faster inference
+            live_stream = _get_tensor_stream(W)
+            cached_stream = XPU_STREAMS[device_index]
+            live_stream_raw = live_stream.value or 0
+            cached_stream_raw = None if cached_stream is None else cached_stream.value or 0
+            use_global_buffer = cached_stream_raw == live_stream_raw
+
+        if use_global_buffer:
+            # Reuse the existing per-device scratch pair only on its owning stream.
             size = shape[0] * shape[1]
             global WEIGHT_BUFFERS
             global ABSMAX_BUFFERS
@@ -574,6 +582,14 @@ elif DEVICE_TYPE in ("cuda", "hip") and HAS_CUDA_STREAM:
         n_elements_absmax = absmax.numel()
 
         if use_global_buffer:
+            live_stream = _get_tensor_stream(W)
+            cached_stream = CUDA_STREAMS[device_index]
+            live_stream_raw = live_stream.value or 0
+            cached_stream_raw = None if cached_stream is None else cached_stream.value or 0
+            use_global_buffer = cached_stream_raw == live_stream_raw
+
+        if use_global_buffer:
+            # Reuse the existing per-device scratch pair only on its owning stream.
             size = shape[0] * shape[1]
             global WEIGHT_BUFFERS
             global ABSMAX_BUFFERS

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -204,6 +204,8 @@ global XPU_STREAMS
 global WEIGHT_BUFFERS
 global ABSMAX_BUFFERS
 
+# These snapshots remain coupled to global-buffer initialization. Native BNB
+# execution paths obtain the live PyTorch stream with _get_tensor_stream instead.
 # DEVICE_COUNT == 0 means no visible accelerator (CPU-only CI runner).
 if DEVICE_TYPE == "xpu":
     if DEVICE_COUNT > 0:
@@ -461,10 +463,8 @@ if DEVICE_TYPE == "xpu" and HAS_XPU_STREAM:
             absmax, shape, dtype, blocksize, compressed_stats, _, _ = quant_state
             offset, state2 = compressed_stats
             absmax2, code2, blocksize2, _, _, _, _ = state2
-        global XPU_STREAMS
         device = W.device
         device_index = device.index
-        XPU_STREAM = XPU_STREAMS[device_index]
 
         n_elements_absmax = absmax.numel()
         if use_global_buffer:
@@ -514,7 +514,7 @@ if DEVICE_TYPE == "xpu" and HAS_XPU_STREAM:
                 ptr_out_absmax,
                 ctypes_c_int(blocksize2),
                 ctypes_c_int(n_elements_absmax),
-                XPU_STREAM,
+                _get_tensor_stream(W),
             )
             out_absmax += offset
 
@@ -530,7 +530,7 @@ if DEVICE_TYPE == "xpu" and HAS_XPU_STREAM:
                 get_ptr(out),
                 ctypes_c_int(blocksize),
                 ctypes_c_int(out.numel()),
-                XPU_STREAM,
+                _get_tensor_stream(W),
             )
         # Careful returning transposed data.
         is_transposed = True if W.shape[0] == 1 else False
@@ -568,10 +568,8 @@ elif DEVICE_TYPE in ("cuda", "hip") and HAS_CUDA_STREAM:
             offset, state2 = compressed_stats
             absmax2, code2, blocksize2, _, _, _, _ = state2
         pass
-        global CUDA_STREAMS
         device = W.device
         device_index = device.index
-        CUDA_STREAM = CUDA_STREAMS[device_index]
 
         n_elements_absmax = absmax.numel()
 
@@ -622,7 +620,7 @@ elif DEVICE_TYPE in ("cuda", "hip") and HAS_CUDA_STREAM:
                 ptr_out_absmax,
                 ctypes_c_int(blocksize2),
                 ctypes_c_int(n_elements_absmax),
-                CUDA_STREAM,
+                _get_tensor_stream(W),
             )
             out_absmax += offset
 
@@ -638,7 +636,7 @@ elif DEVICE_TYPE in ("cuda", "hip") and HAS_CUDA_STREAM:
                 get_ptr(out),
                 ctypes_c_int(blocksize),
                 ctypes_c_int(out.numel()),
-                CUDA_STREAM,
+                _get_tensor_stream(W),
             )
         pass
         # Careful returning transposed data.
@@ -751,10 +749,7 @@ if DEVICE_TYPE == "xpu" and HAS_XPU_STREAM:
             absmax, shape, dtype, blocksize, compressed_stats, quant_type, stats = quant_state
             offset, state2 = compressed_stats
             absmax2, code2, blocksize2, _, _, _, _ = state2
-        global XPU_STREAMS
         device = W.device
-        device_index = device.index
-        XPU_STREAM = XPU_STREAMS[device_index]
 
         bout = shape[0]
 
@@ -795,7 +790,7 @@ if DEVICE_TYPE == "xpu" and HAS_XPU_STREAM:
                 get_ptr(df),
                 ctypes_c_int(blocksize2),
                 ctypes_c_int(df.numel()),
-                XPU_STREAM,
+                _get_tensor_stream(W),
             )
             df += offset
             absmax = df
@@ -820,7 +815,7 @@ if DEVICE_TYPE == "xpu" and HAS_XPU_STREAM:
                 ldb,
                 ldc,
                 blocksize,
-                XPU_STREAM,
+                _get_tensor_stream(W),
             )
 
         return out
@@ -854,10 +849,7 @@ elif DEVICE_TYPE in ("cuda", "hip") and HAS_CUDA_STREAM:
             offset, state2 = compressed_stats
             absmax2, code2, blocksize2, _, _, _, _ = state2
         pass
-        global CUDA_STREAMS
         device = W.device
-        device_index = device.index
-        CUDA_STREAM = CUDA_STREAMS[device_index]
 
         bout = shape[0]
 
@@ -894,7 +886,7 @@ elif DEVICE_TYPE in ("cuda", "hip") and HAS_CUDA_STREAM:
                 get_ptr(df),
                 ctypes_c_int(blocksize2),
                 ctypes_c_int(df.numel()),
-                CUDA_STREAM,
+                _get_tensor_stream(W),
             )
             df += offset
             absmax = df
@@ -919,7 +911,7 @@ elif DEVICE_TYPE in ("cuda", "hip") and HAS_CUDA_STREAM:
                 ldb,
                 ldc,
                 blocksize,
-                CUDA_STREAM,
+                _get_tensor_stream(W),
             )
         pass
 


### PR DESCRIPTION
## Summary

Use PyTorch's live current accelerator stream for direct bitsandbytes native dequantization and GEMV/GEMM calls instead of the raw stream pointer cached during module initialization.

References #10563.

This addresses the cached-stream discrepancy described there. It does not claim that the discrepancy is the proven cause of the reported AMDGPU resets.

## Problem

`CUDA_STREAMS` and `XPU_STREAMS` are populated during module initialization.

Previously, the stream-enabled `fast_dequantize()` and `fast_gemv()` paths reused those cached pointers for native bitsandbytes calls. If PyTorch's current stream changed after import, native BNB work could therefore be submitted to a different stream from the surrounding PyTorch operations.

There was also a second correctness concern once native launches were moved onto each caller's live stream: `fast_dequantize(..., use_global_buffer=True)` reused one persistent `WEIGHT_BUFFERS` / `ABSMAX_BUFFERS` scratch pair per device. Two concurrent callers on distinct streams could otherwise use the same scratch allocation at the same time.

## Change

### Live native execution streams

The affected CUDA/HIP and XPU native calls now use the existing:

```python
_get_tensor_stream(W)
```

helper at each native invocation.

This covers:

- nested absmax dequantization in `fast_dequantize`
- final NF4 dequantization in `fast_dequantize`
- nested absmax dequantization in `fast_gemv`
- final native GEMV/GEMM call in `fast_gemv`

The current stream is queried separately for each native call rather than once per function invocation.

### Stream-safe reusable scratch buffers

Persistent dequant scratch remains bounded to the original one weight/absmax pair per device.

For `fast_dequantize(..., use_global_buffer=True)`:

- if the caller's live current stream matches the device's existing cached stream snapshot, the existing per-device scratch pair is reused;
- if the caller is on a different stream, that invocation uses call-local scratch instead of the persistent shared pair.

This preserves the common-stream reuse optimization without introducing an unbounded per-stream cache.

`CUDA_STREAMS` / `XPU_STREAMS` are now used only to determine eligibility for reuse of the existing scratch cache. They do **not** select the execution stream for native BNB calls.

No synchronization, events, waits, sleeps, global locks, or per-stream persistent dictionaries are introduced.

## Compatibility

The change preserves:

- CUDA and HIP/ROCm routing
- XPU-specific native symbols and ABI
- FP16/BF16 dispatch
- old-list and current object quantization-state formats
- unquantized and FP8 early returns
- CPU / legacy no-stream fallback behavior
- existing device-context and native-kernel readiness handling
- the original one-slot-per-device `WEIGHT_BUFFERS` / `ABSMAX_BUFFERS` shape

## Tests

Focused CPU/mock regression coverage now verifies:

- live stream lookup occurs at native invocation time
- two native calls within one function invocation can observe different current streams
- exact raw stream pointers reach nested and final native calls
- cached stream snapshots do not select native execution streams
- owner-stream scratch reuse is preserved
- alternate streams use call-local scratch
- two distinct alternate streams cannot receive the shared global scratch allocation
- persistent cache cardinality remains one scratch pair per device
- default raw stream pointer `0`
- CUDA, HIP, and XPU routing
- nonzero device indices
- FP16/BF16 dispatch
- old/new quantization-state representations
- unquantized and FP8 early returns
- no synchronization/event/wait/lock workaround is introduced

After maintainer feedback, the regression test was simplified to exercise the real production functions with controlled mocks rather than AST/source-string/ABI assertions.

Results:

```text
24 focused stream regression tests passed
11 existing BNB import/readiness tests passed
35 combined passed, 15 warnings
```

The test file was reduced by 205 lines while retaining the behavioral coverage above.

`py_compile`, Ruff checks, repository formatting, and `git diff --check` also pass.

## ROCm smoke validation

The change was exercised on:

- AMD Radeon RX 7900 XTX / gfx1100
- PyTorch 2.10.0+rocm7.1
- HIP 7.1.25424
- bitsandbytes 0.50.3.dev0

### Live-stream selection smoke

A synthetic nested-NF4 `(256, 2048)` weight was dequantized once on the default PyTorch stream and once on a distinct alternate PyTorch stream.

```text
streams_differ: true
outputs_equal: true
max_abs_diff: 0.0
```

### Scratch-ownership smoke

The same nested-NF4 shape was then exercised with `use_global_buffer=True`.

The default/owner stream reused the persistent global weight buffer. Two distinct alternate streams each used separate call-local output allocations, neither shared the persistent global weight buffer, and the persistent cache remained unchanged.

```text
owner_reused_global_weight: true
alternate_outputs_avoid_global_weight: true
alternate_streams_distinct: true
persistent_cache_unchanged: true
outputs_equal_alt1: true
outputs_equal_alt2: true
max_abs_diff_alt1: 0.0
max_abs_diff_alt2: 0.0
```

Both smoke tests exited successfully, and no matching AMDGPU fault/reset events were recorded during either validation window.

These smoke tests validate the live-stream and scratch-ownership behavior on ROCm. They do not establish the root cause of the separate GPU-reset investigation.

## Scope

This PR is intentionally limited to the stream-correctness changes required for native BNB execution and safe reuse of the existing dequant scratch buffers.

It does not include unrelated investigation changes such as decorator changes, MiniCPM-specific code, diagnostic logging, high-level BNB fallback experiments, or training-path changes.
