### PR TITLE
fix(studio): count rendered GGUF prompts before shared-KV admission

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2083,6 +2083,7 @@ def _openai_llama_admission_tokens(
     image_tokens: int = _OPENAI_LLAMA_ADMISSION_IMAGE_TOKENS,
     injected_tools = None,
     context_window: Optional[int] = None,
+    counted_prompt_tokens: Optional[int] = None,
 ) -> Optional[int]:
     """KV a request will occupy: what is sent, plus what it may generate.
 
@@ -2097,7 +2098,9 @@ def _openai_llama_admission_tokens(
     if not budget:
         return None
     messages = getattr(payload, "messages", None)
-    if isinstance(messages, list) and messages:
+    if counted_prompt_tokens is not None:
+        prompt_tokens = counted_prompt_tokens
+    elif isinstance(messages, list) and messages:
         try:
             estimate_messages, message_image_parts = _openai_llama_admission_messages_for_estimate(
                 messages
@@ -2175,6 +2178,7 @@ def _openai_llama_admission_reserve(
     payload = None,
     tool_loop: bool = False,
     injected_tools = None,
+    counted_prompt_tokens: Optional[int] = None,
 ) -> tuple[LlamaAdmissionReservation, LlamaAdmissionConfig]:
     config = llama_admission_config_from_env()
     capacity = _openai_llama_admission_capacity(request, llama_backend)
@@ -2186,6 +2190,7 @@ def _openai_llama_admission_reserve(
         budget = budget,
         tokens = _openai_llama_admission_tokens(
             payload,
+            counted_prompt_tokens = counted_prompt_tokens,
             budget = budget,
             capacity = capacity,
             tool_loop = tool_loop,
@@ -2199,6 +2204,75 @@ def _openai_llama_admission_reserve(
     return reservation, config
 
 
+def _count_gguf_admission_prompt(
+    llama_backend,
+    payload,
+    messages,
+    tools = None,
+) -> int:
+    """Count the prepared chat, retaining the existing allowance for media embeddings.
+
+    A tokenizer failure reserves the pool instead of admitting overlapping requests
+    on the character estimate that undercounts numeric and other dense ASCII text.
+    """
+    budget = _openai_llama_admission_budget(llama_backend) or 0
+    try:
+        text_messages, images = _openai_llama_admission_messages_for_estimate(messages)
+        count = llama_backend.count_chat_tokens(
+            text_messages,
+            tools = tools,
+            strict = True,
+            chat_template_kwargs = llama_backend._request_reasoning_kwargs(
+                payload.enable_thinking, payload.reasoning_effort, payload.preserve_thinking
+            ),
+            continue_final_message = _continue_final_message(payload),
+        )
+        if type(count) is not int or count <= 0:
+            raise ValueError("Invalid prompt token count")
+        return count + _openai_llama_admission_media_tokens(
+            payload,
+            message_image_parts = images,
+            image_tokens = _openai_llama_admission_image_tokens(llama_backend),
+        )
+    except Exception:
+        logger.debug("Prompt count unavailable; reserving the context pool", exc_info = True)
+        return budget
+
+
+async def _reserve_counted_gguf_chat(
+    *,
+    request,
+    llama_backend,
+    payload,
+    messages,
+    injected_tools = None,
+    tool_loop: bool = False,
+):
+    config = llama_admission_config_from_env()
+    counted = None
+    if config.enabled and config.kv_budget:
+        identity = (
+            getattr(llama_backend, "base_url", None),
+            _openai_llama_admission_budget(llama_backend),
+        )
+        counted = await asyncio.to_thread(
+            _count_gguf_admission_prompt, llama_backend, payload, messages, injected_tools
+        )
+        if identity != (
+            getattr(llama_backend, "base_url", None),
+            _openai_llama_admission_budget(llama_backend),
+        ):
+            counted = _openai_llama_admission_budget(llama_backend)
+    return _openai_llama_admission_reserve(
+        request = request,
+        llama_backend = llama_backend,
+        payload = payload,
+        tool_loop = tool_loop,
+        injected_tools = injected_tools,
+        counted_prompt_tokens = counted,
+    )
+
+
 def _openai_llama_admission_recost(
     reservation,
     conversation,
@@ -2209,6 +2283,7 @@ def _openai_llama_admission_recost(
     output_tokens: Optional[int] = None,
     cancel_event = None,
     injected_tools = None,
+    count_prepared_prompt: bool = False,
 ) -> None:
     """Charge a tool loop for what its conversation now is, not what it opened as.
 
@@ -2257,6 +2332,10 @@ def _openai_llama_admission_recost(
             message_image_parts = message_image_parts,
             image_tokens = _openai_llama_admission_image_tokens(llama_backend),
         )
+        if count_prepared_prompt:
+            prompt_tokens = _count_gguf_admission_prompt(
+                llama_backend, payload, conversation, injected_tools
+            )
         # Reading "Max" literally here would put the run back on the whole cache at its
         # first round boundary.
         share = max(1, budget // max(1, capacity))
@@ -22779,6 +22858,7 @@ async def produce_openai_chat_completions(
                     # loop down to its share on its very first round.
                     output_tokens = effective_max_tokens,
                     injected_tools = tools_to_use,
+                    count_prepared_prompt = True,
                     # A round waiting for cache room must still answer Stop. Same event
                     # the loop polls each iteration, so a wait ends where a cancel would.
                     cancel_event = cancel_event,
@@ -22854,7 +22934,8 @@ async def produce_openai_chat_completions(
 
             _tool_admission_mode = "chat_tool_stream" if payload.stream else "chat_tool_nonstream"
             try:
-                reservation, admission_config = _openai_llama_admission_reserve(
+                reservation, admission_config = await _reserve_counted_gguf_chat(
+                    messages = gguf_messages,
                     request = request,
                     llama_backend = llama_backend,
                     payload = payload,
@@ -23613,7 +23694,8 @@ async def produce_openai_chat_completions(
             _tracker = _TrackedCancel.for_payload(cancel_event, payload, *_cancel_keys)
             _tracker.__enter__()
             try:
-                reservation, admission_config = _openai_llama_admission_reserve(
+                reservation, admission_config = await _reserve_counted_gguf_chat(
+                    messages = gguf_messages,
                     request = request,
                     llama_backend = llama_backend,
                     payload = payload,
@@ -23957,7 +24039,8 @@ async def produce_openai_chat_completions(
             )
         else:
             try:
-                reservation, admission_config = _openai_llama_admission_reserve(
+                reservation, admission_config = await _reserve_counted_gguf_chat(
+                    messages = gguf_messages,
                     request = request,
                     llama_backend = llama_backend,
                     payload = payload,

--- a/studio/backend/tests/test_gguf_admission_token_count.py
+++ b/studio/backend/tests/test_gguf_admission_token_count.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Numeric text must not overcommit the shared KV pool through a character estimate."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from core.inference.llama_admission import LlamaAdmissionQueue
+import routes.inference as inference
+
+
+def _backend(count):
+    return SimpleNamespace(
+        base_url = "test-token-count",
+        context_length = 30000,
+        effective_parallel_slots = 3,
+        count_chat_tokens = Mock(return_value = count),
+        _request_reasoning_kwargs = Mock(return_value = {"enable_thinking": False}),
+    )
+
+
+def _payload():
+    return SimpleNamespace(
+        messages = [{"role": "user", "content": " ".join(map(str, range(1000, 5500)))}],
+        max_tokens = 1024,
+        enable_thinking = False,
+        reasoning_effort = None,
+        preserve_thinking = None,
+    )
+
+
+def test_numeric_prompts_wait_for_room_but_short_prompts_still_overlap(monkeypatch):
+    async def scenario(count):
+        queue = LlamaAdmissionQueue("counted")
+        monkeypatch.setattr(inference, "get_llama_admission_queue", lambda _: queue)
+        backend = _backend(count)
+        payload = _payload()
+        reservations = []
+        for _ in range(3):
+            reservation, _ = await inference._reserve_counted_gguf_chat(
+                request = None,
+                llama_backend = backend,
+                payload = payload,
+                messages = payload.messages,
+            )
+            reservations.append(reservation)
+        leases = [r.lease_nowait() for r in reservations]
+        if count == 22560:
+            assert leases[0] is not None
+            assert leases[1:] == [None, None]
+            assert queue.snapshot().committed == 23584
+            leases[0].release()
+            await asyncio.sleep(0)
+            assert reservations[1].lease_nowait() is not None
+        else:
+            assert all(lease is not None for lease in leases)
+        assert backend.count_chat_tokens.call_count == 3
+
+    asyncio.run(scenario(22560))
+    asyncio.run(scenario(100))
+
+
+def test_counts_prepared_messages_and_tools_with_generation_options():
+    backend = _backend(22560)
+    payload = _payload()
+    prepared = [{"role": "system", "content": "Injected system instructions"}] + payload.messages
+    tools = [{"type": "function", "function": {"name": "lookup", "parameters": {}}}]
+    count = inference._count_gguf_admission_prompt(backend, payload, prepared, tools)
+    assert count == 22560
+    args, kwargs = backend.count_chat_tokens.call_args
+    assert args[0] == prepared
+    assert kwargs == dict(
+        tools = tools,
+        strict = True,
+        chat_template_kwargs = {"enable_thinking": False},
+        continue_final_message = False,
+    )
+    assert (
+        inference._openai_llama_admission_tokens(
+            payload,
+            budget = 30000,
+            capacity = 3,
+            injected_tools = tools,
+            counted_prompt_tokens = count,
+        )
+        == 23584
+    )
+
+
+@pytest.mark.parametrize("result", [0, -1, None, True, "22560"])
+def test_invalid_counts_reserve_the_entire_pool(result):
+    payload = _payload()
+    assert (
+        inference._count_gguf_admission_prompt(_backend(result), payload, payload.messages) == 30000
+    )
+
+
+def test_tokenizer_failure_reserves_the_entire_pool():
+    backend = _backend(0)
+    backend.count_chat_tokens.side_effect = RuntimeError("tokenizer unavailable")
+    payload = _payload()
+    assert inference._count_gguf_admission_prompt(backend, payload, payload.messages) == 30000
+
+
+def test_tool_recost_keeps_the_model_count(monkeypatch):
+    async def scenario():
+        queue = LlamaAdmissionQueue("recost")
+        monkeypatch.setattr(inference, "get_llama_admission_queue", lambda _: queue)
+        backend = _backend(22560)
+        payload = _payload()
+        reservation, _ = await inference._reserve_counted_gguf_chat(
+            request = None,
+            llama_backend = backend,
+            payload = payload,
+            messages = payload.messages,
+            tool_loop = True,
+        )
+        assert reservation.lease_nowait() is not None
+        inference._openai_llama_admission_recost(
+            reservation,
+            payload.messages,
+            request = None,
+            llama_backend = backend,
+            payload = payload,
+            count_prepared_prompt = True,
+        )
+        assert queue.snapshot().committed == 23584
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Concurrent native GGUF chats can overflow a shared KV cache because the character-based admission estimate undercounts numeric text. In the local reproduction, a prompt estimated at 5,687 tokens actually evaluates 22,560 tokens; three such requests are admitted together into a 30,000-token pool and all fail.

Count the prepared chat through llama-server's strict rendered-prompt tokenizer before reserving KV capacity, including injected system text and tool schemas. Count off the event loop and retain the existing output and media allowances. Use the same count for native tool-loop recosting; if counting fails, reserve the full pool so the request runs alone.

Validation:
- Identical local A/B at 30,000 context, 3 slots, Qwen3-1.7B UD-Q4_K_XL, max_tokens=1024: baseline 3/3 shared-context errors; fixed 3/3 completions without errors, with large requests waiting for available capacity.
- Short-prompt control: 3/3 complete, all three start generating before any completes.
- Related admission, recost, media, and route tests: 277 passed, 5 skipped.
- Worktree and pre-push checks pass. Post-fix audit flags only module-private test fixture names shared with unrelated test modules; manually reviewed as harmless.

Scope: native Studio GGUF chat admission. Other protocol passthrough paths, the existing uncapped-output policy, and media embedding estimates are unchanged. This does not establish a fix for the separate MTP batch-index or tool-permission reports. Reproduced on WSL with an RTX 5070 Ti and a cached Qwen3-1.7B model, not the reporter's Windows desktop/Nemotron/5090 setup.

Related to #10671.
