### PR TITLE
Studio: Keep unfinished research reports

### DIFF
--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -1901,17 +1901,24 @@ class ResearchSupervisor:
                             )
             await flush_progress()
             return report, reasoning, finish_reason, usage
-        except (ModelFirstOutputTimeout, ModelOutputIdleTimeout, ModelWallClockTimeout):
+        except (RunCancelled, LeaseLost):
             raise
-        except httpx.ReadTimeout as exc:
-            # Transport backstop: HTTPX raises this with no message, so name the stall instead.
-            if semantic_output_at is None:
-                raise ModelFirstOutputTimeout("Local model never produced output") from exc
-            raise ModelOutputIdleTimeout("Local model stopped producing output") from exc
-        except (TimeoutError, asyncio.TimeoutError) as exc:
-            raise ModelWallClockTimeout(
-                "Local model request exceeded its wall-clock timeout"
-            ) from exc
+        except Exception as exc:
+            if report_progress:
+                await flush_progress()
+            if isinstance(
+                exc, (ModelFirstOutputTimeout, ModelOutputIdleTimeout, ModelWallClockTimeout)
+            ):
+                raise
+            if isinstance(exc, httpx.ReadTimeout):
+                if semantic_output_at is None:
+                    raise ModelFirstOutputTimeout("Local model never produced output") from exc
+                raise ModelOutputIdleTimeout("Local model stopped producing output") from exc
+            if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
+                raise ModelWallClockTimeout(
+                    "Local model request exceeded its wall-clock timeout"
+                ) from exc
+            raise
         finally:
             # revoked before the phase event, so a cancel there cannot leak a live key.
             try:
@@ -2016,8 +2023,26 @@ class ResearchSupervisor:
             error = _safe_error(exc)
             logger.warning("research.run_failed run_id=%s error=%s", run["id"], error)
             try:
+                fresh = await asyncio.to_thread(db.get_run, run["id"])
+                partial_report = ""
+                if not _run_moved_on(fresh, attempt):
+                    partial_report = (
+                        _report_after_boundary(fresh.get("report") or "", _REPORT_BOUNDARY_MARKER)
+                        or ""
+                    )
+                    partial_report = _validate_report_sources(
+                        partial_report, fresh.get("sources") or []
+                    )
+                    partial_report = _validate_report_document_sources(
+                        partial_report, fresh.get("documentSources") or []
+                    ).strip()
                 actual_status = await asyncio.to_thread(
-                    db.finish, run["id"], self.worker_id, "failed", error
+                    db.finish,
+                    run["id"],
+                    self.worker_id,
+                    "failed",
+                    error,
+                    {"report": partial_report} if partial_report else None,
                 )
             except sqlite3.OperationalError:
                 actual_status = await self._finish_after_lease_loss(run["id"])
@@ -2030,7 +2055,15 @@ class ResearchSupervisor:
                 )
             elif actual_status == "failed" and not _run_moved_on(fresh, attempt):
                 await asyncio.to_thread(
-                    _update_assistant, fresh, f"Research failed: {error}", "failed"
+                    _update_assistant,
+                    fresh,
+                    (
+                        f"> **Incomplete report.** Research failed: {error}\n\n{fresh['report']}"
+                        if fresh.get("report")
+                        else f"Research failed: {error}"
+                    ),
+                    "failed",
+                    fresh.get("sources") if fresh.get("report") else None,
                 )
         finally:
             heartbeat.cancel()

--- a/studio/backend/storage/research_runs_db.py
+++ b/studio/backend/storage/research_runs_db.py
@@ -979,7 +979,7 @@ def finish(
         )
         actual_error = None if actual_status == "cancelled" else error
         report_text = None
-        if actual_status == "completed" and event_payload:
+        if actual_status in {"completed", "failed"} and event_payload:
             candidate = event_payload.get("report")
             if isinstance(candidate, str):
                 report_text = candidate

--- a/studio/backend/tests/test_research_interrupted_report.py
+++ b/studio/backend/tests/test_research_interrupted_report.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from core import research_runs as worker
+from storage import research_runs_db as research_db
+from storage import studio_db
+from .test_research_synthesis_recovery import _claimed_run, research_home
+
+
+REPORT = "## Findings\n\n" + "The evidence explains the result. " * 80
+RAW = f"Private preamble.\n{worker._REPORT_BOUNDARY_MARKER}\n{REPORT}"
+
+
+def _transport(monkeypatch, text, error):
+    class Stream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            for offset in range(0, len(text), 300):
+                chunk = {"choices": [{"delta": {"content": text[offset : offset + 300]}}]}
+                yield f"data: {json.dumps(chunk)}\n\n".encode()
+            raise error
+
+    original = httpx.AsyncClient
+    monkeypatch.setattr(
+        worker.httpx,
+        "AsyncClient",
+        lambda **kwargs: original(
+            transport = httpx.MockTransport(lambda request: httpx.Response(200, stream = Stream())),
+            **kwargs,
+        ),
+    )
+    monkeypatch.setattr(
+        worker.auth_storage, "create_api_key", lambda **kwargs: ("fixture", {"id": 1})
+    )
+    monkeypatch.setattr(worker.auth_storage, "revoke_internal_api_key", lambda key_id: None)
+
+
+def _interrupt(monkeypatch, text, error):
+    supervisor = worker.ResearchSupervisor(SimpleNamespace(state = SimpleNamespace(server_port = 1)))
+    run = _claimed_run(supervisor)
+    _transport(monkeypatch, text, error)
+
+    async def research(run):
+        await supervisor._stream_completion(
+            run, [{"role": "user", "content": "Report"}], phase = "synthesis"
+        )
+
+    monkeypatch.setattr(supervisor, "_research", research)
+    asyncio.run(supervisor._process(run))
+    return research_db.get_run(run["id"])
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        httpx.ReadError("connection reset"),
+        worker.ModelOutputIdleTimeout("Model stopped producing output"),
+        worker.ModelWallClockTimeout("Model exceeded its time budget"),
+    ],
+)
+def test_interrupted_stream_retains_last_bytes_in_failed_report_and_chat(
+    research_home, monkeypatch, error
+):
+    run = _interrupt(monkeypatch, RAW, error)
+    assert run["status"] == "failed"
+    assert run["report"] == REPORT.strip()
+    assert run["error"] == worker._safe_error(error)
+    message = studio_db.get_chat_message(run["threadId"], run["assistantMessageId"])
+    text = "\n".join(part["text"] for part in message["content"] if part["type"] == "text")
+    assert "Incomplete report" in text and REPORT.strip() in text
+    assert "Private preamble" not in text
+    terminal = research_db.list_events(run["id"], 0)[-1]
+    assert terminal["type"] == "run.failed"
+    assert terminal["data"]["report"] == REPORT.strip()
+
+
+@pytest.mark.parametrize(
+    "text", ["", REPORT, f"```\n{RAW}\n```", f"{worker._REPORT_BOUNDARY_MARKER}\n"]
+)
+def test_unidentified_report_is_not_exposed(research_home, monkeypatch, text):
+    run = _interrupt(monkeypatch, text, httpx.ReadError("connection reset"))
+    assert run["status"] == "failed"
+    assert run["report"] is None
+
+
+def test_interrupted_report_validates_citations(research_home, monkeypatch):
+    raw = RAW + "\n[invented](https://invented.test)\n\n## Sources\n\nUntrusted source list"
+    run = _interrupt(monkeypatch, raw, httpx.ReadError("connection reset"))
+    assert "invented.test" not in run["report"]
+    assert "Untrusted source list" not in run["report"]
+
+
+@pytest.mark.parametrize("error", [worker.RunCancelled(), worker.LeaseLost()])
+def test_control_flow_interruptions_do_not_publish_partial_report(
+    research_home, monkeypatch, error
+):
+    run = _interrupt(monkeypatch, RAW, error)
+    assert run["report"] is None
+
+
+def test_failed_finish_does_not_promote_raw_progress(research_home):
+    supervisor = worker.ResearchSupervisor(SimpleNamespace(state = SimpleNamespace(server_port = 1)))
+    run = _claimed_run(supervisor)
+    research_db.set_report_progress(run["id"], RAW, worker_id = supervisor.worker_id)
+    assert research_db.finish(run["id"], supervisor.worker_id, "failed", "failed") == "failed"
+    assert research_db.get_run(run["id"])["report"] is None

--- a/studio/frontend/src/features/chat/components/research-message.tsx
+++ b/studio/frontend/src/features/chat/components/research-message.tsx
@@ -79,7 +79,8 @@ export function ResearchMessage(): ReactElement | null {
     );
   }
 
-  if (run.status === "completed" && run.report) {
+  if ((run.status === "completed" || run.status === "failed") && run.report) {
+    const incomplete = run.status === "failed";
     const sources: SourceData[] = run.sources.map((source) => ({
       id: String(source.id ?? source.url),
       url: source.url,
@@ -109,11 +110,22 @@ export function ResearchMessage(): ReactElement | null {
           className="mb-3 flex items-center gap-2 rounded-full text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           <span className="flex size-5 items-center justify-center rounded-full bg-primary/10 text-primary">
-            <Check className="size-3" />
+            {incomplete ? (
+              <TriangleAlert className="size-3" />
+            ) : (
+              <Check className="size-3" />
+            )}
           </span>
-          <span>Deep research completed · {sourceCount} sources</span>
+          <span>
+            {incomplete
+              ? "Deep research failed · Incomplete report"
+              : `Deep research completed · ${sourceCount} sources`}
+          </span>
           <span className="text-primary">View activity</span>
         </button>
+        {incomplete && (
+          <p className="mb-3 text-sm text-destructive">{run.error}</p>
+        )}
         <MarkdownPreview
           markdown={run.report}
           className="max-h-none overflow-visible border-0 bg-transparent p-0 text-ui-15p5"


### PR DESCRIPTION
A research session can fail or time out after writing part of a report. Studio could discard that text when the session ended with an error. The user would see only the error, even though useful work had already been done. This change keeps the available report text and its sources when that happens. The report is marked as incomplete so users know it did not finish. The original error remains visible to explain why the research stopped. Users can reopen the conversation and read the saved partial report later.
