### PR TITLE
Studio: Keep images returned by tools

### DIFF
--- a/studio/backend/core/inference/anthropic_compat.py
+++ b/studio/backend/core/inference/anthropic_compat.py
@@ -162,14 +162,26 @@ def anthropic_messages_to_openai(
                 elif btype == "tool_result":
                     tc = b.get("content", "")
                     if isinstance(tc, list):
-                        tc = " ".join(
-                            p["text"] for p in tc if isinstance(p, dict) and p.get("type") == "text"
+                        parts = []
+                        for item in tc:
+                            if not isinstance(item, dict):
+                                continue
+                            if item.get("type") == "text":
+                                parts.append({"type": "text", "text": item["text"]})
+                            elif item.get("type") == "image":
+                                part = _anthropic_image_block_to_openai_part(item)
+                                if part is not None:
+                                    parts.append(part)
+                        tc = (
+                            parts
+                            if any(p["type"] == "image_url" for p in parts)
+                            else " ".join(p["text"] for p in parts)
                         )
                     tool_results.append(
                         {
                             "role": "tool",
                             "tool_call_id": b["tool_use_id"],
-                            "content": str(tc),
+                            "content": tc if isinstance(tc, list) else str(tc),
                         }
                     )
 
@@ -218,12 +230,16 @@ def fold_tool_results_into_user(messages: list[dict]) -> list[dict]:
         response["content"] = msg.get("content", "")
         if tool_call_id:
             response["tool_call_id"] = tool_call_id
-        out.append(
-            {
-                "role": "user",
-                "content": json.dumps({"tool_response": response}, indent = 2),
-            }
-        )
+        content = response["content"]
+        if isinstance(content, list):
+            response.pop("content")
+            folded_content = [
+                {"type": "text", "text": json.dumps({"tool_response": response}, indent = 2)},
+                *content,
+            ]
+        else:
+            folded_content = json.dumps({"tool_response": response}, indent = 2)
+        out.append({"role": "user", "content": folded_content})
     return out
 
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1997,17 +1997,19 @@ def _openai_llama_admission_messages_for_estimate(messages) -> tuple[list[dict],
                     continue
 
                 part_type = part.get("type")
-                # The same filter anthropic_messages_to_openai applies, so the estimate
-                # charges what that sends. The content list is untyped, so a screenshot an
-                # agent's tool returned, a document and a future block type all arrive
-                # here, and none of them reach the wire to earn an allowance.
+                # Match the native tool-result conversion: text and image blocks reach the wire.
                 if part_type == "tool_result" and isinstance(part.get("content"), list):
                     part = dict(part)
-                    part["content"] = [
-                        block
-                        for block in part["content"]
-                        if isinstance(block, dict) and block.get("type") == "text"
-                    ]
+                    tool_content = []
+                    for block in part["content"]:
+                        if not isinstance(block, dict):
+                            continue
+                        if block.get("type") == "text":
+                            tool_content.append(block)
+                        elif block.get("type") == "image":
+                            image_parts += 1
+                            tool_content.append(_openai_llama_admission_compact_image_part(block))
+                    part["content"] = tool_content
                     estimate_content.append(part)
                     continue
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -7876,39 +7876,36 @@ def _request_has_image(payload) -> bool:
     return _messages_have_image(payload.messages)
 
 
-def _anthropic_request_has_image(payload) -> bool:
-    # Mirror anthropic_messages_to_openai: an Anthropic image block carries
-    # ``type == "image"`` (typed AnthropicImageBlock or a raw dict).
-    for msg in getattr(payload, "messages", None) or []:
-        content = getattr(msg, "content", None)
-        if not isinstance(content, list):
-            continue
-        for block in content:
-            bt = block.get("type") if isinstance(block, dict) else getattr(block, "type", None)
-            if bt == "image":
-                return True
-    return False
-
-
-def _anthropic_local_image_payloads(payload) -> list[str]:
-    """Base64 image sources translated by the Anthropic endpoint."""
-    encoded_images = []
+def _anthropic_image_blocks(payload):
     for msg in getattr(payload, "messages", None) or ():
         content = msg.get("content") if isinstance(msg, dict) else msg.content
         if not isinstance(content, list):
             continue
         for block in content:
-            block_type = block.get("type") if isinstance(block, dict) else block.type
-            if block_type != "image":
-                continue
-            source = block.get("source") if isinstance(block, dict) else block.source
-            source_type = source.get("type") if isinstance(source, dict) else source.type
-            data = source.get("data") if isinstance(source, dict) else source.data
-            if source_type == "base64" and isinstance(data, str):
-                encoded_images.append(data)
-            url = source.get("url") if isinstance(source, dict) else source.url
-            if source_type == "url" and isinstance(url, str) and url.startswith("data:"):
-                encoded_images.append(url.partition(",")[2])
+            block = block if isinstance(block, dict) else block.model_dump()
+            if block.get("type") == "image":
+                yield block
+            elif block.get("type") == "tool_result" and isinstance(block.get("content"), list):
+                for part in block["content"]:
+                    if isinstance(part, dict) and part.get("type") == "image":
+                        yield part
+
+
+def _anthropic_request_has_image(payload) -> bool:
+    return next(_anthropic_image_blocks(payload), None) is not None
+
+
+def _anthropic_local_image_payloads(payload) -> list[str]:
+    encoded_images = []
+    for block in _anthropic_image_blocks(payload):
+        source = block.get("source") or {}
+        source_type = source.get("type")
+        data = source.get("data")
+        if source_type == "base64" and isinstance(data, str):
+            encoded_images.append(data)
+        url = source.get("url")
+        if source_type == "url" and isinstance(url, str) and url.startswith("data:"):
+            encoded_images.append(url.partition(",")[2])
     return encoded_images
 
 
@@ -30678,6 +30675,7 @@ async def anthropic_count_tokens(
     # Reject malformed tools before the switch, like /messages, so an invalid
     # count request can't evict the loaded model.
     _validate_anthropic_client_tools(payload.tools)
+    image_b64s = _anthropic_local_image_payloads(payload)
     # Count with the requested model's tokenizer, like the sibling /messages.
     # Carry the vision guard too: an image count naming a text-only GGUF must not
     # evict a loaded vision model for a swap that can't serve the request.
@@ -30690,6 +30688,9 @@ async def anthropic_count_tokens(
         # model; the middleware likewise excludes count_tokens from its claim.
         claim_resident = False,
         gguf_only = True,
+        image_preflight = (
+            {"b64": image_b64s[0], "b64s": image_b64s, "multiple": False} if image_b64s else None
+        ),
     )
 
     llama_backend = get_llama_cpp_backend()
@@ -30713,6 +30714,9 @@ async def anthropic_count_tokens(
     # matches the prompt the real request would build (otherwise empty-assistant
     # sentinels / synthetic tool history inflate the count or hit the fallback).
     openai_messages = _sanitize_anthropic_openai_messages(openai_messages, llama_backend)
+    await asyncio.to_thread(
+        _normalize_anthropic_openai_images, openai_messages, llama_backend.is_vision
+    )
     openai_tools = anthropic_tools_to_openai(payload.tools or []) or None
     # Only the client-tool passthrough is forwarded verbatim, so reproduce /messages' own
     # routing rather than "any tools": a Studio server-tool alias, or a template without

--- a/studio/backend/tests/test_anthropic_native_tool_images.py
+++ b/studio/backend/tests/test_anthropic_native_tool_images.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import base64
+import copy
+import json
+from io import BytesIO
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from core.inference.anthropic_compat import (
+    anthropic_messages_to_openai,
+    fold_tool_results_into_user,
+)
+from models.inference import AnthropicMessagesRequest
+from routes import inference as inf
+from studio.backend.tests.test_anthropic_messages import _mock_backend
+
+
+def image_block():
+    buffer = BytesIO()
+    Image.new("RGB", (2, 2), "red").save(buffer, format = "WEBP")
+    return {
+        "type": "image",
+        "source": {
+            "type": "base64",
+            "media_type": "image/webp",
+            "data": base64.b64encode(buffer.getvalue()).decode(),
+        },
+    }
+
+
+def payload(parts):
+    return {
+        "model": "vision-test",
+        "max_tokens": 16,
+        "tools": [{"name": "capture", "input_schema": {"type": "object"}}],
+        "messages": [
+            {"role": "user", "content": "Inspect these captures."},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": ident, "name": "capture", "input": {}}
+                    for ident in ("toolu_first", "toolu_second")
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "toolu_first", "content": parts},
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_second",
+                        "content": "second result",
+                    },
+                    {"type": "text", "text": "Compare them."},
+                ],
+            },
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "order", [("image",), ("text", "image"), ("image", "text"), ("text", "image", "text")]
+)
+def test_native_images_keep_order_and_tool_identity(order):
+    parts = [
+        image_block() if kind == "image" else {"type": "text", "text": str(i)}
+        for i, kind in enumerate(order)
+    ]
+    request = AnthropicMessagesRequest(**payload(parts))
+    converted = anthropic_messages_to_openai([m.model_dump() for m in request.messages])
+    assert [m.get("tool_call_id") for m in converted if m["role"] == "tool"] == [
+        "toolu_first",
+        "toolu_second",
+    ]
+    assert [p["type"] for p in converted[2]["content"]] == [
+        "image_url" if k == "image" else k for k in order
+    ]
+    assert converted[3]["content"] == "second result"
+    assert converted[-1]["content"] == "Compare them."
+    assert inf._anthropic_request_has_image(request)
+    assert inf._anthropic_local_image_payloads(request) == [
+        p["source"]["data"] for p in parts if p["type"] == "image"
+    ]
+    folded = fold_tool_results_into_user(converted)
+    assert "toolu_first" in folded[2]["content"][0]["text"]
+    assert any(p["type"] == "image_url" for p in folded[2]["content"])
+
+
+@pytest.mark.parametrize("vision", [True, False])
+def test_native_image_http_generation_and_count_parity(monkeypatch, vision):
+    seen = {}
+
+    async def switch(*args, **kwargs):
+        seen.setdefault("preflight", []).append(kwargs)
+
+    def count(messages, *args, **kwargs):
+        seen["count"] = copy.deepcopy(messages)
+        return 42
+
+    _mock_backend(
+        monkeypatch,
+        is_vision = vision,
+        supports_tool_passthrough = True,
+        base_url = "http://llama.test",
+        effective_parallel_slots = 4,
+        count_chat_tokens = count,
+    )
+    monkeypatch.setattr(inf, "_maybe_auto_switch_model", switch)
+    real_client = httpx.AsyncClient
+
+    def capture(request):
+        seen["wire"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json = {
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": "The image is red."},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 42, "completion_tokens": 5},
+            },
+        )
+
+    monkeypatch.setattr(
+        inf.httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport = httpx.MockTransport(capture)),
+    )
+    app = FastAPI()
+    app.include_router(inf.router, prefix = "/v1")
+    app.dependency_overrides[inf.get_current_subject] = lambda: "test"
+    body = payload([{"type": "text", "text": "capture"}, image_block()])
+    with TestClient(app) as client:
+        response = client.post("/v1/messages", json = body)
+        counted = client.post("/v1/messages/count_tokens", json = body)
+    assert response.status_code == (200 if vision else 400), response.text
+    assert counted.status_code == (200 if vision else 400), counted.text
+    assert len(seen["preflight"]) == 2
+    assert all(
+        p["require_vision"] and len(p["image_preflight"]["b64s"]) == 1 for p in seen["preflight"]
+    )
+    if vision:
+        assert response.json()["content"][0]["text"] == "The image is red."
+        assert counted.json()["input_tokens"] == 42
+        assert seen["wire"]["messages"] == seen["count"]
+        url = seen["wire"]["messages"][2]["content"][1]["image_url"]["url"]
+        assert url.startswith("data:image/png;base64,")
+        assert Image.open(BytesIO(base64.b64decode(url.split(",", 1)[1]))).size == (2, 2)
+    else:
+        assert "wire" not in seen and "count" not in seen

--- a/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
+++ b/studio/backend/tests/test_llama_admission_kv_budget_media_and_tools.py
@@ -15,6 +15,9 @@ estimate for a lease that runs up to 25 growing rounds.
 """
 
 import base64
+import copy
+
+import pytest
 
 from models.inference import AnthropicMessagesRequest
 from routes.inference import (
@@ -491,14 +494,8 @@ class TestAToolResultScreenshotIsNotPricedByItsBase64:
         )
 
     def test_the_charge_matches_what_the_translation_actually_sends(self):
-        """The two halves have to agree, so this fails on whichever side moves first.
-
-        `anthropic_messages_to_openai` keeps only the text blocks of a list
-        `tool_result`, so the nested image never reaches llama-server and earns no mtmd
-        allowance. Start forwarding it and this fails, which is the reminder that
-        admission has to start charging for it.
-        """
-        data = _image_b64(64)
+        """Every forwarded tool image earns an embedding allowance, not a base64 charge."""
+        data = _TINY_PNG
         payload = self._request(data)
 
         estimate_messages, image_parts = _openai_llama_admission_messages_for_estimate(
@@ -513,6 +510,34 @@ class TestAToolResultScreenshotIsNotPricedByItsBase64:
         assert image_parts == (1 if forwarded else 0), (
             "admission charges a bounded image allowance exactly when the translation "
             f"sends the image (forwarded={forwarded}, image_parts={image_parts})"
+        )
+
+    @pytest.mark.parametrize("source_type", ["base64", "url"])
+    @pytest.mark.parametrize("with_text", [False, True])
+    def test_each_nested_image_is_compacted_and_charged(self, source_type, with_text):
+        payload = self._request(_TINY_PNG)
+        blocks = payload.messages[-1].content[0].content
+        first = blocks[-1]
+        second = copy.deepcopy(first)
+        second["source"]["data"] = _OTHER_PNG
+        if source_type == "url":
+            for block in (first, second):
+                block["source"] = {
+                    "type": "url",
+                    "url": f"data:image/png;base64,{block['source']['data']}",
+                }
+        blocks[:] = [first, *blocks[:1], second] if with_text else [first, second]
+        original = payload.model_dump()
+
+        compact, count = _openai_llama_admission_messages_for_estimate(payload.messages)
+        sent = anthropic_messages_to_openai([m.model_dump() for m in payload.messages])
+        forwarded = [p for m in sent if m["role"] == "tool" for p in m["content"]]
+        assert count == sum(p["type"] == "image_url" for p in forwarded) == 2
+        assert _TINY_PNG not in str(compact) and _OTHER_PNG not in str(compact)
+        assert payload.model_dump() == original
+        assert (
+            _openai_llama_admission_tokens(payload, budget = 1_000_000, capacity = 4)
+            >= 2 * _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS
         )
 
 


### PR DESCRIPTION
Claude Code can read an image and send it to Studio as a tool result. Studio accepted the result but dropped the image before passing it to the model. The model could then answer without seeing the screenshot or image it had requested. A result containing only an image could be left with no useful content at all. This change keeps the images and text together in their original order. The images remain available when earlier tool results are included in the conversation. Studio also checks these images when deciding whether the model needs vision support.
