### PR TITLE
Explicitly emit --split-mode layer for manual multi-GPU layer loads

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -23016,6 +23016,11 @@ class LlamaCppBackend:
                             )
                             self._tensor_split = _sanitized_split
                             manual_tensor_split_emitted = True
+                            # A manual layer split should be explicit so inherited
+                            # env / previous server state cannot silently promote
+                            # it to tensor/row. Respect a user --split-mode extra.
+                            if not tensor_parallel and split_mode_override is None:
+                                cmd.extend(["--split-mode", "layer"])
                         else:
                             logger.warning(
                                 "Dropping manual --tensor-split (%d entries for "

--- a/studio/backend/tests/test_llama_cpp_placement.py
+++ b/studio/backend/tests/test_llama_cpp_placement.py
@@ -1790,6 +1790,34 @@ def test_an_explicit_tensor_split_leaves_the_shared_heap_uncredited(tmp_path, mo
     )
 
 
+def test_manual_layer_split_emits_explicit_split_mode(tmp_path):
+    """A manual multi-GPU layer load must declare --split-mode layer so the
+    backend's intent is unambiguous and cannot be flipped by inherited state.
+    Regression for unslothai/unsloth#10549."""
+    backend, gguf = _backend_non_vulkan(
+        tmp_path,
+        memory = [(0, 24_000, 24_000), (1, 24_000, 24_000)],
+    )
+    backend._get_gguf_size_bytes = lambda _path: 1 * 1024**3
+    backend._n_layers = 32
+
+    cmd = _launch(
+        backend,
+        gguf,
+        gpu_memory_mode = "manual",
+        gpu_layers = 33,
+        gpu_ids = [0, 1],
+        tensor_split = [3, 1],
+        tensor_parallel = False,
+    )["cmd"]
+
+    assert backend.tensor_parallel is False
+    assert "--split-mode" in cmd
+    assert cmd[cmd.index("--split-mode") + 1] == "layer"
+    assert "--tensor-split" in cmd
+    assert cmd[cmd.index("--tensor-split") + 1] == "3,1"
+
+
 def _mixed_vulkan(tmp_path, monkeypatch, memory):
     """A 30 GiB GGUF on a host with 4 GiB of RAM left, full manual offload."""
     backend, gguf = _backend(tmp_path, vulkan = True, memory = memory)


### PR DESCRIPTION
Fixes #10549.

## Problem
When a user picks manual GPU placement and supplies per-GPU ratios, the backend emits `--tensor-split` but does **not** emit `--split-mode layer`. It relies on llama.cpp defaulting to layer mode. That makes the backend's intent ambiguous and can silently behave like tensor/row if inherited env or previous server state carries a different split-mode default.

## Fix
When `tensor_parallel=False`, `gpu_memory_mode="manual"`, and the user provides a valid multi-GPU `--tensor-split` without overriding `--split-mode` themselves, append `--split-mode layer` right after `--tensor-split`.

## Test
Added `test_manual_layer_split_emits_explicit_split_mode` in `test_llama_cpp_placement.py`, which verifies the emitted command contains both `--tensor-split` and `--split-mode layer` while `backend.tensor_parallel` stays `False`.

## Local validation
- Ran `pytest studio/backend/tests/test_llama_cpp_placement.py -x` -> 190 passed.
- Captured a manual layer load command on a 4x H100 box and confirmed it now includes `--split-mode layer`.
