### PR TITLE
Studio: Make installed Ollama models available through the API

### DIFF
--- a/studio/backend/core/inference/local_model_resolver.py
+++ b/studio/backend/core/inference/local_model_resolver.py
@@ -80,6 +80,10 @@ def _advertised_loader_id(info) -> Optional[str]:
     an absolute filesystem path so /v1/models and the override key never expose a
     host path (the ./models and LM Studio scanners report the path as info.id)."""
     raw_id = getattr(info, "id", None)
+    from hub.services.models.ollama import is_ollama_manifest_ref
+
+    if isinstance(raw_id, str) and is_ollama_manifest_ref(raw_id):
+        return getattr(info, "model_id", None)
     if not raw_id or not _is_abs_path_id(raw_id):
         return raw_id
     for alt in (getattr(info, "model_id", None), getattr(info, "display_name", None)):
@@ -572,6 +576,16 @@ def _local_weights_entry(loader_id: str, info) -> Optional[_LocalGgufEntry]:
 
 def _local_servable_entry(loader_id: str, info) -> Optional[_LocalGgufEntry]:
     """Entry for whichever backend can serve *info* from disk, GGUF first."""
+    from hub.services.models.ollama import is_ollama_manifest_ref
+
+    raw_id = getattr(info, "id", None)
+    if isinstance(raw_id, str) and is_ollama_manifest_ref(raw_id):
+        from pathlib import Path
+
+        path = getattr(info, "path", None)
+        if path and Path(path).is_file() and getattr(info, "source", None) == "ollama":
+            return _LocalGgufEntry(loader_id, raw_id, ())
+        return None
     return _local_gguf_entry(loader_id, info) or _local_weights_entry(loader_id, info)
 
 
@@ -586,9 +600,6 @@ def local_servable_model(info) -> Optional[tuple[bool, tuple[str, ...]]]:
     from pathlib import Path
 
     path = getattr(info, "path", None)
-    # Ollama-link entries come from a scanner _build_index intentionally skips (it creates symlinks on the request
-    # path), so their advertised ids never resolve. Don't report them as servable, or /v1/models would list unswitchable
-    # models.
     if isinstance(path, str) and any(
         seg in (".studio_links", "ollama_links") for seg in Path(path).parts
     ):
@@ -619,9 +630,8 @@ def _build_index() -> dict[str, _LocalGgufEntry]:
 
     Scans the same roots Unsloth's model picker lists (./models, the active plus
     legacy/default HF caches, LM Studio and Hermes dirs, and user scan folders) so a named
-    local model is never missed and silently served as the loaded one. Ollama's
-    scanner is skipped: it creates symlinks as a side effect and this runs on the
-    request path.
+    local model is never missed and silently served as the loaded one. Ollama
+    discovery retains a read-only manifest reference for materialization at load time.
     """
     # Lazy import: routes.models imports core.inference, so import at call time.
     from pathlib import Path
@@ -629,6 +639,7 @@ def _build_index() -> dict[str, _LocalGgufEntry]:
         _scan_models_dir,
         _scan_hf_cache,
         _scan_lmstudio_dir,
+        _scan_ollama_dir,
         _resolve_hf_cache_dir,
         _is_hidden_model,
     )
@@ -697,6 +708,12 @@ def _build_index() -> dict[str, _LocalGgufEntry]:
     except Exception as exc:
         logger.debug("auto-switch: Hermes scan failed: %s", exc)
     try:
+        from utils.paths import ollama_model_dirs
+        for ollama_dir in ollama_model_dirs():
+            found += _scan_ollama_dir(ollama_dir)
+    except Exception as exc:
+        logger.debug("auto-switch: Ollama scan failed: %s", exc)
+    try:
         from storage.studio_db import list_scan_folders
 
         custom_found = []
@@ -704,7 +721,10 @@ def _build_index() -> dict[str, _LocalGgufEntry]:
             try:
                 fp = Path(folder["path"])
                 custom_found += dedupe_custom_gguf_rows(
-                    _scan_models_dir(fp, limit = 200) + _scan_hf_once(fp) + _scan_lmstudio_dir(fp)
+                    _scan_models_dir(fp, limit = 200)
+                    + _scan_hf_once(fp)
+                    + _scan_lmstudio_dir(fp)
+                    + _scan_ollama_dir(fp, limit = 200)
                 )
             except Exception as exc:
                 logger.debug("auto-switch: scan folder %r failed: %s", folder, exc)

--- a/studio/backend/hub/services/models/catalog_classification.py
+++ b/studio/backend/hub/services/models/catalog_classification.py
@@ -45,7 +45,7 @@ _QWEN3_ASR_HINT = re.compile(
     re.IGNORECASE,
 )
 _ORPHEUS_GGUF_HINT = re.compile(
-    r"(?<![a-z0-9])orpheus[-_. ]*3b(?![a-z0-9])",
+    r"(?<![a-z0-9])orpheus[-_. :]*3b(?![a-z0-9])",
     re.IGNORECASE,
 )
 
@@ -342,11 +342,7 @@ def _gguf_path_audio_type(
 ) -> Optional[str]:
     model_path = Path(path)
     try:
-        paths = (
-            [model_path]
-            if model_path.suffix.lower() == ".gguf" and model_path.is_file()
-            else _iter_gguf_paths(model_path)
-        )
+        paths = [model_path] if model_path.is_file() else _iter_gguf_paths(model_path)
         for gguf_path in paths:
             audio_type = _arch_to_audio_type(
                 _gguf_architecture(str(gguf_path)),
@@ -370,7 +366,7 @@ def _repo_gguf_audio_type(repo_info, selected: Optional[Path] = None) -> Optiona
 def _gguf_path_task(path: str | Path, id_hints: tuple[Optional[str], ...] = ()) -> Optional[str]:
     model_path = Path(path)
     try:
-        if model_path.suffix.lower() == ".gguf" and model_path.is_file():
+        if model_path.is_file():
             hints = id_hints + (model_path.name,)
             if not file_contents_available_locally(model_path):
                 return _unhydrated_gguf_task(hints)

--- a/studio/backend/hub/services/models/ollama.py
+++ b/studio/backend/hub/services/models/ollama.py
@@ -559,6 +559,21 @@ def _validated_ollama_manifest_location(ref: str) -> tuple[Path, Path]:
     return tag_file, canonical_ollama_dir
 
 
+def ollama_model_ref_files(ref: str) -> tuple[str, Optional[str]]:
+    tag_file, ollama_dir = _validated_ollama_manifest_location(ref)
+    info = _ollama_model_info_from_manifest(
+        ollama_dir, tag_file, materialize_links = False, reject_unsupported_layers = True
+    )
+    if info is None:
+        raise ValueError("Could not resolve Ollama model from manifest")
+    manifest = json.loads(tag_file.read_text(encoding = "utf-8-sig"))
+    projector = None
+    for layer in manifest.get("layers") or []:
+        if layer.get("mediaType") == "application/vnd.ollama.image.projector":
+            projector = _ollama_blob_path(ollama_dir / "blobs", layer.get("digest"))
+    return info.path, str(projector) if projector is not None else None
+
+
 def _materialization_lock(tag_file: Path) -> threading.Lock:
     key = os.path.normcase(str(tag_file))
     with _OLLAMA_MATERIALIZE_LOCKS_GUARD:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -8220,9 +8220,6 @@ def _loaded_satisfies(requested: str) -> bool:
             )
             if candidate
         ]
-        if requested.strip().lower().startswith("ollama/"):
-            # Ollama tags identify manifests, even when they look like GGUF quants.
-            return _matches_any(requested, candidates)
         if not _matches_any(base, candidates):
             return False
         if not looks_like_quant(variant):
@@ -8258,8 +8255,6 @@ def _loaded_identity_satisfies(requested: str) -> bool:
     if getattr(llama_backend, "is_loaded", False):
         identifier = getattr(llama_backend, "model_identifier", None)
         advertised = getattr(llama_backend, "_openai_advertised_id", None)
-        if requested.strip().lower().startswith("ollama/"):
-            base = requested
         # A manual load of a local path advertises nothing, so only the path could match
         # and answering from it would skip the recording: /v1/models and every response
         # would report the filename. One request pays the resolver, the rest match the

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -7424,6 +7424,12 @@ def _target_is_vision(
     # invariant (the resolver only yields local paths, where the token is unused,
     # but the rule requires it regardless).
     from utils.models.model_config import is_vision_model
+    if is_ollama_manifest_ref(load_path):
+        from hub.services.models.ollama import ollama_model_ref_files
+        from utils.models.gguf_metadata import mmproj_accepts_image
+
+        _, projector = ollama_model_ref_files(load_path)
+        return projector is not None and (not need_image or mmproj_accepts_image(projector))
     try:
         # Deliberately unguarded: the resolver only yields local paths, so this returns
         # from the mmproj filesystem branch without touching the hub. A reachability
@@ -7504,6 +7510,9 @@ def _target_accepts_request_input(
 def _resolve_target_gguf_file(load_path: str, gguf_variant: Optional[str]) -> Optional[str]:
     from utils.models.model_config import _find_local_gguf_by_variant, detect_gguf_model
 
+    if is_ollama_manifest_ref(load_path):
+        from hub.services.models.ollama import ollama_model_ref_files
+        return ollama_model_ref_files(load_path)[0]
     local_path = os.path.expanduser(load_path)
     if gguf_variant and Path(local_path).is_dir():
         return _find_local_gguf_by_variant(local_path, gguf_variant)

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -7424,13 +7424,13 @@ def _target_is_vision(
     # invariant (the resolver only yields local paths, where the token is unused,
     # but the rule requires it regardless).
     from utils.models.model_config import is_vision_model
-    if is_ollama_manifest_ref(load_path):
-        from hub.services.models.ollama import ollama_model_ref_files
-        from utils.models.gguf_metadata import mmproj_accepts_image
-
-        _, projector = ollama_model_ref_files(load_path)
-        return projector is not None and (not need_image or mmproj_accepts_image(projector))
     try:
+        if is_ollama_manifest_ref(load_path):
+            from hub.services.models.ollama import ollama_model_ref_files
+            from utils.models.gguf_metadata import mmproj_accepts_image
+
+            _, projector = ollama_model_ref_files(load_path)
+            return projector is not None and (not need_image or mmproj_accepts_image(projector))
         # Deliberately unguarded: the resolver only yields local paths, so this returns
         # from the mmproj filesystem branch without touching the hub. A reachability
         # probe here would add seconds per request and prevent nothing.
@@ -8220,6 +8220,9 @@ def _loaded_satisfies(requested: str) -> bool:
             )
             if candidate
         ]
+        if requested.strip().lower().startswith("ollama/"):
+            # Ollama tags identify manifests, even when they look like GGUF quants.
+            return _matches_any(requested, candidates)
         if not _matches_any(base, candidates):
             return False
         if not looks_like_quant(variant):
@@ -8255,6 +8258,8 @@ def _loaded_identity_satisfies(requested: str) -> bool:
     if getattr(llama_backend, "is_loaded", False):
         identifier = getattr(llama_backend, "model_identifier", None)
         advertised = getattr(llama_backend, "_openai_advertised_id", None)
+        if requested.strip().lower().startswith("ollama/"):
+            base = requested
         # A manual load of a local path advertises nothing, so only the path could match
         # and answering from it would skip the recording: /v1/models and every response
         # would report the filename. One request pays the resolver, the rest match the

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -2,7 +2,6 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import asyncio
-import hashlib
 import json
 import os
 import shutil
@@ -744,233 +743,13 @@ def _scan_lmstudio_dir(lm_dir: Path) -> List[LocalModelInfo]:
     return found
 
 
-def _ollama_links_dir(ollama_dir: Path) -> Optional[Path]:
-    """A writable directory for Ollama ``.gguf`` symlinks. Prefers ``<ollama_dir>/.studio_links/`` so
-    links sit next to their blobs; falls back to a per-ollama-dir namespace under Unsloth's cache when
-    the models dir is read-only (common for system installs)."""
-    from utils.paths.storage_roots import cache_root
-
-    primary = ollama_dir / ".studio_links"
-    try:
-        primary.mkdir(exist_ok = True)
-        return primary
-    except OSError as e:
-        logger.debug(
-            "Ollama dir %s not writable for .studio_links (%s); falling back to Unsloth cache",
-            ollama_dir,
-            e,
-        )
-
-    # Fallback: namespace by a hash of ollama_dir so two roots don't collide (cache path only).
-    try:
-        digest = hashlib.sha256(str(ollama_dir.resolve()).encode()).hexdigest()[:12]
-    except OSError:
-        digest = "default"
-    fallback = cache_root() / "ollama_links" / digest
-    try:
-        fallback.mkdir(parents = True, exist_ok = True)
-        return fallback
-    except OSError as e:
-        logger.warning(
-            "Could not create Ollama symlink cache at %s: %s",
-            fallback,
-            e,
-        )
-        return None
-
-
-def _scan_ollama_dir(ollama_dir: Path, limit: Optional[int] = None) -> List[LocalModelInfo]:
-    """Scan an Ollama models directory for downloaded models. Ollama uses a content-addressable layout
-    (``manifests/<host>/<namespace>/<model>/<tag>`` + ``blobs/sha256-...``); ``rglob`` finds every
-    layout depth. The ``application/vnd.ollama.image.model`` layer holds the GGUF weights and
-    ``...image.projector`` is the vision adapter. Ollama blobs lack the ``.gguf`` extension the
-    loading pipeline requires, so create ``.gguf``-named links to them, one subdir per model keyed
-    by a short hash of the manifest path so ``detect_mmproj_file`` only sees that model's projector.
-    Symlinks when possible, else hardlinks."""
-    manifests_root = ollama_dir / "manifests"
-    if not manifests_root.is_dir():
-        return []
-
-    found: List[LocalModelInfo] = []
-    blobs_dir = ollama_dir / "blobs"
-    links_root = _ollama_links_dir(ollama_dir)
-    if links_root is None:
-        logger.warning(
-            "Skipping Ollama scan for %s: no writable location for .gguf links",
-            ollama_dir,
-        )
-        return []
-
-    def _make_link(link_dir: Path, link_name: str, target: Path) -> Optional[str]:
-        """Create a .gguf-named link to an Ollama blob. Symlink, then hardlink; skips the model if neither
-        works (a multi-GB copy in a sync request would block the backend). Idempotent."""
-        link_dir.mkdir(parents = True, exist_ok = True)
-        link_path = link_dir / link_name
-        resolved = target.resolve()
-
-        # Skip if the link already points at the same blob; size checks can reuse stale links.
-        try:
-            if link_path.exists() and os.path.samefile(str(link_path), str(resolved)):
-                return str(link_path)
-        except OSError as e:
-            logger.debug("Error checking existing link %s: %s", link_path, e)
-
-        tmp_path = link_dir / f".{link_name}.tmp-{uuid.uuid4().hex[:8]}"
-        try:
-            if tmp_path.is_symlink() or tmp_path.exists():
-                tmp_path.unlink()
-            try:
-                tmp_path.symlink_to(resolved)
-            except OSError:
-                try:
-                    os.link(str(resolved), str(tmp_path))
-                except OSError:
-                    logger.warning(
-                        "Could not create link for Ollama blob %s "
-                        "(symlinks and hardlinks both failed). "
-                        "Skipping model to avoid blocking the API.",
-                        target,
-                    )
-                    return None
-            os.replace(str(tmp_path), str(link_path))
-            return str(link_path)
-        except OSError as e:
-            logger.debug("Could not create Ollama link %s: %s", link_path, e)
-            try:
-                if tmp_path.is_symlink() or tmp_path.exists():
-                    tmp_path.unlink()
-            except OSError as cleanup_err:
-                logger.debug("Could not clean up tmp path %s: %s", tmp_path, cleanup_err)
-            return None
-
-    try:
-        for tag_file in manifests_root.rglob("*"):
-            if not tag_file.is_file():
-                continue
-
-            rel = tag_file.relative_to(manifests_root)
-            parts = rel.parts
-            if len(parts) < 3:
-                continue
-
-            host = parts[0]
-            repo_parts = list(parts[1:-1])
-            tag = parts[-1]
-
-            if host == "registry.ollama.ai" and repo_parts and repo_parts[0] == "library":
-                repo_name = "/".join(repo_parts[1:])
-            elif host == "registry.ollama.ai":
-                repo_name = "/".join(repo_parts)
-            else:
-                repo_name = "/".join([host] + repo_parts)
-
-            if not repo_name:
-                continue
-
-            display = f"{repo_name}:{tag}"
-
-            manifest_key = rel.as_posix()
-            stem_hash = hashlib.sha256(manifest_key.encode()).hexdigest()[:10]
-
-            try:
-                manifest = json.loads(tag_file.read_text(encoding = "utf-8-sig"))
-            except (json.JSONDecodeError, OSError, UnicodeDecodeError) as e:
-                logger.debug(
-                    "Skipping unreadable/invalid Ollama manifest %s: %s",
-                    tag_file,
-                    e,
-                )
-                continue
-            # rglob("*") hands us every file under manifests/, so a pruned pull, an editor backup, or any stray JSON can
-            # be a list or a string; .get() on one raises AttributeError, which neither this loop's `except OSError`
-            # nor the caller's catches, and one such file would 500 the whole picker.
-            if not isinstance(manifest, dict):
-                logger.debug("Skipping Ollama manifest %s: top level is not an object", tag_file)
-                continue
-
-            config = manifest.get("config")
-            config_digest = config.get("digest", "") if isinstance(config, dict) else ""
-            if not isinstance(config_digest, str):
-                config_digest = ""
-            model_type = ""
-            file_type = ""
-            if config_digest and blobs_dir.is_dir():
-                config_blob = blobs_dir / config_digest.replace(":", "-")
-                if config_blob.is_file():
-                    try:
-                        cfg = json.loads(config_blob.read_text(encoding = "utf-8-sig"))
-                    except (json.JSONDecodeError, OSError, UnicodeDecodeError) as e:
-                        logger.debug(
-                            "Could not parse Ollama config blob %s: %s",
-                            config_blob,
-                            e,
-                        )
-                        cfg = None
-                    if isinstance(cfg, dict):
-                        model_type = cfg.get("model_type", "")
-                        file_type = cfg.get("file_type", "")
-
-            model_link_dir = links_root / stem_hash
-
-            gguf_link_path: Optional[str] = None
-            quant = f"-{file_type}" if file_type else ""
-            safe_name = repo_name.replace("/", "-")
-            layers = manifest.get("layers") or []
-            if not isinstance(layers, list):
-                logger.debug("Skipping Ollama manifest %s: layers is not a list", tag_file)
-                continue
-            for layer in layers:
-                if not isinstance(layer, dict):
-                    continue
-                media = layer.get("mediaType", "")
-                digest = layer.get("digest", "")
-                if not isinstance(digest, str) or not digest:
-                    continue
-
-                if media == "application/vnd.ollama.image.model":
-                    candidate = blobs_dir / digest.replace(":", "-")
-                    if candidate.is_file():
-                        link_name = f"{safe_name}-{tag}{quant}.gguf"
-                        gguf_link_path = _make_link(model_link_dir, link_name, candidate)
-
-                elif media == "application/vnd.ollama.image.projector":
-                    candidate = blobs_dir / digest.replace(":", "-")
-                    if candidate.is_file():
-                        mmproj_name = f"{safe_name}-{tag}-mmproj.gguf"
-                        _make_link(model_link_dir, mmproj_name, candidate)
-
-            if not gguf_link_path:
-                continue
-
-            suffix = ""
-            if model_type:
-                suffix += f" ({model_type}"
-                if file_type:
-                    suffix += f" {file_type}"
-                suffix += ")"
-
-            try:
-                updated_at = tag_file.stat().st_mtime
-            except OSError:
-                updated_at = None
-
-            found.append(
-                LocalModelInfo(
-                    id = gguf_link_path,
-                    model_id = f"ollama/{repo_name}:{tag}",
-                    display_name = display + suffix,
-                    path = gguf_link_path,
-                    # The frontend groups and labels these rows by this value (local-model-options.ts, pickers.tsx);
-                    # "custom" hid them in the generic folder section (#9986).
-                    source = "ollama",
-                    updated_at = updated_at,
-                ),
-            )
-            if limit is not None and len(found) >= limit:
-                return found
-    except OSError as e:
-        logger.warning("Error scanning Ollama directory %s: %s", ollama_dir, e)
-    return found
+def _scan_ollama_dir(ollama_dir: Path, *, limit: Optional[int] = None) -> List[LocalModelInfo]:
+    from hub.services.models.ollama import scan_ollama_dir
+    fields = LocalModelInfo.model_fields
+    return [
+        LocalModelInfo.model_validate({k: v for k, v in row.model_dump().items() if k in fields})
+        for row in scan_ollama_dir(ollama_dir, limit = limit)
+    ]
 
 
 def _scan_hermes_dir(hermes_dir: Path) -> List[LocalModelInfo]:
@@ -991,10 +770,12 @@ class _CompatLocalInventorySources(NamedTuple):
     lm_dirs: tuple[Path, ...]
     known_hf_caches: tuple[Path, ...]
     hermes_dirs: tuple[Path, ...] = ()
+    ollama_dirs: tuple[Path, ...] = ()
 
 
 def _compat_local_inventory_sources() -> _CompatLocalInventorySources:
     from utils.paths import (
+        ollama_model_dirs,
         hermes_model_dirs,
         hf_default_cache_dir,
         legacy_hf_cache_dir,
@@ -1008,6 +789,7 @@ def _compat_local_inventory_sources() -> _CompatLocalInventorySources:
         tuple(lmstudio_model_dirs()),
         tuple(known_hf_hub_caches()),
         tuple(hermes_model_dirs()),
+        tuple(ollama_model_dirs()),
     )
 
 
@@ -1096,6 +878,12 @@ def collect_local_models(
             local_models += _scan_hermes_dir(hermes_dir)
         except Exception as e:
             logger.warning("Error scanning Hermes directory %s: %s", hermes_dir, e)
+
+    for ollama_dir in sources.ollama_dirs:
+        try:
+            local_models += _scan_ollama_dir(ollama_dir)
+        except Exception as e:
+            logger.warning("Error scanning Ollama directory %s: %s", ollama_dir, e)
 
     # Scan user-added custom folders (per-folder cap).
     _MAX_MODELS_PER_FOLDER = 200

--- a/studio/backend/tests/test_ollama_api_catalog.py
+++ b/studio/backend/tests/test_ollama_api_catalog.py
@@ -80,11 +80,7 @@ def test_unsupported_ollama_models_are_withheld(store, broken):
     assert resolver.resolve_local_gguf("ollama/llama3:latest") is None
 
 
-@pytest.mark.parametrize("tag", ["latest", "Q8_0", "IQ3_M"])
-def test_http_catalog_id_autoloads_without_prior_ui_load(store, monkeypatch, tag):
-    manifest = store / "manifests/registry.ollama.ai/library/llama3/latest"
-    manifest.rename(manifest.with_name(tag))
-    model_id = f"ollama/llama3:{tag}"
+def test_http_catalog_id_autoloads_without_prior_ui_load(store, monkeypatch):
     backend = _FakeBackend()
     backend.is_vision = False
     backend.supports_tools = False
@@ -119,7 +115,7 @@ def test_http_catalog_id_autoloads_without_prior_ui_load(store, monkeypatch, tag
         catalog = client.get("/v1/models")
         assert catalog.status_code == 200, catalog.text
         model = catalog.json()["data"][0]
-        assert model["id"] == model_id
+        assert model["id"] == "ollama/llama3:latest"
         assert model["loaded"] is False
         assert seen == []
         response = client.post(
@@ -133,28 +129,9 @@ def test_http_catalog_id_autoloads_without_prior_ui_load(store, monkeypatch, tag
         assert response.status_code == 200, response.text
         assert response.json()["choices"][0]["message"]["content"] == "Fixture response."
         assert response.json()["model"] == model["id"]
-        repeated = client.post(
-            "/v1/chat/completions",
-            json = {
-                "model": model["id"],
-                "max_tokens": 16,
-                "messages": [{"role": "user", "content": "Say hello again."}],
-            },
-        )
-        assert repeated.status_code == 200, repeated.text
     assert len(seen) == 1
     assert seen[0][0].startswith("ollama-manifest:")
-    assert backend._openai_advertised_id == model_id
-
-
-@pytest.mark.parametrize("tag", ["latest", "Q8_0", "8b"])
-def test_resident_ollama_identity_keeps_the_manifest_tag(monkeypatch, tag):
-    model_id = f"ollama/llama3:{tag}"
-    backend = _FakeBackend("ollama-manifest:fixture", advertised_id = model_id)
-    monkeypatch.setattr(inf, "get_llama_cpp_backend", lambda: backend)
-    for satisfies in (inf._loaded_satisfies, inf._loaded_identity_satisfies):
-        assert satisfies(model_id)
-        assert not satisfies("ollama/llama3:Q4_K_M")
+    assert backend._openai_advertised_id == "ollama/llama3:latest"
 
 
 def test_ollama_vision_preflight_reads_projector_without_materializing(store, monkeypatch):

--- a/studio/backend/tests/test_ollama_api_catalog.py
+++ b/studio/backend/tests/test_ollama_api_catalog.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import json
+from contextlib import ExitStack
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from core.inference import local_model_resolver as resolver
+from hub.services.models import ollama
+from routes import inference as inf, models as models_route
+from storage import studio_db
+from utils import paths, hf_cache_settings, openai_auto_switch_settings
+from studio.backend.tests.test_legacy_ollama_source import _write_ollama_store
+from studio.backend.tests.test_openai_auto_switch import (
+    _FakeBackend,
+    _LoadRecorder,
+    _reset_keepwarm,
+)
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    root = tmp_path / "ollama"
+    _write_ollama_store(root)
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(paths, "ollama_model_dirs", lambda: [root])
+    monkeypatch.setattr(ollama, "ollama_model_dirs", lambda: [root])
+    monkeypatch.setattr(paths, "lmstudio_model_dirs", lambda: [])
+    monkeypatch.setattr(paths, "hermes_model_dirs", lambda: [])
+    monkeypatch.setattr(paths, "legacy_hf_cache_dir", lambda: empty)
+    monkeypatch.setattr(paths, "hf_default_cache_dir", lambda: empty)
+    monkeypatch.setattr(hf_cache_settings, "known_hf_hub_caches", lambda: [])
+    monkeypatch.setattr(models_route, "_resolve_hf_cache_dir", lambda: empty)
+    monkeypatch.setattr(studio_db, "list_scan_folders", lambda: [])
+    monkeypatch.setattr(inf, "_CATALOG_CACHE", {"at": 0.0, "models": []})
+    monkeypatch.setattr(inf, "_SERVABLE_SCAN_CACHE", {"entry": None})
+    monkeypatch.setattr(inf, "_peek_inference_backend", lambda: None)
+    monkeypatch.setattr(inf, "_media_model_objects", lambda *args: [])
+    monkeypatch.setattr(inf, "_stt_model_objects", lambda *args: [])
+    resolver.invalidate_index()
+    _reset_keepwarm()
+    yield root
+    resolver.invalidate_index()
+    _reset_keepwarm()
+
+
+def test_catalog_and_resolver_are_read_only_and_share_the_public_id(store, monkeypatch):
+    before = sorted(str(p.relative_to(store)) for p in store.rglob("*"))
+    rows = models_route.collect_local_models(Path("models").resolve())
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.model_id == "ollama/llama3:latest"
+    assert row.id.startswith("ollama-manifest:")
+    assert row.model_format == "gguf"
+    assert resolver.local_servable_model(row) == (True, ())
+    assert resolver.resolve_local_gguf(row.model_id) == (row.id, None, row.model_id)
+    assert sorted(str(p.relative_to(store)) for p in store.rglob("*")) == before
+    monkeypatch.setattr(studio_db, "list_scan_folders", lambda: [{"path": str(store)}])
+    assert len(models_route.collect_local_models(Path("models").resolve())) == 1
+
+
+@pytest.mark.parametrize("broken", ["runtime_layer", "missing_blob"])
+def test_unsupported_ollama_models_are_withheld(store, broken):
+    tag = store / "manifests/registry.ollama.ai/library/llama3/latest"
+    manifest = json.loads(tag.read_text())
+    if broken == "runtime_layer":
+        manifest["layers"].append(
+            {"mediaType": "application/vnd.ollama.image.adapter", "digest": "sha256:" + "c" * 64}
+        )
+        tag.write_text(json.dumps(manifest))
+    else:
+        next((store / "blobs").iterdir()).unlink()
+    assert models_route.collect_local_models(Path("models").resolve()) == []
+    assert resolver.resolve_local_gguf("ollama/llama3:latest") is None
+
+
+def test_http_catalog_id_autoloads_without_prior_ui_load(store, monkeypatch):
+    backend = _FakeBackend()
+    backend.is_vision = False
+    backend.supports_tools = False
+    backend.supports_tool_passthrough = False
+    backend.context_length = 4096
+    backend.count_chat_tokens = lambda *args, **kwargs: 4
+    backend.generate_chat_completion = lambda **kwargs: iter(["Fixture response."])
+    recorder = _LoadRecorder(backend)
+    seen = []
+
+    async def load(request, *args, **kwargs):
+        with ExitStack() as stack:
+            linked = await inf._lease_ollama_model_ref(request, operation = "load", stack = stack)
+            resolved, _, _ = inf._resolve_model_identifier_for_request(
+                request, operation = "load", resolved_ollama_path = linked
+            )
+            assert Path(resolved).suffix == ".gguf"
+            assert Path(resolved).read_bytes() == b"GGUF-not-really"
+            seen.append((request.model_path, resolved))
+            return await recorder(request, *args, **kwargs)
+
+    monkeypatch.setattr(inf, "get_llama_cpp_backend", lambda: backend)
+    monkeypatch.setattr(inf, "_load_model_impl", load)
+    monkeypatch.setattr(inf, "_openai_model_objects", lambda: [])
+    monkeypatch.setattr(openai_auto_switch_settings, "get_openai_auto_switch_enabled", lambda: True)
+    monkeypatch.setattr(inf, "current_date_prompt_line", lambda **kwargs: "")
+    monkeypatch.setattr(inf, "_auto_switch_waiters", {})
+    app = FastAPI()
+    app.include_router(inf.router, prefix = "/v1")
+    app.dependency_overrides[inf.get_current_subject] = lambda: "test"
+    with TestClient(app) as client:
+        catalog = client.get("/v1/models")
+        assert catalog.status_code == 200, catalog.text
+        model = catalog.json()["data"][0]
+        assert model["id"] == "ollama/llama3:latest"
+        assert model["loaded"] is False
+        assert seen == []
+        response = client.post(
+            "/v1/chat/completions",
+            json = {
+                "model": model["id"],
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "Say hello."}],
+            },
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["choices"][0]["message"]["content"] == "Fixture response."
+        assert response.json()["model"] == model["id"]
+    assert len(seen) == 1
+    assert seen[0][0].startswith("ollama-manifest:")
+    assert backend._openai_advertised_id == "ollama/llama3:latest"
+
+
+def test_ollama_vision_preflight_reads_projector_without_materializing(store, monkeypatch):
+    row = models_route._scan_ollama_dir(store)[0]
+    assert inf._target_is_vision(row.id) is False
+    tag = store / "manifests/registry.ollama.ai/library/llama3/latest"
+    manifest = json.loads(tag.read_text())
+    digest = "c" * 64
+    projector = store / "blobs" / f"sha256-{digest}"
+    projector.write_bytes(b"GGUF projector")
+    manifest["layers"].append(
+        {"mediaType": "application/vnd.ollama.image.projector", "digest": f"sha256:{digest}"}
+    )
+    tag.write_text(json.dumps(manifest))
+    from utils.models import gguf_metadata
+
+    monkeypatch.setattr(gguf_metadata, "mmproj_accepts_image", lambda path: path == str(projector))
+    assert inf._target_is_vision(row.id) is True
+    assert inf._resolve_target_gguf_file(row.id, None) == row.path
+    assert not (store / ".studio_links").exists()

--- a/studio/backend/tests/test_ollama_api_catalog.py
+++ b/studio/backend/tests/test_ollama_api_catalog.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import json
+import struct
 from contextlib import ExitStack
 from pathlib import Path
 
@@ -79,7 +80,11 @@ def test_unsupported_ollama_models_are_withheld(store, broken):
     assert resolver.resolve_local_gguf("ollama/llama3:latest") is None
 
 
-def test_http_catalog_id_autoloads_without_prior_ui_load(store, monkeypatch):
+@pytest.mark.parametrize("tag", ["latest", "Q8_0", "IQ3_M"])
+def test_http_catalog_id_autoloads_without_prior_ui_load(store, monkeypatch, tag):
+    manifest = store / "manifests/registry.ollama.ai/library/llama3/latest"
+    manifest.rename(manifest.with_name(tag))
+    model_id = f"ollama/llama3:{tag}"
     backend = _FakeBackend()
     backend.is_vision = False
     backend.supports_tools = False
@@ -114,7 +119,7 @@ def test_http_catalog_id_autoloads_without_prior_ui_load(store, monkeypatch):
         catalog = client.get("/v1/models")
         assert catalog.status_code == 200, catalog.text
         model = catalog.json()["data"][0]
-        assert model["id"] == "ollama/llama3:latest"
+        assert model["id"] == model_id
         assert model["loaded"] is False
         assert seen == []
         response = client.post(
@@ -128,9 +133,28 @@ def test_http_catalog_id_autoloads_without_prior_ui_load(store, monkeypatch):
         assert response.status_code == 200, response.text
         assert response.json()["choices"][0]["message"]["content"] == "Fixture response."
         assert response.json()["model"] == model["id"]
+        repeated = client.post(
+            "/v1/chat/completions",
+            json = {
+                "model": model["id"],
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "Say hello again."}],
+            },
+        )
+        assert repeated.status_code == 200, repeated.text
     assert len(seen) == 1
     assert seen[0][0].startswith("ollama-manifest:")
-    assert backend._openai_advertised_id == "ollama/llama3:latest"
+    assert backend._openai_advertised_id == model_id
+
+
+@pytest.mark.parametrize("tag", ["latest", "Q8_0", "8b"])
+def test_resident_ollama_identity_keeps_the_manifest_tag(monkeypatch, tag):
+    model_id = f"ollama/llama3:{tag}"
+    backend = _FakeBackend("ollama-manifest:fixture", advertised_id = model_id)
+    monkeypatch.setattr(inf, "get_llama_cpp_backend", lambda: backend)
+    for satisfies in (inf._loaded_satisfies, inf._loaded_identity_satisfies):
+        assert satisfies(model_id)
+        assert not satisfies("ollama/llama3:Q4_K_M")
 
 
 def test_ollama_vision_preflight_reads_projector_without_materializing(store, monkeypatch):
@@ -150,4 +174,41 @@ def test_ollama_vision_preflight_reads_projector_without_materializing(store, mo
     monkeypatch.setattr(gguf_metadata, "mmproj_accepts_image", lambda path: path == str(projector))
     assert inf._target_is_vision(row.id) is True
     assert inf._resolve_target_gguf_file(row.id, None) == row.path
+    assert not (store / ".studio_links").exists()
+
+
+def test_removed_ollama_manifest_defers_vision_failure_to_load(store):
+    load_path, _, _ = resolver.resolve_local_gguf("ollama/llama3:latest")
+    (store / "manifests/registry.ollama.ai/library/llama3/latest").unlink()
+    assert inf._target_accepts_request_input(
+        load_path, is_gguf = True, needs_vision = True, needs_audio = False
+    )
+    with pytest.raises(ValueError):
+        ollama.ollama_model_ref_files(load_path)
+
+
+def test_ollama_speech_blob_keeps_task_and_codec_without_materializing(store):
+    from hub.services.models import catalog_classification
+
+    manifest = store / "manifests/registry.ollama.ai/library/llama3/latest"
+    speech_manifest = store / "manifests/registry.ollama.ai/legraphista/Orpheus/3b-ft-q4_k_m"
+    speech_manifest.parent.mkdir(parents = True)
+    manifest.rename(speech_manifest)
+    blob = store / "blobs" / ("sha256-" + "b" * 64)
+
+    def gguf_string(value):
+        raw = value.encode()
+        return struct.pack("<Q", len(raw)) + raw
+
+    blob.write_bytes(
+        b"GGUF"
+        + struct.pack("<IQQ", 3, 0, 1)
+        + gguf_string("general.architecture")
+        + struct.pack("<I", 8)
+        + gguf_string("llama")
+    )
+    row = models_route._scan_ollama_dir(store)[0]
+    assert Path(row.path) == blob
+    assert catalog_classification._local_model_task(row) == "text-to-speech"
+    assert catalog_classification._local_model_audio_type(row) == "snac"
     assert not (store / ".studio_links").exists()

--- a/studio/backend/tests/test_ollama_manifest_shape_guard.py
+++ b/studio/backend/tests/test_ollama_manifest_shape_guard.py
@@ -29,7 +29,7 @@ def _manifest_dir(root, model = "foo"):
 def _write_good_model(
     root,
     model = "good",
-    blob = "sha256-abc123",
+    blob = "sha256:abc123",
 ):
     """A manifest whose model layer resolves to a real blob, i.e. one the scan must surface."""
     blobs = root / "blobs"


### PR DESCRIPTION
Models installed through Ollama could be missing from Studio's API model list. This could happen even when the model files were already on the machine. Apps using the API could not find those models in the list. Requesting an installed model by name could also fail. This change includes supported Ollama models in the available model list. Studio can then find the installed files when a client requests that model. With automatic model switching enabled, Studio can load it and answer the request.
