### PR TITLE
Windows installer: fix installs when the user profile path contains a space

### DIFF
--- a/.github/workflows/cross-platform-parity-ci.yml
+++ b/.github/workflows/cross-platform-parity-ci.yml
@@ -92,6 +92,7 @@ on:
       - 'studio/setup.ps1'
       - 'tests/studio/test_setup_xpu_runtime_prereport.ps1'
       - 'tests/studio/test_xpu_arm64_torchaudio.ps1'
+      - 'tests/studio/test_torch_overrides_merge.ps1'
       - 'tests/studio/test_amd_venv_repair_loop.ps1'
       - 'tests/studio/test_amd_name_arch_r9700.ps1'
       - 'tests/studio/test_application_control_cli_fallback.ps1'
@@ -168,6 +169,7 @@ on:
       - 'studio/setup.ps1'
       - 'tests/studio/test_setup_xpu_runtime_prereport.ps1'
       - 'tests/studio/test_xpu_arm64_torchaudio.ps1'
+      - 'tests/studio/test_torch_overrides_merge.ps1'
       - 'tests/studio/test_amd_venv_repair_loop.ps1'
       - 'tests/studio/test_amd_name_arch_r9700.ps1'
       - 'tests/studio/test_application_control_cli_fallback.ps1'
@@ -270,6 +272,10 @@ jobs:
       - name: XPU arm64 torchaudio tests
         shell: pwsh
         run: pwsh -NoProfile -File tests/studio/test_xpu_arm64_torchaudio.ps1
+      # Same extraction; the spaced-path checks run only on Windows (#10722).
+      - name: Torch overrides merge tests
+        shell: pwsh
+        run: pwsh -NoProfile -File tests/studio/test_torch_overrides_merge.ps1
       # Same again: mocked filesystem reads and one `python -c` child, so no venv, no AMD GPU and
       # no Windows needed. Read the file header before adding cases -- pwsh 7 cannot reproduce the
       # 5.1 half of #8335, so the checks covering it are deliberately source shapes.

--- a/install.ps1
+++ b/install.ps1
@@ -6369,6 +6369,19 @@ exit 0
             $script:TorchOverridesFile = $null
             throw
         }
+        # uv splits --overrides on spaces (#10722); the 8.3 name keeps relative includes resolving.
+        if ($f.Contains(" ")) {
+            $short = $null
+            try { $short = (New-Object -ComObject Scripting.FileSystemObject).GetFile($f).ShortPath } catch { }
+            if (-not $short -or $short.Contains(" ")) {
+                # No short name: skip the freeze rather than fail.
+                substep "[WARN] the torch overrides path has a space and no 8.3 short name;" "Yellow"
+                substep "installing unsloth without freezing the installed PyTorch." "Yellow"
+                Remove-Item -LiteralPath $f -Force -ErrorAction SilentlyContinue
+                return $null
+            }
+            $f = $short
+        }
         return $f
     }
 

--- a/tests/studio/test_torch_overrides_merge.ps1
+++ b/tests/studio/test_torch_overrides_merge.ps1
@@ -35,12 +35,23 @@ $SkipTorch = $false
 # Stand-in interpreter: the helper only runs `& $PythonExe -c` and reads `name==version` lines.
 $work = Join-Path ([System.IO.Path]::GetTempPath()) ("unsloth-ovtest-" + [guid]::NewGuid().ToString("N"))
 New-Item -ItemType Directory -Path $work -Force | Out-Null
-$fakePy = Join-Path $work "fakepython"
-Set-Content -LiteralPath $fakePy -Value @(
-    "#!/usr/bin/env bash"
-    "printf 'torch==2.11.0+cu130\ntorchvision==0.26.0+cu130\ntorchaudio==2.11.0+cu130\n'"
-) -Encoding ascii
-if ($IsLinux -or $IsMacOS) { & chmod +x $fakePy }
+$onWindows = -not ($IsLinux -or $IsMacOS)
+if ($onWindows) {
+    # Windows starts a stand-in only through an extension it can execute.
+    $fakePy = Join-Path $work "fakepython.cmd"
+    Set-Content -LiteralPath $fakePy -Value @(
+        "@echo torch==2.11.0+cu130"
+        "@echo torchvision==0.26.0+cu130"
+        "@echo torchaudio==2.11.0+cu130"
+    ) -Encoding ascii
+} else {
+    $fakePy = Join-Path $work "fakepython"
+    Set-Content -LiteralPath $fakePy -Value @(
+        "#!/usr/bin/env bash"
+        "printf 'torch==2.11.0+cu130\ntorchvision==0.26.0+cu130\ntorchaudio==2.11.0+cu130\n'"
+    ) -Encoding ascii
+    & chmod +x $fakePy
+}
 
 $acute = [char]0x00E9   # e-acute, the cheapest non-ASCII requirement character
 $savedOverride = $env:UV_OVERRIDE
@@ -95,6 +106,35 @@ try {
     $SkipTorch = $true
     Check "returns null under --no-torch" ($null -eq (New-UnslothTorchOverridesFile -PythonExe $fakePy))
     $SkipTorch = $false
+
+    # ── a temp path with a space never reaches uv (#10722) ────────────────────────
+    # UV_OVERRIDE is space-separated itself, so only %TEMP% can hand the helper a spaced path.
+    if ($onWindows) {
+        $spacedTemp = Join-Path $work "John Doe"
+        New-Item -ItemType Directory -Path $spacedTemp -Force | Out-Null
+        $dirShort = $null
+        try { $dirShort = (New-Object -ComObject Scripting.FileSystemObject).GetFolder($spacedTemp).ShortPath } catch { }
+        # Captures the no-8.3 warning.
+        $script:substepCalls = @()
+        function substep { param($Message, $Color) $script:substepCalls += $Message }
+        Remove-Item Env:UV_OVERRIDE -ErrorAction SilentlyContinue
+        $savedTmp = $env:TMP
+        $env:TMP = $spacedTemp   # GetTempPath reads TMP first
+        try { $spaced = New-UnslothTorchOverridesFile -PythonExe $fakePy }
+        finally { $env:TMP = $savedTmp }
+        $made += $spaced
+        if ($dirShort -and -not $dirShort.Contains(" ")) {
+            Check "a spaced temp path comes back without a space" ($spaced -and -not $spaced.Contains(" "))
+            Check "the short path names a file in that same temp directory" (
+                $spaced -and (Test-Path -LiteralPath $spaced) -and ((Split-Path -Parent $spaced) -eq $dirShort))
+        } else {
+            Check "no 8.3 name: no overrides file is returned" ($null -eq $spaced)
+            Check "no 8.3 name: the file it created is removed" (@(Get-ChildItem -LiteralPath $spacedTemp).Count -eq 0)
+            Check "no 8.3 name: the fallback is announced" ($script:substepCalls.Count -gt 0)
+        }
+    } else {
+        Write-Host "  SKIP  spaced-path checks need Windows 8.3 names"
+    }
 
     # ── the merged copy is tracked and locked down ────────────────────────────────
     # The caller's non-torch lines land in this copy, one of which can be an authenticated URL.


### PR DESCRIPTION
Closes #10722.

Also reported [on Reddit](https://www.reddit.com/r/unsloth/comments/1wcgqlx/problems_with_the_windowspowershe_installer_if/), where [another user](https://www.reddit.com/r/unsloth/comments/1wcgqlx/problems_with_the_windowspowershe_installer_if/p8yrq0v/) hit it on a reinstall that had worked before.

## Problem

On Windows, installing Unsloth fails when the user folder has a space in its name, such as `C:\Users\John Doe`:

```
error: File not found: `Doe\AppData\Local\Temp\tmpB12C.tmp`
[ERROR] Failed to install unsloth (exit code 2)
```

Before installing unsloth, `install.ps1` writes a small file to the temp folder that pins the already installed PyTorch packages, and passes it to uv with `--overrides`. uv splits that option's value at spaces, so `C:\Users\John Doe\AppData\Local\Temp\tmpB12C.tmp` turns into two paths that do not exist.

This started with #7256 (v0.1.807-beta). It can also happen without a space in the user name, when the installer falls back to its own temp folder under `Unsloth Studio\temp`.

## Fix

- If the pin file's path has a space, `install.ps1` gives uv the Windows short name for it instead, such as `C:\Users\JOHNDO~1\...`. It is the same file, with no spaces in the path.
- If Windows has no short name for the path (short names can be turned off), the installer prints a warning and installs without the pin, as it did before #7256.

The Linux and macOS installer and the Python setup code already handle this uv behavior (#6503). `install.ps1` was the only place missing it.

## Testing

I ran `install.ps1 --tauri` on a GitHub Windows runner with `TEMP` pointed at `C:\Users\John Doe\AppData\Local\Temp` ([run](https://github.com/oobabooga/unsloth/actions/runs/34542712514)):

| | Temp path with a space | Same, short names off | Normal temp path |
| --- | --- | --- | --- |
| main | fails: ``File not found: `C:\Users\John` `` | not run | installs |
| this PR | installs | installs, with the warning | installs |

`test_torch_overrides_merge.ps1` now runs on Windows and covers both the short name and the fallback. It fails on main and passes here ([run](https://github.com/oobabooga/unsloth/actions/runs/34542989874)), and it is added to the cross-platform parity workflow. The existing Python installer tests pass (3012 passed, 623 skipped).

## Not covered

- I simulated the spaced folder through `TEMP`. I did not test a real Windows account with a space in its name.
- The [report](https://www.reddit.com/r/unsloth/comments/1wcgqlx/problems_with_the_windowspowershe_installer_if/) suggests making `C:\Windows\Temp` the default temp folder. This PR does not do that, because that folder is not writable for every user (#9140).
