### PR TITLE
Studio: add per-model custom llama.cpp INI configuration

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -19684,6 +19684,9 @@ class LlamaCppBackend:
                         "supports_tools",
                     ):
                         setattr(self, "_" + field, template_flags[field])
+                self._idle_slot_clearing_active = _idle_slot_clearing_active(
+                    cmd, supports_cache_ram = bool(caps.get("supports_cache_ram"))
+                )
                 if cancelled() or not self._publish_healthy():
                     self._kill_process()
                     return False
@@ -19697,6 +19700,12 @@ class LlamaCppBackend:
                     1 if self._kv_cache_unified else compiled.n_parallel
                 )
                 self._n_ubatch = tuning.get("n_ubatch", 0)
+                self._requested_n_batch = None
+                self._requested_n_ubatch = None
+                self._requested_load_mode = None
+                self._requested_spec_draft_cache_type = None
+                self._requested_ctx_checkpoints = None
+                self._requested_cache_ram = None
                 self._swa_full = bool(tuning.get("swa_full", False))
                 flash_observed = None
                 for line in self._stdout_lines:
@@ -19738,8 +19747,8 @@ class LlamaCppBackend:
                 self._speculative_type = tuning.get("spec_type")
                 self._requested_spec_mode = self._speculative_type
                 self._spec_draft_n_max = None
-                self._extra_args = list(compiled.argv)
-                self._requested_extra_args = list(intent.extra_args or ())
+                self._extra_args = []
+                self._requested_extra_args = []
                 self._extra_args_source = (intent.model_identifier, intent.hf_variant)
                 self._launch_binary_revision = revision
                 self._capability_probe_inconclusive = False

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -51,6 +51,14 @@ from typing import (
 import httpx
 
 from core.inference.chat_template_helpers import build_dac_tts_prompt
+from core.inference.llama_custom_config import (
+    CompiledCustomConfig,
+    CustomConfigError,
+    CustomConfigSource,
+    compile_custom_config,
+    parse_config_source,
+    parse_option_catalog,
+)
 from core.inference.context_window import (
     _COMPACTION_HEADROOM_RATIO,
     clamp_compaction_headroom_ratio,
@@ -567,8 +575,10 @@ class GgufLoadIntent:
     force_reload: bool = False
 
     cpu_fallback: bool = False
+    llama_cpp_config: Optional[CustomConfigSource] = None
 
     def __post_init__(self):
+        object.__setattr__(self, "llama_cpp_config", parse_config_source(self.llama_cpp_config))
         for key in ("tensor_split", "gpu_ids", "extra_args"):
             value = getattr(self, key)
             if value is not None:
@@ -6508,6 +6518,8 @@ class LlamaCppBackend:
         self._requested_n_ctx: int = 0
         # Last healthy caller intent for crash recovery. Memory-only and never logged.
         self._last_load_intent: Optional[GgufLoadIntent] = None
+        self._compiled_custom_config: Optional[CompiledCustomConfig] = None
+        self._custom_launch_pending = False
         self._mtp_runtime_fallback_lock = threading.Lock()
         self._mtp_runtime_fallback_in_progress = False
         # Background watchdog so an MTP+tensor crash recovers even when no request
@@ -7090,6 +7102,7 @@ class LlamaCppBackend:
         enable_thinking: Optional[bool],
         reasoning_effort: Optional[str] = None,
         preserve_thinking: Optional[bool] = None,
+        request_template_kwargs: Optional[dict] = None,
     ) -> Optional[dict]:
         """Build chat_template_kwargs from per-request reasoning fields.
 
@@ -7136,7 +7149,19 @@ class LlamaCppBackend:
         if self._supports_preserve_thinking and preserve_thinking is not None:
             kwargs["preserve_thinking"] = preserve_thinking
         _coerce_reasoning_effort(getattr(self, "_architecture", None), kwargs)
-        return kwargs or None
+        compiled = getattr(self, "_compiled_custom_config", None)
+        preset = (
+            compiled.summary()["request_defaults"].get("chat_template_kwargs", {})
+            if compiled
+            else {}
+        )
+        merged = dict(preset)
+        if request_template_kwargs is not None:
+            if not isinstance(request_template_kwargs, dict):
+                raise ValueError("chat_template_kwargs must be an object")
+            merged.update(request_template_kwargs)
+        merged.update(kwargs)
+        return merged or None
 
     @property
     def supports_tools(self) -> bool:
@@ -7263,6 +7288,17 @@ class LlamaCppBackend:
     def last_load_intent(self) -> Optional[GgufLoadIntent]:
         return self._last_load_intent
 
+    @property
+    def requested_llama_cpp_config(self) -> Optional[dict]:
+        intent = self._last_load_intent
+        source = intent.llama_cpp_config if intent is not None else None
+        return source.to_wire() if source is not None else None
+
+    @property
+    def llama_cpp_config_summary(self) -> Optional[dict]:
+        compiled = getattr(self, "_compiled_custom_config", None)
+        return compiled.summary() if compiled is not None else None
+
     def _runtime_matches_intent(
         self, intent: GgufLoadIntent, effective_extra_args: Optional[list[str]]
     ) -> bool:
@@ -7270,6 +7306,27 @@ class LlamaCppBackend:
 
         if intent.force_reload:
             return False
+        requested_custom = (
+            intent.llama_cpp_config is not None and intent.llama_cpp_config.mode == "custom"
+        )
+        resident_custom = getattr(self, "_compiled_custom_config", None)
+        if requested_custom or resident_custom is not None:
+            if not requested_custom or resident_custom is None:
+                return False
+            if (
+                intent.model_identifier != self._model_identifier
+                or intent.hf_variant != self._hf_variant
+            ):
+                return False
+            try:
+                resolved = replace(intent, gguf_path = intent.gguf_path or self._gguf_path)
+                compiled = self.prepare_custom_config(resolved)
+                return (
+                    compiled.digest == resident_custom.digest
+                    and not self._binary_changed_since_launch()
+                )
+            except (ValueError, OSError):
+                return False
         if self._requested_n_ctx != int(intent.n_ctx):
             return False
         if not self._is_diffusion and self._requested_n_parallel != max(1, int(intent.n_parallel)):
@@ -8289,6 +8346,7 @@ class LlamaCppBackend:
             # caller that equated "parsed something" with "read the whole thing"
             # would call every flag past the failure point unknown.
             "help_probe_ok": bool(probe_ok),
+            "option_catalog": parse_option_catalog(help_text) if probe_ok else (),
         }
         with cls._capability_cache_lock:
             published = cls._capability_cache.get(cache_key)
@@ -19182,7 +19240,10 @@ class LlamaCppBackend:
 
         # Log the argv per attempt (the text-only mmproj retry re-enters here
         # with --mmproj stripped), redacting the API key.
-        logger.info(f"Starting llama-server: {' '.join(self._redacted_cmd_for_log(cmd))}")
+        if getattr(self, "_custom_launch_pending", False):
+            logger.info("Starting llama-server with validated custom configuration")
+        else:
+            logger.info(f"Starting llama-server: {' '.join(self._redacted_cmd_for_log(cmd))}")
 
         # Check with publication under one lock: the mmproj text-only retry reaches
         # a spawn without passing _spawn_and_wait's boundary.
@@ -19225,6 +19286,494 @@ class LlamaCppBackend:
             target = self._drain_stdout, daemon = True, name = "llama-stdout"
         )
         self._stdout_thread.start()
+        return True
+
+    @staticmethod
+    def _reject_implicit_custom_config(env: Mapping[str, str]) -> None:
+        """Native startup must not load an unrecorded system/user preset."""
+        paths = []
+        if sys.platform == "win32":
+            for key in ("PROGRAMDATA", "APPDATA"):
+                if env.get(key):
+                    paths.append(Path(env[key]) / "llama.cpp" / "config.ini")
+        else:
+            paths.append(Path("/etc/llama.cpp/config.ini"))
+            root = env.get("XDG_CONFIG_HOME")
+            if root:
+                paths.append(Path(root) / "llama.cpp" / "config.ini")
+            else:
+                user_root = env.get("HOME") or str(Path.home())
+                paths.append(Path(user_root) / ".config" / "llama.cpp" / "config.ini")
+        for path in paths:
+            try:
+                path.stat()
+            except FileNotFoundError:
+                continue
+            except OSError:
+                raise CustomConfigError(
+                    "Cannot verify the native system/user configuration path; custom mode cannot launch safely"
+                ) from None
+            raise CustomConfigError(
+                "A native system/user llama.cpp config.ini is present. Custom mode requires "
+                "a single configuration source; remove that implicit configuration before loading."
+            )
+
+    def _custom_binary_and_caps(self) -> tuple[str, dict]:
+        if getattr(self, "_llama_update_in_progress", False):
+            raise CustomConfigError(
+                "llama.cpp is updating; validate the configuration after it finishes"
+            )
+        binary = self._exec_path_for_launch(self._find_llama_server_binary())
+        if not binary:
+            raise LlamaServerNotFoundError(LLAMA_SERVER_NOT_FOUND_DETAIL)
+        self._reject_implicit_custom_config(self._llama_server_env_for_binary(binary))
+        caps = self.probe_server_capabilities(binary)
+        if not caps.get("help_probe_ok") or not caps.get("option_catalog"):
+            raise CustomConfigError(
+                "Custom configuration requires a complete successful help probe from the selected llama-server"
+            )
+        return binary, caps
+
+    def prepare_custom_config(
+        self,
+        intent: GgufLoadIntent,
+        *,
+        validate_resources: bool = True,
+    ) -> CompiledCustomConfig:
+        """Validate strict tuning without unloading, downloading, or changing runtime state."""
+        binary, caps = self._custom_binary_and_caps()
+        projector = intent.mmproj_path
+        if projector and intent.disable_vision and not _mmproj_env_is_audio_only(projector):
+            projector = None
+        compiled = compile_custom_config(
+            intent.llama_cpp_config,
+            caps["option_catalog"],
+            model_path = intent.gguf_path,
+            mmproj_path = projector,
+            validate_resources = validate_resources,
+        )
+        if not validate_resources and any(
+            "identity must be checked" in note for note in compiled.diagnostics
+        ):
+            # The route calls this before evicting another backend. A source
+            # carrying m/mm cannot defer identity until after that eviction.
+            compiled = compile_custom_config(
+                intent.llama_cpp_config,
+                caps["option_catalog"],
+                model_path = intent.gguf_path,
+                mmproj_path = projector,
+                validate_resources = True,
+            )
+        flags = {name for item in caps["option_catalog"] for name in item["names"]}
+        required = {"--host", "--port", "--alias", "--jinja"}
+        if os.getenv("UNSLOTH_DIRECT_STREAM", "0") == "1":
+            required.add("--api-key")
+        if required - flags:
+            raise CustomConfigError(
+                "Selected executable lacks options required for Studio transport, identity, or Jinja tools"
+            )
+        tuning = compiled.summary()["tuning"]
+        if tuning.get("jinja") is False:
+            raise CustomConfigError(
+                "Custom jinja=false conflicts with Studio's Jinja tool integration"
+            )
+        if _metal_device_is_paravirtual():
+            if tuning.get("device") != "none" or tuning.get("gpu_layers") != 0:
+                raise CustomConfigError(
+                    "Virtualized Metal requires explicit device=none and gpu-layers=0 in custom configuration"
+                )
+            if intent.mmproj_path and tuning.get("mmproj_offload") is not False:
+                raise CustomConfigError(
+                    "Virtualized Metal requires mmproj-offload=false for the selected projector"
+                )
+        gpu_layers = tuning.get("gpu_layers")
+        if gpu_layers != 0 and tuning.get("device") != "none":
+            error = self._cuda_sm_gate_error(binary)
+            if error:
+                raise CustomConfigError(error)
+            if self._arch_gate_survivors(binary):
+                raise CustomConfigError(
+                    "The selected runtime requires a GPU compatibility mask; set an administrative device visibility mask before using custom mode"
+                )
+        from utils.model_memory_settings import get_keep_resident, get_no_ram_reserve
+
+        memory = resolve_effective_memory_state(compiled.argv, {})
+        if get_no_ram_reserve() and any(memory):
+            raise CustomConfigError(
+                "Custom memory settings conflict with the operator's no RAM reservation policy"
+            )
+        if get_keep_resident() and not memory[0]:
+            raise CustomConfigError(
+                "Custom memory settings must enable mlock under the operator's keep resident policy"
+            )
+        if validate_resources and intent.gguf_path:
+            if not Path(intent.gguf_path).is_file():
+                raise CustomConfigError("The selected GGUF file is unavailable")
+            refusal = self._non_chat_gguf_refusal_for_path(
+                intent.gguf_path, intent.model_identifier
+            )
+            if refusal:
+                raise CustomConfigError(refusal)
+            if self._gguf_path_is_diffusion(intent.gguf_path, intent.model_identifier):
+                raise CustomConfigError(
+                    "Custom llama.cpp configuration is not supported by the diffusion runner"
+                )
+        return compiled
+
+    def _prepare_custom_launch_command(self, binary, caps, intent, compiled):
+        """Build and size the complete envelope before replacing the old child."""
+        from core.inference.model_ids import public_model_id
+        from core.inference.llama_server_args import windows_command_length, WINDOWS_COMMAND_LIMIT
+
+        port = self._find_free_port()
+        tuning = compiled.summary()["tuning"]
+        cmd = [
+            binary,
+            "-m",
+            intent.gguf_path,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--parallel",
+            str(compiled.n_parallel),
+            "--alias",
+            public_model_id(intent.model_identifier),
+        ]
+        if "jinja" not in tuning:
+            cmd.append("--jinja")
+        if intent.mmproj_path:
+            cmd.extend(["--mmproj", intent.mmproj_path])
+        api_key = None
+        if os.getenv("UNSLOTH_DIRECT_STREAM", "0") == "1":
+            import secrets
+            api_key = secrets.token_urlsafe(32)
+            cmd.extend(["--api-key", api_key])
+        slot_path = slot_binary = None
+        if caps.get("supports_slot_save"):
+            from utils.paths.storage_roots import llama_slot_cache_root
+
+            slot_dir = llama_slot_cache_root()
+            slot_dir.mkdir(parents = True, exist_ok = True)
+            with contextlib.suppress(OSError):
+                os.chmod(slot_dir, 0o700)
+            if sys.platform != "win32" or str(slot_dir).isascii():
+                slot_path = str(slot_dir)
+                slot_binary = (binary, Path(binary).stat().st_mtime_ns)
+                cmd.extend(["--slot-save-path", slot_path])
+        probe = type(self)(manages_processes = False)
+        probe._model_identifier = intent.model_identifier
+        probe._read_gguf_metadata(intent.gguf_path)
+        if probe.is_embedding_gguf:
+            if not any(
+                "--embedding" in d["names"] or "--embeddings" in d["names"]
+                for d in caps["option_catalog"]
+            ):
+                raise CustomConfigError("Selected executable cannot serve this embedding GGUF")
+            if tuning.get("n_ubatch", 0) < compiled.n_parallel:
+                raise CustomConfigError(
+                    "The custom embedding micro-batch must accommodate every parallel slot"
+                )
+            cmd.append("--embedding")
+        cmd.extend(compiled.argv)
+        if sys.platform == "win32" and windows_command_length(cmd) >= WINDOWS_COMMAND_LIMIT:
+            raise CustomConfigError("Custom launch exceeds the Windows command line limit")
+        return cmd, port, api_key, slot_path, slot_binary
+
+    def _load_custom_model(
+        self,
+        intent: GgufLoadIntent,
+        *,
+        load_cancel_event: Optional[threading.Event] = None,
+    ) -> bool:
+        """One strict attempt inside the ordinary serial load/lifecycle boundary."""
+        self._cancel_event.clear()
+        epoch = self._unload_epoch
+
+        def cancelled():
+            return (
+                self._cancel_event.is_set()
+                or self._unload_epoch != epoch
+                or bool(load_cancel_event is not None and load_cancel_event.is_set())
+            )
+
+        if cancelled():
+            return False
+        # Validate syntax, ownership, and selected binary before any model download.
+        self.prepare_custom_config(intent, validate_resources = False)
+        binary, caps = self._custom_binary_and_caps()
+        revision = self._binary_revision(binary)
+        if not revision:
+            raise CustomConfigError("Selected llama-server revision cannot be verified")
+        self._binary_revision_pending = revision
+        model_path, projector = intent.gguf_path, intent.mmproj_path
+        download_cancel = (
+            _CombinedCancelEvent(self._cancel_event, load_cancel_event)
+            if load_cancel_event
+            else self._cancel_event
+        )
+        if intent.hf_repo and not model_path:
+            with _hf_offline_if_unreachable():
+                model_path = self._download_gguf(
+                    hf_repo = _resolve_repo_id_casing(intent.hf_repo),
+                    hf_variant = intent.hf_variant,
+                    hf_token = intent.hf_token,
+                    cancel_event = download_cancel,
+                    allow_smaller_fallback = False,
+                )
+        if cancelled():
+            return False
+        if not model_path or not Path(model_path).is_file():
+            raise CustomConfigError("Custom configuration requires an existing selected GGUF model")
+        if intent.is_vision and not projector and intent.hf_repo:
+            with _hf_offline_if_unreachable():
+                projector = self._download_mmproj(
+                    hf_repo = intent.hf_repo,
+                    hf_token = intent.hf_token,
+                    cancel_event = download_cancel,
+                    near_path = model_path,
+                )
+        if projector:
+            resolved_projector = self._resolve_launch_mmproj_path(
+                model_path = model_path, mmproj_path = projector
+            )
+            if not resolved_projector:
+                raise CustomConfigError(
+                    "The selected projector is missing or does not match the selected GGUF model"
+                )
+            projector = resolved_projector
+            if intent.disable_vision and not _mmproj_env_is_audio_only(projector):
+                projector = None
+        if intent.is_vision and not intent.disable_vision and not projector:
+            raise CustomConfigError(
+                "The selected vision model requires a matching projector for custom mode"
+            )
+        resolved = replace(intent, gguf_path = model_path, mmproj_path = projector, verified_gguf = None)
+        compiled = self.prepare_custom_config(resolved)
+        identity = self._gguf_load_source_identity(model_path, projector)
+        if identity is None:
+            raise CustomConfigError(
+                "The selected model's complete shard identity cannot be verified"
+            )
+        if cancelled():
+            return False
+        current = getattr(self, "_compiled_custom_config", None)
+        if (
+            not intent.force_reload
+            and self.is_loaded
+            and current is not None
+            and current.digest == compiled.digest
+            and self._gguf_load_identity == identity
+            and self._model_identifier == intent.model_identifier
+            and self._launch_binary_revision == revision
+        ):
+            # A comment-only edit updates source without replacing the process.
+            self._compiled_custom_config = compiled
+            self._last_load_intent = resolved
+            return True
+        tuning = compiled.summary()["tuning"]
+        env = self._llama_server_env_for_binary(binary)
+        native_env = {name for item in caps["option_catalog"] for name in item.get("env", [])}
+        for name in tuple(env):
+            if (
+                name.startswith("LLAMA_ARG_")
+                or name in native_env
+                or name in {"LLAMA_API_KEY", "LLAMA_CONFIG", "LLAMA_CONFIG_FILE"}
+            ):
+                env.pop(name, None)
+        self._reject_implicit_custom_config(env)
+        from utils.llama_cpp_path_settings import llama_cpp_path_selection_guard
+
+        cmd, port, api_key, slot_path, slot_binary = self._prepare_custom_launch_command(
+            binary, caps, resolved, compiled
+        )
+        with self._lock:
+            if cancelled():
+                return False
+            with llama_cpp_path_selection_guard():
+                selected_binary = self._exec_path_for_launch(self._find_llama_server_binary())
+                if self._binary_revision(selected_binary) != revision:
+                    raise CustomConfigError(
+                        "Selected llama-server changed during validation; retry the load"
+                    )
+                with self._spawn_lock:
+                    if self._spawn_is_stale():
+                        return False
+                self._reject_implicit_custom_config(env)
+                if self._gguf_load_source_identity(model_path, projector) != identity:
+                    raise CustomConfigError(
+                        "Selected model resources changed during validation; retry the load"
+                    )
+                self._begin_load_warnings()
+                self._kill_process()
+                self._cleanup_cpu_fallback_runtime()
+            self._custom_launch_pending = True
+            try:
+                self._model_identifier = intent.model_identifier
+                self._read_gguf_metadata(model_path)
+                self._gguf_path = model_path
+                self._gguf_load_identity = identity
+                self._hf_repo, self._hf_variant = intent.hf_repo, intent.hf_variant
+                self._port = port
+                self._api_key = api_key
+                self._slot_save_dir = slot_path
+                self._slot_save_binary = slot_binary
+                self._chat_template_override = None
+                self._cpu_fallback_reason = self._mmproj_fallback_reason = None
+                self._mtp_draft_path = self._mtp_draft_suppressed_path = None
+                self._spec_fallback_reason = self._spec_drafter_kind = None
+                self._mtp_runtime_fallback_active = False
+                self._dflash_retry_needed = False
+                self._is_vision = bool(projector)
+                self._disable_vision = intent.disable_vision
+                self._vision_disabled_by_user = intent.disable_vision
+                self._mmproj_has_audio = False
+                self._mmproj_accepts_image = True
+                self._mmproj_projector_type = None
+                if projector:
+                    from utils.models.gguf_metadata import (
+                        mmproj_capabilities,
+                        read_mmproj_projector_type,
+                    )
+                    self._mmproj_has_audio, self._mmproj_accepts_image = mmproj_capabilities(
+                        projector
+                    )
+                    self._mmproj_projector_type = read_mmproj_projector_type(projector)
+                if cancelled() or not self._start_llama_process(
+                    cmd, env, child_gpu_physical_ids = None
+                ):
+                    self._kill_process()
+                    return False
+                if not self._wait_for_health(timeout = 600.0, cancelled = cancelled):
+                    was_cancelled = cancelled() or self._health_wait_cancelled
+                    self._kill_process()
+                    if was_cancelled:
+                        return False
+                    raise CustomConfigError(
+                        "llama-server could not start with the selected custom configuration; no tuning fallback was attempted"
+                    )
+                props = self._query_server_props()
+                settings = (props or {}).get("default_generation_settings") or {}
+                actual_ctx = settings.get("n_ctx")
+                actual_slots = (props or {}).get("total_slots")
+                if (
+                    not isinstance(actual_ctx, int)
+                    or actual_ctx <= 0
+                    or actual_slots != compiled.n_parallel
+                ):
+                    raise CustomConfigError(
+                        "llama-server did not confirm the custom context and parallel slot accounting"
+                    )
+                effective_template = props.get("chat_template")
+                if isinstance(effective_template, str):
+                    self._chat_template = effective_template
+                    template_flags = detect_reasoning_flags(
+                        effective_template,
+                        intent.model_identifier,
+                        log_source = "native custom template",
+                        log_level = "debug",
+                    )
+                    for field in (
+                        "supports_reasoning",
+                        "reasoning_style",
+                        "reasoning_always_on",
+                        "reasoning_effort_levels",
+                        "supports_preserve_thinking",
+                        "preserve_thinking_default",
+                        "supports_tools",
+                    ):
+                        setattr(self, "_" + field, template_flags[field])
+                if cancelled() or not self._publish_healthy():
+                    self._kill_process()
+                    return False
+                self._commit_effective_parallel_slots(compiled.n_parallel)
+                self._requested_n_parallel = compiled.n_parallel
+                self._requested_n_ctx = tuning.get("n_ctx", 0)
+                self._effective_context_length = actual_ctx
+                self._max_context_length = self._context_length
+                self._kv_cache_unified = bool(tuning.get("kv_unified", False))
+                self._kv_cache_context_total = actual_ctx * (
+                    1 if self._kv_cache_unified else compiled.n_parallel
+                )
+                self._n_ubatch = tuning.get("n_ubatch", 0)
+                self._swa_full = bool(tuning.get("swa_full", False))
+                flash_observed = None
+                for line in self._stdout_lines:
+                    flash = re.search(
+                        r"(?:flash_attn\s*=\s*|Flash Attention (?:not supported, set to )?)(enabled|disabled|on|off|1|0)\b",
+                        line,
+                        re.I,
+                    )
+                    if flash:
+                        flash_observed = flash[1].lower() in {"enabled", "on", "1"}
+                self._flash_attn_enabled = flash_observed is True
+                if flash_observed is None:
+                    compiled = replace(
+                        compiled,
+                        diagnostics = compiled.diagnostics
+                        + (
+                            "Native flash-attention outcome was not reported; memory accounting assumes it is disabled.",
+                        ),
+                    )
+                self._effective_cache_types = (
+                    tuning.get("cache_type_k", "f16"),
+                    tuning.get("cache_type_v", "f16"),
+                )
+                self._requested_cache_types = self._effective_cache_types
+                self._cache_type_kv = self._effective_cache_types[0]
+                self._memory_state = resolve_effective_memory_state(compiled.argv, env)
+                self._memory_policy_active = False
+                self._fit_load_mode_flags = []
+                self._vram_fraction_launched = None
+                self._gpu_memory_mode = "manual"
+                self._gpu_layers = (
+                    tuning.get("gpu_layers") if isinstance(tuning.get("gpu_layers"), int) else -1
+                )
+                self._n_cpu_moe = tuning.get("n_cpu_moe", 0)
+                self._tensor_parallel = bool(tuning.get("tensor_parallel", False))
+                self._tensor_split = self._gpu_ids = self._requested_gpu_ids = None
+                self._arch_gate_forced_cpu = False
+                self._layer_preserves_tensor_intent = False
+                self._speculative_type = tuning.get("spec_type")
+                self._requested_spec_mode = self._speculative_type
+                self._spec_draft_n_max = None
+                self._extra_args = list(compiled.argv)
+                self._requested_extra_args = list(intent.extra_args or ())
+                self._extra_args_source = (intent.model_identifier, intent.hf_variant)
+                self._launch_binary_revision = revision
+                self._capability_probe_inconclusive = False
+                self._prompt_cache_disabled = bool(tuning.get("no_cache_prompt", False))
+                self._has_video_input = bool((props.get("modalities") or {}).get("video"))
+                self._gpu_offload_active = classify_gpu_offload_lines(self._stdout_lines)
+                if tuning.get("gpu_layers") == 0 and not projector:
+                    self._gpu_offload_active = self._zero_offload_gpu_flag(cmd, [], env)
+                self._is_audio = False
+                self._audio_type = None
+                self._audio_probed = False
+                self._has_audio_input = False
+            except Exception:
+                self._kill_process()
+                raise
+            finally:
+                self._custom_launch_pending = False
+        # Reuse codec handling outside the lock, matching the managed path.
+        try:
+            detected = self._detect_audio_type_strict()
+            self._audio_probed = True
+            applied = self._apply_detected_audio(detected, intent.audio_codec_path)
+        except Exception:
+            applied = False
+        with self._lock:
+            if not applied or cancelled() or not self._healthy:
+                self._kill_process()
+                return False
+            self._compiled_custom_config = compiled
+            self._last_load_intent = resolved
+            if self._slot_save_dir:
+                self._slot_loaded_identity = (
+                    self._gguf_file_identity(model_path),
+                    self._slot_launch_fingerprint(),
+                )
         return True
 
     @contextlib.contextmanager
@@ -19318,6 +19867,9 @@ class LlamaCppBackend:
             # so any in-flight load has drained) instead of using a half-swapped one.
             if getattr(self, "_llama_update_in_progress", False):
                 raise RuntimeError("llama.cpp is updating; try again in a moment.")
+
+            if intent.llama_cpp_config is not None and intent.llama_cpp_config.mode == "custom":
+                return self._load_custom_model(intent, load_cancel_event = load_cancel_event)
 
             intent = self._preserve_cpu_fallback_intent(intent)
             tensor_parallel = intent.tensor_parallel
@@ -19960,7 +20512,7 @@ class LlamaCppBackend:
                     if _load_cancelled():
                         logger.info("Load cancelled before diffusion server start")
                         return False
-                    return self._start_diffusion_server(
+                    started = self._start_diffusion_server(
                         model_path = model_path,
                         gguf_path = gguf_path,
                         hf_repo = hf_repo,
@@ -19973,6 +20525,10 @@ class LlamaCppBackend:
                         gpu_layers = gpu_layers,
                         cancelled = _load_cancelled,
                     )
+                    if started and getattr(self, "_compiled_custom_config", None) is not None:
+                        self._compiled_custom_config = None
+                        self._last_load_intent = replace(intent, verified_gguf = None)
+                    return started
 
             if not binary:
                 # distinguish a transiently locked binary (antivirus / in-flight
@@ -26345,6 +26901,7 @@ class LlamaCppBackend:
                 # dropped: a respawn replays this snapshot arbitrarily later, so recovery
                 # re-resolves the file instead of trusting a path this request verified.
                 self._last_load_intent = replace(intent, verified_gguf = None)
+                self._compiled_custom_config = None
                 self._mtp_runtime_fallback_active = _mtp_active_for_launched_server
                 self._start_mtp_crash_watchdog()
 
@@ -27005,6 +27562,17 @@ class LlamaCppBackend:
         if self._binary_changed_since_launch():
             logger.info("llama-server selection changed since launch; forcing a reload")
             return False
+        if getattr(self, "_compiled_custom_config", None) is not None or (
+            intent.llama_cpp_config is not None and intent.llama_cpp_config.mode == "custom"
+        ):
+            if not self._runtime_matches_intent(intent, []):
+                return False
+            resolved = replace(
+                intent, gguf_path = intent.gguf_path or self._gguf_path, verified_gguf = None
+            )
+            self._compiled_custom_config = self.prepare_custom_config(resolved)
+            self._last_load_intent = resolved
+            return True
         intent = self._preserve_cpu_fallback_intent(intent, source_matches = True)
         # The stored state is what LAUNCHED, and on a virtualised Metal device that is
         # the CPU-pinned rewrite, not the request. Apply the same rewrite here
@@ -27222,6 +27790,8 @@ class LlamaCppBackend:
             self._launch_binary_revision = ()
             self._cpu_fallback_reason = None
             self._last_load_intent = None
+            self._compiled_custom_config = None
+            self._custom_launch_pending = False
             self._mtp_runtime_fallback_active = False
             self._hf_variant = None
             self._is_vision = False
@@ -28569,7 +29139,7 @@ class LlamaCppBackend:
                 sidecars.append((path, st.st_size, st.st_mtime_ns))
             except OSError:
                 sidecars.append((path, None, None))
-        return (
+        fingerprint = (
             tuple(self._extra_args or ()),
             tuple(sidecars),
             self._requested_n_ctx,
@@ -28581,6 +29151,8 @@ class LlamaCppBackend:
             self._n_ubatch,
             self._flash_attn_enabled,
         )
+        compiled = getattr(self, "_compiled_custom_config", None)
+        return fingerprint + (("custom", compiled.digest),) if compiled is not None else fingerprint
 
     @staticmethod
     def _gguf_load_source_identity(path: str, mmproj_path: Optional[str] = None) -> Optional[tuple]:
@@ -28867,6 +29439,8 @@ class LlamaCppBackend:
         """
         # Cheap async-safe gate: only our live MTP+tensor launch, not cancelled,
         # with a snapshot to replay.
+        if getattr(self, "_compiled_custom_config", None) is not None:
+            return False
         if self._cancel_event.is_set():
             return False
         if not self._mtp_runtime_fallback_active:
@@ -29845,6 +30419,7 @@ class LlamaCppBackend:
         thread_id: Optional[str] = None,
         tools_withheld: bool = False,
         _allow_respawn_retry: bool = True,
+        request_template_kwargs: Optional[dict] = None,
     ) -> Generator[Union[str, dict], None, None]:
         """
         Send a chat completion to llama-server and stream tokens back.
@@ -29894,7 +30469,7 @@ class LlamaCppBackend:
             payload["logit_bias"] = logit_bias
         # Per-request enable_thinking / reasoning_effort / preserve_thinking
         _reasoning_kw = self._request_reasoning_kwargs(
-            enable_thinking, reasoning_effort, preserve_thinking
+            enable_thinking, reasoning_effort, preserve_thinking, request_template_kwargs
         )
         if _reasoning_kw is not None:
             payload["chat_template_kwargs"] = _reasoning_kw
@@ -30196,6 +30771,7 @@ class LlamaCppBackend:
                     reasoning_provenance = reasoning_provenance,
                     context_overflow = retry_context_overflow,
                     context_policy = context_policy,
+                    request_template_kwargs = request_template_kwargs,
                     compaction_headroom_ratio = compaction_headroom_ratio,
                     # The retry refits for the replacement window and can evict more than
                     # the first attempt did. Without the thread those extra turns are
@@ -30264,6 +30840,7 @@ class LlamaCppBackend:
         # MAY BLOCK: recost_waiting waits for cache room. Safe at the top of a round,
         # where the previous round's request has completed.
         on_conversation_grew: Optional[Callable[[list], None]] = None,
+        request_template_kwargs: Optional[dict] = None,
     ) -> Generator[dict, None, None]:
         """
         Agentic loop: let the model call tools, execute them, and continue.
@@ -30830,7 +31407,10 @@ class LlamaCppBackend:
             )
 
             _reasoning_kw = self._request_reasoning_kwargs(
-                _effective_enable_thinking, _effective_reasoning_effort, preserve_thinking
+                _effective_enable_thinking,
+                _effective_reasoning_effort,
+                preserve_thinking,
+                request_template_kwargs,
             )
             # What THIS request may generate, which on a continuation is the remainder of
             # the caller's cap rather than the whole of it. Read before the payload
@@ -32045,7 +32625,7 @@ class LlamaCppBackend:
                             # `enable_thinking`, so admitting under the old kwargs prices
                             # a request nobody sends. Same fix the final pass already has.
                             _off_kw_l = self._request_reasoning_kwargs(
-                                False, None, preserve_thinking
+                                False, None, preserve_thinking, request_template_kwargs
                             )
                             # Counted ONCE in the ordinary case: the eviction attempt
                             # below only runs on a candidate already found too large.
@@ -33373,7 +33953,7 @@ class LlamaCppBackend:
         from core.inference.chat_template_helpers import neutralize_control_markup_in_messages
 
         _reasoning_kw = self._request_reasoning_kwargs(
-            enable_thinking, reasoning_effort, preserve_thinking
+            enable_thinking, reasoning_effort, preserve_thinking, request_template_kwargs
         )
         _final_max_tokens = (
             max_tokens
@@ -34065,7 +34645,9 @@ class LlamaCppBackend:
                             # original thinking-on kwargs prices a different rendered
                             # prompt from the one about to be sent, which refuses a retry
                             # that would have fit or admits one llama-server then rejects.
-                            _off_kw = self._request_reasoning_kwargs(False, None, preserve_thinking)
+                            _off_kw = self._request_reasoning_kwargs(
+                                False, None, preserve_thinking, request_template_kwargs
+                            )
                             _next_cap_r = _remaining_output_budget()
                             # Protect the current user turn and recovery tail.
                             _recovery_tail = _candidate_r[-2:]

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -19395,14 +19395,15 @@ class LlamaCppBackend:
                 raise CustomConfigError(
                     "The selected runtime requires a GPU compatibility mask; set an administrative device visibility mask before using custom mode"
                 )
-        from utils.model_memory_settings import get_keep_resident, get_no_ram_reserve
+        from utils.model_memory_settings import get_model_memory_settings
 
         memory = resolve_effective_memory_state(compiled.argv, {})
-        if get_no_ram_reserve() and any(memory):
+        keep_resident, no_ram_reserve = get_model_memory_settings()
+        if no_ram_reserve and any(memory):
             raise CustomConfigError(
                 "Custom memory settings conflict with the operator's no RAM reservation policy"
             )
-        if get_keep_resident() and not memory[0]:
+        if keep_resident and not no_ram_reserve and not memory[0]:
             raise CustomConfigError(
                 "Custom memory settings must enable mlock under the operator's keep resident policy"
             )
@@ -19745,7 +19746,9 @@ class LlamaCppBackend:
                 self._prompt_cache_disabled = bool(tuning.get("no_cache_prompt", False))
                 self._has_video_input = bool((props.get("modalities") or {}).get("video"))
                 self._gpu_offload_active = classify_gpu_offload_lines(self._stdout_lines)
-                if tuning.get("gpu_layers") == 0 and not projector:
+                if compiled.explicit_cpu_only and not projector:
+                    self._gpu_offload_active = False
+                elif tuning.get("gpu_layers") == 0 and not projector:
                     self._gpu_offload_active = self._zero_offload_gpu_flag(cmd, [], env)
                 self._is_audio = False
                 self._audio_type = None

--- a/studio/backend/core/inference/llama_custom_config.py
+++ b/studio/backend/core/inference/llama_custom_config.py
@@ -12,12 +12,14 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from decimal import Decimal
 import hashlib
 import json
 import math
 import ntpath
 import os
 import re
+import struct
 import sys
 
 from . import llama_server_args as policy
@@ -189,6 +191,17 @@ class CompiledCustomConfig:
     request_defaults: tuple[tuple[str, object], ...]
     diagnostics: tuple[str, ...]
 
+    @property
+    def explicit_cpu_only(self) -> bool:
+        """Main-model placement is explicitly CPU-only; callers still check companions."""
+        tuning = dict(self.tuning)
+        return (
+            tuning.get("gpu_layers") == 0
+            and tuning.get("device") == "none"
+            and tuning.get("spec_type") in (None, "none", "off")
+            and not tuning.get("tensor_parallel", False)
+        )
+
     def summary(self) -> dict:
         return {
             "mode": "custom",
@@ -324,6 +337,16 @@ def _typed(name: str, value: str, descriptor: Mapping, section: str, key: str):
             raise _error(section, key, "requires a finite numeric value") from None
         if not math.isfinite(number):
             raise _error(section, key, "requires a finite numeric value")
+        # Native sampling callbacks parse float32, not Python's float64. Check
+        # both overflow and nonzero values that would silently round to zero.
+        try:
+            native_number = struct.unpack("f", struct.pack("f", number))[0]
+        except OverflowError:
+            raise _error(section, key, "number is outside the native float domain") from None
+        if not math.isfinite(native_number) or (
+            native_number == 0 and not Decimal(value).is_zero()
+        ):
+            raise _error(section, key, "number is outside the native float domain")
         return _FLOAT_FIELDS[name], number
     if name == "chat-template-kwargs":
         try:

--- a/studio/backend/core/inference/llama_custom_config.py
+++ b/studio/backend/core/inference/llama_custom_config.py
@@ -1,0 +1,580 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Compile one native INI preset into an immutable Studio launch configuration.
+
+The grammar follows common/preset.cpp: comments terminate even quoted values,
+strings are not unquoted, duplicate keys replace, and repeated sections reset.
+The caller must obtain a complete successful help probe from the selected binary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import hashlib
+import json
+import math
+import ntpath
+import os
+import re
+import sys
+
+from . import llama_server_args as policy
+
+MAX_INI_BYTES = 64 * 1024
+MAX_SECTIONS = 128
+MAX_ENTRIES = 2048
+NORMALIZATION_VERSION = 1
+_TRUE = frozenset({"on", "enabled", "true", "1"})
+_FALSE = frozenset({"off", "disabled", "false", "0"})
+_NAME = r"--?[A-Za-z][A-Za-z0-9_-]*"
+_DECL = re.compile(rf"^({_NAME}(?:,\s*{_NAME})*)(.*)$")
+
+
+class CustomConfigError(ValueError):
+    """A configuration error safe to expose without logging its source values."""
+
+
+@dataclass(frozen = True)
+class CustomConfigSource:
+    version: int = 1
+    mode: str = "managed"
+    ini: str | None = None
+    section: str | None = None
+
+    def to_wire(self) -> dict:
+        result = {"version": self.version, "mode": self.mode}
+        if self.mode == "custom":
+            result.update(ini = self.ini, section = self.section)
+        return result
+
+
+def parse_config_source(value: Mapping | CustomConfigSource | None) -> CustomConfigSource | None:
+    if value is None:
+        return None
+    if isinstance(value, CustomConfigSource):
+        # Validate constructed instances too; the dataclass is not a trust boundary.
+        value = {
+            "version": value.version,
+            "mode": value.mode,
+            "ini": value.ini,
+            "section": value.section,
+        }
+        if value["mode"] == "managed" and value["ini"] is None and value["section"] is None:
+            value = {"version": value["version"], "mode": value["mode"]}
+    if not isinstance(value, Mapping):
+        raise CustomConfigError("llama_cpp_config must be an object")
+    if type(value.get("version")) is not int or value["version"] != 1:
+        raise CustomConfigError("llama_cpp_config version must be 1")
+    mode = value.get("mode")
+    if not isinstance(mode, str) or mode not in {"managed", "custom"}:
+        raise CustomConfigError("llama_cpp_config mode must be managed or custom")
+    allowed = {"version", "mode"} if mode == "managed" else {"version", "mode", "ini", "section"}
+    if set(value) - allowed:
+        raise CustomConfigError("llama_cpp_config contains unsupported fields")
+    if mode == "managed":
+        return CustomConfigSource()
+    ini, section = value.get("ini"), value.get("section")
+    if not isinstance(ini, str) or not ini.strip():
+        raise CustomConfigError("Custom configuration requires INI text")
+    try:
+        size = len(ini.encode("utf-8"))
+    except UnicodeEncodeError:
+        raise CustomConfigError("INI text contains invalid Unicode") from None
+    if size > MAX_INI_BYTES:
+        raise CustomConfigError("INI text exceeds the 64 KiB limit")
+    if any((ord(c) < 32 and c not in "\r\n\t") or ord(c) == 127 for c in ini):
+        raise CustomConfigError("INI text contains control characters")
+    if section is not None and (
+        not isinstance(section, str)
+        or not section
+        or len(section) > 512
+        or any(c in section for c in "\r\n[]")
+    ):
+        raise CustomConfigError("Select a valid INI section name")
+    return CustomConfigSource(1, "custom", ini, section)
+
+
+def parse_option_catalog(help_text: str) -> tuple[dict, ...]:
+    """Read native help declaration groups, never flags mentioned in prose.
+
+    Unsupported/removed declarations remain unavailable. Unknown arity is marked
+    -1 so a named option cannot accidentally become a valueless switch.
+    """
+    groups: list[tuple[str, list[str]]] = []
+    for line in help_text.splitlines():
+        if _DECL.match(line):
+            groups.append((line, []))
+        elif groups and line[:1].isspace():
+            groups[-1][1].append(line.strip())
+    result = []
+    for line, continuation in groups:
+        match = _DECL.match(line)
+        names = re.findall(_NAME, match[1])
+        rest = match[2]
+        if rest.startswith("  ") or not rest.strip():
+            hint, description = "", rest.strip()
+        else:
+            parts = re.split(r"\s{2,}", rest.strip(), maxsplit = 1)
+            hint = parts[0]
+            description = parts[1] if len(parts) > 1 else ""
+        description = " ".join([description, *continuation]).strip()
+        if re.search(r"\b(?:removed|no longer supported|no longer available)\b", description, re.I):
+            continue
+        hints = re.findall(r"\[[^]]*\]|\{[^}]*\}|<[^>]*>|\S+", hint)
+        arity = len(hints) if len(hints) <= 2 else -1
+        # Native emits every positive alias before its negative aliases.
+        negatives = []
+        for index, name in enumerate(names):
+            if name.startswith("--no-") and "--" + name[5:] in names:
+                start = index
+                if index > 0 and not names[index - 1].startswith("--"):
+                    start -= 1
+                negatives = names[start:]
+                break
+        env = re.findall(r"\(env:\s*([A-Za-z_][A-Za-z0-9_]*)\)", description)
+        if negatives:
+            env += [
+                e.replace("LLAMA_ARG_", "LLAMA_ARG_NO_", 1)
+                for e in list(env)
+                if e.startswith("LLAMA_ARG_")
+            ]
+        default = re.search(r"\bdefault:\s*([^)]*)", description)
+        default_value = default[1].strip() if default else None
+        if default_value:
+            default_value = default_value.split(",", 1)[0].strip().strip("'\"")
+        descriptor = {
+            "names": names,
+            "env": env,
+            "arity": arity,
+            "default": default_value,
+            "negative_names": negatives,
+        }
+        # Bounded enum hints are stronger evidence than a universal enum registry.
+        if len(hints) == 1 and hints[0][:1] in "[{<" and hints[0][-1:] in "]}>":
+            choices = re.split(r"[|,]", hints[0][1:-1])
+            if (
+                len(choices) > 1
+                and all(re.fullmatch(r"[\w+.-]+", c) for c in choices)
+                and not any(
+                    ".." in c or re.fullmatch(r"[A-Z][A-Z0-9_]*|dev[0-9]+", c) for c in choices
+                )
+            ):
+                descriptor["choices"] = choices
+        # These native convenience presets explicitly change model/port identity.
+        if re.search(r"(?:download weights|model.*from the internet)", description, re.I):
+            descriptor["resource_preset"] = True
+        result.append(descriptor)
+    return tuple(result)
+
+
+@dataclass(frozen = True)
+class _JsonValue:
+    encoded: str
+
+
+def _wire(value):
+    return json.loads(value.encoded) if isinstance(value, _JsonValue) else value
+
+
+@dataclass(frozen = True)
+class CompiledCustomConfig:
+    source: CustomConfigSource
+    argv: tuple[str, ...]
+    digest: str
+    source_digest: str
+    n_parallel: int
+    tuning: tuple[tuple[str, object], ...]
+    request_defaults: tuple[tuple[str, object], ...]
+    diagnostics: tuple[str, ...]
+
+    def summary(self) -> dict:
+        return {
+            "mode": "custom",
+            "section": self.source.section,
+            "digest": self.digest,
+            "tuning": {k: _wire(v) for k, v in self.tuning},
+            "request_defaults": {k: _wire(v) for k, v in self.request_defaults},
+            "diagnostics": list(self.diagnostics),
+        }
+
+
+def _error(section: str, key: str, message: str) -> CustomConfigError:
+    # Keys follow the ASCII grammar; bounded section labels cannot expose values.
+    return CustomConfigError(f"INI section [{section[:80]}], key '{key[:80]}': {message}")
+
+
+def _sections(ini: str) -> dict[str, dict[str, tuple[str, int]]]:
+    sections: dict[str, dict[str, tuple[str, int]]] = {}
+    section = "default"
+    headers = entries = 0
+    for number, raw in enumerate(re.split(r"\r\n|\r|\n", ini), 1):
+        header = re.fullmatch(r"\[[ \t]*([^]]+)\][ \t]*(?:[;#].*)?", raw)
+        if header:
+            # The native section-name capture greedily includes trailing spaces.
+            section = header[1]
+            if len(section) > 512:
+                raise CustomConfigError(f"INI section name is too long at line {number}")
+            headers += 1
+            if headers > MAX_SECTIONS:
+                raise CustomConfigError("INI text exceeds the 128 section limit")
+            sections[section] = {}
+            continue
+        line = re.split(r"[;#]", raw, maxsplit = 1)[0].rstrip(" \t")
+        if not line.strip():
+            continue
+        entry = re.fullmatch(r"([A-Za-z_][A-Za-z0-9_.-]*)[ \t]*=[ \t]*(.*)", line)
+        if not entry:
+            raise CustomConfigError(f"Invalid INI syntax at line {number}")
+        entries += 1
+        if entries > MAX_ENTRIES:
+            raise CustomConfigError("INI text exceeds the 2048 entry limit")
+        sections.setdefault(section, {})[entry[1]] = (entry[2], number)
+    return sections
+
+
+# Canonical names here carry Studio accounting/request semantics, not support.
+# Availability and aliases always come from the selected executable's catalog.
+_INT_FIELDS = {
+    "ctx-size": ("n_ctx", 0),
+    "batch-size": ("n_batch", 1),
+    "ubatch-size": ("n_ubatch", 1),
+    "parallel": ("n_parallel", 1),
+    "n-parallel": ("n_parallel", 1),
+    "threads": ("n_threads", -1),
+    "n-cpu-moe": ("n_cpu_moe", 0),
+    "gpu-layers": ("gpu_layers", -1),
+    "n-gpu-layers": ("gpu_layers", -1),
+    "top-k": ("top_k", -(2**31)),
+    "seed": ("seed", -1),
+    "repeat-last-n": ("repeat_last_n", -1),
+    "predict": ("n_predict", -2),
+    "n-predict": ("n_predict", -2),
+}
+_FLOAT_FIELDS = {
+    "temp": "temperature",
+    "temperature": "temperature",
+    "top-p": "top_p",
+    "min-p": "min_p",
+    "repeat-penalty": "repeat_penalty",
+    "presence-penalty": "presence_penalty",
+    "frequency-penalty": "frequency_penalty",
+    "typical": "typical_p",
+    "typical-p": "typical_p",
+}
+_TUNING_FIELDS = {
+    "cache-type-k": "cache_type_k",
+    "cache-type-v": "cache_type_v",
+    "load-mode": "load_mode",
+    "spec-type": "spec_type",
+    "split-mode": "split_mode",
+}
+_REQUEST = frozenset(
+    {
+        "top_k",
+        "seed",
+        "repeat_last_n",
+        "n_predict",
+        *_FLOAT_FIELDS.values(),
+        "chat_template_kwargs",
+        "reasoning_effort",
+        "chat_template",
+    }
+)
+_RESOURCE_NAMES = frozenset({"--model", "-m", "--mmproj", "-mm"})
+_PARALLEL_NAMES = frozenset({"--parallel", "--n-parallel", "-np"})
+# Alternate model selectors and opaque configuration would introduce a second source.
+_OPAQUE = frozenset(
+    {
+        "--config",
+        "--config-file",
+        "--preset",
+        "--preset-file",
+        "--in-file",
+        "--model-draft",
+        "--spec-draft-model",
+        "-md",
+        "--model-url-draft",
+        "--spec-draft-model-url",
+        "--hf-repo-draft",
+        "--spec-draft-hf-repo",
+        "--hf-file-draft",
+        "--spec-draft-hf-file",
+    }
+)
+
+
+def _typed(name: str, value: str, descriptor: Mapping, section: str, key: str):
+    if name in _INT_FIELDS:
+        field, minimum = _INT_FIELDS[name]
+        if name in {"gpu-layers", "n-gpu-layers"} and value in {"auto", "all"}:
+            return field, value
+        if not re.fullmatch(r"[+-]?[0-9]+", value):
+            raise _error(section, key, "requires a native integer value")
+        number = int(value)
+        maximum = 2**32 - 1 if name == "seed" else 2**31 - 1
+        if number < minimum or number > maximum:
+            raise _error(section, key, "integer is outside the native domain")
+        return field, number
+    if name in _FLOAT_FIELDS:
+        try:
+            number = float(value)
+        except ValueError:
+            raise _error(section, key, "requires a finite numeric value") from None
+        if not math.isfinite(number):
+            raise _error(section, key, "requires a finite numeric value")
+        return _FLOAT_FIELDS[name], number
+    if name == "chat-template-kwargs":
+        try:
+            obj = json.loads(value, parse_constant = lambda _: (_ for _ in ()).throw(ValueError()))
+            if not isinstance(obj, dict):
+                raise ValueError()
+            encoded = json.dumps(
+                obj, sort_keys = True, separators = (",", ":"), ensure_ascii = True, allow_nan = False
+            )
+        except (ValueError, RecursionError):
+            raise _error(section, key, "requires a valid JSON object") from None
+        return "chat_template_kwargs", _JsonValue(encoded)
+    if descriptor.get("choices") and value not in descriptor["choices"]:
+        raise _error(section, key, "value is not supported by the selected executable")
+    return _TUNING_FIELDS.get(name, name.replace("-", "_")), value
+
+
+def _path_identity(path: str, platform: str) -> str:
+    if platform == "win32":
+        # realpath handles junctions when running on Windows; ntpath also supports
+        # platform-specific comparison in host-independent tests.
+        path = os.path.realpath(path) if os.name == "nt" else ntpath.abspath(path)
+        return ntpath.normcase(ntpath.normpath(path))
+    return os.path.realpath(path)
+
+
+def compile_custom_config(
+    source,
+    catalog: Sequence[Mapping],
+    *,
+    model_path: str | None = None,
+    mmproj_path: str | None = None,
+    platform: str | None = None,
+    validate_resources: bool = True,
+) -> CompiledCustomConfig:
+    source = parse_config_source(source)
+    if source is None or source.mode != "custom":
+        raise CustomConfigError("Compilation requires custom mode")
+    platform = platform or sys.platform
+    if not catalog:
+        raise CustomConfigError(
+            "Custom configuration requires a complete successful executable help probe"
+        )
+    lookup: dict[str, tuple[str, Mapping]] = {}
+    descriptors: dict[str, Mapping] = {}
+    for descriptor in catalog:
+        names = descriptor.get("names", [])
+        negative = descriptor.get("negative_names", [])
+        positives = [n for n in names if n not in negative]
+        if not positives or any(not re.fullmatch(_NAME, n) for n in names):
+            raise CustomConfigError("Executable option catalog is malformed; repeat the help probe")
+        canonical = positives[-1]
+        if canonical in descriptors:
+            raise CustomConfigError(
+                "Executable option declarations are ambiguous; repeat the help probe"
+            )
+        descriptors[canonical] = descriptor
+        for spelling in [*(n.lstrip("-") for n in names), *descriptor.get("env", [])]:
+            if spelling in lookup and lookup[spelling][0] != canonical:
+                raise CustomConfigError(
+                    "Executable option aliases are ambiguous; repeat the help probe"
+                )
+            lookup[spelling] = (canonical, descriptor)
+    if not any(_PARALLEL_NAMES.intersection(d["names"]) for d in catalog) or not any(
+        "--model" in d["names"] or "-m" in d["names"] for d in catalog
+    ):
+        raise CustomConfigError(
+            "Executable help probe is incomplete: model and parallel declarations are required"
+        )
+    sections = _sections(source.ini)
+    named = set(sections) - {"*"}
+    if source.section is None and named:
+        raise CustomConfigError("Select an explicit named INI section")
+    if source.section is not None and (source.section == "*" or source.section not in named):
+        raise CustomConfigError("Selected INI section does not exist")
+    selected = ["*"] + ([source.section] if source.section is not None else [])
+    effective = {}
+    diagnostics = []
+    for section in selected:
+        identities = set()
+        for key, (value, line) in sections.get(section, {}).items():
+            if key == "version":
+                if value != "1":
+                    raise _error(section, key, "only preset metadata version 1 is supported")
+                continue
+            if key in {"load-on-startup", "__PRESET_LOAD_ON_STARTUP"}:
+                if value not in _TRUE | _FALSE:
+                    raise _error(section, key, "requires a boolean value")
+                diagnostic = "load-on-startup is router metadata; Studio's explicit Load action controls startup."
+                if diagnostic not in diagnostics:
+                    diagnostics.append(diagnostic)
+                continue
+            if key not in lookup:
+                raise _error(section, key, "unknown or unavailable in the selected executable")
+            canonical, descriptor = lookup[key]
+            if canonical in identities:
+                raise _error(
+                    section, key, "multiple aliases declare the same option in this section"
+                )
+            identities.add(canonical)
+            effective[canonical] = (descriptor, value, section, key)
+    argv: list[str] = []
+    tuning, defaults, normalized = {}, {}, {}
+    resources = {
+        "model": _path_identity(model_path, platform) if model_path else None,
+        "mmproj": _path_identity(mmproj_path, platform) if mmproj_path else None,
+    }
+    n_parallel = None
+    for canonical, (descriptor, value, section, key) in sorted(effective.items()):
+        names = set(descriptor["names"])
+        if names & _RESOURCE_NAMES:
+            resource = "mmproj" if names & {"-mm", "--mmproj"} else "model"
+            if validate_resources:
+                if (
+                    not resources[resource]
+                    or _path_identity(value, platform) != resources[resource]
+                ):
+                    raise _error(
+                        section, key, "must match the model/projector already selected in Studio"
+                    )
+                actual = mmproj_path if resource == "mmproj" else model_path
+                if not os.path.isfile(actual):
+                    raise _error(
+                        section, key, "the selected Studio resource must be an existing file"
+                    )
+            else:
+                diagnostics.append(
+                    f"{resource} identity must be checked against the resolved Studio resource before launch."
+                )
+            continue
+        if names & _PARALLEL_NAMES:
+            _, number = _typed("parallel", value, descriptor, section, key)
+            if not 1 <= number <= 64:
+                raise _error(section, key, "parallel slots must be between 1 and 64")
+            n_parallel = number
+            continue
+        if (
+            any(policy.is_managed_flag(n) for n in names)
+            or names & _OPAQUE
+            or descriptor.get("resource_preset")
+        ):
+            raise _error(
+                section,
+                key,
+                "this option is managed by Studio and cannot be set in custom configuration",
+            )
+        arity = descriptor.get("arity", -1)
+        if arity not in {0, 1}:
+            raise _error(
+                section, key, "option arity is ambiguous or requires unsupported multiple values"
+            )
+        name = canonical.lstrip("-")
+        if arity == 0:
+            if value not in _TRUE | _FALSE:
+                raise _error(
+                    section,
+                    key,
+                    "requires a native boolean value (true/false, on/off, enabled/disabled, 1/0)",
+                )
+            enabled = value in _TRUE
+            negative_names = descriptor.get("negative_names", [])
+            if key in {n.lstrip("-") for n in negative_names}:
+                enabled = not enabled
+            # Native INI negative environment aliases are not negated by parse_bool_arg.
+            if enabled:
+                argv.append(canonical)
+            elif negative_names:
+                argv.append(negative_names[-1])
+            normalized[name] = enabled
+            tuning[name.replace("-", "_")] = enabled
+        else:
+            if not value:
+                raise _error(section, key, "requires a nonempty value")
+            field, typed = _typed(name, value, descriptor, section, key)
+            normalized[name] = _wire(typed)
+            (defaults if field in _REQUEST else tuning)[field] = typed
+            emitted = (
+                typed.encoded
+                if isinstance(typed, _JsonValue)
+                else str(typed)
+                if isinstance(typed, (int, float))
+                else value
+            )
+            argv.extend([canonical, emitted])
+    if n_parallel is None:
+        descriptor = next(d for d in catalog if _PARALLEL_NAMES.intersection(d["names"]))
+        value = descriptor.get("default")
+        if (
+            not isinstance(value, str)
+            or not re.fullmatch(r"[0-9]+", value)
+            or not 1 <= int(value) <= 64
+        ):
+            raise CustomConfigError(
+                "Native parallel default is automatic or unavailable; set np explicitly between 1 and 64"
+            )
+        n_parallel = int(value)
+    tuning["n_parallel"] = n_parallel
+    # Resolve concrete native accounting defaults without putting competing flags
+    # on argv. Model-dependent defaults such as context 0 retain their meaning.
+    for canonical, descriptor in descriptors.items():
+        name = canonical.lstrip("-")
+        field = _INT_FIELDS.get(name, (None,))[0] or _TUNING_FIELDS.get(name)
+        default = descriptor.get("default")
+        if field and field not in tuning and field not in defaults and default is not None:
+            try:
+                resolved_field, typed = _typed(name, default, descriptor, "*", name)
+            except CustomConfigError:
+                continue
+            if resolved_field not in _REQUEST:
+                tuning[resolved_field] = typed
+    if "split_mode" in tuning:
+        tuning["tensor_parallel"] = tuning["split_mode"] == "tensor"
+    # The shared policy's shape/Windows limits apply after alias reconciliation.
+    # Avoid its legacy GPU parser for the native 'auto'/'all' spellings.
+    total = sum(len(token.encode("utf-8")) for token in argv)
+    limit = (
+        policy.MAX_EXTRA_ARGS_BYTES_WINDOWS if platform == "win32" else policy.MAX_EXTRA_ARGS_BYTES
+    )
+    if len(argv) > policy.MAX_EXTRA_ARG_TOKENS or total > limit:
+        raise CustomConfigError(
+            "Compiled custom arguments exceed the supported argument size limit"
+        )
+    if (
+        platform == "win32"
+        and policy.windows_command_length(argv)
+        > policy.WINDOWS_COMMAND_LIMIT - policy.WINDOWS_COMMAND_RESERVE
+    ):
+        raise CustomConfigError(
+            "Compiled custom arguments exceed the Windows command line limit after quoting"
+        )
+    identity = {
+        "normalization_version": NORMALIZATION_VERSION,
+        "section": source.section,
+        "options": normalized,
+        "resources": resources,
+        "n_parallel": n_parallel,
+        "tuning": {k: _wire(v) for k, v in tuning.items()},
+        "request_defaults": {k: _wire(v) for k, v in defaults.items()},
+    }
+    digest = hashlib.sha256(
+        json.dumps(
+            identity, sort_keys = True, separators = (",", ":"), ensure_ascii = True, allow_nan = False
+        ).encode()
+    ).hexdigest()
+    return CompiledCustomConfig(
+        source,
+        tuple(argv),
+        digest,
+        hashlib.sha256(source.ini.encode("utf-8")).hexdigest(),
+        n_parallel,
+        tuple(sorted(tuning.items())),
+        tuple(sorted(defaults.items())),
+        tuple(diagnostics),
+    )

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -1544,6 +1544,13 @@ class ResearchSupervisor:
             )
         if inference.get("topP") is not None:
             payload["top_p"] = inference["topP"]
+        if "samplingFieldsExplicit" in inference and not inference.get("providerType"):
+            fields = list(inference["samplingFieldsExplicit"])
+            if enable_thinking is not None:
+                fields.append("enable_thinking")
+                if enable_thinking is False:
+                    fields.append("reasoning_effort")
+            payload["sampling_fields_explicit"] = list(dict.fromkeys(fields))
         if enable_thinking is not None:
             payload["enable_thinking"] = enable_thinking
         elif inference.get("enableThinking") is not None:

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -31,9 +31,10 @@ from core.inference.llama_server_args import (
 from core.inference.runtime_context import MAX_REQUESTABLE_CONTEXT
 from core.inference.video_families import MAX_VIDEO_NUM_FRAMES
 from picker.schemas import MAX_CHAT_TEMPLATE_BYTES
+from models.llama_custom_config import LlamaCppConfigFields
 
 
-class LoadRequest(BaseModel):
+class LoadRequest(LlamaCppConfigFields):
     """Request to load a model for inference"""
 
     model_path: str = Field(..., description = "Model identifier or local path")
@@ -437,7 +438,7 @@ class SttLoadRequest(BaseModel):
     )
 
 
-class ValidateModelRequest(BaseModel):
+class ValidateModelRequest(LlamaCppConfigFields):
     """Check whether an identifier resolves to a ModelConfig; does NOT load weights."""
 
     model_path: str = Field(..., description = "Model identifier or local path")
@@ -691,6 +692,7 @@ class ValidateModelResponse(BaseModel):
     """
 
     valid: bool = Field(..., description = "Whether the model identifier looks valid")
+    llama_cpp_config_summary: Optional[Dict[str, Any]] = None
     message: str = Field(..., description = "Human-readable validation message")
     identifier: Optional[str] = Field(None, description = "Resolved model identifier")
     display_name: Optional[str] = Field(None, description = "Display name derived from identifier")
@@ -750,7 +752,7 @@ class ValidateModelResponse(BaseModel):
     )
 
 
-class EstimateMemoryRequest(BaseModel):
+class EstimateMemoryRequest(LlamaCppConfigFields):
     """Settings a Load-Model panel is about to submit, priced before it submits them.
 
     Every field mirrors the load request it previews, so the estimate answers for the
@@ -1067,6 +1069,9 @@ class GenerateRequest(BaseModel):
 
 class _InferenceRuntimeFields(BaseModel):
     """Runtime fields shared by load and status responses."""
+
+    requested_llama_cpp_config: Optional[Dict[str, Any]] = None
+    llama_cpp_config_summary: Optional[Dict[str, Any]] = None
 
     is_vision: bool = Field(False, description = "Whether model is a vision model")
     is_diffusion: bool = Field(
@@ -1975,6 +1980,13 @@ class ChatCompletionRequest(BaseModel):
 
     Non-OpenAI extension fields are marked with 'x-unsloth'.
     """
+
+    chat_template_kwargs: Optional[Dict[str, Any]] = None
+    sampling_fields_explicit: Optional[List[str]] = Field(
+        None,
+        max_length = 16,
+        description = "Studio fields explicitly edited by the caller; omitted for ordinary API clients.",
+    )
 
     # Accept unknown fields so future OpenAI fields aren't dropped before route
     # code runs. Mirrors AnthropicMessagesRequest and ResponsesRequest.

--- a/studio/backend/models/llama_custom_config.py
+++ b/studio/backend/models/llama_custom_config.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Shared wire fields for a selected model's llama.cpp configuration."""
+
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class LlamaCppConfigFields(BaseModel):
+    llama_cpp_config: Optional[dict[str, Any]] = Field(
+        None,
+        description = "Versioned per-model INI configuration, or an explicit managed-mode reset.",
+    )
+
+    @field_validator("llama_cpp_config", mode = "before")
+    @classmethod
+    def validate_llama_cpp_config(cls, value):
+        if value is None:
+            return None
+        from core.inference.llama_custom_config import parse_config_source
+        return parse_config_source(value).to_wire()

--- a/studio/backend/routes/chat_history.py
+++ b/studio/backend/routes/chat_history.py
@@ -151,6 +151,7 @@ class ChatThreadSettings(BaseModel):
     topK: Optional[int] = Field(default = None, ge = -1, le = 100)
     minP: Optional[float] = Field(default = None, ge = 0, le = 1)
     repetitionPenalty: Optional[float] = Field(default = None, ge = 1, le = 2)
+    samplingFieldsExplicit: Optional[list[str]] = Field(default = None, max_length = 16)
     presencePenalty: Optional[float] = Field(default = None, ge = 0, le = 2)
     seed: SamplingSeed = None
     # Not length-capped, like the installation-wide copy: truncating here would
@@ -384,6 +385,7 @@ class ChatInferenceSettings(BaseModel):
     topK: Optional[float] = None
     minP: Optional[float] = None
     repetitionPenalty: Optional[float] = None
+    samplingFieldsExplicit: Optional[list[str]] = Field(default = None, max_length = 16)
     presencePenalty: Optional[float] = None
     maxSeqLength: Optional[float] = None
     maxTokens: Optional[float] = None

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -14867,6 +14867,17 @@ async def _load_model_impl(
                 request.speculative_type,
             )
         )
+        if custom_compiled is not None:
+            # Custom mode ignores managed placement, including a saved CPU-only
+            # choice. Only explicit native CPU placement can skip the handoff.
+            chat_load_needs_gpu = not (
+                custom_compiled.explicit_cpu_only
+                and not (
+                    _load_keeps_a_projector(config, disable_vision = request.disable_vision)
+                    if config.is_vision
+                    else bool(getattr(config, "gguf_mmproj_file", None))
+                )
+            )
         # Ahead of the arbiter: acquire_for evicts a resident Images/Video pipeline and the
         # confirmation below cancels the running generations, both before load_model's own
         # copy of this check runs. A header-sized read spares them. Fails open into that copy.
@@ -15070,13 +15081,18 @@ async def _load_model_impl(
             # loading; the response reports the backend's actual tensor_parallel
             # state so the UI toggle reflects the fallback.
             try:
-                success = await load_with_tensor_fallback(
-                    _attempt_gguf_load,
-                    requested_tensor = request.tensor_parallel,
-                    extra_args = extra_llama_args,
-                    label = config.identifier,
-                    cancelled = lambda: _gguf_load_cancelled(llama_backend, load_cancel_event),
-                )
+                if custom_compiled is not None:
+                    success = await _run_gguf_load_attempt(
+                        llama_backend, load_intent, load_cancel_event
+                    )
+                else:
+                    success = await load_with_tensor_fallback(
+                        _attempt_gguf_load,
+                        requested_tensor = request.tensor_parallel,
+                        extra_args = extra_llama_args,
+                        label = config.identifier,
+                        cancelled = lambda: _gguf_load_cancelled(llama_backend, load_cancel_event),
+                    )
             except Exception:
                 # A GGUF load can raise before tearing down the old llama-server (e.g. an
                 # update-in-progress guard fires before _kill_process), leaving the prior

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -6833,6 +6833,8 @@ def _llama_runtime_fields(llama_backend: LlamaCppBackend) -> dict:
         # running with no extras would come back carrying the arguments of the load
         # that just failed. None stays for "nothing was ever set", which is the only
         # case where inheriting is the right answer.
+        requested_llama_cpp_config = getattr(llama_backend, "requested_llama_cpp_config", None),
+        llama_cpp_config_summary = getattr(llama_backend, "llama_cpp_config_summary", None),
         requested_llama_extra_args = (
             None
             if llama_backend.is_diffusion
@@ -12814,6 +12816,8 @@ async def _prepare_load_placement(
     request: LoadRequest | ValidateModelRequest,
     extra_args: Optional[list[str]],
 ) -> _LoadPlacement:
+    if _custom_llama_config(request):
+        return _LoadPlacement(None, None, False, _classify_diffusion_gguf(config))
     requested = request.gpu_ids or None
     if not config.is_gguf:
         return _LoadPlacement(requested, None, False, False)
@@ -13198,6 +13202,12 @@ def _guard_chat_load_against_training(
             )
         return
 
+    if _custom_llama_config(request):
+        raise HTTPException(
+            status_code = 409,
+            detail = "Custom llama.cpp placement cannot be verified beside active training. Stop training before loading this configuration.",
+        )
+
     from core.inference.llama_cpp import _diffusion_manual_ngl, _scale_diffusion_required_gb
 
     is_gguf = bool(getattr(config, "is_gguf", False))
@@ -13415,6 +13425,86 @@ def _guard_chat_load_against_training(
     raise HTTPException(status_code = 409, detail = detail)
 
 
+def _custom_llama_config(request) -> bool:
+    source = getattr(request, "llama_cpp_config", None)
+    return isinstance(source, dict) and source.get("mode") == "custom"
+
+
+def _resolve_llama_cpp_config(
+    request,
+    config = None,
+    model_identifier = None,
+):
+    """Resolve one source without combining configuration from different model rows."""
+    from core.inference.llama_custom_config import parse_config_source
+    from utils.openai_auto_switch_settings import resolve_override_for_load
+
+    source = getattr(request, "llama_cpp_config", None)
+    identifier = model_identifier or request.model_path
+    variant = getattr(request, "gguf_variant", None) or getattr(config, "gguf_variant", None)
+    if source is None:
+        _, override = resolve_override_for_load(
+            identifier, getattr(config, "identifier", None), variant
+        )
+        source = override.get("llama_cpp_config")
+    if source is None:
+        resident = get_llama_cpp_backend()
+        intent = getattr(resident, "last_load_intent", None)
+        if (
+            intent is not None
+            and _same_loaded_identifier(getattr(intent, "model_identifier", None), identifier)
+            and (getattr(intent, "hf_variant", None) or "").casefold() == (variant or "").casefold()
+        ):
+            source = getattr(intent, "llama_cpp_config", None)
+    if source is None:
+        return request
+    source = parse_config_source(source)
+    return request.model_copy(update = {"llama_cpp_config": source.to_wire()})
+
+
+async def _preflight_custom_llama_config(
+    request,
+    config,
+    *,
+    native_grant_backed = False,
+):
+    """Validate custom intent before any backend or GPU owner can be evicted."""
+    if not _custom_llama_config(request):
+        return None
+    if not config.is_gguf:
+        raise HTTPException(
+            status_code = 400, detail = "Custom llama.cpp configuration requires a GGUF model."
+        )
+    if _classify_diffusion_gguf(config) is True:
+        raise HTTPException(
+            status_code = 400,
+            detail = "Custom llama.cpp configuration cannot launch a diffusion model.",
+        )
+    model_path = getattr(config, "gguf_file", None)
+    mmproj_path = getattr(config, "gguf_mmproj_file", None)
+    if native_grant_backed and mmproj_path:
+        _validate_native_gguf_companion(mmproj_path, model_path, "vision companion")
+    intent = GgufLoadIntent(
+        model_identifier = _public_model_identifier(request.model_path, config.identifier),
+        gguf_path = model_path,
+        mmproj_path = mmproj_path,
+        hf_repo = getattr(config, "gguf_hf_repo", None),
+        hf_variant = getattr(config, "gguf_variant", None),
+        hf_token = request.hf_token,
+        is_vision = getattr(config, "is_vision", False),
+        disable_vision = getattr(request, "disable_vision", False),
+        llama_cpp_config = request.llama_cpp_config,
+    )
+    try:
+        return await asyncio.to_thread(
+            get_llama_cpp_backend().prepare_custom_config,
+            intent,
+            validate_resources = bool(model_path),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code = 400, detail = redact_native_paths(str(exc))) from exc
+
+
 def _resolve_inherited_extra_args(
     request,
     config: ModelConfig,
@@ -13425,6 +13515,8 @@ def _resolve_inherited_extra_args(
     """Effective pass-through extras for a GGUF request that omitted the field:
     the previous same-model load's extras, shadow-stripped, so a settings-Apply
     reload (which does not round-trip the extras field) keeps them (#5401)."""
+    if _custom_llama_config(request):
+        return []
     if getattr(request, "llama_extra_args", None) is not None:
         return extra_llama_args
     if not getattr(config, "is_gguf", False):
@@ -14272,10 +14364,13 @@ async def _load_model_impl(
     model_log_label = request.model_path
     gguf_load_stack = ExitStack()
     try:
+        request = _resolve_llama_cpp_config(request)
         # Validate user pass-through args up front so a managed-flag collision
         # returns 400 before any model work.
         try:
-            extra_llama_args = validate_extra_args(request.llama_extra_args)
+            extra_llama_args = validate_extra_args(
+                [] if _custom_llama_config(request) else request.llama_extra_args
+            )
         except ValueError as exc:
             # Keep the curated validation message (names the flag); just strip paths.
             logger.warning("inference.validate_extra_args_failed: %s", exc)
@@ -14413,7 +14508,12 @@ async def _load_model_impl(
             )
 
         is_direct_gguf_request = model_identifier.lower().endswith(".gguf")
-        if llama_backend.is_loaded and (request.gguf_variant or is_direct_gguf_request):
+        if (
+            llama_backend.is_loaded
+            and (request.gguf_variant or is_direct_gguf_request)
+            and getattr(request, "llama_cpp_config", None) is None
+            and getattr(llama_backend, "requested_llama_cpp_config", None) is None
+        ):
             reused = _reuse_loaded_gguf(
                 _active_gguf_intent(
                     request,
@@ -14431,7 +14531,9 @@ async def _load_model_impl(
                 if not llama_backend.holds_no_vram:
                     await asyncio.to_thread(acquire_for, CHAT)
                 return reused
-        if not (request.gguf_variant or is_direct_gguf_request):
+        if not (request.gguf_variant or is_direct_gguf_request) and not _custom_llama_config(
+            request
+        ):
             if (
                 _same_loaded_identifier(backend.active_model_name, model_identifier)
                 and _mlx_runtime_settings_match(backend, request)
@@ -14536,6 +14638,14 @@ async def _load_model_impl(
                 status_code = 400,
                 detail = f"Invalid model identifier: {model_log_label}",
             )
+
+        request = _resolve_llama_cpp_config(request, config, public_model_identifier)
+        custom_compiled = await _preflight_custom_llama_config(
+            request, config, native_grant_backed = native_grant_backed
+        )
+        if custom_compiled is not None:
+            _n_parallel = custom_compiled.n_parallel
+            effective_chat_template_override = None
 
         # Resolve inherited extras once before command-dependent preflights.
         extra_llama_args = _resolve_inherited_extra_args(
@@ -15535,6 +15645,13 @@ async def validate_model(
                 detail = f"Invalid model identifier: {model_log_label}",
             )
 
+        request = _resolve_llama_cpp_config(
+            request, config, _public_model_identifier(request.model_path, model_identifier)
+        )
+        custom_compiled = await _preflight_custom_llama_config(
+            request, config, native_grant_backed = native_grant_backed
+        )
+
         # The caller's own list when it sent one, or the resolver hands back this
         # fourth argument unchanged and a --ctx-size the load is about to use would
         # be missing from the estimate that approves it.
@@ -15809,6 +15926,9 @@ async def validate_model(
 
         return ValidateModelResponse(
             valid = True,
+            llama_cpp_config_summary = custom_compiled.summary()
+            if custom_compiled is not None
+            else None,
             message = "Model identifier is valid.",
             identifier = model_log_label if native_grant_backed else config.identifier,
             display_name = model_log_label
@@ -16442,6 +16562,10 @@ async def estimate_memory(
     from core.inference.llama_cpp import _args_place_tensors_on_cpu
     from core.inference.llama_server_args import _effective_tensor_parallel
 
+    request = _resolve_llama_cpp_config(request)
+    if _custom_llama_config(request):
+        # Managed memory estimates include policies that strict mode does not apply.
+        return EstimateMemoryResponse(available = False, reason = "unsizable")
     if is_ollama_manifest_ref(request.model_path):
         # Resolving one writes a .gguf link to disk; that belongs to the load path.
         return EstimateMemoryResponse(available = False, reason = "unsupported_source")
@@ -21427,6 +21551,19 @@ async def delete_openai_container(
         await client.close()
 
 
+def _custom_request_defaults(model_id) -> dict:
+    backend = get_llama_cpp_backend()
+    summary = getattr(backend, "llama_cpp_config_summary", None)
+    if not isinstance(summary, dict) or not _same_loaded_identifier(
+        getattr(backend, "model_identifier", None), model_id
+    ):
+        return {}
+    defaults = dict(summary.get("request_defaults") or {})
+    if "repeat_penalty" in defaults:
+        defaults["repetition_penalty"] = defaults.pop("repeat_penalty")
+    return defaults
+
+
 def _fill_recommended_sampling_openai(payload, model_id) -> None:
     """Apply per-model recommended sampling (and any operator UNSLOTH_SAMPLING_* pin) to a
     ChatCompletionRequest in place.
@@ -21438,13 +21575,34 @@ def _fill_recommended_sampling_openai(payload, model_id) -> None:
     """
     from utils.inference.inference_config import resolve_effective_sampling, SAMPLING_FIELD_NAMES
 
-    explicit = {
-        f: (getattr(payload, f) if f in payload.model_fields_set else None)
-        for f in SAMPLING_FIELD_NAMES
-    }
-    effective = resolve_effective_sampling(model_id, explicit)
+    preset = _custom_request_defaults(model_id)
+    fields = getattr(payload, "_sampling_original_fields", None)
+    if fields is None:
+        fields = frozenset(payload.model_fields_set)
+        hint = getattr(payload, "sampling_fields_explicit", None)
+        if preset and hint is not None:
+            provenance_fields = frozenset(
+                (
+                    *SAMPLING_FIELD_NAMES,
+                    "frequency_penalty",
+                    "enable_thinking",
+                    "reasoning_effort",
+                    "preserve_thinking",
+                )
+            )
+            fields = (fields - provenance_fields) | fields.intersection(hint)
+        object.__setattr__(payload, "_sampling_original_fields", fields)
+    explicit = {f: (getattr(payload, f) if f in fields else None) for f in SAMPLING_FIELD_NAMES}
+    effective = resolve_effective_sampling(model_id, explicit, preset_defaults = preset)
     for field, value in effective.items():
         setattr(payload, field, value)
+    if preset:
+        for field in ("frequency_penalty", "seed"):
+            if field not in fields and field in preset:
+                setattr(payload, field, preset[field])
+        for field in ("enable_thinking", "reasoning_effort", "preserve_thinking"):
+            if field not in fields:
+                setattr(payload, field, None)
 
 
 # /v1/completions is proxied to llama-server verbatim; its repetition knob is "repeat_penalty",
@@ -21467,9 +21625,19 @@ def _fill_recommended_sampling_completions(body: dict, model_id) -> None:
     from utils.inference.inference_config import resolve_effective_sampling, SAMPLING_FIELD_NAMES
 
     explicit = {f: body.get(_COMPLETIONS_SAMPLING_BODY_KEY.get(f, f)) for f in SAMPLING_FIELD_NAMES}
-    effective = resolve_effective_sampling(model_id, explicit, fill_defaults = False)
+    preset = _custom_request_defaults(model_id)
+    effective = resolve_effective_sampling(
+        model_id, explicit, fill_defaults = False, preset_defaults = preset
+    )
     for field, value in effective.items():
         body[_COMPLETIONS_SAMPLING_BODY_KEY.get(field, field)] = value
+    for field, value in preset.items():
+        if field == "repetition_penalty":
+            continue
+        if field == "chat_template_kwargs":
+            body[field] = {**value, **(body.get(field) or {})}
+        else:
+            body.setdefault(field, value)
 
 
 class _DisconnectPolicyRequest:
@@ -22809,6 +22977,7 @@ async def produce_openai_chat_completions(
 
             def gguf_generate_with_tools():
                 return llama_backend.generate_chat_completion_with_tools(
+                    request_template_kwargs = payload.chat_template_kwargs,
                     messages = gguf_messages,
                     tools = tools_to_use,
                     temperature = payload.temperature,
@@ -23571,6 +23740,7 @@ async def produce_openai_chat_completions(
         def gguf_generate(choice_index: int = 0):
             _seed = _choice_seed(payload.seed, choice_index, negative_is_random = True)
             return llama_backend.generate_chat_completion(
+                request_template_kwargs = payload.chat_template_kwargs,
                 messages = gguf_messages,
                 image_b64 = image_b64,
                 temperature = payload.temperature,
@@ -33613,6 +33783,11 @@ def _build_openai_passthrough_body(
             payload.enable_thinking,
             payload.reasoning_effort,
             payload.preserve_thinking,
+            **(
+                {"request_template_kwargs": payload.chat_template_kwargs}
+                if payload.chat_template_kwargs is not None
+                else {}
+            ),
         )
         if llama_backend is not None
         else None

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -14364,6 +14364,7 @@ async def _load_model_impl(
     model_log_label = request.model_path
     gguf_load_stack = ExitStack()
     try:
+        requested_llama_cpp_config = request.llama_cpp_config
         request = _resolve_llama_cpp_config(request)
         # Validate user pass-through args up front so a managed-flag collision
         # returns 400 before any model work.
@@ -14639,7 +14640,17 @@ async def _load_model_impl(
                 detail = f"Invalid model identifier: {model_log_label}",
             )
 
-        request = _resolve_llama_cpp_config(request, config, public_model_identifier)
+        request = _resolve_llama_cpp_config(
+            request.model_copy(update = {"llama_cpp_config": requested_llama_cpp_config}),
+            config,
+            public_model_identifier,
+        )
+        try:
+            extra_llama_args = validate_extra_args(
+                [] if _custom_llama_config(request) else request.llama_extra_args
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code = 400, detail = redact_native_paths(str(exc))) from exc
         custom_compiled = await _preflight_custom_llama_config(
             request, config, native_grant_backed = native_grant_backed
         )
@@ -21613,6 +21624,14 @@ def _fill_recommended_sampling_openai(payload, model_id) -> None:
     for field, value in effective.items():
         setattr(payload, field, value)
     if preset:
+        predict = preset.get("n_predict")
+        if (
+            payload.max_tokens is None
+            and payload.max_completion_tokens is None
+            and isinstance(predict, int)
+            and predict >= 0
+        ):
+            payload.max_tokens = predict
         for field in ("frequency_penalty", "seed"):
             if field not in fields and field in preset:
                 setattr(payload, field, preset[field])

--- a/studio/backend/routes/research_runs.py
+++ b/studio/backend/routes/research_runs.py
@@ -221,6 +221,7 @@ def _sanitize_config(
         "maxOutputTokensPublished",
         "enableThinking",
         "reasoningEffort",
+        "samplingFieldsExplicit",
     }
     unknown = set(request) - allowed
     if unknown:
@@ -262,10 +263,36 @@ def _sanitize_config(
             )
         request["providerType"] = saved_provider_type
 
-    # Mirrors the ragScope guard below. Every allowed field is a scalar, but "model" is stringified, so
+    if "samplingFieldsExplicit" in request:
+        fields = request["samplingFieldsExplicit"]
+        sampling_fields = {
+            "temperature",
+            "top_p",
+            "top_k",
+            "min_p",
+            "repetition_penalty",
+            "presence_penalty",
+            "frequency_penalty",
+            "enable_thinking",
+            "reasoning_effort",
+            "preserve_thinking",
+        }
+        if (
+            not isinstance(fields, list)
+            or len(fields) > 16
+            or any(not isinstance(field, str) or field not in sampling_fields for field in fields)
+        ):
+            raise HTTPException(status_code = 400, detail = "Invalid samplingFieldsExplicit")
+        request["samplingFieldsExplicit"] = list(dict.fromkeys(fields))
+
+    # Mirrors the ragScope guard below. Other allowed fields are scalars, but "model" is stringified, so
     # {"auth": "sk-..."} would slip past the sensitive-key scan (inner key unlisted) into the durable config as the
     # model id.
-    if any(isinstance(value, (dict, list, tuple)) for value in request.values()):
+    if any(
+        isinstance(value, (dict, list, tuple))
+        for key, value in request.items()
+        if key != "samplingFieldsExplicit"
+    ):
         raise HTTPException(status_code = 400, detail = "Invalid inferenceRequest value")
     model = str(request.get("model") or thread.get("modelId") or "").strip()
     if not model:

--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -38,6 +38,7 @@ from core.rag.config import (
     effective_gguf_repo_for_embedding_model,
 )
 from loggers import get_logger
+from models.llama_custom_config import LlamaCppConfigFields
 from utils.utils import safe_error_detail, log_and_http_error
 from utils.personalization_settings import (
     MAX_AVATAR_DATA_URL_BYTES,
@@ -759,7 +760,7 @@ MAX_GGUF_VARIANT_KEY_LEN = 4096
 MAX_GPU_IDS = MAX_GPU_ID + 1
 
 
-class ModelOverridePayload(BaseModel):
+class ModelOverridePayload(LlamaCppConfigFields):
     """One model's saved launch config, applied when the API loads that model.
 
     Everything past ``model_id`` is optional and omitted means "app default", so a
@@ -1695,6 +1696,22 @@ def update_openai_auto_switch_override(
                         _kept_tuning[name] = _stored_tuning.get(name)
                 break
         removed_keys: list[str] = []
+        kept_custom_config = payload.llama_cpp_config
+        if kept_custom_config is None and not is_removal:
+            config_ids = [payload.model_id]
+            for candidate in (
+                _bare_model_id(payload.model_id),
+                _legacy_standalone_gguf_key(payload.model_id),
+                *cached_repo_alias_keys(payload.model_id),
+            ):
+                if candidate and candidate not in config_ids:
+                    config_ids.append(candidate)
+            config_ids.sort(key = lambda key: not is_cache_load_path_key(key))
+            for config_id in config_ids:
+                stored_config = get_model_override(config_id)
+                if stored_config:
+                    kept_custom_config = stored_config.get("llama_cpp_config")
+                    break
         if payload.remove is True:
             # An explicit remove wins over any other field. Remove the key a load resolves to, not the literal one sent
             # (the browser normalizes casing), and every spelling: clearing one of two leaves the survivor as the sole
@@ -1748,6 +1765,7 @@ def update_openai_auto_switch_override(
             set_model_override(
                 target_id,
                 llama_extra_args = extra_args,
+                llama_cpp_config = kept_custom_config,
                 keep_empty_extra_args = keep_empty,
                 max_seq_length = payload.max_seq_length,
                 custom_context_length = payload.custom_context_length,

--- a/studio/backend/tests/test_llama_admission_compat_matrix.py
+++ b/studio/backend/tests/test_llama_admission_compat_matrix.py
@@ -235,8 +235,8 @@ class TestOldCallers:
             inspect.signature(LlamaCppBackend.generate_chat_completion_with_tools).parameters
         )
         assert (
-            names[-1] == "on_conversation_grew"
-        ), f"the hook must be last; signature ends {names[-3:]}"
+            names.index("on_conversation_grew") == names.index("tool_choice") + 1
+        ), "the hook must retain its original positional slot after tool_choice"
 
     def test_the_wait_timeout_has_a_sane_default(self):
         import inspect

--- a/studio/backend/tests/test_llama_cpp_mtp_detection.py
+++ b/studio/backend/tests/test_llama_cpp_mtp_detection.py
@@ -2826,7 +2826,7 @@ def test_diffusion_load_clears_the_previous_models_spec_fallback():
     src = inspect.getsource(LlamaCppBackend.load_model)
     diffusion = src.find("if self._is_diffusion:")
     assert diffusion != -1
-    start = src.find("return self._start_diffusion_server", diffusion)
+    start = src.find("started = self._start_diffusion_server", diffusion)
     assert start != -1
     assert "self._spec_fallback_reason = None" in src[diffusion:start]
     assert "self._spec_drafter_kind = None" in src[diffusion:start]
@@ -3223,6 +3223,30 @@ def test_a_slot_clamp_from_an_inconclusive_probe_is_also_retried(monkeypatch):
     assert _matches(clamped, n_parallel = 4, **_same_settings_apply()) is False
 
 
+def _diffusion_return_lines(load_model):
+    assignments = [
+        node
+        for node in ast.walk(load_model)
+        if isinstance(node, ast.Assign)
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Attribute)
+        and node.value.func.attr == "_start_diffusion_server"
+    ]
+    assert len(assignments) == 1
+    target = assignments[0].targets[0]
+    assert isinstance(target, ast.Name)
+    returns = [
+        node.lineno
+        for node in ast.walk(load_model)
+        if isinstance(node, ast.Return)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == target.id
+        and node.lineno > assignments[0].lineno
+    ]
+    assert len(returns) == 1, "diffusion must return its launch result"
+    return returns
+
+
 def test_the_probe_marker_is_committed_only_once_the_runtime_is_replaced():
     """The marker describes the RUNNING runtime, so load_model must not write it before
     the launch is committed.
@@ -3252,14 +3276,7 @@ def test_the_probe_marker_is_committed_only_once_the_runtime_is_replaced():
     ]
     assert len(writes) == 1, f"expected one commit-point write, found {len(writes)}"
 
-    diffusion_returns = [
-        node.lineno
-        for node in ast.walk(load_model)
-        if isinstance(node, ast.Return)
-        and isinstance(node.value, ast.Call)
-        and isinstance(node.value.func, ast.Attribute)
-        and node.value.func.attr == "_start_diffusion_server"
-    ]
+    diffusion_returns = _diffusion_return_lines(load_model)
     assert diffusion_returns, "the diffusion early return moved; re-pin this test"
     assert writes[0] > max(diffusion_returns), (
         "the marker is written before the diffusion early return, so a diffusion runner "
@@ -3311,14 +3328,7 @@ def test_a_diffusion_load_never_pays_for_the_capability_probe():
             or (isinstance(node.func, ast.Name) and node.func.id == "_launch_caps")
         )
     ]
-    diffusion_return = max(
-        node.lineno
-        for node in ast.walk(load_model)
-        if isinstance(node, ast.Return)
-        and isinstance(node.value, ast.Call)
-        and isinstance(node.value.func, ast.Attribute)
-        and node.value.func.attr == "_start_diffusion_server"
-    )
+    diffusion_return = max(_diffusion_return_lines(load_model))
     # The probes that legitimately sit above the diffusion return are the pre-existing
     # ones, and every one of them is guarded by the feature that needs it (the
     # --kv-unified clamp behind n_parallel > 1, the DSpark lookup behind its own request),

--- a/studio/backend/tests/test_llama_custom_config.py
+++ b/studio/backend/tests/test_llama_custom_config.py
@@ -1,0 +1,441 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+from dataclasses import FrozenInstanceError
+import json
+
+import pytest
+
+from core.inference.llama_custom_config import (
+    CustomConfigError,
+    CustomConfigSource,
+    compile_custom_config,
+    parse_config_source,
+    parse_option_catalog,
+)
+
+
+# Native help's alias padding, wrapped declaration, description/default/env lines.
+HELP = """----- common params -----
+-m,    --model FNAME                    model file
+                                        (env: LLAMA_ARG_MODEL)
+-mm,   --mmproj FILE                    projector file
+                                        (env: LLAMA_ARG_MMPROJ)
+-np,   --parallel N                     number of server slots (default: 1)
+                                        (env: LLAMA_ARG_N_PARALLEL)
+-c,    --ctx-size N                     context (default: 0, 0 = loaded from model)
+                                        (env: LLAMA_ARG_CTX_SIZE)
+-b,    --batch-size N                   logical batch (default: 2048)
+-ub,   --ubatch-size N                  physical batch (default: 512)
+-t,    --threads N                      CPU threads (default: -1)
+-ngl,  --gpu-layers, --n-gpu-layers N   layers (default: auto)
+                                        (env: LLAMA_ARG_N_GPU_LAYERS)
+-ncmoe, --n-cpu-moe N                   CPU expert layers
+-ctk,  --cache-type-k TYPE              cache (default: f16)
+-ctv,  --cache-type-v TYPE              cache (default: f16)
+-fit,  --fit [on|off]                   fit ('on' or 'off', default: 'on')
+--temp N                                temperature (default: 0.8)
+--top-k N                               top k (default: 40)
+--top-p N                               top p (default: 0.95)
+--min-p N                               min p (default: 0.05)
+--repeat-penalty N                      repeat penalty
+--presence-penalty N                    presence penalty
+--frequency-penalty N                   frequency penalty
+--seed N                                seed
+--chat-template-kwargs STRING          template kwargs
+--reasoning-effort STRING              reasoning effort
+--mmproj-offload, --no-mmproj-offload
+                                        offload projector (default: true)
+                                        (env: LLAMA_ARG_MMPROJ_OFFLOAD)
+-kvo,  --kv-offload, -nkvo, --no-kv-offload
+                                        offload KV (default: true)
+                                        (env: LLAMA_ARG_KV_OFFLOAD)
+--no-warmup                             skip warmup
+--mlock                                 lock model
+-sm,   --split-mode {none,layer,row,tensor}
+                                        splitting (default: layer)
+--load-mode MODE                        loading (default: auto)
+--spec-default                          enable default speculative decoding config
+--host HOST                             binding
+                                        (env: LLAMA_ARG_HOST)
+--port PORT                             port
+--api-key KEY                           API key
+                                        (env: LLAMA_API_KEY)
+-ag,   --agent, -no-ag, --no-agent       tools
+                                        (env: LLAMA_ARG_AGENT)
+--models-preset FILE                    router preset
+--config FILE                           system configuration
+--model-draft FILE                     draft model
+--gpt-oss-120b-default                  use gpt-oss-120b (note: can download weights from the internet)
+--control-vector-layer-range START END
+                                        control vector layers
+--old-option N                          option removed; use --fit
+--json-schema STRING                    arbitrary supported one-value option
+"""
+
+
+@pytest.fixture
+def catalog():
+    return parse_option_catalog(HELP)
+
+
+def source(ini, section = None):
+    return {"version": 1, "mode": "custom", "ini": ini, "section": section}
+
+
+def compile_ini(
+    ini,
+    catalog,
+    section = None,
+    **kwargs,
+):
+    return compile_custom_config(source(ini, section), catalog, **kwargs)
+
+
+def test_reporter_selected_section_owns_context_json_and_resources(catalog, tmp_path):
+    model, projector = tmp_path / "model with spaces.gguf", tmp_path / "mmproj.gguf"
+    model.touch()
+    projector.touch()
+    ini = f"""[*]
+version = 1
+c = 128000
+np = 2
+chat-template-kwargs = {{"global": true}}
+[free-27B-Q3.8]
+m = {model}
+mm = {projector}
+ctx-size = 56000
+np = 1 # one slot
+b = 1024 ; batch comment
+ub = 256
+fit = off
+ngl = -1
+mmproj-offload = false
+no-warmup = true
+min-p = 0.0
+chat-template-kwargs = {{"enable_thinking": false, "reasoning_effort": "high"}}
+load-on-startup = false
+[other-model]
+c = 262144
+unknown-other-binary-option = 1
+"""
+    compiled = compile_ini(
+        ini, catalog, "free-27B-Q3.8", model_path = str(model), mmproj_path = str(projector)
+    )
+    assert compiled.n_parallel == 1
+    assert "--parallel" not in compiled.argv and "--model" not in compiled.argv
+    assert "--mmproj" not in compiled.argv
+    assert compiled.argv[compiled.argv.index("--ctx-size") + 1] == "56000"
+    assert "128000" not in compiled.argv and "262144" not in compiled.argv
+    assert compiled.argv[compiled.argv.index("--fit") + 1] == "off"
+    assert "--no-mmproj-offload" in compiled.argv and "--no-warmup" in compiled.argv
+    summary = compiled.summary()
+    assert summary["tuning"]["n_batch"] == 1024
+    assert summary["tuning"]["gpu_layers"] == -1
+    assert summary["request_defaults"]["min_p"] == 0.0
+    assert summary["request_defaults"]["chat_template_kwargs"] == {
+        "enable_thinking": False,
+        "reasoning_effort": "high",
+    }
+    assert (
+        json.loads(compiled.argv[compiled.argv.index("--chat-template-kwargs") + 1])
+        == summary["request_defaults"]["chat_template_kwargs"]
+    )
+    assert "Load action controls startup" in summary["diagnostics"][0]
+
+
+def test_catalog_aliases_arity_defaults_negative_pairs(catalog):
+    parallel = next(d for d in catalog if "--parallel" in d["names"])
+    assert parallel == {
+        "names": ["-np", "--parallel"],
+        "env": ["LLAMA_ARG_N_PARALLEL"],
+        "arity": 1,
+        "default": "1",
+        "negative_names": [],
+    }
+    projector = next(d for d in catalog if "--mmproj-offload" in d["names"])
+    assert projector["arity"] == 0
+    assert projector["negative_names"] == ["--no-mmproj-offload"]
+    assert "LLAMA_ARG_NO_MMPROJ_OFFLOAD" in projector["env"]
+    kv = next(d for d in catalog if "--kv-offload" in d["names"])
+    assert kv["negative_names"] == ["-nkvo", "--no-kv-offload"]
+    assert next(d for d in catalog if "--control-vector-layer-range" in d["names"])["arity"] == 2
+    assert not any("--old-option" in d["names"] for d in catalog)
+
+
+def test_help_device_placeholder_list_is_not_an_enum(catalog):
+    devices = parse_option_catalog(
+        "-dev, --device <dev1,dev2,..>             comma-separated device list\n"
+    )
+    assert devices[0]["arity"] == 1
+    assert "choices" not in devices[0]
+    assert compile_ini("[*]\ndevice=none", (*catalog, *devices)).argv == ("--device", "none")
+
+
+@pytest.mark.parametrize("key", ["c", "ctx-size", "LLAMA_ARG_CTX_SIZE"])
+def test_aliases_normalize_to_same_digest(key, catalog):
+    compiled = compile_ini(f"[*]\n{key}=56000", catalog)
+    control = compile_ini("[*]\nctx-size=56000", catalog)
+    assert compiled.argv == control.argv
+    assert compiled.digest == control.digest
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "flag"),
+    [
+        ("mmproj-offload", "false", "--no-mmproj-offload"),
+        ("no-mmproj-offload", "true", "--no-mmproj-offload"),
+        ("no-mmproj-offload", "false", "--mmproj-offload"),
+        ("LLAMA_ARG_MMPROJ_OFFLOAD", "0", "--no-mmproj-offload"),
+        # Native preset parse_bool_arg only inverts CLI keys; environment keys map
+        # to the option unchanged, unlike environment handling at process startup.
+        ("LLAMA_ARG_NO_MMPROJ_OFFLOAD", "true", "--mmproj-offload"),
+        ("nkvo", "false", "--kv-offload"),
+        ("no-warmup", "true", "--no-warmup"),
+    ],
+)
+def test_boolean_semantics(key, value, flag, catalog):
+    compiled = compile_ini(f"[*]\n{key}={value}", catalog)
+    assert compiled.argv == (flag,)
+
+
+def test_false_unpaired_switch_is_omitted_but_preserved_in_summary(catalog):
+    compiled = compile_ini("[*]\nmlock=false", catalog)
+    assert compiled.argv == ()
+    assert compiled.summary()["tuning"]["mlock"] is False
+
+
+@pytest.mark.parametrize("value", ["FALSE", "yes", "no", "arbitrary"])
+def test_invalid_boolean_is_not_silently_treated_truthy(value, catalog):
+    with pytest.raises(CustomConfigError, match = "native boolean"):
+        compile_ini(f"[*]\nmlock={value}", catalog)
+
+
+def test_native_values_are_not_slider_clamped(catalog):
+    compiled = compile_ini(
+        "[*]\nb=100000\nub=90000\nt=-1\nngl=-1\ntop-k=-1\ntemp=-1\nmin-p=0\npresence-penalty=-3\nseed=4294967295",
+        catalog,
+    )
+    assert compiled.summary()["tuning"]["n_batch"] == 100000
+    assert compiled.summary()["tuning"]["n_threads"] == -1
+    assert compiled.summary()["request_defaults"]["temperature"] == -1
+    assert compiled.summary()["request_defaults"]["top_k"] == -1
+    assert compiled.summary()["request_defaults"]["presence_penalty"] == -3
+    assert compiled.summary()["request_defaults"]["seed"] == 4294967295
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["np=0", "np=-1", "np=65", "c=-1", "b=0", "t=nan", "min-p=nan", "temp=inf", "c=2147483648"],
+)
+def test_typed_invalid_domains(text, catalog):
+    with pytest.raises(CustomConfigError):
+        compile_ini("[*]\n" + text, catalog)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "host",
+        "LLAMA_ARG_HOST",
+        "port",
+        "api-key",
+        "LLAMA_API_KEY",
+        "agent",
+        "ag",
+        "no-agent",
+        "LLAMA_ARG_AGENT",
+        "models-preset",
+        "config",
+        "model-draft",
+        "gpt-oss-120b-default",
+    ],
+)
+def test_reserved_aliases_fail_before_any_resource_execution(key, catalog):
+    with pytest.raises(CustomConfigError, match = "managed by Studio") as error:
+        compile_ini(f"[*]\n{key}=never-leak-secret", catalog)
+    assert "never-leak-secret" not in str(error.value)
+
+
+def test_supported_spec_default_is_not_misclassified_as_model_preset(catalog):
+    assert compile_ini("[*]\nspec-default=true", catalog).argv == ("--spec-default",)
+
+
+@pytest.mark.parametrize("key", ["m", "model", "LLAMA_ARG_MODEL"])
+def test_model_alias_reconciliation(key, catalog, tmp_path):
+    model = tmp_path / "selected.gguf"
+    model.touch()
+    assert compile_ini(f"[*]\n{key}={model}", catalog, model_path = str(model)).argv == ()
+    with pytest.raises(CustomConfigError, match = "must match"):
+        compile_ini(f"[*]\n{key}={tmp_path / 'other.gguf'}", catalog, model_path = str(model))
+
+
+def test_resource_preflight_defers_identity_only(catalog):
+    result = compile_ini("[*]\nm=placeholder", catalog, validate_resources = False)
+    assert "before launch" in result.diagnostics[0]
+    with pytest.raises(CustomConfigError, match = "managed by Studio"):
+        compile_ini("[*]\nm=placeholder\nhost=evil", catalog, validate_resources = False)
+
+
+def test_reconciled_resource_must_exist(catalog, tmp_path):
+    path = str(tmp_path / "nonexistent.gguf")
+    with pytest.raises(CustomConfigError, match = "existing file"):
+        compile_ini(f"[*]\nm={path}", catalog, model_path = path)
+
+
+def test_windows_path_identity_and_literal_no_expansion(catalog, monkeypatch):
+    monkeypatch.setattr("core.inference.llama_custom_config.os.path.isfile", lambda _: True)
+    result = compile_ini(
+        "[*]\nm=C:\\Models\\folder\\..\\A Model.gguf",
+        catalog,
+        model_path = "c:/models/a model.gguf",
+        platform = "win32",
+    )
+    assert result.argv == ()
+    with pytest.raises(CustomConfigError, match = "must match"):
+        compile_ini(
+            "[*]\nm=%MODEL_PATH%", catalog, model_path = "c:/models/a model.gguf", platform = "win32"
+        )
+
+
+def test_selection_required_even_for_one_named_section(catalog):
+    with pytest.raises(CustomConfigError, match = "explicit named"):
+        compile_ini("[only]\nc=1", catalog)
+    with pytest.raises(CustomConfigError, match = "does not exist"):
+        compile_ini("[only]\nc=1", catalog, "missing")
+    assert compile_ini("[only]\nc=1", catalog, "only").summary()["tuning"]["n_ctx"] == 1
+
+
+def test_native_duplicate_key_and_section_replacement(catalog):
+    result = compile_ini("[*]\nc=10\nc=20\n[chosen]\nb=100\n[chosen]\nc=30", catalog, "chosen")
+    assert result.summary()["tuning"]["n_ctx"] == 30
+    assert result.summary()["tuning"]["n_batch"] == 2048
+    with pytest.raises(CustomConfigError, match = "multiple aliases"):
+        compile_ini("[*]\nc=10\nctx-size=20", catalog)
+
+
+def test_global_and_selected_aliases_replace_without_duplicate_argv(catalog):
+    result = compile_ini("[*]\nLLAMA_ARG_CTX_SIZE=10\n[chosen]\nc=20", catalog, "chosen")
+    assert result.argv == ("--ctx-size", "20")
+
+
+def test_quotes_are_literal_comments_are_not_quote_aware(catalog):
+    result = compile_ini('[*]\njson-schema="literal spaces" ; comment', catalog)
+    assert result.argv == ("--json-schema", '"literal spaces"')
+    with pytest.raises(CustomConfigError, match = "valid JSON"):
+        compile_ini('[*]\nchat-template-kwargs={"text":"hash # truncates"}', catalog)
+
+
+@pytest.mark.parametrize("ini", ["[*]\n c=1", "[*]\n--ctx-size=1", "[broken", "[*]\nnot-an-entry"])
+def test_malformed_native_grammar_fails(ini, catalog):
+    with pytest.raises(CustomConfigError, match = "syntax"):
+        compile_ini(ini, catalog)
+
+
+@pytest.mark.parametrize("key", ["unknown", "old-option", "control-vector-layer-range"])
+def test_unknown_removed_or_multivalue_rejected(key, catalog):
+    with pytest.raises(CustomConfigError):
+        compile_ini(f"[*]\n{key}=1", catalog)
+
+
+def test_empty_and_partial_catalog_fail(catalog):
+    for incomplete in [(), catalog[:1], catalog[2:3]]:
+        with pytest.raises(CustomConfigError, match = "probe"):
+            compile_ini("[*]\nc=1", incomplete)
+
+
+def test_conflicting_help_aliases_fail(catalog):
+    duplicate = {
+        "names": ["-c", "--different"],
+        "env": [],
+        "arity": 1,
+        "default": None,
+        "negative_names": [],
+    }
+    with pytest.raises(CustomConfigError, match = "ambiguous"):
+        compile_ini("[*]\nc=1", (*catalog, duplicate))
+
+
+def test_auto_parallel_default_requires_explicit_slots():
+    catalog = parse_option_catalog(
+        HELP.replace("slots (default: 1)", "slots (default: -1, -1 = auto)")
+    )
+    with pytest.raises(CustomConfigError, match = "set np explicitly"):
+        compile_ini("[*]\nc=1", catalog)
+    assert compile_ini("[*]\nc=1\nnp=3", catalog).n_parallel == 3
+
+
+def test_absent_reset_and_wire_roundtrip():
+    assert parse_config_source(None) is None
+    reset = parse_config_source({"version": 1, "mode": "managed"})
+    assert reset == CustomConfigSource()
+    assert reset.to_wire() == {"version": 1, "mode": "managed"}
+    custom = source("[*]\nc=1")
+    assert parse_config_source(custom).to_wire() == custom
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        [],
+        {"version": True, "mode": "managed"},
+        {"version": 2, "mode": "managed"},
+        {"version": 1, "mode": "bad"},
+        {"version": 1, "mode": "managed", "ini": "secret"},
+        source(""),
+        source("[*]\nc=\x00"),
+        source("[*]\nc=\ud800"),
+        source("x" * 65537),
+        {**source("[*]"), "argv": ["--host"]},
+    ],
+)
+def test_wire_shape_encoding_and_size_bounds(value):
+    with pytest.raises(CustomConfigError):
+        parse_config_source(value)
+
+
+def test_source_instance_is_revalidated():
+    with pytest.raises(CustomConfigError):
+        parse_config_source(CustomConfigSource(version = 4))
+
+
+def test_compiled_and_nested_values_are_immutable(catalog):
+    result = compile_ini('[*]\nchat-template-kwargs={"nested":{"a":[1,2]}}', catalog)
+    with pytest.raises(FrozenInstanceError):
+        result.n_parallel = 3
+    with pytest.raises(FrozenInstanceError):
+        dict(result.request_defaults)["chat_template_kwargs"].encoded = "{}"
+    decoded = result.summary()
+    decoded["request_defaults"]["chat_template_kwargs"]["nested"]["a"].append(3)
+    assert result.summary()["request_defaults"]["chat_template_kwargs"]["nested"]["a"] == [1, 2]
+
+
+def test_canonical_digest_comments_order_json_and_selection(catalog):
+    a = compile_ini('[*]\nc=56000\nchat-template-kwargs={"b":2,"a":1}', catalog)
+    b = compile_ini(
+        '[*]\nchat-template-kwargs = { "a": 1, "b": 2 }\nctx-size=56000 # note', catalog
+    )
+    assert a.digest == b.digest and a.source_digest != b.source_digest
+    assert (
+        a.digest != compile_ini('[*]\nc=56001\nchat-template-kwargs={"b":2,"a":1}', catalog).digest
+    )
+    assert (
+        compile_ini("[a]\nc=1\n[b]\nc=1", catalog, "a").digest
+        != compile_ini("[a]\nc=1\n[b]\nc=1", catalog, "b").digest
+    )
+
+
+def test_argument_and_windows_serialization_bounds(catalog):
+    # Backslashes before quotes need escaping in CreateProcess's one string.
+    value = '\\" ' * 6000
+    with pytest.raises(CustomConfigError, match = "Windows command"):
+        compile_ini("[*]\njson-schema=" + value, catalog, platform = "win32")
+    with pytest.raises(CustomConfigError, match = "size limit"):
+        compile_ini("[*]\njson-schema=" + "x" * 33000, catalog, platform = "linux")
+
+
+def test_section_and_entry_count_bounds(catalog):
+    with pytest.raises(CustomConfigError, match = "section limit"):
+        compile_ini("[*]\n" * 129, catalog)
+    with pytest.raises(CustomConfigError, match = "entry limit"):
+        compile_ini("[*]\n" + "c=1\n" * 2049, catalog)

--- a/studio/backend/tests/test_llama_custom_config.py
+++ b/studio/backend/tests/test_llama_custom_config.py
@@ -79,6 +79,18 @@ def catalog():
     return parse_option_catalog(HELP)
 
 
+@pytest.mark.parametrize("value", ["1e100", "-1e100", "1e-100", "-1e-100", "1e-1000"])
+def test_native_float_domain_rejects_overflow_and_underflow(catalog, value):
+    with pytest.raises(CustomConfigError, match = "native float domain"):
+        compile_custom_config(source(f"[*]\nnp=1\ntemp={value}"), catalog)
+
+
+@pytest.mark.parametrize("value", ["0", "-0.0", "0.25", "-0.5", "1e-40", "3.4028234663852886e38"])
+def test_native_float_domain_preserves_representable_values(catalog, value):
+    compiled = compile_custom_config(source(f"[*]\nnp=1\ntemp={value}"), catalog)
+    assert compiled.summary()["request_defaults"]["temperature"] == float(value)
+
+
 def source(ini, section = None):
     return {"version": 1, "mode": "custom", "ini": ini, "section": section}
 

--- a/studio/backend/tests/test_llama_custom_launch.py
+++ b/studio/backend/tests/test_llama_custom_launch.py
@@ -1,0 +1,402 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+from dataclasses import replace
+from contextlib import nullcontext
+import importlib.util
+from pathlib import Path
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from core.inference import llama_cpp as llama
+from core.inference.llama_custom_config import CustomConfigError, parse_option_catalog
+
+_spec = importlib.util.spec_from_file_location(
+    "_custom_config_fixtures", Path(__file__).with_name("test_llama_custom_config.py")
+)
+_fixtures = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_fixtures)
+HELP, source = _fixtures.HELP, _fixtures.source
+
+
+@pytest.fixture
+def launch(monkeypatch, tmp_path):
+    backend = llama.LlamaCppBackend(manages_processes = False)
+    model = tmp_path / "selected.gguf"
+    binary = tmp_path / "llama-server.exe"
+    model.touch()
+    binary.touch()
+    catalog = parse_option_catalog(
+        HELP
+        + "--alias NAME                            public model id\n--jinja                                use Jinja\n"
+    )
+    caps = {"help_probe_ok": True, "option_catalog": catalog}
+    monkeypatch.setattr(backend, "_find_llama_server_binary", lambda: str(binary))
+    monkeypatch.setattr(backend, "_exec_path_for_launch", lambda p: p)
+    monkeypatch.setattr(backend, "probe_server_capabilities", lambda p: caps)
+    monkeypatch.setattr(backend, "_binary_revision", lambda p: (str(p), 1))
+    monkeypatch.setattr(backend, "_cuda_sm_gate_error", lambda p: None)
+    monkeypatch.setattr(backend, "_arch_gate_survivors", lambda p: [])
+    monkeypatch.setattr(backend, "_non_chat_gguf_refusal_for_path", lambda *args: None)
+    monkeypatch.setattr(backend, "_gguf_path_is_diffusion", lambda *args: False)
+    monkeypatch.setattr(llama, "_metal_device_is_paravirtual", lambda: False)
+    monkeypatch.setattr("utils.model_memory_settings.get_keep_resident", lambda: False)
+    monkeypatch.setattr("utils.model_memory_settings.get_no_ram_reserve", lambda: False)
+    monkeypatch.setattr(backend, "_spawn_is_stale", lambda: False)
+    monkeypatch.setattr(
+        backend,
+        "_llama_server_env_for_binary",
+        lambda p: {
+            "PATH": "runtime-libraries",
+            "CUDA_VISIBLE_DEVICES": "1",
+            "LLAMA_ARG_CTX_SIZE": "128000",
+            "LLAMA_ARG_MODELS_PRESET": "never-read.ini",
+            "LLAMA_API_KEY": "inherited-secret",
+            "LLAMA_ARG_MMPROJ": "different-projector.gguf",
+            "RUNTIME_UNRELATED": "retained",
+        },
+    )
+    monkeypatch.setattr(
+        llama.LlamaCppBackend,
+        "_read_gguf_metadata",
+        lambda self, path: setattr(self, "_context_length", 128000),
+    )
+    monkeypatch.setattr(backend, "_find_free_port", lambda: 8123)
+    monkeypatch.setattr(backend, "_detect_audio_type_strict", lambda: None)
+    monkeypatch.setattr(backend, "_apply_detected_audio", lambda *a: True)
+    monkeypatch.delenv("UNSLOTH_DIRECT_STREAM", raising = False)
+    captured, kills = [], []
+
+    def kill():
+        kills.append(backend._process)
+        backend._process = None
+        backend._healthy = False
+
+    def spawn(cmd, env, *, child_gpu_physical_ids):
+        captured.append((list(cmd), dict(env)))
+        backend._process = SimpleNamespace(poll = lambda: None)
+        return True
+
+    monkeypatch.setattr(backend, "_kill_process", kill)
+    monkeypatch.setattr(backend, "_start_llama_process", spawn)
+    monkeypatch.setattr(backend, "_wait_for_health", lambda **kwargs: True)
+    monkeypatch.setattr(
+        backend,
+        "_query_server_props",
+        lambda: {
+            "total_slots": 2,
+            "default_generation_settings": {"n_ctx": 28000},
+            "modalities": {"video": False},
+        },
+    )
+    intent = llama.GgufLoadIntent(
+        model_identifier = "selected",
+        gguf_path = str(model),
+        n_ctx = 128000,
+        n_parallel = 8,
+        gpu_layers = 55,
+        n_batch = 100,
+        extra_args = ("--ctx-size", "99999"),
+        llama_cpp_config = source(
+            "[*]\nnp=2\nc=56000\nfit=off\nngl=0\nb=100000\nub=3000\nno-warmup=true\nmmproj-offload=false"
+        ),
+    )
+    return SimpleNamespace(
+        backend = backend, intent = intent, captured = captured, kills = kills, caps = caps
+    )
+
+
+def test_custom_dispatch_precedes_managed_mutation_and_preserves_tuning(launch, monkeypatch):
+    backend = launch.backend
+    monkeypatch.setattr(
+        backend,
+        "_preserve_cpu_fallback_intent",
+        lambda *_: pytest.fail("managed fallback must not run"),
+    )
+    monkeypatch.setattr(
+        backend,
+        "_build_speculative_flags",
+        lambda **_: pytest.fail("managed speculation must not run"),
+    )
+    assert backend.load_model(launch.intent)
+    cmd, env = launch.captured[0]
+    assert cmd.count("--parallel") == 1 and cmd[cmd.index("--parallel") + 1] == "2"
+    assert cmd[cmd.index("--ctx-size") + 1] == "56000"
+    assert cmd[cmd.index("--fit") + 1] == "off"
+    assert cmd[cmd.index("--batch-size") + 1] == "100000"
+    assert "128000" not in cmd and "99999" not in cmd and "--flash-attn" not in cmd
+    assert "--no-warmup" in cmd and "--no-mmproj-offload" in cmd
+    assert cmd[cmd.index("--host") + 1] == "127.0.0.1"
+    assert env == {
+        "PATH": "runtime-libraries",
+        "CUDA_VISIBLE_DEVICES": "1",
+        "RUNTIME_UNRELATED": "retained",
+    }
+    assert backend.effective_parallel_slots == 2
+    assert backend.context_length == 28000
+    assert backend.last_load_intent.llama_cpp_config == launch.intent.llama_cpp_config
+    assert backend.llama_cpp_config_summary["tuning"]["n_ctx"] == 56000
+    assert backend._mtp_runtime_fallback_active is False
+
+
+@pytest.mark.parametrize("text", ["host=evil", "c=bad", "np=99", "unknown=1", "config=second.ini"])
+def test_invalid_config_does_not_replace_healthy_resident(launch, text):
+    backend = launch.backend
+    resident = backend._process = object()
+    backend._healthy = True
+    with pytest.raises(CustomConfigError):
+        backend.load_model(replace(launch.intent, llama_cpp_config = source("[*]\n" + text)))
+    assert backend._process is resident and backend._healthy
+    assert not launch.kills and not launch.captured
+
+
+def test_incomplete_help_does_not_unload(launch):
+    launch.caps["help_probe_ok"] = False
+    with pytest.raises(CustomConfigError, match = "complete successful help"):
+        launch.backend.load_model(launch.intent)
+    assert not launch.kills
+
+
+def test_start_failure_is_terminal_and_does_not_commit_intent(launch, monkeypatch):
+    old_intent = llama.GgufLoadIntent("previous")
+    launch.backend._last_load_intent = old_intent
+    monkeypatch.setattr(launch.backend, "_wait_for_health", lambda **_: False)
+    launch.backend._health_wait_cancelled = False
+    with pytest.raises(CustomConfigError, match = "no tuning fallback"):
+        launch.backend.load_model(launch.intent)
+    assert len(launch.captured) == 1
+    assert launch.backend._process is None
+    assert launch.backend.last_load_intent is old_intent
+
+
+def test_cancel_before_validation_does_not_replace(launch):
+    cancel = threading.Event()
+    cancel.set()
+    assert launch.backend.load_model(launch.intent, load_cancel_event = cancel) is False
+    assert not launch.kills and not launch.captured
+
+
+def test_cancel_during_health_cleans_child_and_does_not_retry(launch, monkeypatch):
+    cancel = threading.Event()
+
+    def wait(**_):
+        cancel.set()
+        return False
+
+    monkeypatch.setattr(launch.backend, "_wait_for_health", wait)
+    assert launch.backend.load_model(launch.intent, load_cancel_event = cancel) is False
+    assert len(launch.captured) == 1 and launch.backend._process is None
+    assert launch.backend.last_load_intent is None
+
+
+def test_props_accounting_mismatch_is_terminal(launch, monkeypatch):
+    monkeypatch.setattr(
+        launch.backend,
+        "_query_server_props",
+        lambda: {"total_slots": 8, "default_generation_settings": {"n_ctx": 1}},
+    )
+    with pytest.raises(CustomConfigError, match = "confirm.*accounting"):
+        launch.backend.load_model(launch.intent)
+    assert len(launch.captured) == 1 and launch.backend.last_load_intent is None
+
+
+def test_comment_only_change_dedupes_but_tuning_change_relaunches(launch):
+    assert launch.backend.load_model(launch.intent)
+    old_digest = launch.backend.llama_cpp_config_summary["digest"]
+    commented = replace(
+        launch.intent, llama_cpp_config = source(launch.intent.llama_cpp_config.ini + "\n# note")
+    )
+    assert launch.backend.load_model(commented)
+    assert len(launch.captured) == 1
+    assert launch.backend.requested_llama_cpp_config["ini"].endswith("# note")
+    changed = replace(
+        launch.intent,
+        llama_cpp_config = source(launch.intent.llama_cpp_config.ini.replace("56000", "57000")),
+    )
+    assert launch.backend.load_model(changed)
+    assert len(launch.captured) == 2
+    assert launch.backend.llama_cpp_config_summary["digest"] != old_digest
+
+
+def test_replay_preserves_compiled_tuning_and_bypasses_mtp_recovery(launch):
+    assert launch.backend.load_model(launch.intent)
+    replay = launch.backend.last_load_intent
+    launch.backend._healthy = False
+    assert launch.backend.load_model(replay)
+    assert launch.captured[0] == launch.captured[1]
+    launch.backend._mtp_runtime_fallback_active = True
+    assert launch.backend._maybe_recover_from_mtp_crash() is False
+
+
+def test_managed_intent_cannot_dedupe_against_custom_and_unload_clears(launch):
+    assert launch.backend.load_model(launch.intent)
+    assert (
+        launch.backend._runtime_matches_intent(
+            replace(launch.intent, llama_cpp_config = {"version": 1, "mode": "managed"}), []
+        )
+        is False
+    )
+    assert launch.backend.unload_model()
+    assert launch.backend.llama_cpp_config_summary is None
+    assert launch.backend.requested_llama_cpp_config is None
+
+
+def test_jinja_conflict_and_virtual_metal_refused_before_kill(launch, monkeypatch):
+    bad = replace(launch.intent, llama_cpp_config = source("[*]\nnp=2\njinja=false"))
+    with pytest.raises(CustomConfigError, match = "Jinja"):
+        launch.backend.load_model(bad)
+    monkeypatch.setattr(llama, "_metal_device_is_paravirtual", lambda: True)
+    with pytest.raises(CustomConfigError, match = "Virtualized Metal"):
+        launch.backend.load_model(launch.intent)
+    assert not launch.kills
+
+
+def test_implicit_native_config_is_refused(monkeypatch, tmp_path):
+    monkeypatch.setattr(llama.sys, "platform", "win32")
+    native = tmp_path / "llama.cpp"
+    native.mkdir()
+    (native / "config.ini").touch()
+    with pytest.raises(CustomConfigError, match = "single configuration source"):
+        llama.LlamaCppBackend._reject_implicit_custom_config({"APPDATA": str(tmp_path)})
+
+
+def test_binary_changed_between_preflight_and_kill_is_refused(launch, monkeypatch):
+    calls = 0
+
+    def revision(path):
+        nonlocal calls
+        calls += 1
+        return (str(path), calls)
+
+    monkeypatch.setattr(launch.backend, "_binary_revision", revision)
+    with pytest.raises(CustomConfigError, match = "changed during validation"):
+        launch.backend.load_model(launch.intent)
+    assert not launch.kills
+
+
+def test_remote_preflight_cannot_defer_selected_resource_identity(launch):
+    remote = replace(
+        launch.intent,
+        gguf_path = None,
+        hf_repo = "example/model-GGUF",
+        llama_cpp_config = source("[*]\nnp=2\nm=unresolved.gguf"),
+    )
+    with pytest.raises(CustomConfigError, match = "must match"):
+        launch.backend.prepare_custom_config(remote, validate_resources = False)
+    assert not launch.kills and not launch.captured
+
+
+def test_remote_resolution_cannot_change_the_requested_quantization(launch, monkeypatch):
+    seen = []
+
+    def download(**kwargs):
+        seen.append(kwargs)
+        return launch.intent.gguf_path
+
+    monkeypatch.setattr(launch.backend, "_download_gguf", download)
+    monkeypatch.setattr(llama, "_hf_offline_if_unreachable", nullcontext)
+    monkeypatch.setattr(llama, "_resolve_repo_id_casing", lambda repo: repo)
+    monkeypatch.setattr(llama, "_hub_download_blocks_gguf_load", lambda *a, **k: False)
+    remote = replace(launch.intent, gguf_path = None, hf_repo = "example/model-GGUF")
+    assert launch.backend.load_model(remote)
+    assert len(seen) == 1 and seen[0]["allow_smaller_fallback"] is False
+
+
+def test_vision_disabled_resource_conflict_is_refused_in_preflight(launch, tmp_path, monkeypatch):
+    projector = tmp_path / "mmproj.gguf"
+    projector.touch()
+    monkeypatch.setattr(llama, "_mmproj_env_is_audio_only", lambda p: False)
+    intent = replace(
+        launch.intent,
+        mmproj_path = str(projector),
+        disable_vision = True,
+        llama_cpp_config = source(f"[*]\nnp=2\nmm={projector}"),
+    )
+    with pytest.raises(CustomConfigError, match = "must match"):
+        launch.backend.prepare_custom_config(intent)
+    assert not launch.kills
+
+
+def test_strict_adoption_never_applies_managed_placement(launch, monkeypatch):
+    assert launch.backend.load_model(launch.intent)
+    monkeypatch.setattr(
+        launch.backend,
+        "_preserve_cpu_fallback_intent",
+        lambda *a, **k: pytest.fail("managed placement"),
+    )
+    monkeypatch.setattr(launch.backend, "_binary_changed_since_launch", lambda: False)
+    changed_source = replace(
+        launch.intent, llama_cpp_config = source(launch.intent.llama_cpp_config.ini + "\n# edit")
+    )
+    assert launch.backend.adopt_load_intent_if_matched(changed_source)
+    assert launch.backend.last_load_intent.llama_cpp_config == changed_source.llama_cpp_config
+    assert len(launch.captured) == 1
+
+
+def test_reasoning_kwargs_merge_preserves_custom_arbitrary_values(launch):
+    config = replace(
+        launch.intent,
+        llama_cpp_config = source(
+            '[*]\nnp=2\nchat-template-kwargs={"enable_thinking":false,"custom":{"nested":1},"reasoning_effort":"high"}'
+        ),
+    )
+    compiled = launch.backend.prepare_custom_config(config)
+    launch.backend._compiled_custom_config = compiled
+    launch.backend._supports_reasoning = True
+    launch.backend._reasoning_style = "enable_thinking"
+    assert launch.backend._request_reasoning_kwargs(None)["enable_thinking"] is False
+    value = launch.backend._request_reasoning_kwargs(
+        True, request_template_kwargs = {"custom": {"nested": 2}, "extra": 0}
+    )
+    assert value == {
+        "enable_thinking": True,
+        "custom": {"nested": 2},
+        "reasoning_effort": "high",
+        "extra": 0,
+    }
+    assert launch.backend.llama_cpp_config_summary["request_defaults"]["chat_template_kwargs"][
+        "custom"
+    ] == {"nested": 1}
+
+
+def test_actual_native_template_controls_reasoning_capabilities(launch, monkeypatch):
+    launch.backend._supports_reasoning = True
+    launch.backend._supports_tools = True
+    template = "{% for message in messages %}{{ message['content'] }}{% endfor %}"
+    monkeypatch.setattr(
+        launch.backend,
+        "_query_server_props",
+        lambda: {
+            "total_slots": 2,
+            "default_generation_settings": {"n_ctx": 28000},
+            "chat_template": template,
+        },
+    )
+    assert launch.backend.load_model(launch.intent)
+    assert launch.backend._chat_template == template
+    assert launch.backend._supports_reasoning is False
+    assert launch.backend._supports_tools is False
+
+
+@pytest.mark.parametrize(
+    ("line", "enabled"),
+    [
+        ("llama_context: Flash Attention enabled", True),
+        ("llama_context: Flash Attention not supported, set to disabled", False),
+        ("llama_context: flash_attn = disabled", False),
+    ],
+)
+def test_flash_accounting_uses_observed_native_outcome(launch, line, enabled):
+    launch.backend._stdout_lines = ["llama_context: flash_attn = auto", line]
+    assert launch.backend.load_model(launch.intent)
+    assert launch.backend._flash_attn_enabled is enabled
+
+
+def test_unreported_native_flash_is_conservative_and_diagnosed(launch):
+    assert launch.backend.load_model(launch.intent)
+    assert launch.backend._flash_attn_enabled is False
+    assert any(
+        "not reported" in note for note in launch.backend.llama_cpp_config_summary["diagnostics"]
+    )

--- a/studio/backend/tests/test_llama_custom_launch.py
+++ b/studio/backend/tests/test_llama_custom_launch.py
@@ -42,8 +42,9 @@ def launch(monkeypatch, tmp_path):
     monkeypatch.setattr(backend, "_non_chat_gguf_refusal_for_path", lambda *args: None)
     monkeypatch.setattr(backend, "_gguf_path_is_diffusion", lambda *args: False)
     monkeypatch.setattr(llama, "_metal_device_is_paravirtual", lambda: False)
-    monkeypatch.setattr("utils.model_memory_settings.get_keep_resident", lambda: False)
-    monkeypatch.setattr("utils.model_memory_settings.get_no_ram_reserve", lambda: False)
+    monkeypatch.setattr(
+        "utils.model_memory_settings.get_model_memory_settings", lambda: (False, False)
+    )
     monkeypatch.setattr(backend, "_spawn_is_stale", lambda: False)
     monkeypatch.setattr(
         backend,
@@ -141,7 +142,19 @@ def test_custom_dispatch_precedes_managed_mutation_and_preserves_tuning(launch, 
     assert backend._mtp_runtime_fallback_active is False
 
 
-@pytest.mark.parametrize("text", ["host=evil", "c=bad", "np=99", "unknown=1", "config=second.ini"])
+@pytest.mark.parametrize(
+    "text",
+    [
+        "host=evil",
+        "c=bad",
+        "np=99",
+        "unknown=1",
+        "config=second.ini",
+        "temp=1e100",
+        "temp=1e-100",
+        "temp=1e-1000",
+    ],
+)
 def test_invalid_config_does_not_replace_healthy_resident(launch, text):
     backend = launch.backend
     resident = backend._process = object()
@@ -152,11 +165,48 @@ def test_invalid_config_does_not_replace_healthy_resident(launch, text):
     assert not launch.kills and not launch.captured
 
 
+@pytest.mark.parametrize(
+    "keep,no_reserve", [(False, False), (True, False), (False, True), (True, True)]
+)
+@pytest.mark.parametrize("mlock", [False, True])
+def test_custom_memory_policy_respects_no_reserve_precedence(
+    launch, monkeypatch, keep, no_reserve, mlock
+):
+    monkeypatch.setattr(
+        "utils.model_memory_settings.get_model_memory_settings", lambda: (keep, no_reserve)
+    )
+    intent = replace(
+        launch.intent, llama_cpp_config = source(f"[*]\nnp=2\nmlock={str(mlock).lower()}")
+    )
+    allowed = (not no_reserve or not mlock) and (not keep or no_reserve or mlock)
+    if allowed:
+        launch.backend.prepare_custom_config(intent)
+    else:
+        with pytest.raises(CustomConfigError, match = "memory settings"):
+            launch.backend.prepare_custom_config(intent)
+    assert not launch.kills and not launch.captured
+
+
 def test_incomplete_help_does_not_unload(launch):
     launch.caps["help_probe_ok"] = False
     with pytest.raises(CustomConfigError, match = "complete successful help"):
         launch.backend.load_model(launch.intent)
     assert not launch.kills
+
+
+def test_explicit_custom_cpu_placement_reports_no_vram(launch):
+    launch.caps["option_catalog"] = parse_option_catalog(
+        HELP + "\n--device DEVICES                       device selection\n"
+        "--alias NAME                            public model id\n"
+        "--jinja                                 Jinja templates\n"
+    )
+    intent = replace(
+        launch.intent,
+        llama_cpp_config = source("[*]\nnp=2\nc=56000\nngl=0\ndevice=none\nfit=off"),
+    )
+    assert launch.backend.load_model(intent)
+    assert launch.backend.holds_no_vram
+    assert "--device" in launch.captured[0][0]
 
 
 def test_start_failure_is_terminal_and_does_not_commit_intent(launch, monkeypatch):

--- a/studio/backend/tests/test_llama_custom_launch.py
+++ b/studio/backend/tests/test_llama_custom_launch.py
@@ -109,6 +109,56 @@ def launch(monkeypatch, tmp_path):
     )
 
 
+def test_custom_flags_are_not_inheritable_managed_extras(launch):
+    assert launch.backend.load_model(launch.intent)
+    assert "--no-warmup" in launch.captured[0][0]
+    assert launch.backend.extra_args == []
+    assert launch.backend.requested_extra_args == []
+
+
+@pytest.mark.parametrize(
+    "previous,supported,setting,expected",
+    [
+        (True, True, "0", False),
+        (False, True, "128", True),
+        (True, False, None, False),
+        (False, True, None, True),
+    ],
+)
+def test_custom_launch_recomputes_idle_slot_clearing(
+    launch, previous, supported, setting, expected
+):
+    launch.backend._idle_slot_clearing_active = previous
+    launch.caps["supports_cache_ram"] = supported
+    launch.caps["option_catalog"] = parse_option_catalog(
+        HELP + "\n--alias NAME                            model id\n"
+        "--jinja                                 templates\n"
+        "--cache-ram N                           idle cache MiB\n"
+    )
+    ini = "[*]\nnp=2\nc=56000\nngl=0\nfit=off"
+    if setting is not None:
+        ini += "\ncache-ram=" + setting
+    assert launch.backend.load_model(replace(launch.intent, llama_cpp_config = source(ini)))
+    assert launch.backend.idle_slot_clearing_active is expected
+
+
+def test_custom_launch_clears_previous_managed_request_echoes(launch):
+    fields = (
+        "n_batch",
+        "n_ubatch",
+        "load_mode",
+        "spec_draft_cache_type",
+        "ctx_checkpoints",
+        "cache_ram",
+    )
+    for field, previous in zip(fields, (777, 555, "fast", "q8_0", 8, 4096)):
+        setattr(launch.backend, "_requested_" + field, previous)
+    assert launch.backend.load_model(launch.intent)
+    for field in fields:
+        assert getattr(launch.backend, "_requested_" + field) is None, field
+    assert launch.backend._n_ubatch == 3000
+
+
 def test_custom_dispatch_precedes_managed_mutation_and_preserves_tuning(launch, monkeypatch):
     backend = launch.backend
     monkeypatch.setattr(

--- a/studio/backend/tests/test_llama_custom_placement.py
+++ b/studio/backend/tests/test_llama_custom_placement.py
@@ -37,6 +37,7 @@ def route_probe(
     device = "none",
     vision = False,
     projector = None,
+    inherited_config = False,
 ):
     events = []
     config = NS(
@@ -104,15 +105,26 @@ def route_probe(
         "section": None,
     }
     request = LoadRequest(
-        model_path = "selected.gguf",
-        gguf_variant = "Q4_K_M",
-        llama_cpp_config = source,
+        model_path = "owner/repo" if inherited_config else "selected.gguf",
+        gguf_variant = None if inherited_config else "Q4_K_M",
+        llama_cpp_config = None if inherited_config else source,
         gpu_memory_mode = mode,
         gpu_layers = layers,
         speculative_type = "off",
         tensor_parallel = tensor,
     )
     with (
+        patch(
+            "utils.openai_auto_switch_settings.resolve_override_for_load",
+            side_effect = lambda _identifier, _alias, variant: (
+                "override",
+                {
+                    "llama_cpp_config": source
+                    if variant
+                    else {**source, "ini": source["ini"].replace("ngl=0", "ngl=99")}
+                },
+            ),
+        ),
         patch.object(r, "get_llama_cpp_backend", return_value = backend),
         patch.object(r, "get_inference_backend", return_value = NS(active_model_name = None)),
         patch.object(
@@ -163,6 +175,10 @@ def test_custom_route_never_retries_from_managed_tensor_toggle(tensor, raises):
 
 def test_uncertain_custom_device_keeps_gpu_handoff():
     assert route_probe("manual", 0, 0, device = None) == ["acquire_gpu"]
+
+
+def test_auto_selected_variant_replaces_early_bare_custom_override():
+    assert route_probe("auto", -1, 0, inherited_config = True) == ["drain_without_acquire"]
 
 
 @pytest.mark.parametrize("vision,projector", [(True, None), (False, "audio-projector.gguf")])

--- a/studio/backend/tests/test_llama_custom_placement.py
+++ b/studio/backend/tests/test_llama_custom_placement.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import asyncio
+from types import SimpleNamespace as NS
+from unittest.mock import patch
+import pytest
+from fastapi import HTTPException
+from routes import inference as r
+from models.inference import LoadRequest
+from core.inference import llama_cpp as lc
+from core.inference.llama_custom_config import compile_custom_config, parse_option_catalog
+import importlib.util
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "_placement_config_fixtures", Path(__file__).with_name("test_llama_custom_config.py")
+)
+_fixtures = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_fixtures)
+HELP = _fixtures.HELP
+
+
+class Reached(HTTPException):
+    def __init__(self):
+        super().__init__(409, "Reached side-effect boundary")
+
+
+def route_probe(
+    mode,
+    layers,
+    ini_layers,
+    *,
+    attempts = False,
+    raises = False,
+    tensor = False,
+    device = "none",
+    vision = False,
+    projector = None,
+):
+    events = []
+    config = NS(
+        identifier = "selected.gguf",
+        display_name = "selected",
+        is_gguf = True,
+        is_vision = vision,
+        gguf_file = "selected.gguf",
+        gguf_mmproj_file = projector,
+        gguf_mtp_file = None,
+        gguf_dspark_file = None,
+        gguf_dflash_file = None,
+        gguf_variant = "Q4_K_M",
+        gguf_hf_repo = None,
+        is_local = True,
+    )
+    backend = NS(
+        is_loaded = False,
+        model_identifier = None,
+        last_load_intent = None,
+        requested_llama_cpp_config = None,
+        prepare_custom_config = lambda intent, **k: compile_custom_config(
+            intent.llama_cpp_config,
+            parse_option_catalog(
+                HELP + "\n--device DEVICES                       device selection\n"
+            ),
+        ),
+        matches_load_source = lambda *a: False,
+        adopt_load_intent_if_matched = lambda *a, **k: False,
+        non_chat_gguf_refusal_for_intent = lambda *a: None,
+        host_offload_warning_for_intent = lambda *a: None,
+        load_cancelled = lambda: False,
+    )
+
+    def acquire(*a, **k):
+        events.append("acquire_gpu")
+        if not attempts:
+            raise Reached()
+
+    async def drained(**k):
+        events.append("drain_without_acquire")
+        if not attempts:
+            raise Reached()
+
+    async def failed_attempt(backend, intent, cancel):
+        events.append(
+            {
+                "attempt": intent.llama_cpp_config,
+                "tensor": intent.tensor_parallel,
+                "extras": intent.extra_args,
+            }
+        )
+        if raises:
+            raise ValueError("Native load failed")
+        return False
+
+    async def no_audio(c, q, p):
+        return p
+
+    device_line = f"\ndevice={device}" if device is not None else ""
+    source = {
+        "version": 1,
+        "mode": "custom",
+        "ini": f"[*]\nnp=1\nngl={ini_layers}\nfit=off{device_line}",
+        "section": None,
+    }
+    request = LoadRequest(
+        model_path = "selected.gguf",
+        gguf_variant = "Q4_K_M",
+        llama_cpp_config = source,
+        gpu_memory_mode = mode,
+        gpu_layers = layers,
+        speculative_type = "off",
+        tensor_parallel = tensor,
+    )
+    with (
+        patch.object(r, "get_llama_cpp_backend", return_value = backend),
+        patch.object(r, "get_inference_backend", return_value = NS(active_model_name = None)),
+        patch.object(
+            r,
+            "_resolve_model_identifier_for_request",
+            return_value = ("selected.gguf", "selected.gguf", False),
+        ),
+        patch.object(r, "resolve_effective_chat_template_override", return_value = None),
+        patch.object(r, "ModelConfig", NS(from_identifier = lambda **k: config)),
+        patch.object(r, "_classify_diffusion_gguf", return_value = False),
+        patch.object(r, "_effective_parallel_slots", return_value = 1),
+        patch.object(r, "_preflight_native_audio_placement", side_effect = no_audio),
+        patch.object(r, "_guard_chat_load_against_training", return_value = None),
+        patch.object(r, "_raise_if_sidecar_swap_in_progress"),
+        patch.object(r, "_wait_for_model_switch_idle", side_effect = drained),
+        patch.object(r, "_run_gguf_load_attempt", side_effect = failed_attempt),
+        patch.object(lc.LlamaCppBackend, "_is_vulkan_backend", return_value = False),
+        patch("core.inference.gpu_arbiter.acquire_for", side_effect = acquire),
+    ):
+        with pytest.raises(HTTPException) as caught:
+            asyncio.run(
+                r._load_model_impl(
+                    request, NS(app = NS(state = NS(llama_parallel_slots = 1))), current_subject = "review"
+                )
+            )
+        assert caught.value.status_code == (400 if raises else 500 if attempts else 409)
+    return events
+
+
+@pytest.mark.parametrize(
+    "mode,layers,ini_layers",
+    [("auto", -1, 0), ("manual", 0, 99), ("manual", 0, 0), ("auto", -1, 99)],
+)
+def test_custom_arbiter_uses_native_placement_not_managed_fields(mode, layers, ini_layers):
+    events = route_probe(mode, layers, ini_layers)
+    assert events == (["drain_without_acquire"] if ini_layers == 0 else ["acquire_gpu"])
+
+
+@pytest.mark.parametrize("tensor", [False, True])
+@pytest.mark.parametrize("raises", [False, True])
+def test_custom_route_never_retries_from_managed_tensor_toggle(tensor, raises):
+    events = route_probe("auto", -1, 0, attempts = True, tensor = tensor, raises = raises)
+    attempted = [event for event in events if isinstance(event, dict)]
+    assert len(attempted) == 1
+    assert attempted[0]["attempt"].mode == "custom"
+    assert attempted[0]["extras"] == ()
+
+
+def test_uncertain_custom_device_keeps_gpu_handoff():
+    assert route_probe("manual", 0, 0, device = None) == ["acquire_gpu"]
+
+
+@pytest.mark.parametrize("vision,projector", [(True, None), (False, "audio-projector.gguf")])
+def test_custom_cpu_main_does_not_skip_companion_handoff(vision, projector):
+    assert route_probe("manual", 0, 0, vision = vision, projector = projector) == ["acquire_gpu"]

--- a/studio/backend/tests/test_llama_custom_routes.py
+++ b/studio/backend/tests/test_llama_custom_routes.py
@@ -119,6 +119,17 @@ def preset_backend(monkeypatch):
     return backend
 
 
+@pytest.mark.parametrize("predict", [0, 128])
+@pytest.mark.parametrize("caps", [{}, {"max_tokens": 64}, {"max_completion_tokens": 32}])
+def test_custom_predict_fills_only_an_omitted_chat_cap(preset_backend, predict, caps):
+    preset_backend.llama_cpp_config_summary["request_defaults"]["n_predict"] = predict
+    payload = ChatCompletionRequest(messages = [], **caps)
+    routes._fill_recommended_sampling_openai(payload, "model.gguf")
+    assert routes._effective_openai_max_tokens(payload) == caps.get(
+        "max_completion_tokens", caps.get("max_tokens", predict)
+    )
+
+
 def test_preset_beats_auto_seeded_ui_values_and_retains_native_domains(preset_backend):
     payload = ChatCompletionRequest(
         messages = [],

--- a/studio/backend/tests/test_llama_custom_routes.py
+++ b/studio/backend/tests/test_llama_custom_routes.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Custom configuration persistence, preflight and request-default boundaries."""
+
+from types import SimpleNamespace
+from pathlib import Path
+import sys
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from models.inference import ChatCompletionRequest, LoadRequest, ValidateModelRequest
+from routes import inference as routes
+from routes.chat_history import ChatInferenceSettings
+from utils import openai_auto_switch_settings as settings
+from utils.inference import inference_config as sampling
+from core.inference.llama_custom_config import CustomConfigError
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from test_openai_auto_switch import _put, override_store  # noqa: E402, F401
+
+
+CUSTOM = {"version": 1, "mode": "custom", "ini": "[*]\nnp=1\nc=56000\nfit=off", "section": None}
+MANAGED = {"version": 1, "mode": "managed"}
+MODEL = "unsloth/example-GGUF:Q4_K_M"
+
+
+def test_override_roundtrip_and_managed_reset(override_store):
+    _put(MODEL, llama_cpp_config = CUSTOM, llama_extra_args = ["--temp", "0.7"])
+    row = settings.get_model_override(MODEL)
+    assert row["llama_cpp_config"] == CUSTOM
+    assert settings.model_override_load_kwargs(row, is_gguf = True) == {"llama_cpp_config": CUSTOM}
+    _put(MODEL, llama_cpp_config = MANAGED)
+    row = settings.get_model_override(MODEL)
+    assert row["llama_cpp_config"] == MANAGED
+    assert row["llama_extra_args"] == ["--temp", "0.7"]
+    assert settings.model_override_load_kwargs(row, is_gguf = True)["llama_extra_args"] == [
+        "--temp",
+        "0.7",
+    ]
+
+
+def test_older_client_save_preserves_custom_source(override_store):
+    _put(MODEL, llama_cpp_config = CUSTOM)
+    _put(MODEL, custom_context_length = 8192)
+    assert settings.get_model_override(MODEL)["llama_cpp_config"] == CUSTOM
+
+
+def test_quant_reset_stops_bare_model_fallback(override_store):
+    _put("unsloth/example-GGUF", llama_cpp_config = CUSTOM)
+    _put(MODEL, llama_cpp_config = MANAGED)
+    _, row = settings.resolve_override_for_load("unsloth/example-GGUF", variant = "Q4_K_M")
+    assert row["llama_cpp_config"] == MANAGED
+
+
+@pytest.mark.parametrize("schema", [LoadRequest, ValidateModelRequest])
+def test_source_schema_fails_closed(schema):
+    with pytest.raises(ValidationError):
+        schema(model_path = "model.gguf", llama_cpp_config = {"version": 2, "mode": "custom"})
+
+
+def test_corrupt_saved_source_does_not_become_managed():
+    with pytest.raises(ValueError):
+        settings.normalize_model_override({"llama_cpp_config": {"version": 1, "mode": "custom"}})
+
+
+def test_source_inheritance_is_model_scoped_and_reset_is_explicit(monkeypatch):
+    monkeypatch.setattr(settings, "resolve_override_for_load", lambda *a, **k: (None, {}))
+    resident = SimpleNamespace(
+        last_load_intent = SimpleNamespace(
+            model_identifier = "/models/Original.gguf", hf_variant = None, llama_cpp_config = CUSTOM
+        )
+    )
+    monkeypatch.setattr(routes, "get_llama_cpp_backend", lambda: resident)
+    same = routes._resolve_llama_cpp_config(LoadRequest(model_path = "/models/Original.gguf"))
+    other = routes._resolve_llama_cpp_config(LoadRequest(model_path = "/models/Other.gguf"))
+    reset = routes._resolve_llama_cpp_config(
+        LoadRequest(model_path = "/models/Original.gguf", llama_cpp_config = MANAGED)
+    )
+    assert same.llama_cpp_config == CUSTOM
+    assert other.llama_cpp_config is None
+    assert reset.llama_cpp_config == MANAGED
+
+
+def test_custom_ignores_legacy_extras():
+    request = LoadRequest(
+        model_path = "model.gguf", llama_cpp_config = CUSTOM, llama_extra_args = ["--ctx-size", "128000"]
+    )
+    assert (
+        routes._resolve_inherited_extra_args(
+            request, SimpleNamespace(is_gguf = True), "model.gguf", request.llama_extra_args
+        )
+        == []
+    )
+
+
+@pytest.fixture
+def preset_backend(monkeypatch):
+    defaults = {
+        "temperature": 0.25,
+        "top_k": 180,
+        "repeat_penalty": 0.9,
+        "frequency_penalty": -0.5,
+        "seed": 12,
+        "chat_template_kwargs": {"enable_thinking": False, "custom_key": "kept"},
+    }
+    backend = SimpleNamespace(
+        model_identifier = "model.gguf",
+        llama_cpp_config_summary = {"mode": "custom", "request_defaults": defaults},
+    )
+    monkeypatch.setattr(routes, "get_llama_cpp_backend", lambda: backend)
+    monkeypatch.setattr(
+        sampling, "_recommended_sampling", lambda _: {"temperature": 0.8, "top_k": 20}
+    )
+    for field in sampling.SAMPLING_FIELD_NAMES:
+        monkeypatch.delenv(sampling._SAMPLING_FIELDS[field][0], raising = False)
+    return backend
+
+
+def test_preset_beats_auto_seeded_ui_values_and_retains_native_domains(preset_backend):
+    payload = ChatCompletionRequest(
+        messages = [],
+        temperature = 0.8,
+        top_k = 20,
+        enable_thinking = True,
+        sampling_fields_explicit = [],
+        seed = 3,
+    )
+    routes._fill_recommended_sampling_openai(payload, "model.gguf")
+    assert (payload.temperature, payload.top_k, payload.repetition_penalty) == (0.25, 180, 0.9)
+    assert payload.frequency_penalty == -0.5
+    assert payload.enable_thinking is None
+    assert payload.seed == 3
+    routes._fill_recommended_sampling_openai(payload, "model.gguf")
+    assert payload.temperature == 0.25
+
+
+def test_explicit_zero_and_false_survive_preset(preset_backend):
+    payload = ChatCompletionRequest(
+        messages = [],
+        temperature = 0,
+        enable_thinking = False,
+        sampling_fields_explicit = ["temperature", "enable_thinking"],
+    )
+    routes._fill_recommended_sampling_openai(payload, "model.gguf")
+    assert payload.temperature == 0
+    assert payload.enable_thinking is False
+
+
+def test_operator_pin_remains_highest(preset_backend, monkeypatch):
+    monkeypatch.setenv("UNSLOTH_SAMPLING_TEMPERATURE", "0.4")
+    payload = ChatCompletionRequest(messages = [], temperature = 0.1)
+    routes._fill_recommended_sampling_openai(payload, "model.gguf")
+    assert payload.temperature == 0.4
+
+
+def test_raw_completion_defaults_merge_without_losing_limits(preset_backend):
+    body = {
+        "temperature": 0,
+        "max_tokens": 5,
+        "stop": ["END"],
+        "chat_template_kwargs": {"custom_key": "explicit"},
+    }
+    routes._fill_recommended_sampling_completions(body, "model.gguf")
+    assert body["temperature"] == 0
+    assert body["repeat_penalty"] == 0.9
+    assert body["chat_template_kwargs"] == {"enable_thinking": False, "custom_key": "explicit"}
+    assert (body["max_tokens"], body["stop"]) == (5, ["END"])
+
+
+def test_defaults_never_leak_to_other_model(preset_backend):
+    assert routes._custom_request_defaults("other.gguf") == {}
+
+
+def test_chat_settings_preserve_sampling_provenance():
+    payload = {"temperature": 0.8, "samplingFieldsExplicit": []}
+    assert ChatInferenceSettings.model_validate(payload).model_dump(exclude_unset = True) == payload
+
+
+@pytest.mark.asyncio
+async def test_non_gguf_custom_validation_refuses_without_backend_access(monkeypatch):
+    monkeypatch.setattr(
+        routes, "get_llama_cpp_backend", lambda: pytest.fail("Must not touch resident")
+    )
+    with pytest.raises(HTTPException) as exc:
+        await routes._preflight_custom_llama_config(
+            ValidateModelRequest(model_path = "model", llama_cpp_config = CUSTOM),
+            SimpleNamespace(is_gguf = False),
+        )
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["load", "validate"])
+async def test_route_rejects_custom_before_resident_or_gpu_eviction(
+    monkeypatch, tmp_path, operation
+):
+    model = str(tmp_path / "selected.gguf")
+    calls = []
+
+    def reject(intent, **kwargs):
+        calls.append((intent.model_identifier, kwargs))
+        raise CustomConfigError("INI section [*], key 'host': reserved by Studio")
+
+    resident = SimpleNamespace(
+        is_loaded = True,
+        model_identifier = "resident.gguf",
+        prepare_custom_config = reject,
+        last_load_intent = None,
+    )
+    monkeypatch.setattr(routes, "get_llama_cpp_backend", lambda: resident)
+    monkeypatch.setattr(
+        routes, "get_inference_backend", lambda: SimpleNamespace(active_model_name = None)
+    )
+    monkeypatch.setattr(
+        routes, "_resolve_model_identifier_for_request", lambda *a, **k: (model, model, False)
+    )
+    monkeypatch.setattr(routes, "resolve_effective_chat_template_override", lambda **k: None)
+    config = SimpleNamespace(
+        identifier = model,
+        is_gguf = True,
+        is_vision = False,
+        gguf_file = model,
+        gguf_mmproj_file = None,
+        gguf_variant = "Q4_K_M",
+        gguf_hf_repo = None,
+    )
+    monkeypatch.setattr(routes, "ModelConfig", SimpleNamespace(from_identifier = lambda **k: config))
+    monkeypatch.setattr(routes, "_classify_diffusion_gguf", lambda _: False)
+    monkeypatch.setattr(
+        "core.inference.gpu_arbiter.acquire_for",
+        lambda *a, **k: pytest.fail("GPU owner was evicted"),
+    )
+    request_context = SimpleNamespace(
+        app = SimpleNamespace(state = SimpleNamespace(llama_parallel_slots = 1))
+    )
+    with pytest.raises(HTTPException) as exc:
+        if operation == "load":
+            await routes._load_model_impl(
+                LoadRequest(model_path = model, gguf_variant = "Q4_K_M", llama_cpp_config = CUSTOM),
+                request_context,
+                current_subject = "custom-test",
+            )
+        else:
+            await routes.validate_model(
+                ValidateModelRequest(
+                    model_path = model, gguf_variant = "Q4_K_M", llama_cpp_config = CUSTOM
+                ),
+                request_context,
+                current_subject = "custom-test",
+            )
+    assert exc.value.status_code == 400
+    assert "reserved by Studio" in str(exc.value.detail)
+    assert calls == [(model, {"validate_resources": True})]
+    assert resident.is_loaded and resident.model_identifier == "resident.gguf"

--- a/studio/backend/tests/test_metal_paravirtual_guard.py
+++ b/studio/backend/tests/test_metal_paravirtual_guard.py
@@ -1051,7 +1051,7 @@ def test_a_diffusion_load_drops_the_drafter_state_it_inherits():
     tail = src[at : at + 600]
     assert "self._mtp_draft_path = None" in tail
     assert "self._mtp_draft_suppressed_path = None" in tail
-    assert at < src.index("return self._start_diffusion_server(")
+    assert at < src.index("started = self._start_diffusion_server(")
 
 
 def test_the_drafter_pin_covers_the_device_not_just_the_layers():

--- a/studio/backend/tests/test_parallel_slots_per_load.py
+++ b/studio/backend/tests/test_parallel_slots_per_load.py
@@ -233,7 +233,7 @@ def test_load_model_commits_requested_from_intent():
     # first, so a failed start cannot poison the next inheritance check.
     # Matched without the argument list, so adding one does not break this again.
     healthy = src.find("self._publish_healthy(", 0, commit if commit != -1 else None)
-    snapshot = src.find("self._last_load_intent = replace(intent")
+    snapshot = src.find("self._last_load_intent = replace(intent", commit)
     assert commit != -1, "load_model must commit the requested slot count"
     assert healthy != -1 and healthy < commit < snapshot
 

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -1724,6 +1724,45 @@ def test_stream_completion_opts_out_of_the_tool_loop(monkeypatch):
     assert sent[0]["json"]["thread_id"] == "research:run-1"
 
 
+@pytest.mark.parametrize("fields", [[], ["temperature", "top_p"]])
+@pytest.mark.parametrize("thinking", [None, False, True])
+def test_research_sampling_provenance_survives_durable_config_and_worker(
+    monkeypatch, fields, thinking
+):
+    config = _sanitize_config(
+        _make_payload(inferenceRequest = {"model": "m", "samplingFieldsExplicit": fields}),
+        {"modelId": "m"},
+    )
+    sent = _install_fake_client(monkeypatch, [_response(200, body = _stream_body())])
+    supervisor = _make_supervisor(_noop_check_active)
+    run = _waiting_run(30.0)
+    run["config"]["inferenceRequest"] = config["inferenceRequest"]
+    asyncio.run(
+        supervisor._stream_completion(
+            run,
+            [{"role": "user"}],
+            report_progress = False,
+            enable_thinking = thinking,
+        )
+    )
+    expected = fields + ([] if thinking is None else ["enable_thinking"])
+    if thinking is False:
+        expected.append("reasoning_effort")
+    assert sent[0]["json"]["sampling_fields_explicit"] == expected
+
+
+@pytest.mark.parametrize(
+    "fields", [None, "temperature", [1], [{}], ["unknown"], ["temperature"] * 17]
+)
+def test_research_sampling_provenance_rejects_invalid_values(fields):
+    with pytest.raises(HTTPException) as exc:
+        _sanitize_config(
+            _make_payload(inferenceRequest = {"model": "m", "samplingFieldsExplicit": fields}),
+            {"modelId": "m"},
+        )
+    assert exc.value.status_code == 400
+
+
 def test_codex_research_hops_route_saved_provider_with_run_scoped_cache(monkeypatch):
     sent = _install_fake_client(monkeypatch, [_response(200, body = _stream_body())])
     supervisor = _make_supervisor(_noop_check_active)

--- a/studio/backend/tests/test_tp_vision_regression.py
+++ b/studio/backend/tests/test_tp_vision_regression.py
@@ -556,7 +556,7 @@ def test_diffusion_load_clears_preserved_tensor_flag():
     src = inspect.getsource(LlamaCppBackend.load_model)
     diff = src.find("if self._is_diffusion:")
     assert diff != -1
-    start = src.find("return self._start_diffusion_server", diff)
+    start = src.find("started = self._start_diffusion_server", diff)
     assert start != -1
     assert "self._layer_preserves_tensor_intent = False" in src[diff:start]
 

--- a/studio/backend/utils/inference/inference_config.py
+++ b/studio/backend/utils/inference/inference_config.py
@@ -204,8 +204,15 @@ def resolve_effective_sampling(
     explicit: Dict[str, Any],
     *,
     fill_defaults: bool = True,
+    preset_defaults: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
-    """Resolve the effective sampling params for a request. ``explicit`` maps each field in :data:`SAMPLING_FIELD_NAMES` to the client-sent value, or ``None`` when the client omitted it. Precedence, highest first: an operator ``UNSLOTH_SAMPLING_*`` pin, the client's explicit value, the per-model recommendation, then the static schema default. When ``fill_defaults`` is False a field with none of the first three is omitted rather than set to the static default, so a raw proxy body (``/v1/completions``) keeps llama-server's own default for that field."""
+    """Resolve sampling from operator pins, explicit values, custom preset defaults,
+    model recommendations, then schema defaults, in that order.
+
+    ``explicit`` maps each sampling field to the client value or ``None`` when
+    omitted. With ``fill_defaults=False``, omit unresolved fields so a raw
+    completions proxy retains the native server's defaults.
+    """
     recommended = _recommended_sampling(model_id or "")
     effective: Dict[str, Any] = {}
     for field, (_env, default, _lo, _hi, _int) in _SAMPLING_FIELDS.items():
@@ -214,6 +221,8 @@ def resolve_effective_sampling(
             effective[field] = override
         elif explicit.get(field) is not None:
             effective[field] = explicit[field]
+        elif preset_defaults and field in preset_defaults:
+            effective[field] = preset_defaults[field]
         elif field in recommended:
             effective[field] = recommended[field]
         elif fill_defaults:

--- a/studio/backend/utils/openai_auto_switch_settings.py
+++ b/studio/backend/utils/openai_auto_switch_settings.py
@@ -408,6 +408,12 @@ def normalize_model_override(
     """Validate one per-model launch config, dropping anything unusable. Silently drops rather than raising: an override is a convenience mirror of the UI's config, so one stale field (a KV dtype this llama.cpp build lost, a GPU id from another host) must not block persisting the rest or fail the API load that reads it. ``validate_extra_args`` is the caller's job, since it lives in the llama_server_args allow-list module this one must not import. ``keep_empty_extra_args`` keeps an explicit empty list, the difference between "this model has no launch flags" and "nothing is stored for this model": the same thing everywhere except under a fallback, where a quant whose row is gone reads the bare repository row instead and a cleared box would come back holding whatever that legacy row carries."""
     entry: dict[str, Any] = {}
 
+    if payload.get("llama_cpp_config") is not None:
+        from core.inference.llama_custom_config import parse_config_source
+
+        # A broken custom configuration must not silently become a managed load.
+        entry["llama_cpp_config"] = parse_config_source(payload["llama_cpp_config"]).to_wire()
+
     extra_args = payload.get("llama_extra_args")
     if isinstance(extra_args, (list, tuple)) and extra_args:
         entry["llama_extra_args"] = [str(arg) for arg in extra_args]
@@ -542,6 +548,16 @@ def model_override_load_kwargs(override: dict[str, Any], *, is_gguf: bool) -> di
     if not override:
         return {}
     kwargs: dict[str, Any] = {}
+
+    if is_gguf and override.get("llama_cpp_config") is not None:
+        from core.inference.llama_custom_config import parse_config_source
+
+        custom = parse_config_source(override["llama_cpp_config"])
+        kwargs["llama_cpp_config"] = custom.to_wire()
+        if custom.mode == "custom":
+            if override.get("disable_vision") is not None:
+                kwargs["disable_vision"] = override["disable_vision"]
+            return kwargs
 
     max_seq_length = resolve_fit_max_seq_length(override, is_gguf = is_gguf)
     if max_seq_length is not None:

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+// eslint-disable-next-line no-restricted-imports -- The picker barrel imports chat; auto-load needs only its API leaf.
+import { fetchLoadModelOverride } from "@/features/model-picker/api/model-overrides";
+// eslint-disable-next-line no-restricted-imports -- Keep the import-free config helpers independent of the picker UI.
+import {
+  llamaCppConfigPayload,
+  customSamplingPayload,
+} from "@/features/model-picker/model-config/llama-cpp-config";
 import { mlxRuntimeStateFrom } from "../lib/mlx-runtime-state";
 import {
   clearedServerTuningState,
@@ -3051,6 +3058,19 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
     // The stored override can live only on the server while this config is local, and nothing is
     // resident at startup for /load's omission path to inherit from. Sanitized like every
     // hydration, so it becomes an EXPLICIT list /load validates strictly.
+    if (
+      candidate.kind === "gguf" &&
+      !isDiffusion &&
+      config.llamaCppConfig === undefined
+    ) {
+      config.llamaCppConfig = (
+        await fetchLoadModelOverride(
+          modelPath,
+          candidate.id,
+          candidate.ggufVariant ?? null,
+        )
+      )?.llama_cpp_config;
+    }
     let resolvedExtraArgs = config.llamaExtraArgs;
     if (candidate.kind === "gguf" && !isDiffusion) {
       try {
@@ -3142,6 +3162,7 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
               // it disagrees with the launch.
               ...serverTuningLoadPayload(config),
               // Checked with the same arguments the load sends, or a list the backend refuses would pass this gate.
+              ...llamaCppConfigPayload(config.llamaCppConfig),
               ...(resolvedExtraArgs !== undefined
                 ? { llama_extra_args: resolvedExtraArgs ?? [] }
                 : {}),
@@ -3201,6 +3222,7 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
             ...serverTuningLoadPayload(config),
             // Remembered pass-through args: nothing is resident at startup to inherit them from.
             // Undefined predates the field; a cleared list is an explicit none.
+            ...llamaCppConfigPayload(config.llamaCppConfig),
             ...(resolvedExtraArgs !== undefined
               ? { llama_extra_args: resolvedExtraArgs ?? [] }
               : {}),
@@ -3310,6 +3332,11 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
           ...committedServerTuningState(config, loadResp.is_diffusion ?? false),
           // What this launch is running, for a later rollback: the status applier cannot seed it while
           // the model-loading lease is held, and a failed switch would restore the wrong args.
+          loadedLlamaCppConfig:
+            loadResp.requested_llama_cpp_config ?? config.llamaCppConfig ?? null,
+          llamaCppConfig:
+            loadResp.requested_llama_cpp_config ?? config.llamaCppConfig,
+          llamaCppConfigSummary: loadResp.llama_cpp_config_summary ?? null,
           loadedLlamaExtraArgs:
             loadResp.requested_llama_extra_args !== undefined
               ? (loadResp.requested_llama_extra_args ?? [])
@@ -3359,6 +3386,9 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
           // Same reason, and the baseline must clear so a rollback to THIS model does not resend a
           // GGUF's arguments.
           loadedLlamaExtraArgs: null,
+          llamaCppConfig: undefined,
+          loadedLlamaCppConfig: null,
+          llamaCppConfigSummary: null,
           tensorParallel: loadResp.tensor_parallel ?? false,
           loadedTensorParallel: loadResp.tensor_parallel ?? false,
           loadedDisableVision: loadResp.disable_vision ?? false,
@@ -4043,6 +4073,8 @@ export function createOpenAIStreamAdapter(
             : withResolvedModel({
                 ...sendTimeRuntime,
                 ...queuedRunSettings,
+                loadedLlamaCppConfig: sendTimeRuntime.loadedLlamaCppConfig,
+                llamaCppConfigSummary: sendTimeRuntime.llamaCppConfigSummary,
                 // The queued snapshot carries no model of its own.
                 params: {
                   ...queuedRunSettings.params,
@@ -4387,6 +4419,8 @@ export function createOpenAIStreamAdapter(
           : {
               ...liveRuntime,
               ...queuedRunSettings,
+              loadedLlamaCppConfig: liveRuntime.loadedLlamaCppConfig,
+              llamaCppConfigSummary: liveRuntime.llamaCppConfigSummary,
               params: {
                 ...queuedRunSettings.params,
                 checkpoint:
@@ -4970,6 +5004,10 @@ export function createOpenAIStreamAdapter(
               // stop-chats prompt counts one run as two.
               ...(resolvedThreadId ? { thread_id: resolvedThreadId } : {}),
               stream: false,
+              ...customSamplingPayload(
+                runtime.loadedLlamaCppConfig,
+                params.samplingFieldsExplicit,
+              ),
               temperature: params.temperature,
               top_p: params.topP,
               max_tokens: params.maxTokens,
@@ -6009,6 +6047,10 @@ export function createOpenAIStreamAdapter(
               contextPolicy: runtime.contextPolicy,
               compactionHeadroomRatio: runtime.compactionHeadroomRatio,
             }),
+            ...customSamplingPayload(
+              runtime.loadedLlamaCppConfig,
+              params.samplingFieldsExplicit,
+            ),
             temperature: params.temperature,
             top_p: params.topP,
             max_tokens: params.maxTokens,

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -2059,6 +2059,8 @@ function isAutoLoadableGgufVariant(variant: GgufVariantDetail | null): boolean {
 }
 
 type QueuedResolvedModelRuntime = {
+  loadedLlamaCppConfig: ChatRuntimeState["loadedLlamaCppConfig"];
+  llamaCppConfigSummary: ChatRuntimeState["llamaCppConfigSummary"];
   checkpoint: string;
   activeGgufVariant: string | null;
   supportsTools: boolean;
@@ -2209,6 +2211,8 @@ function queuedResolvedModelFromStore(
     (model) => model.id === state.params.checkpoint,
   );
   return {
+    loadedLlamaCppConfig: state.loadedLlamaCppConfig,
+    llamaCppConfigSummary: state.llamaCppConfigSummary,
     checkpoint: state.params.checkpoint,
     activeGgufVariant: state.activeGgufVariant,
     supportsTools: state.supportsTools,
@@ -3058,22 +3062,18 @@ async function autoLoadSmallestModel(options?: AutoLoadOptions): Promise<{
     // The stored override can live only on the server while this config is local, and nothing is
     // resident at startup for /load's omission path to inherit from. Sanitized like every
     // hydration, so it becomes an EXPLICIT list /load validates strictly.
-    if (
-      candidate.kind === "gguf" &&
-      !isDiffusion &&
-      config.llamaCppConfig === undefined
-    ) {
-      config.llamaCppConfig = (
-        await fetchLoadModelOverride(
-          modelPath,
-          candidate.id,
-          candidate.ggufVariant ?? null,
-        )
-      )?.llama_cpp_config;
-    }
     let resolvedExtraArgs = config.llamaExtraArgs;
     if (candidate.kind === "gguf" && !isDiffusion) {
       try {
+        if (config.llamaCppConfig === undefined) {
+          config.llamaCppConfig = (
+            await fetchLoadModelOverride(
+              modelPath,
+              candidate.id,
+              candidate.ggufVariant ?? null,
+            )
+          )?.llama_cpp_config;
+        }
         const managed = await loadManagedLlamaFlags();
         const clean = (tokens: readonly string[]) =>
           sanitizeStoredExtraArgs(tokens, managed?.managed ?? new Set<string>(), {
@@ -3818,6 +3818,8 @@ async function resolveQueuedEmptyLocalModel(abortSignal: AbortSignal): Promise<{
           loaded: true,
           blockedByTrustRemoteCode: false,
           modelRuntime: {
+            loadedLlamaCppConfig: status.requested_llama_cpp_config ?? null,
+            llamaCppConfigSummary: status.llama_cpp_config_summary ?? null,
             checkpoint,
             activeGgufVariant: status.gguf_variant ?? null,
             supportsTools: status.supports_tools ?? false,
@@ -4050,6 +4052,8 @@ export function createOpenAIStreamAdapter(
                   checkpoint: queuedEmptyModelRuntime.checkpoint,
                 },
                 activeGgufVariant: queuedEmptyModelRuntime.activeGgufVariant,
+                loadedLlamaCppConfig: queuedEmptyModelRuntime.loadedLlamaCppConfig,
+                llamaCppConfigSummary: queuedEmptyModelRuntime.llamaCppConfigSummary,
                 supportsTools: queuedEmptyModelRuntime.supportsTools,
                 supportsReasoning: queuedEmptyModelRuntime.supportsReasoning,
                 reasoningAlwaysOn: queuedEmptyModelRuntime.reasoningAlwaysOn,
@@ -4126,6 +4130,10 @@ export function createOpenAIStreamAdapter(
           (runtime.reasoningEnabled && runtime.reasoningEffort !== "none");
         const inferenceRequest = buildResearchInferenceRequest({
           checkpoint: selectedCheckpoint,
+          samplingFieldsExplicit: customSamplingPayload(
+            runtime.loadedLlamaCppConfig,
+            params.samplingFieldsExplicit,
+          ).sampling_fields_explicit,
           external:
             researchExternalSelection && researchExternalProvider
               ? {
@@ -4419,8 +4427,12 @@ export function createOpenAIStreamAdapter(
           : {
               ...liveRuntime,
               ...queuedRunSettings,
-              loadedLlamaCppConfig: liveRuntime.loadedLlamaCppConfig,
-              llamaCppConfigSummary: liveRuntime.llamaCppConfigSummary,
+              loadedLlamaCppConfig: queuedEmptyModelRuntime
+                ? queuedEmptyModelRuntime.loadedLlamaCppConfig
+                : liveRuntime.loadedLlamaCppConfig,
+              llamaCppConfigSummary: queuedEmptyModelRuntime
+                ? queuedEmptyModelRuntime.llamaCppConfigSummary
+                : liveRuntime.llamaCppConfigSummary,
               params: {
                 ...queuedRunSettings.params,
                 checkpoint:

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -275,6 +275,25 @@ export async function loadModel(
     });
   if (options?.signal?.aborted)
     throw options.signal.reason ?? new DOMException("Aborted", "AbortError");
+  if (payload.llama_cpp_config?.mode === "custom") {
+    if (payload.nativePathLease && !payload.nativePathToken) {
+      throw new Error(
+        "Please re-select the local model file to validate its custom configuration.",
+      );
+    }
+    const validationLease = payload.nativePathToken
+      ? (
+          await consumeNativePathToken(payload.nativePathToken, "validate-model")
+        ).nativePathLease
+      : null;
+    const validation = await validateModel({
+      ...payload,
+      nativePathLease: validationLease,
+    });
+    if (!validation.valid) throw new Error(validation.message);
+    if (options?.signal?.aborted)
+      throw options.signal.reason ?? new DOMException("Aborted", "AbortError");
+  }
   options?.onRequestStart?.();
   // Announced after the token prompt, so a cancelled load never shows a row. The indicator
   // otherwise had nothing to show until its next 5s poll.
@@ -290,10 +309,19 @@ export async function loadModel(
           hf_token: preparedToken.token,
           native_path_lease: payload.nativePathLease ?? null,
           nativePathLease: undefined,
+          nativePathToken: undefined,
         }),
         signal: options?.signal,
       });
       const loaded = await parseJsonOrThrow<LoadModelResponse>(response, "Model load");
+      if (
+        payload.llama_cpp_config?.mode === "custom" &&
+        loaded.llama_cpp_config_summary?.mode !== "custom"
+      ) {
+        throw new Error(
+          "The server did not confirm the custom llama.cpp configuration. Update Studio and try again.",
+        );
+      }
       // Unconditional: absent on nearly every load, anything malformed is ignored,
       // and the model is already resident by the time this runs. Both identities are
       // passed -- a cached Hub candidate is requested by its loadId while the runtime
@@ -362,6 +390,9 @@ export async function validateModel(
       n_parallel: payload.n_parallel,
       // A --ctx-size or cache override in here changes the estimate, so a preflight that dropped them
       // would approve a different command from the one that runs.
+      ...(payload.llama_cpp_config !== undefined
+        ? { llama_cpp_config: payload.llama_cpp_config }
+        : {}),
       ...(payload.llama_extra_args !== undefined
         ? // biome-ignore lint/style/useNamingConvention: API schema
           { llama_extra_args: payload.llama_extra_args }
@@ -375,7 +406,17 @@ export async function validateModel(
       spec_draft_n_max: payload.spec_draft_n_max ?? null,
     }),
   });
-  return parseJsonOrThrow<ValidateModelResponse>(response);
+  const validated = await parseJsonOrThrow<ValidateModelResponse>(response);
+  if (
+    payload.llama_cpp_config?.mode === "custom" &&
+    validated.valid &&
+    validated.llama_cpp_config_summary?.mode !== "custom"
+  ) {
+    throw new Error(
+      "This server cannot validate custom llama.cpp configuration. Update Studio and try again.",
+    );
+  }
+  return validated;
 }
 
 /** Read a GGUF's header dims (native context length, layer count, MoE expert-layer count) from its

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+// eslint-disable-next-line no-restricted-imports -- Keep sampling provenance independent of the picker UI barrel.
+import {
+  SAMPLING_WIRE_FIELDS,
+  explicitSamplingFields,
+} from "@/features/model-picker/model-config/llama-cpp-config";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -805,7 +810,22 @@ export function ChatSettingsPanel({
 
   function set<K extends keyof InferenceParams>(key: K) {
     return (v: InferenceParams[K]) => {
-      const nextParams = { ...params, [key]: v };
+      const wire = SAMPLING_WIRE_FIELDS[key as keyof typeof SAMPLING_WIRE_FIELDS];
+      const nextParams = {
+        ...params,
+        [key]: v,
+        ...(wire
+          ? {
+              samplingFieldsExplicit: [
+                ...new Set([
+                  ...(params.samplingFieldsExplicit ??
+                    Object.values(SAMPLING_WIRE_FIELDS)),
+                  wire,
+                ]),
+              ],
+            }
+          : {}),
+      };
       const nextSource = isSamePresetConfig(activePresetBaseline, nextParams)
         ? getPresetSource(activePreset)
         : "modified";
@@ -852,6 +872,9 @@ export function ChatSettingsPanel({
     presetParams: Parameters<typeof applyPresetParams>[1],
   ): InferenceParams {
     const nextParams = applyPresetParams(params, presetParams);
+    nextParams.samplingFieldsExplicit = explicitSamplingFields(
+      presetParams as unknown as Record<string, unknown>,
+    );
     // Same reason the effect waits for a provider: without one `maxTokensMax` is the fallback, so
     // applying a preset here would lower the value for good.
     if (!isExternalModel || activeExternalProvider == null) return nextParams;

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+// eslint-disable-next-line no-restricted-imports -- The picker barrel imports chat; this payload helper is import-free.
+import { llamaCppConfigPayload } from "@/features/model-picker/model-config/llama-cpp-config";
 import { mlxRuntimeStateFrom } from "../lib/mlx-runtime-state";
 import {
   type ServerTuningValues,
@@ -1428,6 +1430,12 @@ export function useChatModelRuntime() {
           // them", and the route preserves the stored flags when the field is omitted, so a fallback
           // would clear flags the user set elsewhere.
           const loadLlamaExtraArgs = pendingLoadConfig?.llamaExtraArgs;
+          const loadLlamaCppConfig =
+            pendingLoadConfig?.llamaCppConfig ??
+            (currentCheckpoint === modelId &&
+            previousVariant === (ggufVariant ?? null)
+              ? stateBeforeUnload.llamaCppConfig
+              : undefined);
           let loadNBatch =
             pendingLoadConfig?.nBatch ?? stateBeforeUnload.nBatch;
           let loadNUbatch =
@@ -1542,6 +1550,9 @@ export function useChatModelRuntime() {
                     // The same list the load below sends: a --ctx-size or cache override changes the memory this
                     // preflight estimates, so omitting it approves a different command and /load then refuses
                     // the target with the real arguments.
+                    ...(!targetIsDiffusion
+                      ? llamaCppConfigPayload(loadLlamaCppConfig)
+                      : {}),
                     ...(!targetIsDiffusion && loadLlamaExtraArgs !== undefined
                       ? { llama_extra_args: loadLlamaExtraArgs ?? [] }
                       : {}),
@@ -1606,7 +1617,9 @@ export function useChatModelRuntime() {
               // preflight, so a rejected target truncates replies for a model that never loads. Idle,
               // unload first and free VRAM early.
               if (!forceCancelActive) {
-                await unloadModel({ model_path: currentCheckpoint });
+                if (loadLlamaCppConfig?.mode !== "custom") {
+                  await unloadModel({ model_path: currentCheckpoint });
+                }
               }
               // Set either way: /load can still leave no model resident, and an unneeded rollback hits
               // already_loaded before the gate.
@@ -1742,6 +1755,7 @@ export function useChatModelRuntime() {
             const loadResponse = await loadModel({
               model_path: loadPath,
               nativePathLease: loadNativePathLease,
+              nativePathToken,
               hf_token: hfToken,
               max_seq_length: loadMaxSeqLength,
               load_in_4bit: true,
@@ -1758,6 +1772,9 @@ export function useChatModelRuntime() {
               n_parallel: isGguf ? loadNParallel : null,
               // Sent only once known, and [] is the explicit "launch with none": the flags are llama-server's,
               // so neither a transformers load nor a diffusion GGUF carries them.
+              ...(isGguf && !targetIsDiffusion
+                ? llamaCppConfigPayload(loadLlamaCppConfig)
+                : {}),
               ...(isGguf && !targetIsDiffusion && loadLlamaExtraArgs !== undefined
                 ? { llama_extra_args: loadLlamaExtraArgs ?? [] }
                 : {}),
@@ -1974,6 +1991,13 @@ export function useChatModelRuntime() {
               // process's list, so the last thing we knew still holds unless this was a different model. An
               // explicit empty list is recorded as empty, not null, since omitting the field is what makes /load
               // inherit. The server's echo comes first, as the only account of what the launch carried.
+              loadedLlamaCppConfig:
+                loadResponse.requested_llama_cpp_config ??
+                loadLlamaCppConfig ??
+                null,
+              llamaCppConfig:
+                loadResponse.requested_llama_cpp_config ?? loadLlamaCppConfig,
+              llamaCppConfigSummary: loadResponse.llama_cpp_config_summary ?? null,
               loadedLlamaExtraArgs:
                 loadResponse.requested_llama_extra_args !== undefined
                   ? (loadResponse.requested_llama_extra_args ?? [])
@@ -2068,6 +2092,7 @@ export function useChatModelRuntime() {
                   // The pin it loaded from: without it this retries the ref that needed pinning.
                   model_path: previousActiveLoadId || previousCheckpoint,
                   nativePathLease: rollbackNativePathLease,
+                  nativePathToken: previousActiveNativePathToken,
                   hf_token: hfToken,
                   max_seq_length: rollbackMaxSeqLength,
                   load_in_4bit: true,
@@ -2103,6 +2128,9 @@ export function useChatModelRuntime() {
                   }),
                   // Explicit, unlike the batch pair above: the failed switch left the TARGET resident, so an
                   // omitted field here inherits across models, which the route refuses.
+                  ...llamaCppConfigPayload(
+                    stateBeforeUnload.loadedLlamaCppConfig ?? undefined,
+                  ),
                   ...(stateBeforeUnload.loadedLlamaExtraArgs != null
                     ? { llama_extra_args: stateBeforeUnload.loadedLlamaExtraArgs }
                     : {}),
@@ -2128,6 +2156,13 @@ export function useChatModelRuntime() {
                   rollbackResponse.speculative_type,
                 );
                 useChatRuntimeStore.setState({
+                  llamaCppConfig:
+                    stateBeforeUnload.loadedLlamaCppConfig ?? undefined,
+                  loadedLlamaCppConfig: stateBeforeUnload.loadedLlamaCppConfig,
+                  llamaCppConfigSummary:
+                    rollbackResponse.llama_cpp_config_summary ??
+                    stateBeforeUnload.llamaCppConfigSummary,
+                  params: stateBeforeUnload.params,
                   activeModelIsLocal: rollbackResponse.is_local_model ?? false,
                   activeLoadId: previousActiveLoadId ?? null,
                   activeNativePathToken: previousActiveNativePathToken ?? null,

--- a/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
+++ b/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
@@ -555,6 +555,11 @@ export function applyActiveModelStatusToStore(
     // status, not just the first: another client can reload the SAME model with different
     // arguments, and a pinned baseline would resurrect arguments that are not running.
     // seedLoadParams still guards it, so a mid-switch poll cannot overwrite performLoad.
+    ...(status.requested_llama_cpp_config !== undefined && seedLoadParams ? {
+      llamaCppConfig: status.requested_llama_cpp_config ?? undefined,
+      loadedLlamaCppConfig: status.requested_llama_cpp_config ?? null,
+      llamaCppConfigSummary: status.llama_cpp_config_summary ?? null,
+    } : {}),
     ...(status.requested_llama_extra_args !== undefined &&
       (status.is_gguf ?? true) &&
       seedLoadParams && {

--- a/studio/frontend/src/features/chat/lib/per-model-params.ts
+++ b/studio/frontend/src/features/chat/lib/per-model-params.ts
@@ -9,11 +9,13 @@ import type {
   InferenceParams,
   PersistedInferenceParams,
 } from "../types/runtime";
+import { explicitSamplingFields } from "../../model-picker/model-config/llama-cpp-config.ts";
 
 export type PersistedInferenceParamKey = keyof PersistedInferenceParams;
 
 /** Params that persist across a reload. `checkpoint` is the key, not a value. */
 export const PERSISTED_INFERENCE_PARAM_KEYS = [
+  "samplingFieldsExplicit",
   "temperature",
   "topP",
   "topK",
@@ -125,6 +127,9 @@ export function getReplayedParams(
   // Key by key, not a spread: the row accepts every persisted key from any writer, and a spread
   // would carry maxSeqLength and stale keys into params.
   const replayed = { ...current };
+  if (current.samplingFieldsExplicit !== undefined || remembered.samplingFieldsExplicit !== undefined) {
+    replayed.samplingFieldsExplicit = explicitSamplingFields(remembered as Record<string, unknown>);
+  }
   for (const key of REMEMBERED_INFERENCE_PARAM_KEYS) {
     const value = remembered[key];
     if (value !== undefined) {

--- a/studio/frontend/src/features/chat/lib/per-model-params.ts
+++ b/studio/frontend/src/features/chat/lib/per-model-params.ts
@@ -10,33 +10,17 @@ import type {
   PersistedInferenceParams,
 } from "../types/runtime";
 import { explicitSamplingFields } from "../../model-picker/model-config/llama-cpp-config.ts";
+import {
+  PERSISTED_INFERENCE_PARAM_KEYS,
+  REMEMBERED_INFERENCE_PARAM_KEYS,
+  type PersistedInferenceParamKey,
+} from "./persisted-inference-param-keys.ts";
 
-export type PersistedInferenceParamKey = keyof PersistedInferenceParams;
-
-/** Params that persist across a reload. `checkpoint` is the key, not a value. */
-export const PERSISTED_INFERENCE_PARAM_KEYS = [
-  "samplingFieldsExplicit",
-  "temperature",
-  "topP",
-  "topK",
-  "minP",
-  "repetitionPenalty",
-  "presencePenalty",
-  "maxSeqLength",
-  "maxTokens",
-  "systemPrompt",
-  "systemVariables",
-  "trustRemoteCode",
-  "fastMode",
-  "seed",
-] as const satisfies readonly PersistedInferenceParamKey[];
-
-/** What the memory records. `maxSeqLength` is left out: the context belongs to the load config,
- *  and a second copy would advertise one never loaded. */
-export const REMEMBERED_INFERENCE_PARAM_KEYS =
-  PERSISTED_INFERENCE_PARAM_KEYS.filter(
-    (key): key is PersistedInferenceParamKey => key !== "maxSeqLength",
-  );
+export {
+  PERSISTED_INFERENCE_PARAM_KEYS,
+  REMEMBERED_INFERENCE_PARAM_KEYS,
+  type PersistedInferenceParamKey,
+} from "./persisted-inference-param-keys.ts";
 
 export function setInferenceParam(
   params: InferenceParams,

--- a/studio/frontend/src/features/chat/lib/persisted-inference-param-keys.ts
+++ b/studio/frontend/src/features/chat/lib/persisted-inference-param-keys.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import type { PersistedInferenceParams } from "../types/runtime";
+
+export type PersistedInferenceParamKey = keyof PersistedInferenceParams;
+
+/** Params that persist across a reload. `checkpoint` is the key, not a value. */
+export const PERSISTED_INFERENCE_PARAM_KEYS = [
+  "samplingFieldsExplicit",
+  "temperature",
+  "topP",
+  "topK",
+  "minP",
+  "repetitionPenalty",
+  "presencePenalty",
+  "maxSeqLength",
+  "maxTokens",
+  "systemPrompt",
+  "systemVariables",
+  "trustRemoteCode",
+  "fastMode",
+  "seed",
+] as const satisfies readonly PersistedInferenceParamKey[];
+
+/** What per-model memory records. Context length belongs to the load config. */
+export const REMEMBERED_INFERENCE_PARAM_KEYS =
+  PERSISTED_INFERENCE_PARAM_KEYS.filter(
+    (key): key is PersistedInferenceParamKey => key !== "maxSeqLength",
+  );

--- a/studio/frontend/src/features/chat/lib/resident-config-match.ts
+++ b/studio/frontend/src/features/chat/lib/resident-config-match.ts
@@ -31,6 +31,7 @@ type ResidentRuntime = Pick<
   | "disable_vision"
   | "chat_template_override"
   | "requested_llama_extra_args"
+  | "requested_llama_cpp_config"
   | "gpu_memory_mode"
   | "gpu_layers"
   | "n_cpu_moe"
@@ -535,6 +536,10 @@ export function residentRuntimeMatchesConfig(
   // the live runtime, which was hydrated from the resident model.
   if (!config) {
     return true;
+  }
+  if (config.llamaCppConfig?.mode === "custom" || status.requested_llama_cpp_config?.mode === "custom") {
+    // The server must revalidate capabilities and resource identity before deduplicating.
+    return false;
   }
   const placementPreserved =
     // A virtualised Metal device pins every GGUF request to the CPU before either comparator runs, so

--- a/studio/frontend/src/features/chat/research-inference-request.ts
+++ b/studio/frontend/src/features/chat/research-inference-request.ts
@@ -18,6 +18,7 @@ export interface ResearchInferenceRequest {
   externalModel?: string;
   temperature?: number;
   topP?: number;
+  samplingFieldsExplicit?: string[];
   maxTokens?: number;
   maxOutputTokens?: number;
   maxOutputTokensFromSavedCap?: boolean;
@@ -41,6 +42,7 @@ export function buildResearchInferenceRequest(input: {
   };
   temperature: number;
   topP: number;
+  samplingFieldsExplicit?: readonly string[];
   maxTokens: number;
   reasoningRequested: boolean;
   reasoningStyle: string;
@@ -54,6 +56,9 @@ export function buildResearchInferenceRequest(input: {
   const model = input.external?.modelId ?? input.checkpoint;
   const request: ResearchInferenceRequest = {
     model,
+    ...(!input.external && input.samplingFieldsExplicit !== undefined
+      ? { samplingFieldsExplicit: [...input.samplingFieldsExplicit] }
+      : {}),
     ...(input.external
       ? {
           providerId: input.external.providerId,

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+// eslint-disable-next-line no-restricted-imports -- The picker barrel imports chat; compare loads need only its API leaf.
+import { fetchLoadModelOverride } from "@/features/model-picker/api/model-overrides";
+// eslint-disable-next-line no-restricted-imports -- Keep the import-free payload helper independent of the picker UI.
+import { llamaCppConfigPayload } from "@/features/model-picker/model-config/llama-cpp-config";
 import { mlxRuntimeStateFrom } from "./lib/mlx-runtime-state";
 import {
   clearedServerTuningState,
@@ -1333,6 +1337,15 @@ export function SharedComposer({
                   windowsCommandBudget: managed?.windowsCommandBudget,
                 },
               );
+            if (ownConfig.llamaCppConfig === undefined) {
+              ownConfig.llamaCppConfig = (
+                await fetchLoadModelOverride(
+                  sel.id,
+                  sel.id,
+                  sel.ggufVariant ?? null,
+                )
+              )?.llama_cpp_config;
+            }
             const local = ownConfig.llamaExtraArgs;
             if (local === undefined) {
               const resolvedArgs = await fetchLoadExtraArgs(
@@ -1469,6 +1482,7 @@ export function SharedComposer({
                 n_parallel: ownConfig.nParallel ?? null,
                 // Only when this panel has read the stored value: omitted, the load inherits it, which is what
                 // keeps CLI-set flags working.
+                ...llamaCppConfigPayload(ownConfig.llamaCppConfig),
                 ...(ownConfig.llamaExtraArgs !== undefined
                   ? // biome-ignore lint/style/useNamingConvention: API schema
                     { llama_extra_args: ownConfig.llamaExtraArgs ?? [] }
@@ -1558,6 +1572,7 @@ export function SharedComposer({
                 n_parallel: ownConfig.nParallel ?? null,
                 // Only when this panel has read the stored value: omitted, the load inherits it, which keeps
                 // CLI-set flags working.
+                ...llamaCppConfigPayload(ownConfig.llamaCppConfig),
                 ...(ownConfig.llamaExtraArgs !== undefined
                   ? // biome-ignore lint/style/useNamingConvention: API schema
                     { llama_extra_args: ownConfig.llamaExtraArgs ?? [] }
@@ -1652,6 +1667,10 @@ export function SharedComposer({
             : clearedServerTuningState()),
           // What this pane's launch is running, for a later rollback: the status applier is held off for
           // the whole load, so a switch straight after would snapshot the other model's list.
+          loadedLlamaCppConfig:
+            resp.requested_llama_cpp_config ?? ownConfig.llamaCppConfig ?? null,
+          llamaCppConfig: resp.requested_llama_cpp_config ?? ownConfig.llamaCppConfig,
+          llamaCppConfigSummary: resp.llama_cpp_config_summary ?? null,
           loadedLlamaExtraArgs:
             resp.requested_llama_extra_args !== undefined
               ? (resp.requested_llama_extra_args ?? [])

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -54,15 +54,17 @@ import {
 } from "../utils/project-attachment-target";
 import { getExternalMaxOutputTokens } from "../provider-capabilities";
 import {
-  PERSISTED_INFERENCE_PARAM_KEYS,
-  REMEMBERED_INFERENCE_PARAM_KEYS,
-  type PersistedInferenceParamKey,
   getRememberedParamsPatch,
   getReplayedParams,
   pickRememberedChanges,
   pickRememberedParams,
   setInferenceParam,
 } from "../lib/per-model-params";
+import {
+  PERSISTED_INFERENCE_PARAM_KEYS,
+  REMEMBERED_INFERENCE_PARAM_KEYS,
+  type PersistedInferenceParamKey,
+} from "../lib/persisted-inference-param-keys";
 import {
   type ChatLoraSummary,
   type ChatModelRow,
@@ -3168,15 +3170,24 @@ function getHydratedSettingsState(
     loadedBeforeHydration &&
     settings.inferenceParamsByModel?.[checkpoint] === undefined;
   const params = { ...state.params };
+  const samplingSnapshot = {
+    ...settings.inferenceParams,
+    reasoningEnabled: settings.reasoningEnabled,
+    reasoningEffort: settings.reasoningEffort,
+    preserveThinking: settings.preserveThinking,
+  };
+  const hasPersistedSamplingState =
+    settings.inferenceParams !== undefined ||
+    settings.reasoningEnabled !== undefined ||
+    settings.reasoningEffort !== undefined ||
+    settings.preserveThinking !== undefined;
   if (
-    settings.inferenceParams &&
+    hasPersistedSamplingState &&
     !keepModelDefaults &&
     inferenceParamMutationVersions.samplingFieldsExplicit ===
       versions.inferenceParams.samplingFieldsExplicit
   ) {
-    params.samplingFieldsExplicit = explicitSamplingFields(
-      settings.inferenceParams as Record<string, unknown>,
-    );
+    params.samplingFieldsExplicit = explicitSamplingFields(samplingSnapshot);
   }
   for (const key of PERSISTED_INFERENCE_PARAM_KEYS) {
     const value = settings.inferenceParams?.[key];

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -1,6 +1,17 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+// eslint-disable-next-line no-restricted-imports -- The picker barrel imports this store; provenance helpers are import-free.
+import {
+  explicitSamplingFields,
+  markSamplingFields,
+  SAMPLING_WIRE_FIELDS,
+} from "@/features/model-picker/model-config/llama-cpp-config";
+// eslint-disable-next-line no-restricted-imports -- These wire types belong to the same import-free config leaf.
+import type {
+  LlamaCppConfig,
+  LlamaCppConfigSummary,
+} from "@/features/model-picker/model-config/llama-cpp-config";
 import { authFetch } from "@/features/auth";
 import {
   mirrorHfTokenInto,
@@ -2345,6 +2356,9 @@ type ChatRuntimeStore = {
   /** Pass-through args the resident model is running, as far as this client knows. A rollback
    *  resends them: by then the target load has replaced the backend's inheritance source. */
   loadedLlamaExtraArgs: string[] | null;
+  llamaCppConfig?: LlamaCppConfig;
+  loadedLlamaCppConfig: LlamaCppConfig | null;
+  llamaCppConfigSummary: LlamaCppConfigSummary | null;
   /** user --ubatch-size override for gguf loads (null = llama.cpp default 512) */
   nUbatch: number | null;
   loadedNUbatch: number | null;
@@ -2990,6 +3004,9 @@ function getHydratedCustomPresets(
         params: {
           ...DEFAULT_INFERENCE_PARAMS,
           ...preset.params,
+          samplingFieldsExplicit: explicitSamplingFields(
+            preset.params as Record<string, unknown>,
+          ),
         },
         ...(loadConfig ? { loadConfig } : {}),
       };
@@ -3151,6 +3168,16 @@ function getHydratedSettingsState(
     loadedBeforeHydration &&
     settings.inferenceParamsByModel?.[checkpoint] === undefined;
   const params = { ...state.params };
+  if (
+    settings.inferenceParams &&
+    !keepModelDefaults &&
+    inferenceParamMutationVersions.samplingFieldsExplicit ===
+      versions.inferenceParams.samplingFieldsExplicit
+  ) {
+    params.samplingFieldsExplicit = explicitSamplingFields(
+      settings.inferenceParams as Record<string, unknown>,
+    );
+  }
   for (const key of PERSISTED_INFERENCE_PARAM_KEYS) {
     const value = settings.inferenceParams?.[key];
     // A slider moved before this response landed is held for the open chat. The edit wins in the
@@ -3982,6 +4009,8 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   nBatch: null,
   loadedNBatch: null,
   loadedLlamaExtraArgs: null,
+  loadedLlamaCppConfig: null,
+  llamaCppConfigSummary: null,
   nUbatch: null,
   loadedNUbatch: null,
   specDraftCacheDtype: null,
@@ -4258,6 +4287,32 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       // first, leaving stale per-turn counters under the new checkpoint.
       const checkpointChanged = state.params.checkpoint !== params.checkpoint;
       const fromModelDefaults = options?.fromModelDefaults === true;
+      if (fromModelDefaults) {
+        const explicit =
+          !checkpointChanged && state.llamaCppConfig?.mode === "custom"
+            ? explicitSamplingFields(
+                state.params as unknown as Record<string, unknown>,
+              )
+            : [];
+        params = { ...params, samplingFieldsExplicit: explicit };
+        for (const [key, wire] of Object.entries(SAMPLING_WIRE_FIELDS)) {
+          if (explicit.includes(wire) && key in state.params) {
+            (params as unknown as Record<string, unknown>)[key] =
+              state.params[key as keyof InferenceParams];
+          }
+        }
+      } else if (!checkpointChanged && options?.persist !== false) {
+        const changedSampling = Object.entries(SAMPLING_WIRE_FIELDS)
+          .filter(
+            ([key]) =>
+              key in params &&
+              params[key as keyof InferenceParams] !==
+                state.params[key as keyof InferenceParams],
+          )
+          .map(([, wire]) => wire);
+        if (changedSampling.length)
+          params = markSamplingFields(params, ...changedSampling);
+      }
       // Remember what the outgoing model was running with before replacing it.
       const outgoing = checkpointChanged
         ? rememberOutgoingModel(state, state.params)
@@ -4703,7 +4758,12 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       // will say so again if it still holds.
       constraintSuppressedThreadFields.clear();
       const stored = hasThreadScopedSettings(settings)
-        ? (settings as ThreadScopedSettings)
+        ? {
+            ...settings,
+            samplingFieldsExplicit: explicitSamplingFields(
+              settings as Record<string, unknown>,
+            ),
+          }
         : null;
       activeThreadScopedSettings = stored;
       const nextState: Partial<ChatRuntimeStore> = {};
@@ -4871,6 +4931,8 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       nBatch: null,
       loadedNBatch: null,
       loadedLlamaExtraArgs: null,
+      loadedLlamaCppConfig: null,
+      llamaCppConfigSummary: null,
       nUbatch: null,
       loadedNUbatch: null,
       specDraftCacheDtype: null,
@@ -4912,7 +4974,11 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       pendingImageEditReference: null,
     }));
   },
-  setReasoningEnabled: (reasoningEnabled, options) =>
+  setReasoningEnabled: (reasoningEnabled, options) => {
+    if (options?.persist !== false) {
+      const live = get();
+      live.setParams(markSamplingFields(live.params, "enable_thinking"));
+    }
     set((state) => {
       if (options?.persist !== false) {
         saveBool(CHAT_REASONING_ENABLED_KEY, reasoningEnabled);
@@ -4923,7 +4989,8 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
         reasoningEnabled,
         queuedSettingsEpoch: state.queuedSettingsEpoch + 1,
       };
-    }),
+    });
+  },
   setLastOpenRouterChosenModel: (lastOpenRouterChosenModel) =>
     set({ lastOpenRouterChosenModel }),
   setReasoningStyle: (reasoningStyle) =>
@@ -4931,7 +4998,9 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       reasoningStyle,
       queuedSettingsEpoch: state.queuedSettingsEpoch + 1,
     })),
-  setReasoningEffort: (reasoningEffort) =>
+  setReasoningEffort: (reasoningEffort) => {
+    const live = get();
+    live.setParams(markSamplingFields(live.params, "reasoning_effort"));
     set((state) => {
       setScalarSettingVersion(
         "reasoningEffort",
@@ -4942,8 +5011,11 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
         reasoningEffort,
         queuedSettingsEpoch: state.queuedSettingsEpoch + 1,
       };
-    }),
-  setPreserveThinking: (preserveThinking) =>
+    });
+  },
+  setPreserveThinking: (preserveThinking) => {
+    const live = get();
+    live.setParams(markSamplingFields(live.params, "preserve_thinking"));
     set((state) => {
       setScalarSettingVersion(
         "preserveThinking",
@@ -4955,7 +5027,8 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
         preserveThinking,
         queuedSettingsEpoch: state.queuedSettingsEpoch + 1,
       };
-    }),
+    });
+  },
   setToolsEnabled: (toolsEnabled, options) =>
     set((state) => {
       if (options?.persist !== false) {

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -4,6 +4,7 @@
 // eslint-disable-next-line no-restricted-imports -- The picker barrel imports this store; provenance helpers are import-free.
 import {
   explicitSamplingFields,
+  inheritedSamplingFields,
   markSamplingFields,
   SAMPLING_WIRE_FIELDS,
 } from "@/features/model-picker/model-config/llama-cpp-config";
@@ -4771,8 +4772,9 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       const stored = hasThreadScopedSettings(settings)
         ? {
             ...settings,
-            samplingFieldsExplicit: explicitSamplingFields(
+            samplingFieldsExplicit: inheritedSamplingFields(
               settings as Record<string, unknown>,
+              (globalThreadScopedDefaults ?? {}) as Record<string, unknown>,
             ),
           }
         : null;

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+// eslint-disable-next-line no-restricted-imports -- Share the config wire types without expanding the picker UI barrel.
+import type {
+  LlamaCppConfig,
+  LlamaCppConfigSummary,
+} from "@/features/model-picker/model-config/llama-cpp-config";
 import type { TransformersUpgradeInfo } from "@/features/transformers-upgrade";
 
 export type CpuFallbackReason = "vulkan_startup_crash";
@@ -54,6 +59,8 @@ export interface LoadModelRequest {
    *  llama-server they all decode on. Set only after the user confirms. */
   force_cancel_active?: boolean;
   nativePathLease?: string | null;
+  /** Frontend-only source for a separately scoped custom validation grant. */
+  nativePathToken?: string | null;
   hf_token: string | null;
   max_seq_length: number;
   load_in_4bit: boolean;
@@ -95,6 +102,7 @@ export interface LoadModelRequest {
    *  flag. Omit/null inherits the stored per-model value; [] launches with none. GGUF only. */
   // biome-ignore lint/style/useNamingConvention: API schema
   llama_extra_args?: string[] | null;
+  llama_cpp_config?: LlamaCppConfig;
   /** Split the model across GPUs by tensor (--split-mode tensor) instead of by layer for GGUF models.
    *  Multi-GPU only. */
   tensor_parallel?: boolean | null;
@@ -121,6 +129,8 @@ export interface LoadModelRequest {
 }
 
 export interface ValidateModelResponse {
+  requested_llama_cpp_config?: LlamaCppConfig | null;
+  llama_cpp_config_summary?: LlamaCppConfigSummary | null;
   valid: boolean;
   message: string;
   identifier?: string | null;
@@ -294,6 +304,8 @@ export interface LoadModelResponse {
   requested_cache_ram?: number | null;
   /** Pass-through llama-server arguments the running load was invoked with. */
   requested_llama_extra_args?: string[] | null;
+  requested_llama_cpp_config?: LlamaCppConfig | null;
+  llama_cpp_config_summary?: LlamaCppConfigSummary | null;
 }
 
 export interface UnloadModelRequest {
@@ -398,6 +410,8 @@ export interface InferenceStatusResponse {
   requested_cache_ram?: number | null;
   /** Pass-through llama-server arguments the running load was invoked with. */
   requested_llama_extra_args?: string[] | null;
+  requested_llama_cpp_config?: LlamaCppConfig | null;
+  llama_cpp_config_summary?: LlamaCppConfigSummary | null;
   n_layers?: number | null;
   /** Model's MoE expert-layer count (the n_cpu_moe ceiling); 0 if not MoE. */
   n_moe_layers?: number;
@@ -559,6 +573,7 @@ export interface OpenAIChatMessage {
 }
 
 export interface OpenAIChatCompletionsRequest {
+  sampling_fields_explicit?: string[];
   model: string;
   messages: OpenAIChatMessage[];
   stream: boolean;

--- a/studio/frontend/src/features/chat/types/runtime.ts
+++ b/studio/frontend/src/features/chat/types/runtime.ts
@@ -2,6 +2,8 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 export interface InferenceParams {
+  /** Absent on legacy user snapshots; [] identifies automatic UI defaults. */
+  samplingFieldsExplicit?: string[];
   temperature: number;
   topP: number;
   topK: number;
@@ -57,6 +59,7 @@ export type PersistedInferenceParams = Partial<
 >;
 
 export const DEFAULT_INFERENCE_PARAMS: InferenceParams = {
+  samplingFieldsExplicit: [],
   temperature: 0.6,
   topP: 0.95,
   topK: 20,

--- a/studio/frontend/src/features/chat/utils/chat-settings-storage.ts
+++ b/studio/frontend/src/features/chat/utils/chat-settings-storage.ts
@@ -22,6 +22,7 @@ import {
 } from "../presets/preset-policy";
 import type { ReasoningEffort } from "../stores/chat-runtime-store";
 import { MAX_SAMPLING_SEED } from "../types/runtime";
+import { explicitSamplingFields } from "../../model-picker/model-config/llama-cpp-config";
 import {
   sanitizeCompactionHeadroomRatio,
   sanitizeContextPolicy,
@@ -144,6 +145,13 @@ function sanitizeInferenceParams(
   if (!isRecord(value)) return undefined;
 
   const params: PersistedInferenceParams = {};
+  if (Array.isArray(value.samplingFieldsExplicit)) {
+    // Presence is meaningful: [] says these are automatic defaults, while an absent
+    // mask identifies a legacy snapshot whose explicit fields must be inferred.
+    params.samplingFieldsExplicit = [
+      ...new Set(explicitSamplingFields(value)),
+    ];
+  }
   for (const field of NUMERIC_INFERENCE_FIELDS) {
     const fieldValue = value[field];
     if (typeof fieldValue === "number" && Number.isFinite(fieldValue)) {

--- a/studio/frontend/src/features/chat/utils/queued-chat-run-settings.ts
+++ b/studio/frontend/src/features/chat/utils/queued-chat-run-settings.ts
@@ -39,6 +39,9 @@ const QUEUED_SETTING_KEYS = [
   // queued against. Without this an Ollama or native-path GGUF, which reports no quant and
   // no .gguf suffix, reads as non-GGUF and loses its compaction policy.
   "loadedIsGguf",
+  "loadedLlamaCppConfig",
+  "llamaCppConfig",
+  "llamaCppConfigSummary",
   "autoHealToolCalls",
   "nudgeToolCalls",
   "maxToolCallsPerMessage",

--- a/studio/frontend/src/features/chat/utils/qwen-params.ts
+++ b/studio/frontend/src/features/chat/utils/qwen-params.ts
@@ -12,6 +12,7 @@ import { resolveQwenThinkingParams } from "./qwen-sampling-table";
  *  both the thread assistant UI and the shared chat composer. */
 export function applyQwenThinkingParams(thinkingOn: boolean): void {
   const store = useChatRuntimeStore.getState();
+  if (store.loadedLlamaCppConfig?.mode === "custom") return;
   const checkpoint = store.params.checkpoint?.toLowerCase() ?? "";
   const params = resolveQwenThinkingParams(checkpoint, thinkingOn);
   if (params === null || store.activePresetSource !== "builtin-default") {

--- a/studio/frontend/src/features/chat/utils/thread-scoped-settings.ts
+++ b/studio/frontend/src/features/chat/utils/thread-scoped-settings.ts
@@ -13,6 +13,7 @@ import type {
   ReasoningEffort,
 } from "../stores/chat-runtime-store";
 import { MAX_SAMPLING_SEED } from "../types/runtime.ts";
+import { explicitSamplingFields } from "../../model-picker/model-config/llama-cpp-config.ts";
 import {
   isRecord,
   sanitizeBoundedNumber,
@@ -23,6 +24,7 @@ import {
 export type ThreadPermissionMode = Exclude<PermissionMode, "full">;
 
 export interface ThreadScopedSettings {
+  samplingFieldsExplicit?: string[];
   reasoningEnabled?: boolean;
   reasoningEffort?: ReasoningEffort;
   toolsEnabled?: boolean;
@@ -53,6 +55,7 @@ export interface ThreadScopedSettings {
 
 /** The subset living under `params` rather than as a store field of its own. */
 export const THREAD_SCOPED_PARAM_KEYS = [
+  "samplingFieldsExplicit",
   "temperature",
   "topP",
   "topK",
@@ -124,6 +127,7 @@ const THREAD_SCOPED_STRING_KEYS = [
 ] as const satisfies readonly (keyof ThreadScopedSettings)[];
 
 export const THREAD_SCOPED_SETTING_KEYS = [
+  "samplingFieldsExplicit",
   ...THREAD_SCOPED_STRING_KEYS,
   ...THREAD_SCOPED_BOOLEAN_KEYS,
   ...(Object.keys(
@@ -169,6 +173,9 @@ export function sanitizeThreadScopedSettings(
   const settings: ThreadScopedSettings = {};
   if (!isRecord(value)) return settings;
   const target = settings as Record<string, unknown>;
+  if (value.samplingFieldsExplicit !== undefined) {
+    settings.samplingFieldsExplicit = explicitSamplingFields(value);
+  }
   for (const key of THREAD_SCOPED_BOOLEAN_KEYS) {
     if (typeof value[key] === "boolean") target[key] = value[key];
   }

--- a/studio/frontend/src/features/model-picker/api/memory-estimate.ts
+++ b/studio/frontend/src/features/model-picker/api/memory-estimate.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import type { LlamaCppConfig } from "../model-config/llama-cpp-config";
 import { authFetch } from "@/features/auth";
 import { consumeNativePathToken } from "@/features/native-intents/api";
 
@@ -79,6 +80,7 @@ export interface MemoryEstimateRequest {
   nCpuMoe?: number | null;
   selectedGpuIds?: number[] | null;
   llamaExtraArgs?: string[] | null;
+  llamaCppConfig?: LlamaCppConfig;
 }
 
 const UNAVAILABLE: MemoryEstimate = {
@@ -133,6 +135,7 @@ function estimateRequestBody(
 ): string {
   return JSON.stringify({
     model_path: payload.modelPath,
+    ...(payload.llamaCppConfig !== undefined ? { llama_cpp_config: payload.llamaCppConfig } : {}),
     gguf_variant: payload.ggufVariant ?? null,
     hf_token: payload.hfToken ?? null,
     native_path_lease: nativePathLease,

--- a/studio/frontend/src/features/model-picker/api/model-overrides.ts
+++ b/studio/frontend/src/features/model-picker/api/model-overrides.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import type { LlamaCppConfig } from "../model-config/llama-cpp-config";
 // Server-side mirror of the per-model config. per-model-config.ts lives in browser
 // localStorage, so an API auto-switch load came up with none of the user's settings.
 // routes/inference.py reads this map and rebuilds the picker's LoadRequest.
@@ -26,6 +27,7 @@ const OVERRIDES_URL = "/api/settings/openai-auto-switch/overrides";
 export interface ApiModelOverride {
   // biome-ignore lint/style/useNamingConvention: API schema
   llama_extra_args?: string[];
+  llama_cpp_config?: LlamaCppConfig;
   // biome-ignore lint/style/useNamingConvention: API schema
   max_seq_length?: number;
   // biome-ignore lint/style/useNamingConvention: API schema
@@ -315,6 +317,7 @@ export function fromApiOverride(
     chatTemplateOverride:
       override.chat_template_override ?? local.chatTemplateOverride,
     llamaExtraArgs: extraArgs,
+    llamaCppConfig: override.llama_cpp_config ?? local.llamaCppConfig,
     gpuMemoryMode: override.gpu_memory_mode ?? local.gpuMemoryMode,
     gpuLayers: override.gpu_layers ?? local.gpuLayers,
     nCpuMoe: override.n_cpu_moe ?? local.nCpuMoe,
@@ -396,6 +399,9 @@ export function toApiOverride(config: PerModelConfig | null): ApiModelOverride {
   // The one field where absent does NOT mean "app default": the route preserves
   // llama_extra_args it is not sent, which kept CLI-set flags alive while this panel had no
   // control. So `undefined` stays omitted and a cleared box sends an explicit empty list.
+  if (config.llamaCppConfig !== undefined) {
+    payload.llama_cpp_config = config.llamaCppConfig;
+  }
   if (config.llamaExtraArgs !== undefined) {
     payload.llama_extra_args = config.llamaExtraArgs ?? [];
   }

--- a/studio/frontend/src/features/model-picker/components/custom-llama-config-editor.tsx
+++ b/studio/frontend/src/features/model-picker/components/custom-llama-config-editor.tsx
@@ -159,9 +159,16 @@ export function CustomLlamaConfigEditor({
             spellCheck={false}
             className="min-h-40 w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 font-mono text-ui-11"
             value={ini}
-            onChange={(event) =>
-              onChange({ ...value, ini: event.target.value })
-            }
+            onChange={(event) => {
+              const nextIni = event.target.value;
+              onChange({
+                ...value,
+                ini: nextIni,
+                section: customConfigSections(nextIni).includes(value.section ?? "")
+                  ? value.section
+                  : null,
+              });
+            }}
           />
           {sections.length > 0 && (
             <div className="space-y-1.5">

--- a/studio/frontend/src/features/model-picker/components/custom-llama-config-editor.tsx
+++ b/studio/frontend/src/features/model-picker/components/custom-llama-config-editor.tsx
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { useEffect, useId, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+// eslint-disable-next-line no-restricted-imports -- The chat barrel imports the picker; validation needs only its API leaf.
+import { validateModel } from "@/features/chat/api/chat-api";
+import { consumeNativePathToken } from "@/features/native-intents";
+import {
+  customConfigSections,
+  MAX_LLAMA_CPP_CONFIG_BYTES,
+  type LlamaCppConfig,
+  type LlamaCppConfigSummary,
+} from "../model-config/llama-cpp-config";
+
+export function CustomLlamaConfigEditor({
+  value,
+  onChange,
+  modelPath,
+  ggufVariant,
+  hfToken,
+  nativePathToken,
+  onLoadableChange,
+  effectiveSummary,
+}: {
+  value: LlamaCppConfig | undefined;
+  onChange: (value: LlamaCppConfig) => void;
+  modelPath: string;
+  ggufVariant?: string | null;
+  hfToken: string | null;
+  nativePathToken?: string | null;
+  onLoadableChange: (value: boolean) => void;
+  effectiveSummary?: LlamaCppConfigSummary | null;
+}) {
+  const id = useId();
+  const revision = useRef(0);
+  const [validationResult, setResult] = useState<{
+    inputKey: string;
+    message: string;
+    summary?: LlamaCppConfigSummary | null;
+    valid: boolean;
+  } | null>(null);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const active = value?.mode === "custom";
+  const ini = active ? value.ini : "";
+  const section = active ? value.section : null;
+  const inputKey = JSON.stringify([
+    modelPath,
+    ggufVariant,
+    active,
+    ini,
+    section,
+  ]);
+  const [previousInputKey, setPreviousInputKey] = useState(inputKey);
+  if (previousInputKey !== inputKey) {
+    setPreviousInputKey(inputKey);
+    setResult(null);
+    setBusyKey(null);
+  }
+  const result =
+    validationResult?.inputKey === inputKey ? validationResult : null;
+  const busy = busyKey === inputKey;
+  const sections = customConfigSections(ini);
+  const oversized =
+    new TextEncoder().encode(ini).length > MAX_LLAMA_CPP_CONFIG_BYTES;
+  useEffect(() => {
+    revision.current += 1;
+    // Load repeats authoritative preflight. An unvalidated draft may still be submitted.
+    onLoadableChange(!active || !oversized);
+  }, [
+    ini,
+    section,
+    active,
+    oversized,
+    modelPath,
+    ggufVariant,
+    onLoadableChange,
+  ]);
+  const validate = async () => {
+    const current = ++revision.current;
+    setBusyKey(inputKey);
+    try {
+      const lease = nativePathToken
+        ? (await consumeNativePathToken(nativePathToken, "validate-model"))
+            .nativePathLease
+        : null;
+      const response = await validateModel({
+        model_path: modelPath,
+        gguf_variant: ggufVariant,
+        hf_token: hfToken,
+        nativePathLease: lease,
+        max_seq_length: 4096,
+        load_in_4bit: false,
+        is_lora: false,
+        llama_cpp_config: value,
+      });
+      if (current !== revision.current) return;
+      const valid =
+        response.valid && response.llama_cpp_config_summary?.mode === "custom";
+      setResult({
+        inputKey,
+        valid,
+        message: valid
+          ? "Configuration validated."
+          : response.message || "Configuration could not be validated.",
+        summary: response.llama_cpp_config_summary,
+      });
+      onLoadableChange(valid);
+    } catch (error) {
+      if (current !== revision.current) return;
+      setResult({
+        inputKey,
+        valid: false,
+        message: error instanceof Error ? error.message : "Validation failed.",
+      });
+      onLoadableChange(false);
+    } finally {
+      if (current === revision.current) setBusyKey(null);
+    }
+  };
+  const summary = result?.summary ?? effectiveSummary;
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="text-ui-12 font-medium">
+          Custom llama.cpp configuration
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() =>
+            onChange(
+              active
+                ? { version: 1, mode: "managed" }
+                : { version: 1, mode: "custom", ini: "[*]\n", section: null },
+            )
+          }
+        >
+          {active ? "Use Studio settings" : "Use custom configuration"}
+        </Button>
+      </div>
+      {active && (
+        <>
+          <p className="text-ui-11 text-muted-foreground">
+            Engine tuning comes from this configuration. Chat settings you edit
+            still apply.
+          </p>
+          <textarea
+            id={id}
+            aria-label="llama.cpp INI configuration"
+            spellCheck={false}
+            className="min-h-40 w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 font-mono text-ui-11"
+            value={ini}
+            onChange={(event) =>
+              onChange({ ...value, ini: event.target.value })
+            }
+          />
+          {sections.length > 0 && (
+            <div className="space-y-1.5">
+              <label className="text-ui-11" htmlFor={`${id}-section`}>
+                Section
+              </label>
+              <Select
+                value={section ?? ""}
+                onValueChange={(next) => onChange({ ...value, section: next })}
+              >
+                <SelectTrigger id={`${id}-section`}>
+                  <SelectValue placeholder="Choose a section" />
+                </SelectTrigger>
+                <SelectContent>
+                  {sections.map((name) => (
+                    <SelectItem key={name} value={name}>
+                      {name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+          {oversized && (
+            <p role="alert" className="text-ui-11 text-destructive">
+              Configuration must fit within 64 KiB.
+            </p>
+          )}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={busy || oversized}
+            onClick={() => void validate()}
+          >
+            {busy ? "Validating…" : "Validate configuration"}
+          </Button>
+          {result && (
+            <p
+              role="status"
+              className={`text-ui-11 ${result.valid ? "text-muted-foreground" : "text-destructive"}`}
+            >
+              {result.message}
+            </p>
+          )}
+          {summary && (
+            <details className="text-ui-11 text-muted-foreground">
+              <summary>
+                Effective configuration
+                {summary.section ? ` · ${summary.section}` : ""}
+              </summary>
+              <pre className="mt-2 whitespace-pre-wrap break-all">
+                {JSON.stringify(
+                  {
+                    tuning: summary.tuning,
+                    sampling: summary.request_defaults,
+                  },
+                  null,
+                  2,
+                )}
+              </pre>
+              {summary.diagnostics.map((message, index) => (
+                <p key={`${index}-${message}`}>{message}</p>
+              ))}
+            </details>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { CustomLlamaConfigEditor } from "./custom-llama-config-editor";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { InfoHint } from "@/components/ui/info-hint";
@@ -1822,6 +1823,8 @@ export function ModelConfigPage({
   // refuse. Held by the panel rather than the row, since the row unmounts whenever Advanced
   // settings collapse while its tokens stay in the config.
   const [extraArgsLoadable, setExtraArgsLoadable] = useState(true);
+  const [customConfigLoadable, setCustomConfigLoadable] = useState(true);
+  const effectiveCustomSummary = useChatRuntimeStore((s) => s.llamaCppConfigSummary);
   // True until the stored-arguments read below settles: a load started before it lands sends no
   // llama_extra_args, and /load cannot inherit them from a process that is not running.
   const [extraArgsHydrating, setExtraArgsHydrating] = useState(
@@ -2504,6 +2507,7 @@ export function ModelConfigPage({
           nCpuMoe: runtimeConfig.nCpuMoe ?? null,
           selectedGpuIds: runtimeConfig.selectedGpuIds ?? null,
           llamaExtraArgs: runtimeConfig.llamaExtraArgs ?? null,
+          llamaCppConfig: runtimeConfig.llamaCppConfig,
         }
       : null;
   const memoryEstimate = useMemoryEstimate(memoryEstimateRequest);
@@ -2884,7 +2888,28 @@ export function ModelConfigPage({
         </div>
       )}
 
-      <div className="space-y-3.5">
+      {target.isGguf && !resolvedIsDiffusion && (
+        <div className="mb-3.5">
+          <CustomLlamaConfigEditor
+            value={config.llamaCppConfig}
+            onChange={(llamaCppConfig) => update({ llamaCppConfig })}
+            modelPath={target.id}
+            ggufVariant={target.ggufVariant}
+            hfToken={hfToken || null}
+            nativePathToken={nativePathToken}
+            onLoadableChange={setCustomConfigLoadable}
+            effectiveSummary={
+              isActiveModel && atBaseline ? effectiveCustomSummary : null
+            }
+          />
+        </div>
+      )}
+      <fieldset
+        disabled={config.llamaCppConfig?.mode === "custom"}
+        inert={config.llamaCppConfig?.mode === "custom" ? true : undefined}
+        className={`min-w-0 space-y-3.5 ${config.llamaCppConfig?.mode === "custom" ? "opacity-50" : ""}`}
+        aria-label="Studio engine settings"
+      >
         {target.isGguf && (
           <>
             {/* Above Context Length on purpose: that is the control moving this number most, and a readout
@@ -3042,7 +3067,7 @@ export function ModelConfigPage({
             />
           </>
         )}
-      </div>
+      </fieldset>
 
       <div
         className={
@@ -3083,6 +3108,7 @@ export function ModelConfigPage({
                 // running process's arguments, so a reload after Reset kept the flags the box says are gone.
                 ...DEFAULT_PER_MODEL_CONFIG,
                 llamaExtraArgs: null,
+                llamaCppConfig: { version: 1, mode: "managed" },
               })
             }
           >
@@ -3095,7 +3121,8 @@ export function ModelConfigPage({
             disabled={
               stagedMetadataPending ||
               budgetSettling ||
-              !extraArgsLoadable ||
+              !customConfigLoadable ||
+              (config.llamaCppConfig?.mode !== "custom" && !extraArgsLoadable) ||
               extraArgsHydrating ||
               (isActiveModel &&
                 atBaseline &&

--- a/studio/frontend/src/features/model-picker/hooks/use-active-model-config.ts
+++ b/studio/frontend/src/features/model-picker/hooks/use-active-model-config.ts
@@ -39,6 +39,7 @@ export function useActiveModelConfig(): ActiveModelConfigState {
   const loadMode = useChatRuntimeStore((s) => s.loadMode);
   const ctxCheckpoints = useChatRuntimeStore((s) => s.ctxCheckpoints);
   const cacheRam = useChatRuntimeStore((s) => s.cacheRam);
+  const llamaCppConfig = useChatRuntimeStore((s) => s.loadedLlamaCppConfig);
   const tensorParallel = useChatRuntimeStore((s) => s.tensorParallel);
   const disableVision = useChatRuntimeStore((s) => s.disableVision);
   const chatTemplateOverride = useChatRuntimeStore(
@@ -75,6 +76,7 @@ export function useActiveModelConfig(): ActiveModelConfigState {
       return null;
     }
     const base: PerModelConfig = {
+      llamaCppConfig: isGguf ? llamaCppConfig ?? undefined : undefined,
       customContextLength: customContextLength ?? null,
       // A self-sizing backend carries no pin here, exactly as the GGUF path does: this
       // is the runtime's resolved length, and reading it back as the user's choice would
@@ -123,6 +125,7 @@ export function useActiveModelConfig(): ActiveModelConfigState {
     loadMode,
     ctxCheckpoints,
     cacheRam,
+    llamaCppConfig,
     tensorParallel,
     disableVision,
     chatTemplateOverride,

--- a/studio/frontend/src/features/model-picker/hooks/use-memory-estimate.ts
+++ b/studio/frontend/src/features/model-picker/hooks/use-memory-estimate.ts
@@ -50,6 +50,7 @@ function estimateKey(request: MemoryEstimateRequest | null): string | null {
     request.nCpuMoe ?? null,
     request.selectedGpuIds ?? null,
     request.llamaExtraArgs ?? null,
+    request.llamaCppConfig ?? null,
   ]);
 }
 

--- a/studio/frontend/src/features/model-picker/model-config/apply-per-model-config.ts
+++ b/studio/frontend/src/features/model-picker/model-config/apply-per-model-config.ts
@@ -47,6 +47,7 @@ export function applyPerModelConfigToRuntime(
         )
       : { ids: null, indexKind: null };
   useChatRuntimeStore.setState({
+    llamaCppConfig: options.isDiffusion ? undefined : config.llamaCppConfig,
     customContextLength: config.customContextLength ?? null,
     mlxKvBits: config.mlxKvBits ?? null,
     kvCacheDtype: config.kvCacheDtype ?? null,
@@ -104,6 +105,7 @@ export function currentRuntimePerModelConfig(
 ): PerModelConfig {
   const s = useChatRuntimeStore.getState();
   return {
+    llamaCppConfig: s.llamaCppConfig,
     customContextLength: s.customContextLength ?? null,
     maxSeqLength: options.includeMaxSeqLength
       ? normalizeMaxSeqLength(s.params.maxSeqLength)
@@ -137,6 +139,7 @@ export function perModelConfigsEqual(
   b: PerModelConfig,
 ): boolean {
   return (
+    JSON.stringify(a.llamaCppConfig) === JSON.stringify(b.llamaCppConfig) &&
     (a.customContextLength ?? null) === (b.customContextLength ?? null) &&
     normalizeMaxSeqLength(a.maxSeqLength) ===
       normalizeMaxSeqLength(b.maxSeqLength) &&

--- a/studio/frontend/src/features/model-picker/model-config/config-signature.ts
+++ b/studio/frontend/src/features/model-picker/model-config/config-signature.ts
@@ -45,6 +45,7 @@ export function loadedConfigSignature(
     return "none";
   }
   return [
+    JSON.stringify(config.llamaCppConfig) ?? "",
     config.customContextLength ?? "",
     config.maxSeqLength ?? "",
     config.kvCacheDtype ?? "",

--- a/studio/frontend/src/features/model-picker/model-config/llama-cpp-config.ts
+++ b/studio/frontend/src/features/model-picker/model-config/llama-cpp-config.ts
@@ -83,6 +83,19 @@ export function explicitSamplingFields(
     .map(([, wire]) => wire);
 }
 
+export function inheritedSamplingFields(
+  snapshot: Record<string, unknown>,
+  fallback: Record<string, unknown>,
+): string[] {
+  const own = new Set(explicitSamplingFields(snapshot));
+  const inherited = new Set(explicitSamplingFields(fallback));
+  return Object.entries(SAMPLING_WIRE_FIELDS)
+    .filter(([key, wire]) =>
+      (snapshot[key] !== undefined ? own : inherited).has(wire),
+    )
+    .map(([, wire]) => wire);
+}
+
 export function markSamplingFields<
   T extends { samplingFieldsExplicit?: string[] },
 >(params: T, ...fields: string[]): T {

--- a/studio/frontend/src/features/model-picker/model-config/llama-cpp-config.ts
+++ b/studio/frontend/src/features/model-picker/model-config/llama-cpp-config.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+export type LlamaCppConfig =
+  | { version: 1; mode: "managed" }
+  | { version: 1; mode: "custom"; ini: string; section: string | null };
+
+export interface LlamaCppConfigSummary {
+  mode: "custom";
+  section: string | null;
+  digest: string;
+  tuning: Record<string, unknown>;
+  request_defaults: Record<string, unknown>;
+  diagnostics: string[];
+}
+
+export const MAX_LLAMA_CPP_CONFIG_BYTES = 65_536;
+
+/** Shape validation only. The selected server is authoritative for INI semantics. */
+export function normalizeLlamaCppConfig(
+  value: unknown,
+): LlamaCppConfig | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const source = value as Record<string, unknown>;
+  if (source.version !== 1) return undefined;
+  if (source.mode === "managed") return { version: 1, mode: "managed" };
+  if (
+    source.mode !== "custom" ||
+    typeof source.ini !== "string" ||
+    (source.section !== null && typeof source.section !== "string") ||
+    new TextEncoder().encode(source.ini).length > MAX_LLAMA_CPP_CONFIG_BYTES
+  )
+    return undefined;
+  return {
+    version: 1,
+    mode: "custom",
+    ini: source.ini,
+    section: source.section,
+  };
+}
+
+/** Suggestions for the selector, never a parser or a validation verdict. */
+export function customConfigSections(ini: string): string[] {
+  return [
+    ...new Set(
+      [...ini.matchAll(/^\s*\[([^\]\r\n]+)\]\s*(?:[#;].*)?$/gm)]
+        .map((match) => match[1])
+        .filter((name) => name !== "*"),
+    ),
+  ];
+}
+
+export function llamaCppConfigPayload(config: LlamaCppConfig | undefined) {
+  return config === undefined ? {} : { llama_cpp_config: config };
+}
+
+export const SAMPLING_WIRE_FIELDS = {
+  temperature: "temperature",
+  topP: "top_p",
+  topK: "top_k",
+  minP: "min_p",
+  repetitionPenalty: "repetition_penalty",
+  presencePenalty: "presence_penalty",
+  frequencyPenalty: "frequency_penalty",
+  reasoningEnabled: "enable_thinking",
+  reasoningEffort: "reasoning_effort",
+  preserveThinking: "preserve_thinking",
+} as const;
+
+export function explicitSamplingFields(
+  snapshot: Record<string, unknown>,
+): string[] {
+  if (Array.isArray(snapshot.samplingFieldsExplicit)) {
+    return snapshot.samplingFieldsExplicit.filter(
+      (field): field is string =>
+        typeof field === "string" &&
+        (Object.values(SAMPLING_WIRE_FIELDS) as string[]).includes(field),
+    );
+  }
+  // Presence in an old saved snapshot is user intent, regardless of its numeric value.
+  return Object.entries(SAMPLING_WIRE_FIELDS)
+    .filter(([key]) => snapshot[key] !== undefined)
+    .map(([, wire]) => wire);
+}
+
+export function markSamplingFields<
+  T extends { samplingFieldsExplicit?: string[] },
+>(params: T, ...fields: string[]): T {
+  return {
+    ...params,
+    samplingFieldsExplicit: [
+      ...new Set([
+        ...(params.samplingFieldsExplicit ??
+          Object.values(SAMPLING_WIRE_FIELDS)),
+        ...fields,
+      ]),
+    ],
+  };
+}
+
+/** Unset provenance is a legacy user snapshot; an empty list is an automatic seed. */
+export function customSamplingPayload(
+  config: LlamaCppConfig | null | undefined,
+  explicit: readonly string[] | undefined,
+) {
+  return config?.mode === "custom"
+    ? {
+        sampling_fields_explicit:
+          explicit === undefined
+            ? Object.values(SAMPLING_WIRE_FIELDS)
+            : [...explicit],
+      }
+    : {};
+}

--- a/studio/frontend/src/features/model-picker/model-config/per-model-config.ts
+++ b/studio/frontend/src/features/model-picker/model-config/per-model-config.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { normalizeLlamaCppConfig, type LlamaCppConfig } from "./llama-cpp-config";
 import type { GpuIndexKind } from "@/hooks/use-gpu-info";
 import {
   ggufVariantFromStorageKey,
@@ -46,6 +47,7 @@ export interface PerModelConfig {
      *  alive); `null` means the user cleared the box and must be sent as an explicit `[]`; a non-empty list is what
      *  to launch with. */
   llamaExtraArgs?: string[] | null;
+  llamaCppConfig?: LlamaCppConfig;
   // GPU Memory controls (per-model, GGUF-only), optional so older blobs parse. Absent or null
   // selectedGpuIds means automatic. --tensor-split is not remembered: it follows the GPU set.
   gpuMemoryMode?: "auto" | "manual";
@@ -296,8 +298,8 @@ const LEGACY_STORAGE_KEY = "unsloth_load_settings";
 const LEGACY_MIGRATION_FLAG = "unsloth_model_configs_migrated";
 // would normalize the unknown field straight back out of the record.
 // v2 added nBatch/nUbatch, v3 llamaExtraArgs, v4 disableVision, v5 the llama-server tuning group
-// (loadMode / specDraftCacheDtype / ctxCheckpoints / cacheRam); a client from before any of them
-const STORAGE_SCHEMA_VERSION = 5;
+// (loadMode / specDraftCacheDtype / ctxCheckpoints / cacheRam), v6 custom llama.cpp configuration.
+const STORAGE_SCHEMA_VERSION = 6;
 const PRE_SERVER_TUNING_SCHEMA_VERSION = 4;
 const PRE_VISION_SCHEMA_VERSION = 3;
 const PRE_EXTRA_ARGS_SCHEMA_VERSION = 2;
@@ -331,6 +333,7 @@ const STORED_CONFIG_FIELDS = new Set([
   "disableVision",
   "chatTemplateOverride",
   "llamaExtraArgs",
+  "llamaCppConfig",
   "gpuMemoryMode",
   "gpuLayers",
   "nCpuMoe",
@@ -955,6 +958,7 @@ function normalizeV1(partial: RawConfig): PerModelConfig {
         ? partial.chatTemplateOverride
         : null,
     llamaExtraArgs: normalizeLlamaExtraArgs(partial.llamaExtraArgs),
+    llamaCppConfig: normalizeLlamaCppConfig(partial.llamaCppConfig),
     ...normalizeGpuFields(partial),
   };
 }
@@ -989,8 +993,10 @@ function toStoredConfig(config: PerModelConfig): StoredPerModelConfig {
     normalized.specDraftCacheDtype != null ||
     normalized.ctxCheckpoints != null ||
     normalized.cacheRam != null;
-  const version = hasServerTuning
+  const version = normalized.llamaCppConfig !== undefined
     ? STORAGE_SCHEMA_VERSION
+    : hasServerTuning
+    ? 5
     : normalized.disableVision
       ? PRE_SERVER_TUNING_SCHEMA_VERSION
       : normalized.llamaExtraArgs != null && normalized.llamaExtraArgs.length > 0
@@ -1163,6 +1169,7 @@ export function isDefaultConfig(config: PerModelConfig): boolean {
     // Or a config whose only change is Extra Arguments reads as default, and savePerModelConfig
     // deletes the entry it was asked to remember.
     (config.llamaExtraArgs == null || config.llamaExtraArgs.length === 0) &&
+    config.llamaCppConfig === undefined &&
     gpuFieldsAtDefault(config)
   );
 }
@@ -1186,6 +1193,9 @@ export function savePerModelConfig(
      *  without this their server overrides would keep applying with nothing in the UI able to forget them. */
   evicted?: { modelId: string; ggufVariant: string | null }[],
 ): boolean {
+  if (config.llamaCppConfig !== undefined && normalizeLlamaCppConfig(config.llamaCppConfig) === undefined) {
+    return false;
+  }
   if (
     typeof config.chatTemplateOverride === "string" &&
     !isChatTemplateWithinLimit(config.chatTemplateOverride)

--- a/studio/frontend/src/features/model-picker/model-config/resident-memory-request.ts
+++ b/studio/frontend/src/features/model-picker/model-config/resident-memory-request.ts
@@ -25,7 +25,7 @@ type ResidentState = Pick<
   | "loadedCpuFallback"
   | "specFallbackReason"
   | "mmprojFallbackReason"
->;
+> & { loadedLlamaCppConfig?: ReturnType<typeof useChatRuntimeStore.getState>["loadedLlamaCppConfig"] };
 
 /** Editable controls can already describe the next load. */
 export function selectResidentEstimateSettings(state: ResidentState) {
@@ -62,6 +62,7 @@ export function selectResidentEstimateSettings(state: ResidentState) {
     nCpuMoe: state.loadedNCpuMoe,
     selectedGpuIds: state.loadedGpuIds,
     llamaExtraArgs: state.loadedLlamaExtraArgs,
+    ...(state.loadedLlamaCppConfig != null ? { llamaCppConfig: state.loadedLlamaCppConfig } : {}),
   };
 }
 

--- a/studio/frontend/src/hooks/use-model-memory.ts
+++ b/studio/frontend/src/hooks/use-model-memory.ts
@@ -289,6 +289,7 @@ function budgetIsMeaningful(config: PerModelConfig | undefined): boolean {
   // Pass-through args are appended after Unsloth's own flags, so an -ngl or a device pin in that box
   // is what the launch actually uses. Reading only the structured fields left the bar charting a
   // CPU-offloaded run against every GPU on the host.
+  if (config.llamaCppConfig?.mode === "custom") return false;
   if (extraArgsOwnPlacement(config.llamaExtraArgs)) return false;
   // Same reasoning one term over: these do not move the cache, they resize it. A --swa-full in the
   // box has the launch reserve a full-context cache while the bar priced the compact sliding window.

--- a/studio/frontend/tests/llama-cpp-custom-api.test.ts
+++ b/studio/frontend/tests/llama-cpp-custom-api.test.ts
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import vm from "node:vm";
+import ts from "typescript";
+import { readSrc } from "./helpers/kit.ts";
+
+// Execute the shipped API functions with a captured transport, without mounting UI barrels.
+const source = readSrc("features/chat/api/chat-api.ts");
+const load = source.slice(
+  source.indexOf("export async function loadModel("),
+  source.indexOf("export async function countChatInputTokens("),
+);
+const validateStart = source.indexOf("export async function validateModel(");
+const validate = source.slice(
+  validateStart,
+  source.indexOf("/** Read a GGUF's header", validateStart),
+);
+const compiled = ts.transpileModule(`${load}\n${validate}`, {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2022,
+  },
+}).outputText;
+const custom = {
+  version: 1,
+  mode: "custom",
+  ini: "[*]\ntemp=0\n",
+  section: null,
+};
+const summary = {
+  mode: "custom",
+  section: null,
+  digest: "test-digest",
+  tuning: {},
+  request_defaults: { temperature: 0 },
+  diagnostics: [],
+};
+const request = {
+  model_path: "model.gguf",
+  hf_token: null,
+  max_seq_length: 4096,
+  load_in_4bit: false,
+  is_lora: false,
+  llama_cpp_config: custom,
+};
+
+function harness(validateResponse: unknown, loadResponse: unknown) {
+  const calls: { url: string; body: Record<string, unknown> }[] = [];
+  const grants: { token: string; operation: string }[] = [];
+  const context = {
+    exports: {} as {
+      validateModel: (request: unknown) => Promise<unknown>;
+      loadModel: (request: unknown) => Promise<unknown>;
+    },
+    prepareHfTokenForUse: async () => ({ proceed: true, token: null }),
+    consumeNativePathToken: async (token: string, operation: string) => {
+      grants.push({ token, operation });
+      return { nativePathLease: `${token}:${operation}:fresh-grant` };
+    },
+    authFetch: async (url: string, init: RequestInit) => {
+      calls.push({ url, body: JSON.parse(String(init.body)) });
+      return url.endsWith("/validate") ? validateResponse : loadResponse;
+    },
+    parseJsonOrThrow: async (response: unknown) => response,
+    withModelLoadNotice: async (
+      _runtime: string,
+      _model: string,
+      run: () => Promise<unknown>,
+    ) => run(),
+    showCarveoutAdvice: () => {},
+  };
+  vm.runInNewContext(compiled, context);
+  return { calls, grants, ...context.exports };
+}
+
+test("custom validation sends the exact source and rejects a server that silently ignores it", async () => {
+  const api = harness({ valid: true, message: "Found" }, {});
+  await assert.rejects(api.validateModel(request), /cannot validate custom/);
+  assert.deepEqual(api.calls[0].body.llama_cpp_config, custom);
+});
+
+test("a direct custom load validates support before any load mutation", async () => {
+  const api = harness({ valid: true }, { status: "loaded" });
+  await assert.rejects(api.loadModel(request), /cannot validate custom/);
+  assert.deepEqual(
+    api.calls.map((call) => call.url),
+    ["/api/inference/validate"],
+  );
+});
+
+test("a successful custom response retains the backend summary and raw source", async () => {
+  const response = {
+    status: "loaded",
+    requested_llama_cpp_config: custom,
+    llama_cpp_config_summary: summary,
+  };
+  const api = harness(
+    { valid: true, llama_cpp_config_summary: summary },
+    response,
+  );
+  assert.deepEqual(await api.loadModel(request), response);
+  assert.deepEqual(api.calls[1].body.llama_cpp_config, custom);
+});
+
+test("custom load refuses an unconfirmed success after preflight", async () => {
+  const api = harness(
+    { valid: true, llama_cpp_config_summary: summary },
+    { status: "loaded" },
+  );
+  await assert.rejects(api.loadModel(request), /did not confirm the custom/);
+});
+
+test("managed calls keep the ordinary one-request contract", async () => {
+  const api = harness({ valid: true }, { status: "loaded" });
+  const { llama_cpp_config: _ignored, ...managed } = request;
+  await api.loadModel(managed);
+  assert.deepEqual(
+    api.calls.map((call) => call.url),
+    ["/api/inference/load"],
+  );
+  assert.equal("llama_cpp_config" in api.calls[0].body, false);
+});
+
+test("native custom loads mint validation grants without reusing the load grant", async () => {
+  for (const token of ["selected-file", "previous-file-for-rollback"]) {
+    const api = harness(
+      { valid: true, llama_cpp_config_summary: summary },
+      { status: "loaded", llama_cpp_config_summary: summary },
+    );
+    await api.loadModel({
+      ...request,
+      nativePathToken: token,
+      nativePathLease: `${token}:load-model:original-grant`,
+    });
+    assert.deepEqual(api.grants, [{ token, operation: "validate-model" }]);
+    assert.equal(
+      api.calls[0].body.native_path_lease,
+      `${token}:validate-model:fresh-grant`,
+    );
+    assert.equal(
+      api.calls[1].body.native_path_lease,
+      `${token}:load-model:original-grant`,
+    );
+    for (const call of api.calls) {
+      assert.equal("nativePathToken" in call.body, false);
+      assert.equal("nativePathLease" in call.body, false);
+    }
+  }
+  const runtime = readSrc("features/chat/hooks/use-chat-model-runtime.ts");
+  assert.match(
+    runtime,
+    /nativePathLease: loadNativePathLease,\s*nativePathToken,/,
+  );
+  assert.match(
+    runtime,
+    /nativePathLease: rollbackNativePathLease,\s*nativePathToken: previousActiveNativePathToken,/,
+  );
+});
+
+test("a native custom load without a redeemable token never reuses its load grant", async () => {
+  const api = harness(
+    { valid: true, llama_cpp_config_summary: summary },
+    { status: "loaded", llama_cpp_config_summary: summary },
+  );
+  await assert.rejects(
+    api.loadModel({ ...request, nativePathLease: "load-only-grant" }),
+    /re-select the local model file/,
+  );
+  assert.equal(api.calls.length, 0);
+  assert.equal(api.grants.length, 0);
+});

--- a/studio/frontend/tests/llama-cpp-custom-config.test.ts
+++ b/studio/frontend/tests/llama-cpp-custom-config.test.ts
@@ -49,6 +49,41 @@ const custom = {
 } as const;
 const managed = { version: 1, mode: "managed" } as const;
 
+test("removing a selected section clears the editor's stale selection", async () => {
+  const ts = await import("typescript");
+  const source = ts.createSourceFile(
+    "editor.tsx",
+    readSrc("features/model-picker/components/custom-llama-config-editor.tsx"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  let callback = "";
+  function visit(node: import("typescript").Node) {
+    if (ts.isJsxSelfClosingElement(node) && node.tagName.getText(source) === "textarea") {
+      const change = node.attributes.properties.find(
+        (attr) => ts.isJsxAttribute(attr) && attr.name.getText(source) === "onChange",
+      );
+      if (change && ts.isJsxAttribute(change) && change.initializer && ts.isJsxExpression(change.initializer)) {
+        callback = change.initializer.expression?.getText(source) ?? "";
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(source);
+  assert.ok(callback);
+  let changed: typeof custom | undefined;
+  const onChange = new Function("value", "onChange", "customConfigSections", `return (${callback})`)(
+    custom,
+    (next: typeof custom) => { changed = next; },
+    customConfigSections,
+  );
+  onChange({ target: { value: "[*]\nnp=1" } });
+  assert.equal(changed?.section, null);
+  onChange({ target: { value: custom.ini } });
+  assert.equal(changed?.section, "my-model");
+});
+
 test("custom source and selection round-trip through storage and API without consuming legacy extras", () => {
   store.clear();
   const config = {

--- a/studio/frontend/tests/llama-cpp-custom-config.test.ts
+++ b/studio/frontend/tests/llama-cpp-custom-config.test.ts
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  installLocalStorageFake,
+  registerStoreStubResolver,
+  readSrc,
+} from "./helpers/kit.ts";
+
+registerStoreStubResolver();
+const { store } = installLocalStorageFake();
+const {
+  normalizeLlamaCppConfig,
+  customConfigSections,
+  llamaCppConfigPayload,
+  customSamplingPayload,
+  markSamplingFields,
+  explicitSamplingFields,
+} = await import(
+  "../src/features/model-picker/model-config/llama-cpp-config.ts"
+);
+const {
+  DEFAULT_PER_MODEL_CONFIG,
+  PER_MODEL_CONFIG_STORAGE_KEY,
+  savePerModelConfig,
+  resolveInitialConfig,
+} = await import(
+  "../src/features/model-picker/model-config/per-model-config.ts"
+);
+const { fromApiOverride, toApiOverride, resolveStoredOverride } = await import(
+  "../src/features/model-picker/api/model-overrides.ts"
+);
+const { getReplayedParams, pickRememberedParams } = await import(
+  "../src/features/chat/lib/per-model-params.ts"
+);
+const { DEFAULT_INFERENCE_PARAMS } = await import(
+  "../src/features/chat/types/runtime.ts"
+);
+const { snapshotQueuedChatRunSettings } = await import(
+  "../src/features/chat/utils/queued-chat-run-settings.ts"
+);
+const custom = {
+  version: 1,
+  mode: "custom",
+  ini: "[*]\nfit=off\n[my-model]\nctx-size=56000\ntemp=0\n",
+  section: "my-model",
+} as const;
+const managed = { version: 1, mode: "managed" } as const;
+
+test("custom source and selection round-trip through storage and API without consuming legacy extras", () => {
+  store.clear();
+  const config = {
+    ...DEFAULT_PER_MODEL_CONFIG,
+    llamaExtraArgs: ["--threads", "3"],
+    llamaCppConfig: custom,
+  };
+  assert.equal(savePerModelConfig("org/model", "Q4", config), true);
+  const read = resolveInitialConfig("org/model", "Q4").config;
+  assert.deepEqual(read.llamaCppConfig, custom);
+  assert.deepEqual(
+    fromApiOverride(toApiOverride(read), DEFAULT_PER_MODEL_CONFIG)
+      .llamaCppConfig,
+    custom,
+  );
+  assert.deepEqual(read.llamaExtraArgs, ["--threads", "3"]);
+  const records = JSON.parse(store.get(PER_MODEL_CONFIG_STORAGE_KEY)!);
+  assert.equal(
+    Object.values(records).some(
+      (row: unknown) => (row as { version: number }).version === 6,
+    ),
+    true,
+  );
+  assert.equal(
+    savePerModelConfig("org/model", "Q4", { ...read, llamaCppConfig: managed }),
+    true,
+  );
+  const reset = resolveInitialConfig("org/model", "Q4").config;
+  assert.deepEqual(reset.llamaCppConfig, managed);
+  assert.deepEqual(reset.llamaExtraArgs, ["--threads", "3"]);
+});
+
+test("a per-quant managed tombstone blocks bare-model custom fallback locally and on the mirror", () => {
+  store.clear();
+  savePerModelConfig("org/model", null, {
+    ...DEFAULT_PER_MODEL_CONFIG,
+    llamaCppConfig: custom,
+  });
+  savePerModelConfig("org/model", "Q4", {
+    ...DEFAULT_PER_MODEL_CONFIG,
+    llamaCppConfig: managed,
+  });
+  assert.deepEqual(
+    resolveInitialConfig("org/model", "Q4").config.llamaCppConfig,
+    managed,
+  );
+  assert.deepEqual(
+    resolveStoredOverride(
+      {
+        "org/model": { llama_cpp_config: custom },
+        "org/model:Q4": { llama_cpp_config: managed },
+      },
+      ["org/model:Q4", "org/model"],
+    )?.llama_cpp_config,
+    managed,
+  );
+});
+
+test("absent and explicit reset remain different request values", () => {
+  assert.deepEqual(llamaCppConfigPayload(undefined), {});
+  assert.deepEqual(llamaCppConfigPayload(managed), {
+    llama_cpp_config: managed,
+  });
+  assert.equal(
+    "llama_cpp_config" in toApiOverride(DEFAULT_PER_MODEL_CONFIG),
+    false,
+  );
+  assert.deepEqual(
+    fromApiOverride({}, { ...DEFAULT_PER_MODEL_CONFIG, llamaCppConfig: custom })
+      .llamaCppConfig,
+    custom,
+  );
+});
+
+test("UTF-8 cap rejects an oversized edit without erasing its saved predecessor", () => {
+  store.clear();
+  savePerModelConfig("org/model", "Q4", {
+    ...DEFAULT_PER_MODEL_CONFIG,
+    llamaCppConfig: custom,
+  });
+  const oversized = { ...custom, ini: "é".repeat(32769) };
+  assert.equal(normalizeLlamaCppConfig(oversized), undefined);
+  assert.equal(
+    savePerModelConfig("org/model", "Q4", {
+      ...DEFAULT_PER_MODEL_CONFIG,
+      llamaCppConfig: oversized,
+    }),
+    false,
+  );
+  assert.deepEqual(
+    resolveInitialConfig("org/model", "Q4").config.llamaCppConfig,
+    custom,
+  );
+  assert.equal(
+    normalizeLlamaCppConfig({ ...custom, ini: "é".repeat(32768) })?.mode,
+    "custom",
+  );
+});
+
+test("selector suggestions never implicitly select a sole named section", () => {
+  assert.deepEqual(customConfigSections("[*]\n[only]\nctx-size=56000"), [
+    "only",
+  ]);
+  assert.deepEqual(
+    normalizeLlamaCppConfig({ ...custom, section: null })?.mode,
+    "custom",
+  );
+  // Backend validates null against the source; the frontend does not invent a selection.
+  assert.equal(
+    (
+      llamaCppConfigPayload({ ...custom, section: null })
+        .llama_cpp_config as typeof custom
+    ).section,
+    null,
+  );
+});
+
+test("large per-model sources still obey the aggregate storage budget", () => {
+  store.clear();
+  const evicted: { modelId: string; ggufVariant: string | null }[] = [];
+  for (let index = 0; index < 22; index += 1) {
+    assert.equal(
+      savePerModelConfig(
+        `org/model-${index}`,
+        null,
+        {
+          ...DEFAULT_PER_MODEL_CONFIG,
+          llamaCppConfig: { ...custom, ini: "#".repeat(60_000) },
+        },
+        evicted,
+      ),
+      true,
+    );
+  }
+  assert.ok(evicted.length > 0);
+  assert.ok(
+    new TextEncoder().encode(store.get(PER_MODEL_CONFIG_STORAGE_KEY)!).length <=
+      1024 * 1024,
+  );
+  assert.equal(
+    resolveInitialConfig("org/model-21", null).config.llamaCppConfig?.mode,
+    "custom",
+  );
+});
+
+test("automatic sampling yields to the preset; explicit equal values, zero and false survive", () => {
+  assert.deepEqual(customSamplingPayload(custom, []), {
+    sampling_fields_explicit: [],
+  });
+  const params = markSamplingFields(
+    { ...DEFAULT_INFERENCE_PARAMS, temperature: 0 },
+    "temperature",
+    "enable_thinking",
+  );
+  assert.deepEqual(
+    customSamplingPayload(custom, params.samplingFieldsExplicit),
+    { sampling_fields_explicit: ["temperature", "enable_thinking"] },
+  );
+  assert.deepEqual(
+    explicitSamplingFields({ temperature: 0, reasoningEnabled: false }),
+    ["temperature", "enable_thinking"],
+  );
+  assert.deepEqual(customSamplingPayload(managed, []), {});
+});
+
+test("model memory and queued snapshots retain provenance separately from automatic values", () => {
+  const params = markSamplingFields(
+    { ...DEFAULT_INFERENCE_PARAMS, checkpoint: "org/model" },
+    "temperature",
+  );
+  const remembered = pickRememberedParams(params);
+  const replayed = getReplayedParams(
+    true,
+    { "org/model": remembered },
+    { ...DEFAULT_INFERENCE_PARAMS },
+    "org/model",
+    true,
+  );
+  assert.deepEqual(replayed.samplingFieldsExplicit, ["temperature"]);
+  const legacy = getReplayedParams(
+    true,
+    { "org/model": { temperature: 0, topP: 0.95 } },
+    { ...DEFAULT_INFERENCE_PARAMS },
+    "org/model",
+    true,
+  );
+  assert.deepEqual(legacy.samplingFieldsExplicit, ["temperature", "top_p"]);
+  const queued = snapshotQueuedChatRunSettings({
+    params,
+    loadedLlamaCppConfig: custom,
+    llamaCppConfig: custom,
+  } as never);
+  const next = markSamplingFields(params, "top_p");
+  assert.deepEqual(queued.params.samplingFieldsExplicit, ["temperature"]);
+  assert.deepEqual(next.samplingFieldsExplicit, ["temperature", "top_p"]);
+  assert.deepEqual(queued.loadedLlamaCppConfig, custom);
+});
+
+test("all ordinary load, preflight and estimate producers carry the config; rollback uses its resident source", () => {
+  assert.equal(
+    readSrc("features/chat/hooks/use-chat-model-runtime.ts").match(
+      /llamaCppConfigPayload\(loadLlamaCppConfig\)/g,
+    )?.length,
+    2,
+  );
+  assert.match(
+    readSrc("features/chat/api/chat-api.ts"),
+    /llama_cpp_config: payload\.llama_cpp_config/,
+  );
+  assert.match(
+    readSrc("features/model-picker/api/memory-estimate.ts"),
+    /llama_cpp_config: payload\.llamaCppConfig/,
+  );
+  assert.match(
+    readSrc("features/chat/shared-composer.tsx"),
+    /llamaCppConfigPayload\(ownConfig\.llamaCppConfig\)/,
+  );
+  assert.match(
+    readSrc("features/chat/api/chat-adapter.ts"),
+    /llamaCppConfigPayload\(config\.llamaCppConfig\)/,
+  );
+  assert.match(
+    readSrc("features/chat/hooks/use-chat-model-runtime.ts"),
+    /llamaCppConfigPayload\(\s*stateBeforeUnload\.loadedLlamaCppConfig/,
+  );
+  assert.match(
+    readSrc("features/chat/lib/apply-inference-status-to-store.ts"),
+    /loadedLlamaCppConfig: status\.requested_llama_cpp_config/,
+  );
+});

--- a/studio/frontend/tests/llama-cpp-custom-sampling-store.test.ts
+++ b/studio/frontend/tests/llama-cpp-custom-sampling-store.test.ts
@@ -112,6 +112,27 @@ test("a legacy thread snapshot keeps explicit zero and false while new automatic
   assert.deepEqual(live.params.samplingFieldsExplicit, []);
 });
 
+for (const [name, settings, expectedMask] of [
+  ["non-sampling legacy row", { toolsEnabled: true }, ["temperature", "top_p"]],
+  ["partial legacy row", { temperature: 0.2 }, ["temperature", "top_p"]],
+  ["partial automatic row", { temperature: 0.2, samplingFieldsExplicit: [] }, ["top_p"]],
+] as const) {
+  test(`thread restore inherits global provenance for a ${name}`, () => {
+    reset();
+    const live = useChatRuntimeStore.getState();
+    live.setParams({ ...live.params, temperature: 0.4, topP: 0.7 });
+    useChatRuntimeStore.getState().applyThreadScopedSettings(
+      "sparse",
+      "samplingFieldsExplicit" in settings
+        ? { ...settings, samplingFieldsExplicit: [...settings.samplingFieldsExplicit] }
+        : settings,
+    );
+    const restored = useChatRuntimeStore.getState();
+    assert.equal(restored.params.topP, 0.7);
+    assert.deepEqual(restored.params.samplingFieldsExplicit, [...expectedMask]);
+  });
+}
+
 test("explicit reasoning and preserve-thinking choices use their direct wire names", () => {
   reset();
   const live = useChatRuntimeStore.getState();

--- a/studio/frontend/tests/llama-cpp-custom-sampling-store.test.ts
+++ b/studio/frontend/tests/llama-cpp-custom-sampling-store.test.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { register } from "node:module";
+import { installLocalStorageFake } from "./helpers/kit.ts";
+
+const { store } = installLocalStorageFake();
+store.set("unsloth_chat_settings_imported_to_studio_db", "true");
+register("./store-settings-resolver.mjs", import.meta.url);
+const { useChatRuntimeStore } = await import(
+  "../src/features/chat/stores/chat-runtime-store.ts"
+);
+const { DEFAULT_INFERENCE_PARAMS } = await import(
+  "../src/features/chat/types/runtime.ts"
+);
+const { markSamplingFields } = await import(
+  "../src/features/model-picker/model-config/llama-cpp-config.ts"
+);
+const custom = {
+  version: 1,
+  mode: "custom",
+  ini: "[*]\ntemp=0\n",
+  section: null,
+} as const;
+
+function reset() {
+  useChatRuntimeStore.getState().applyThreadScopedSettings(null, null);
+  useChatRuntimeStore.setState({
+    params: { ...DEFAULT_INFERENCE_PARAMS, checkpoint: "org/model" },
+    llamaCppConfig: custom,
+    loadedLlamaCppConfig: custom,
+    activeThreadId: null,
+    settingsHydrated: false,
+    rememberParamsPerModel: false,
+    paramsByModel: {},
+  });
+}
+
+test("a custom same-model recommendation refresh preserves explicitly edited zero", () => {
+  reset();
+  let live = useChatRuntimeStore.getState();
+  live.setParams({ ...live.params, temperature: 0 });
+  live = useChatRuntimeStore.getState();
+  assert.deepEqual(live.params.samplingFieldsExplicit, ["temperature"]);
+  live.setParams(
+    { ...live.params, temperature: 0.8, topP: 0.8 },
+    { fromModelDefaults: true },
+  );
+  live = useChatRuntimeStore.getState();
+  assert.equal(live.params.temperature, 0);
+  assert.equal(live.params.topP, 0.8);
+  assert.deepEqual(live.params.samplingFieldsExplicit, ["temperature"]);
+});
+
+test("an edit equal to the visible default remains explicit across default seeding", () => {
+  reset();
+  const live = useChatRuntimeStore.getState();
+  live.setParams(markSamplingFields(live.params, "temperature"));
+  live.setParams(
+    { ...live.params, temperature: 0.8 },
+    { fromModelDefaults: true },
+  );
+  assert.equal(
+    useChatRuntimeStore.getState().params.temperature,
+    DEFAULT_INFERENCE_PARAMS.temperature,
+  );
+  assert.deepEqual(
+    useChatRuntimeStore.getState().params.samplingFieldsExplicit,
+    ["temperature"],
+  );
+});
+
+test("changing model resets automatic provenance and replays only the destination's memory", () => {
+  reset();
+  let live = useChatRuntimeStore.getState();
+  live.setParams({ ...live.params, temperature: 0 });
+  useChatRuntimeStore.setState({
+    rememberParamsPerModel: true,
+    paramsByModel: { "org/other": { topP: 0.25 } },
+  });
+  live = useChatRuntimeStore.getState();
+  live.setParams(
+    { ...DEFAULT_INFERENCE_PARAMS, checkpoint: "org/other", temperature: 0.8 },
+    { fromModelDefaults: true },
+  );
+  live = useChatRuntimeStore.getState();
+  assert.equal(live.params.temperature, 0.8);
+  assert.equal(live.params.topP, 0.25);
+  assert.deepEqual(live.params.samplingFieldsExplicit, ["top_p"]);
+});
+
+test("a legacy thread snapshot keeps explicit zero and false while new automatic snapshots stay empty", () => {
+  reset();
+  useChatRuntimeStore.getState().applyThreadScopedSettings("legacy", {
+    temperature: 0,
+    reasoningEnabled: false,
+  });
+  let live = useChatRuntimeStore.getState();
+  assert.equal(live.params.temperature, 0);
+  assert.equal(live.reasoningEnabled, false);
+  assert.deepEqual(live.params.samplingFieldsExplicit, [
+    "temperature",
+    "enable_thinking",
+  ]);
+  live.applyThreadScopedSettings("automatic", {
+    temperature: 0.6,
+    samplingFieldsExplicit: [],
+  });
+  live = useChatRuntimeStore.getState();
+  assert.deepEqual(live.params.samplingFieldsExplicit, []);
+});
+
+test("explicit reasoning and preserve-thinking choices use their direct wire names", () => {
+  reset();
+  const live = useChatRuntimeStore.getState();
+  live.setReasoningEnabled(false);
+  live.setPreserveThinking(false);
+  assert.deepEqual(
+    useChatRuntimeStore.getState().params.samplingFieldsExplicit,
+    ["enable_thinking", "preserve_thinking"],
+  );
+});

--- a/studio/frontend/tests/mlx-context-pin-record-compat.test.ts
+++ b/studio/frontend/tests/mlx-context-pin-record-compat.test.ts
@@ -204,12 +204,11 @@ const ROWS: Row[] = [
     mlxRequest: 32768,
     transformersRequest: 32768,
     note:
-      "The task called v4 the 'future' record. It is not: STORAGE_SCHEMA_VERSION is 5 " +
-      "in this tree and in main, not 3, so v4 is a v4-client record and reads normally.",
+      "Version 4 is below STORAGE_SCHEMA_VERSION 6, so it reads normally.",
   },
   {
-    name: "version 6 (genuinely future)",
-    raw: { version: 6, customContextLength: 32768 },
+    name: "version 7 (genuinely future)",
+    raw: { version: 7, customContextLength: 32768 },
     normalizedPin: null,
     rawPin: 32768,
     isDefault: true,
@@ -330,7 +329,7 @@ test("a patched pin round-trips through storage on both backends", () => {
 test("both pin shapes are stamped version 1, so neither is distinguishable by version", () => {
   assert.equal(stampedVersion({ customContextLength: 32768 }), 1);
   assert.equal(stampedVersion({ maxSeqLength: 32768 }), 1);
-  // The old client's only forwards guard is `version > 5`, and v1 invites any client
+  // The current client's forwards guard is `version > 6`, and v1 invites any client
   // back to v1 to rewrite the record.
   assert.equal(
     stage({ version: 1, customContextLength: 32768 }).remembered,
@@ -342,6 +341,10 @@ test("both pin shapes are stamped version 1, so neither is distinguishable by ve
   );
   assert.equal(
     stage({ version: 6, customContextLength: 32768 }).remembered,
+    true,
+  );
+  assert.equal(
+    stage({ version: 7, customContextLength: 32768 }).remembered,
     false,
   );
 });

--- a/studio/frontend/tests/per-model-params-hydration.test.ts
+++ b/studio/frontend/tests/per-model-params-hydration.test.ts
@@ -856,7 +856,12 @@ test("a browser that only read an entry does not write it back", async () => {
     );
   }
   settingsHttp.puts.length = 0;
-  assert.deepEqual(patch, { [LLAMA]: { temperature: 0.42 } });
+  assert.deepEqual(patch, {
+    [LLAMA]: {
+      samplingFieldsExplicit: ["temperature"],
+      temperature: 0.42,
+    },
+  });
 
   // And switching away from it writes nothing more: the edit already said it,
   // and the rest of the entry is not this browser's to restate.
@@ -928,7 +933,15 @@ test("two edits to one model inside a debounce window both survive", async () =>
 
   assert.deepEqual(
     settingsHttp.puts.map((put) => put.inferenceParamsByModel),
-    [{ [QWEN]: { temperature: 0.42, topP: 0.11 } }],
+    [
+      {
+        [QWEN]: {
+          samplingFieldsExplicit: ["temperature", "top_p"],
+          temperature: 0.42,
+          topP: 0.11,
+        },
+      },
+    ],
     "one PUT carrying both edits, not the last one alone",
   );
 });

--- a/studio/frontend/tests/qwen-defaults-migration-hydration.test.ts
+++ b/studio/frontend/tests/qwen-defaults-migration-hydration.test.ts
@@ -41,6 +41,17 @@ const LEGACY_GLOBAL = {
   presencePenalty: 0.0,
   maxTokens: 8192,
 };
+const LEGACY_EXPLICIT_FIELDS = [
+  "temperature",
+  "top_p",
+  "top_k",
+  "min_p",
+  "repetition_penalty",
+  "presence_penalty",
+];
+const legacyMaskPut = {
+  inferenceParams: { samplingFieldsExplicit: LEGACY_EXPLICIT_FIELDS },
+};
 const BUILTIN_DEFAULT = {
   activePreset: "Default",
   activePresetSource: "builtin-default",
@@ -154,9 +165,13 @@ test("active-model adoption retries a migration deferred during hydration", asyn
   const migrated = useChatRuntimeStore.getState();
   assert.equal(migrated.paramsByModel[QWEN38]?.minP, 0);
   assert.equal(migrated.paramsByModel[QWEN38]?.presencePenalty, 1.5);
-  assert.equal(
-    settingsHttp.puts.some((put) => put.inferenceParams !== undefined),
-    false,
+  assert.deepEqual(
+    settingsHttp.puts.find((put) => put.inferenceParams !== undefined),
+    {
+      inferenceParams: {
+        samplingFieldsExplicit: LEGACY_EXPLICIT_FIELDS,
+      },
+    },
   );
   assert.equal(hasModelPut(), true);
 });
@@ -447,6 +462,7 @@ test("resident-model adoption migrates a deferred global-only snapshot", async (
     (put) => put.inferenceParams !== undefined,
   );
   assert.deepEqual(globalPut?.inferenceParams, {
+    samplingFieldsExplicit: [],
     minP: 0,
     presencePenalty: 1.5,
   });
@@ -524,7 +540,7 @@ test("a retry cannot overwrite an edit made after its confirming read", async ()
   );
   await sleep(50);
 
-  assert.equal(settingsHttp.puts.length, 0);
+  assert.deepEqual(settingsHttp.puts, [legacyMaskPut]);
   assert.equal(persistedRow().presencePenalty, 0.4);
 });
 
@@ -569,7 +585,7 @@ test("a retry revalidates the checkpoint after its confirming read", async () =>
   releaseConfirmation(legacySettings);
   await sleep(50);
 
-  assert.equal(settingsHttp.puts.length, 0);
+  assert.deepEqual(settingsHttp.puts, [legacyMaskPut]);
   assert.equal(persistedRow().presencePenalty, 0);
 });
 
@@ -599,7 +615,7 @@ test("a retry fences reasoning added after a confirming read", async () => {
   );
   await sleep(50);
 
-  assert.equal(settingsHttp.puts.length, 0);
+  assert.deepEqual(settingsHttp.puts, [legacyMaskPut]);
   assert.equal(settingsHttp.settings.reasoningEnabled, false);
   assert.equal(persistedRow().presencePenalty, 0);
 });
@@ -834,6 +850,7 @@ test("deferred adoption migrates the authoritative global when memory is off", a
     (put) => put.inferenceParams !== undefined,
   );
   assert.deepEqual(globalPatch?.inferenceParams, {
+    samplingFieldsExplicit: [],
     minP: 0,
     presencePenalty: 1.5,
   });
@@ -878,7 +895,9 @@ test("a retry fences optional global fields added after confirmation", async () 
   );
   await sleep(50);
 
-  assert.equal(settingsHttp.puts.length, 0);
+  assert.deepEqual(settingsHttp.puts, [
+    { inferenceParams: { samplingFieldsExplicit: [] } },
+  ]);
   assert.equal(
     (
       settingsHttp.settings.inferenceParams as Record<string, unknown>

--- a/studio/frontend/tests/qwen-defaults-migration-safety.test.ts
+++ b/studio/frontend/tests/qwen-defaults-migration-safety.test.ts
@@ -36,6 +36,17 @@ const LEGACY_SNAPSHOT = {
   systemVariables: "",
   fastMode: false,
 };
+const LEGACY_EXPLICIT_FIELDS = [
+  "temperature",
+  "top_p",
+  "top_k",
+  "min_p",
+  "repetition_penalty",
+  "presence_penalty",
+];
+const legacyMaskPut = {
+  inferenceParams: { samplingFieldsExplicit: LEGACY_EXPLICIT_FIELDS },
+};
 
 function resetHttp(settings: Record<string, unknown>): void {
   settingsHttp.settings = settings;
@@ -51,7 +62,12 @@ function resetHttp(settings: Record<string, unknown>): void {
 /** The store as it stands with the legacy Qwen3.8 snapshot loaded and active. */
 function seedActiveQwen(overrides: Record<string, unknown> = {}): void {
   useChatRuntimeStore.setState((state) => ({
-    params: { ...state.params, ...LEGACY_SNAPSHOT, checkpoint: QWEN38 },
+    params: {
+      ...state.params,
+      ...LEGACY_SNAPSHOT,
+      checkpoint: QWEN38,
+      samplingFieldsExplicit: LEGACY_EXPLICIT_FIELDS,
+    },
     paramsByModel: { [QWEN38]: LEGACY_SNAPSHOT },
     activePreset: "Default",
     activePresetSource: "builtin-default",
@@ -111,7 +127,7 @@ test("a rejected retry leaves local sampling on the value the server kept", asyn
 
   await adoptQwenDefaults();
 
-  assert.equal(settingsHttp.puts.length, 0);
+  assert.deepEqual(settingsHttp.puts, [legacyMaskPut]);
   assert.equal(serverRow().presencePenalty, 0.4);
   // The local store must not advertise the rejected values.
   const after = useChatRuntimeStore.getState();
@@ -128,7 +144,9 @@ test("an accepted retry still applies the migration locally", async () => {
 
   await adoptQwenDefaults();
 
-  assert.equal(settingsHttp.puts.length, 1);
+  assert.equal(settingsHttp.puts.length, 2);
+  assert.deepEqual(settingsHttp.puts[0], legacyMaskPut);
+  assert.ok("inferenceParamsByModel" in (settingsHttp.puts[1] ?? {}));
   assert.equal(serverRow().presencePenalty, 1.5);
   assert.equal(serverRow().minP, 0);
   const after = useChatRuntimeStore.getState();
@@ -136,7 +154,7 @@ test("an accepted retry still applies the migration locally", async () => {
   assert.equal(after.params.minP, 0);
 });
 
-test("a backend without the conditional route persists nothing and shows nothing", async () => {
+test("a backend without the conditional route does not apply the migration", async () => {
   resetHttp({ ...LEGACY_SETTINGS });
   // The desktop app adopts backends above a version floor, so an older one that
   // never learned this route is a supported install rather than an error.
@@ -145,21 +163,21 @@ test("a backend without the conditional route persists nothing and shows nothing
 
   await adoptQwenDefaults();
 
-  assert.equal(settingsHttp.puts.length, 0);
+  assert.deepEqual(settingsHttp.puts, [legacyMaskPut]);
   assert.equal(serverRow().presencePenalty, 0);
   assert.equal(serverRow().minP, 0.01);
   const after = useChatRuntimeStore.getState();
   assert.notEqual(after.params.presencePenalty, 1.5);
 });
 
-test("the browser build's 405 is treated the same as an absent route", async () => {
+test("the browser build's 405 does not apply the migration either", async () => {
   resetHttp({ ...LEGACY_SETTINGS });
   settingsHttp.conditionalStatus = 405;
   seedActiveQwen();
 
   await adoptQwenDefaults();
 
-  assert.equal(settingsHttp.puts.length, 0);
+  assert.deepEqual(settingsHttp.puts, [legacyMaskPut]);
   assert.equal(serverRow().presencePenalty, 0);
   assert.notEqual(useChatRuntimeStore.getState().params.presencePenalty, 1.5);
 });

--- a/studio/frontend/tests/research-inference-request.test.ts
+++ b/studio/frontend/tests/research-inference-request.test.ts
@@ -9,10 +9,29 @@ import { buildResearchInferenceRequest } from "../src/features/chat/research-inf
 const clamp = (effort: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max") =>
   effort === "xhigh" ? "high" as const : effort;
 
+test("local research preserves automatic and explicit sampling provenance", () => {
+  for (const samplingFieldsExplicit of [[], ["temperature", "top_p"]]) {
+    const request = buildResearchInferenceRequest({
+      checkpoint: "local/model.gguf",
+      temperature: 0.2,
+      topP: 0.9,
+      maxTokens: 4096,
+      samplingFieldsExplicit,
+      reasoningRequested: false,
+      reasoningStyle: "none",
+      reasoningEffort: "none",
+      reasoningEffortLevels: ["none"],
+      clampReasoningEffort: clamp,
+    });
+    assert.deepEqual(request.samplingFieldsExplicit, samplingFieldsExplicit);
+  }
+});
+
 test("Codex research keeps provider routing and clamps generation settings", () => {
   assert.deepEqual(
     buildResearchInferenceRequest({
       checkpoint: "external::provider::gpt-5.6-sol",
+      samplingFieldsExplicit: [],
       external: {
         providerId: "provider",
         providerType: "openai_codex",

--- a/studio/frontend/tests/resident-config-match-accelerator-matrix.test.ts
+++ b/studio/frontend/tests/resident-config-match-accelerator-matrix.test.ts
@@ -451,6 +451,8 @@ test("every PerModelConfig field is either compared or deliberately excluded", (
     // Qualifies selectedGpuIds rather than adding a dimension of its own: it is read, as
     // the reconciler's namespace argument, but /status has no field to compare it against.
     "selectedGpuIndexKind",
+    // Custom intent always reaches backend preflight and compiled-identity comparison.
+    "llamaCppConfig",
   ]);
   const unclassified = [...declared].filter(
     (field) => !compared.has(field) && !excluded.has(field),

--- a/studio/frontend/tests/sampling-persistence-hydration.test.ts
+++ b/studio/frontend/tests/sampling-persistence-hydration.test.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { register } from "node:module";
+import test from "node:test";
+
+import type { PersistedChatSettings } from "../src/features/chat/api/chat-settings-api.ts";
+import { installLocalStorageFake } from "./helpers/kit.ts";
+
+const { store: localStorageFake } = installLocalStorageFake();
+localStorageFake.set("unsloth_chat_settings_imported_to_studio_db", "true");
+register("./store-settings-resolver.mjs", import.meta.url);
+
+const { settingsHttp } = await import("./helpers/store-stubs/settings-http.ts");
+const {
+  sanitizeChatSettings,
+  savePersistedChatSettingsPatch,
+} = await import(
+  "../src/features/chat/utils/chat-settings-storage.ts"
+);
+const { useChatRuntimeStore } = await import(
+  "../src/features/chat/stores/chat-runtime-store.ts"
+);
+
+function resetForHydration(): void {
+  settingsHttp.getResponses.length = 0;
+  settingsHttp.puts.length = 0;
+  useChatRuntimeStore.setState((state) => ({
+    params: {
+      ...state.params,
+      checkpoint: "unsloth/Llama-3.2-3B-Instruct-GGUF",
+      samplingFieldsExplicit: ["top_p"],
+    },
+    paramsByModel: {},
+    reasoningAlwaysOn: false,
+    reasoningEnabled: true,
+    reasoningEffort: "high",
+    preserveThinking: true,
+    rememberParamsPerModel: false,
+    settingsHydrated: false,
+  }));
+}
+
+test("sampling masks survive the settings sanitizer for every inference-param container", () => {
+  const sanitized = sanitizeChatSettings({
+    inferenceParams: {
+      samplingFieldsExplicit: [],
+      temperature: 0.6,
+    },
+    inferenceParamsByModel: {
+      llama: {
+        samplingFieldsExplicit: [
+          "temperature",
+          "not_a_sampling_field",
+          "temperature",
+        ],
+        temperature: 0.2,
+      },
+    },
+    customPresets: [
+      {
+        name: "Focused",
+        params: {
+          samplingFieldsExplicit: ["reasoning_effort"],
+          temperature: 0.4,
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(sanitized.inferenceParams?.samplingFieldsExplicit, []);
+  assert.deepEqual(
+    sanitized.inferenceParamsByModel?.llama?.samplingFieldsExplicit,
+    ["temperature"],
+  );
+  assert.deepEqual(
+    sanitized.customPresets?.[0]?.params.samplingFieldsExplicit,
+    ["reasoning_effort"],
+  );
+});
+
+test("an empty automatic mask survives write, response sanitization, and hydration", async () => {
+  const snapshot: PersistedChatSettings = {
+    inferenceParams: {
+      samplingFieldsExplicit: [],
+      temperature: 0.6,
+      topP: 0.95,
+    },
+    reasoningEnabled: false,
+    reasoningEffort: "low",
+    preserveThinking: false,
+  };
+  settingsHttp.settings = { ...snapshot };
+  settingsHttp.puts.length = 0;
+
+  const saved = await savePersistedChatSettingsPatch(snapshot);
+  assert.deepEqual(
+    (
+      settingsHttp.puts[0]?.inferenceParams as
+        | Record<string, unknown>
+        | undefined
+    )?.samplingFieldsExplicit,
+    [],
+  );
+  assert.deepEqual(saved.inferenceParams?.samplingFieldsExplicit, []);
+
+  resetForHydration();
+  settingsHttp.settings = { ...saved };
+  await useChatRuntimeStore.getState().hydratePersistedSettings();
+
+  assert.deepEqual(
+    useChatRuntimeStore.getState().params.samplingFieldsExplicit,
+    [],
+  );
+});
+
+test("legacy top-level reasoning scalars become explicit sampling fields", async () => {
+  resetForHydration();
+  settingsHttp.settings = {
+    reasoningEnabled: false,
+    reasoningEffort: "low",
+    preserveThinking: false,
+  };
+
+  await useChatRuntimeStore.getState().hydratePersistedSettings();
+
+  const hydrated = useChatRuntimeStore.getState();
+  assert.equal(hydrated.reasoningEnabled, false);
+  assert.equal(hydrated.reasoningEffort, "low");
+  assert.equal(hydrated.preserveThinking, false);
+  assert.deepEqual(hydrated.params.samplingFieldsExplicit, [
+    "enable_thinking",
+    "reasoning_effort",
+    "preserve_thinking",
+  ]);
+});
+
+test("a reasoning edit made during hydration keeps its newer explicit mask", async () => {
+  resetForHydration();
+  settingsHttp.settings = {
+    reasoningEnabled: false,
+    reasoningEffort: "high",
+    preserveThinking: false,
+  };
+  settingsHttp.hold();
+
+  const hydration = useChatRuntimeStore.getState().hydratePersistedSettings();
+  useChatRuntimeStore.getState().setReasoningEffort("low");
+  settingsHttp.release?.();
+  await hydration;
+
+  const hydrated = useChatRuntimeStore.getState();
+  assert.equal(hydrated.reasoningEffort, "low");
+  assert.deepEqual(hydrated.params.samplingFieldsExplicit, [
+    "top_p",
+    "reasoning_effort",
+  ]);
+});

--- a/studio/frontend/tests/server-tuning-settings.test.ts
+++ b/studio/frontend/tests/server-tuning-settings.test.ts
@@ -113,9 +113,13 @@ test("a record only claims the new schema version when it carries one", () => {
   // toStoredConfig stamps the OLDEST version that understands every field
   // present, so an older client can still rewrite a record it fully knows.
   const source = readSrc("features/model-picker/model-config/per-model-config.ts");
-  assert.match(source, /const STORAGE_SCHEMA_VERSION = 5;/);
+  assert.match(source, /const STORAGE_SCHEMA_VERSION = 6;/);
   assert.match(source, /const PRE_SERVER_TUNING_SCHEMA_VERSION = 4;/);
-  assert.match(source, /hasServerTuning\s*\n?\s*\?\s*STORAGE_SCHEMA_VERSION/);
+  assert.match(
+    source,
+    /normalized\.llamaCppConfig !== undefined\s*\n?\s*\?\s*STORAGE_SCHEMA_VERSION/,
+  );
+  assert.match(source, /hasServerTuning\s*\n?\s*\?\s*5/);
 });
 
 test("blank knobs are omitted from the load payload", () => {

--- a/studio/frontend/tests/thread-scoped-commit-restores-defaults.test.ts
+++ b/studio/frontend/tests/thread-scoped-commit-restores-defaults.test.ts
@@ -100,7 +100,13 @@ test("a chat left mid-read keeps its edits, and the next chat gets the defaults"
   // The edits went to the chat they were made in.
   assert.deepEqual(
     threadRows.writesFor(CHAT_A).map((write) => write.settingsPatch),
-    [{ temperature: EDITED_TEMPERATURE, systemPrompt: EDITED_PROMPT }],
+    [
+      {
+        samplingFieldsExplicit: ["temperature"],
+        temperature: EDITED_TEMPERATURE,
+        systemPrompt: EDITED_PROMPT,
+      },
+    ],
     "the held edits did not reach the chat they were made in",
   );
 

--- a/studio/frontend/tests/thread-scoped-sampling-simulation.test.ts
+++ b/studio/frontend/tests/thread-scoped-sampling-simulation.test.ts
@@ -468,6 +468,14 @@ test("B3: leaving mid-read sends the held edit to its own chat, not the next one
     .filter((write) => write.settingsPatch !== undefined);
   assert.equal(merged.length, 1);
   assert.deepEqual(merged[0].settingsPatch, {
+    samplingFieldsExplicit: [
+      "temperature",
+      "top_p",
+      "top_k",
+      "min_p",
+      "repetition_penalty",
+      "presence_penalty",
+    ],
     temperature: 1.37,
     systemPrompt: "HELD EDIT 5f3a",
   });
@@ -654,6 +662,14 @@ test("B7: a tab closing with a held edit beacons it to the chat it was made in",
     localStorageFake.get("unsloth_chat_thread_settings_replay") ?? "{}",
   ) as Record<string, { settingsPatch?: Record<string, unknown> }>;
   assert.deepEqual(beaconed.A?.settingsPatch, {
+    samplingFieldsExplicit: [
+      "temperature",
+      "top_p",
+      "top_k",
+      "min_p",
+      "repetition_penalty",
+      "presence_penalty",
+    ],
     temperature: 1.37,
     systemPrompt: "HELD EDIT 5f3a",
   });

--- a/tests/studio/test_autoload_hf_token_preflight.py
+++ b/tests/studio/test_autoload_hf_token_preflight.py
@@ -103,6 +103,7 @@ def _run(script: str, harness: str):
 _HARNESS_TEMPLATE = """\
 // Real classification block, sliced verbatim from chat-adapter.ts.
 export async function classify(ctx: any) {{
+  const fetchLoadModelOverride = async () => undefined;
   const {{
     candidate,
     config,

--- a/tests/studio/test_chat_autoload_failure_gate.py
+++ b/tests/studio/test_chat_autoload_failure_gate.py
@@ -127,6 +127,7 @@ export type Scenario = {
   // Which backend the host serves with, and what the record holds: both decide the ask.
   platform?: { deviceType: string; chatOnlyReason: string | null };
   config?: Record<string, unknown>;
+  overrideError?: boolean;
 };
 
 // The stored-arguments hydration the auto-load runs before it calls /load. Neutral
@@ -137,6 +138,13 @@ export type Scenario = {
 // llamaExtraArgs still sends exactly what it set.
 export async function loadManagedLlamaFlags(): Promise<any> {
   return null;
+}
+export async function fetchLoadModelOverride(): Promise<any> {
+  if (SCENARIO.overrideError) throw new Error("override endpoint unavailable");
+  return undefined;
+}
+export function llamaCppConfigPayload(config: any): any {
+  return config === undefined ? {} : { llama_cpp_config: config };
 }
 export async function fetchLoadExtraArgs(
   _loadId: string,
@@ -317,6 +325,8 @@ function makeStore(): any {
     // has to resolve a local model of its own.
     params: { maxSeqLength: 4096, checkpoint: SCENARIO?.visibleCheckpoint ?? "" },
     activeGgufVariant: null,
+    loadedLlamaCppConfig: null,
+    llamaCppConfigSummary: null,
     activePresetSource: null,
     gpuMemoryMode: "auto",
     selectedGpuIds: null,
@@ -948,6 +958,7 @@ def _run(
             customContextLength: s.customContextLength ?? null,
             loadedCustomContextLength: s.loadedCustomContextLength ?? null,
             loadedContextLength: s.loadedContextLength ?? null,
+            loadedLlamaCppConfig: s.loadedLlamaCppConfig ?? null,
           }},
         }}));
         """
@@ -980,6 +991,29 @@ def _toasts(out: dict, kind: str) -> list[dict]:
 
 def _downloads_started(out: dict) -> list[str]:
     return [event["repoId"] for event in out["events"] if event["kind"] == "download.start"]
+
+
+def test_override_outage_does_not_block_managed_autoload():
+    out = _run(
+        "scenario({ ggufRepos: [GEMMA], variants: { [GEMMA.repo_id]: GEMMA_VARIANTS },"
+        " overrideError: true })"
+    )
+    assert _loaded_paths(out) == [GEMMA_REPO]
+    assert out["result"]["loaded"] is True
+
+
+def test_queued_background_custom_load_retains_its_own_sampling_config():
+    out = _run(
+        "scenario({ visibleCheckpoint: EXTERNAL, ggufRepos: [GEMMA],"
+        " variants: { [GEMMA.repo_id]: GEMMA_VARIANTS },"
+        " load: p => ({ ...LOADED(p), requested_llama_cpp_config: CUSTOM,"
+        " llama_cpp_config_summary: { mode: 'custom', digest: 'local' } }) })",
+        queued = True,
+        prelude = "const CUSTOM = { version: 1, mode: 'custom', ini: '[*]\\nnp=1', section: null };",
+    )
+    assert out["result"]["modelRuntime"]["loadedLlamaCppConfig"]["mode"] == "custom"
+    assert out["result"]["modelRuntime"]["llamaCppConfigSummary"]["digest"] == "local"
+    assert out["store"]["loadedLlamaCppConfig"] is None
 
 
 def test_failed_cached_load_does_not_download_the_default_model():

--- a/tests/studio/test_diffusion_gpu_layers_contract.py
+++ b/tests/studio/test_diffusion_gpu_layers_contract.py
@@ -229,7 +229,9 @@ def test_the_dedupe_compares_the_requested_split_through_the_paravirtual_rewrite
     assert "_metal_device_is_paravirtual()" in adopt
     assert "paravirtual_normalized_request(" in adopt
     # Normalized before the runtime comparison reads it, or the rewrite changes nothing.
-    assert adopt.index("paravirtual_normalized_request(") < adopt.index("_runtime_matches_intent(")
+    assert adopt.index("paravirtual_normalized_request(") < adopt.index(
+        "_runtime_matches_intent(intent, candidate_extra_args)"
+    )
     runtime = bodies["_runtime_matches_intent"]
     assert "_diffusion_manual_ngl(intent.gpu_memory_mode, intent.gpu_layers)" in runtime
     assert "self.diffusion_requested_ngl" in runtime


### PR DESCRIPTION
## Summary

Add per-model INI configuration with explicit section selection. Custom mode owns llama.cpp tuning without Studio's optimizer or startup fallback rewriting it.

## Motivation

Extra arguments are additive and can compete with Studio's generated settings. A custom configuration needs to remain effective across loads, requests and recovery.

## Changes

- Compile the selected preset against the chosen executable's supported options. Reject reserved settings before replacing the resident model.
- Persist the source and explicit managed-mode reset. Preserve legacy extra arguments when switching modes.
- Apply preset sampling defaults below explicit request values and operator policy. Retain configuration identity during reload and crash recovery.

## How to test

From `studio/backend`:
`python -m pytest tests/test_llama_custom_config.py tests/test_llama_custom_launch.py tests/test_llama_custom_routes.py -q`

From `studio/frontend`:
`node --experimental-strip-types --test --test-concurrency=1 "tests/llama-cpp-custom*.test.ts"`
`npm run typecheck`

The affected regression runs passed 613 backend and 600 frontend tests. A real Windows CPU launch confirmed selected context, sampling, resident preservation and crash recovery. Mocked-API browser checks covered save, hydration, reset and narrow layout.

## Migration notes

The configuration field is optional. Existing managed settings remain valid; custom mode does not migrate legacy extra arguments. Native validation and load use separate operation-scoped path grants.

## Notes for reviewers

This adds per-model pasted configuration, not global policy or file watching. The CPU fixture does not establish the reported CUDA performance difference. Full-app and native desktop UI testing remain separate from the mocked browser checks.

## Screenshots

<!-- paste before/after screenshots here -->

## Related

Refs #10359
