### PR TITLE
Use model-neutral image generation tooltips

### DIFF
--- a/studio/frontend/src/features/images/images-page.tsx
+++ b/studio/frontend/src/features/images/images-page.tsx
@@ -4155,7 +4155,7 @@ export function ImagesPage({
             <div className="pt-2">
               <SliderField
                 label="Steps"
-                hint="9 is the recommended setting for Z-Image-Turbo. More steps rarely help."
+                hint="Number of denoising steps. Start with the selected model's default; more steps take longer and may not improve quality."
                 value={steps}
                 min={1}
                 max={50}
@@ -4165,7 +4165,7 @@ export function ImagesPage({
             </div>
             <SliderField
               label="Guidance"
-              hint="Keep this at 0 for Z-Image-Turbo. Higher values make its output worse. Other models use guidance."
+              hint="Controls how strongly the model follows the prompt. Start with the selected model's default; distilled models may require low or zero guidance."
               value={guidance}
               min={0}
               max={15}


### PR DESCRIPTION
The Steps and Guidance tooltips recommended Z-Image-Turbo settings for every image model. Replace that advice with general explanations that direct users to the selected model's defaults. Generation defaults and slider values are unchanged.

Addresses the tooltip report in #10716.

Validation:

- All five existing generation-default tests and TypeScript checks passed. No new permanent tests for wording-only changes.
- The rendered tooltip content and unchanged slider values were checked in Chrome, Edge, Firefox, Chromium and WebKit. The old wording is reproduced on unchanged main.
- Existing Images-page lint diagnostics are unchanged. Shipping Safari was not tested because remote automation is disabled.

Broader CI: the Python 3.13 job passed 39,875 tests but failed the existing one-second DeepSeek parser timing assertion at 1.14 seconds. This PR only changes two tooltip strings. Some other checks remain queued or running.
