### PR TITLE
Studio: Show Anthropic web search errors

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -2501,7 +2501,11 @@ class ExternalProviderClient:
                     }
                     return f"data: {_json.dumps(chunk)}"
 
-                def _format_web_search_results(results: list[Any]) -> str:
+                def _format_web_search_results(results: list[Any] | dict[str, Any]) -> str:
+                    if isinstance(results, dict):
+                        if results.get("type") == "web_search_tool_result_error":
+                            return f"Error: {results.get('error_code') or 'unknown'}"
+                        return ""
                     blocks: list[str] = []
                     for r in results:
                         if not isinstance(r, dict):
@@ -2646,7 +2650,7 @@ class ExternalProviderClient:
                                 content = content_block.get("content") or []
                                 current_result_block = {
                                     "tool_use_id": tool_use_id,
-                                    "results": list(content) if isinstance(content, list) else [],
+                                    "results": content if isinstance(content, (list, dict)) else [],
                                 }
                             elif block_type == "server_tool_use" and block_name == "web_fetch":
                                 tool_use_id = content_block.get("id", "") or (
@@ -3059,7 +3063,9 @@ class ExternalProviderClient:
                     web_search_requested = bool(enabled_tools and "web_search" in enabled_tools)
                     web_search_invocations = len(web_search_calls)
                     total_results = sum(
-                        len(sc.get("results") or []) for sc in web_search_calls.values()
+                        len(sc["results"])
+                        for sc in web_search_calls.values()
+                        if isinstance(sc.get("results"), list)
                     )
                     queries = [sc["query"] for sc in web_search_calls.values() if sc.get("query")]
                     # cache_read_input_tokens > 0 proves the cache_control marker works (turn 1 shows cache_creation

--- a/studio/backend/tests/test_anthropic_web_search_errors.py
+++ b/studio/backend/tests/test_anthropic_web_search_errors.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from core.inference import external_provider as ep_mod
+from .test_anthropic_web_fetch import _anthropic_sse, _make_client, _tool_events
+
+
+@pytest.mark.parametrize(
+    "content, expected",
+    [
+        ({"type": "web_search_tool_result_error", "error_code": code}, f"Error: {code}")
+        for code in (
+            "too_many_requests",
+            "invalid_tool_input",
+            "max_uses_exceeded",
+            "query_too_long",
+            "request_too_large",
+            "unavailable",
+        )
+    ]
+    + [
+        ([], "(search complete)"),
+        (
+            [{"type": "web_search_result", "url": "https://example.com", "title": "Example"}],
+            "Title: Example\nURL: https://example.com",
+        ),
+    ],
+)
+def test_native_search_result_preserves_outcome_and_answer(monkeypatch, content, expected):
+    events = [
+        {"type": "message_start", "message": {"usage": {}}},
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "server_tool_use", "id": "search-1", "name": "web_search"},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "input_json_delta", "partial_json": '{"query":"example"}'},
+        },
+        {"type": "content_block_stop", "index": 0},
+        {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {
+                "type": "web_search_tool_result",
+                "tool_use_id": "search-1",
+                "content": content,
+            },
+        },
+        {"type": "content_block_stop", "index": 1},
+        {"type": "content_block_start", "index": 2, "content_block": {"type": "text", "text": ""}},
+        {
+            "type": "content_block_delta",
+            "index": 2,
+            "delta": {"type": "text_delta", "text": "The answer continues."},
+        },
+        {"type": "content_block_stop", "index": 2},
+        {"type": "message_stop"},
+    ]
+
+    async def run():
+        def handler(request):
+            body = json.loads(request.content)
+            assert any(t["name"] == "web_search" and t["max_uses"] == 5 for t in body["tools"])
+            return httpx.Response(200, content = _anthropic_sse(events))
+
+        async with httpx.AsyncClient(transport = httpx.MockTransport(handler)) as transport:
+            monkeypatch.setattr(ep_mod, "_http_client", transport)
+            return [
+                line
+                async for line in _make_client()._stream_anthropic(
+                    messages = [{"role": "user", "content": "Search for example"}],
+                    model = "claude-sonnet-4-5",
+                    temperature = 0.7,
+                    top_p = 0.95,
+                    max_tokens = 1024,
+                    enabled_tools = ["web_search"],
+                )
+            ]
+
+    lines = asyncio.run(run())
+    start, end = _tool_events(lines)
+    assert start["arguments"] == {"query": "example", "_server_tool": True}
+    assert end == {"type": "tool_end", "tool_call_id": "search-1", "result": expected}
+    assert any("The answer continues." in line for line in lines)
+    assert lines[-1] == "data: [DONE]"


### PR DESCRIPTION
Anthropic can return a search error while continuing to write an answer. Studio was dropping the error details when reading the search result. The search then appeared as `(search complete)`, even though it had failed. This made it difficult to tell whether the search had returned useful information. This change keeps the error details and shows the error code in the tool result. The assistant's answer can continue and remains visible alongside the error. Successful searches keep their source links, and empty results keep their usual display.
