### PR TITLE
Studio: Use saved Hugging Face login for model downloads

### DIFF
--- a/studio/backend/hub/services/download_lifecycle.py
+++ b/studio/backend/hub/services/download_lifecycle.py
@@ -165,9 +165,9 @@ def spawn_worker(
             # No tuning module: that unsloth_zoo is also the one setting HF_XET_HIGH_PERFORMANCE=1 at import, and the inherited "1" would hand the worker a 64GB ceiling, since xet-core applies the preset AFTER reading the environment.
             for key in ("HF_XET_HIGH_PERFORMANCE", "HF_XET_HP"):
                 env[key] = "0"
-    # Fall back to the backend's own HF_TOKEN so private repos stay downloadable, but never for a repo an API caller named: that would lend them the owner's identity.
     if not hf_token and allow_ambient_token:
-        hf_token = os.environ.get("HF_TOKEN") or None
+        from huggingface_hub.utils import get_token_to_send
+        hf_token = get_token_to_send(None)
     env["HF_HUB_DISABLE_IMPLICIT_TOKEN"] = "0" if hf_token else "1"
     # hf_transfer's parallel Range chunks can leave sparse partials even in "http" mode, so disable it and keep the worker's writer sequential.
     env["HF_HUB_ENABLE_HF_TRANSFER"] = "0"

--- a/studio/backend/hub/services/download_lifecycle.py
+++ b/studio/backend/hub/services/download_lifecycle.py
@@ -167,7 +167,11 @@ def spawn_worker(
                 env[key] = "0"
     if not hf_token and allow_ambient_token:
         from huggingface_hub.utils import get_token_to_send
-        hf_token = get_token_to_send(None)
+        try:
+            hf_token = get_token_to_send(None)
+        except (OSError, UnicodeError):
+            logger.warning("Could not read the saved Hugging Face token; downloading anonymously")
+            hf_token = None
     env["HF_HUB_DISABLE_IMPLICIT_TOKEN"] = "0" if hf_token else "1"
     # hf_transfer's parallel Range chunks can leave sparse partials even in "http" mode, so disable it and keep the worker's writer sequential.
     env["HF_HUB_ENABLE_HF_TRANSFER"] = "0"

--- a/studio/backend/tests/test_hub_download_ambient_token.py
+++ b/studio/backend/tests/test_hub_download_ambient_token.py
@@ -414,3 +414,29 @@ def test_forbidden_ambient_token_is_not_resolved(monkeypatch, cached_hf_login):
         )
     )
     assert env["HF_HUB_DISABLE_IMPLICIT_TOKEN"] == "1"
+
+
+@pytest.mark.parametrize("failure", ["unreadable", "invalid_encoding"])
+def test_unusable_cached_login_does_not_block_an_anonymous_worker(
+    monkeypatch, cached_hf_login, failure
+):
+    from pathlib import Path
+    from huggingface_hub import constants
+
+    token_path = Path(constants.HF_TOKEN_PATH)
+    if failure == "invalid_encoding":
+        token_path.write_bytes(b"\xff\xfe\xff")
+    else:
+        original_read_text = Path.read_text
+
+        def read_text(path, *args, **kwargs):
+            if path == token_path:
+                raise PermissionError("cached token is unreadable")
+            return original_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", read_text)
+
+    env = _spawn_env(monkeypatch, None, allow_ambient_token = True)
+
+    assert "HF_TOKEN" not in env
+    assert env["HF_HUB_DISABLE_IMPLICIT_TOKEN"] == "1"

--- a/studio/backend/tests/test_hub_download_ambient_token.py
+++ b/studio/backend/tests/test_hub_download_ambient_token.py
@@ -270,7 +270,10 @@ def test_an_explicit_request_token_wins_over_the_backend_one(monkeypatch):
     assert env["HF_TOKEN"] == "request-token"
 
 
-def test_an_anonymous_job_stays_anonymous_on_the_http_retry(monkeypatch, tmp_path):
+@pytest.mark.parametrize("allow_ambient", [False, True])
+def test_http_retry_preserves_ambient_token_policy(
+    monkeypatch, tmp_path, cached_hf_login, allow_ambient
+):
     """The recovery ladder must carry the token policy: a job started without the ambient token
     must not pick it up when the Xet worker fails and the HTTP one takes over."""
     monkeypatch.setattr(state_dir, "cache_root", lambda: tmp_path / "state")
@@ -289,6 +292,14 @@ def test_an_anonymous_job_stays_anonymous_on_the_http_retry(monkeypatch, tmp_pat
         blob_hashes = frozenset({"blob"}),
     )[0]
     retried = []
+    environments = []
+    original_spawn = download_lifecycle.spawn_worker
+
+    def fake_popen(*args, **kwargs):
+        environments.append(kwargs["env"])
+        return _Proc(0)
+
+    monkeypatch.setattr(download_lifecycle.subprocess, "Popen", fake_popen)
 
     def fake_spawn(
         _args,
@@ -299,7 +310,13 @@ def test_an_anonymous_job_stays_anonymous_on_the_http_retry(monkeypatch, tmp_pat
         **_kwargs,
     ):
         retried.append(allow_ambient_token)
-        return _Proc(0)
+        return original_spawn(
+            _args,
+            _token,
+            use_xet = use_xet,
+            allow_ambient_token = allow_ambient_token,
+            **_kwargs,
+        )
 
     monkeypatch.setattr(download_lifecycle, "spawn_worker", fake_spawn)
     monkeypatch.setattr(download_lifecycle, "register_worker", lambda *a, **k: True)
@@ -315,7 +332,85 @@ def test_an_anonymous_job_stays_anonymous_on_the_http_retry(monkeypatch, tmp_pat
         repo_id = "Org/Model",
         transport = download_registry.TRANSPORT_XET,
         watch_name = "model-watch",
-        allow_ambient_token = False,
+        allow_ambient_token = allow_ambient,
     )
 
-    assert retried == [False], "the HTTP retry regained the backend's token"
+    assert retried == [allow_ambient]
+    assert len(environments) == 1
+    assert environments[0].get("HF_TOKEN") == (cached_hf_login if allow_ambient else None)
+
+
+@pytest.fixture
+def cached_hf_login(monkeypatch, tmp_path):
+    from huggingface_hub import constants
+
+    token_path = tmp_path / "token"
+    token_path.write_text("hf_test_cached_login\n")
+    monkeypatch.setattr(constants, "HF_TOKEN_PATH", str(token_path))
+    monkeypatch.setattr(constants, "HF_HUB_DISABLE_IMPLICIT_TOKEN", False)
+    for key in (
+        "HF_TOKEN",
+        "HF_HUB_TOKEN",
+        "HUGGING_FACE_HUB_TOKEN",
+        "HUGGINGFACE_HUB_TOKEN",
+        "HUGGINGFACEHUB_API_TOKEN",
+    ):
+        monkeypatch.delenv(key, raising = False)
+    return "hf_test_cached_login"
+
+
+@pytest.mark.parametrize("allow_ambient", [False, True])
+@pytest.mark.parametrize("explicit", [None, "hf_test_request"])
+@pytest.mark.parametrize("implicit_disabled", [False, True])
+def test_cached_login_obeys_caller_and_implicit_auth_policy(
+    monkeypatch, cached_hf_login, allow_ambient, explicit, implicit_disabled
+):
+    from huggingface_hub import constants
+
+    monkeypatch.setattr(constants, "HF_HUB_DISABLE_IMPLICIT_TOKEN", implicit_disabled)
+    env = _spawn_env(monkeypatch, explicit, allow_ambient_token = allow_ambient)
+
+    expected = explicit or (cached_hf_login if allow_ambient and not implicit_disabled else None)
+    assert env.get("HF_TOKEN") == expected
+    assert env["HF_HUB_DISABLE_IMPLICIT_TOKEN"] == ("0" if expected else "1")
+
+
+def test_environment_token_takes_precedence_over_cached_login(monkeypatch, cached_hf_login):
+    monkeypatch.setenv("HF_TOKEN", "hf_test_environment")
+
+    env = _spawn_env(monkeypatch, None, allow_ambient_token = True)
+
+    assert env["HF_TOKEN"] == "hf_test_environment"
+
+
+def test_forbidden_ambient_token_is_not_resolved(monkeypatch, cached_hf_login):
+    import huggingface_hub.utils
+
+    def unexpected_resolution(*args):
+        pytest.fail("A restricted caller must not resolve the owner's credentials")
+
+    monkeypatch.setattr(huggingface_hub.utils, "get_token_to_send", unexpected_resolution)
+    env = _spawn_env(
+        monkeypatch,
+        None,
+        allow_ambient_token = False,
+        cache_env = {
+            "HF_TOKEN": "hf_test_environment",
+            "HF_HUB_TOKEN": "hf_test_alias",
+            "HUGGING_FACE_HUB_TOKEN": "hf_test_alias",
+            "HUGGINGFACE_HUB_TOKEN": "hf_test_alias",
+            "HUGGINGFACEHUB_API_TOKEN": "hf_test_alias",
+        },
+    )
+
+    assert not any(
+        key in env
+        for key in (
+            "HF_TOKEN",
+            "HF_HUB_TOKEN",
+            "HUGGING_FACE_HUB_TOKEN",
+            "HUGGINGFACE_HUB_TOKEN",
+            "HUGGINGFACEHUB_API_TOKEN",
+        )
+    )
+    assert env["HF_HUB_DISABLE_IMPLICIT_TOKEN"] == "1"

--- a/studio/backend/tests/test_hub_download_ambient_token.py
+++ b/studio/backend/tests/test_hub_download_ambient_token.py
@@ -425,7 +425,7 @@ def test_unusable_cached_login_does_not_block_an_anonymous_worker(
 
     token_path = Path(constants.HF_TOKEN_PATH)
     if failure == "invalid_encoding":
-        token_path.write_bytes(b"\xff\xfe\xff")
+        token_path.write_bytes(b"\x81")
     else:
         original_read_text = Path.read_text
 


### PR DESCRIPTION
Studio could fail to download a model that requires Hugging Face access. This could happen even after the user had logged in and received access to the model. The download process checked for a supplied token but missed the saved login. As a result, the download could run without the user's login and be rejected. This change passes the saved login to the download process when allowed. A token supplied for a specific download still takes priority over the saved login. Requests that are not allowed to use the saved login keep that restriction.
