### PR TITLE
Bound the hub fetch in the GPU inference smoke test

### DIFF
--- a/tests/studio/test_gpu_inference_smoke.py
+++ b/tests/studio/test_gpu_inference_smoke.py
@@ -67,6 +67,7 @@ def test_gpu_generation_smoke():
     # Gemma is numerically unstable in fp16 (it emits only <pad>); use bf16 where supported, else fp32. The model is
     # tiny, so fp32 is still fast.
     dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float32
+
     def load():
         tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
         model = AutoModelForCausalLM.from_pretrained(MODEL_ID, dtype = dtype).to("cuda")

--- a/tests/studio/test_gpu_inference_smoke.py
+++ b/tests/studio/test_gpu_inference_smoke.py
@@ -14,6 +14,8 @@ check, not a benchmark. Select/deselect it by name, e.g. `-k gpu_generation`.
 
 from __future__ import annotations
 
+import threading
+
 import pytest
 
 torch = pytest.importorskip("torch")
@@ -25,6 +27,34 @@ MODEL_ID = "unsloth/gemma-3-270m-it"
 # stay a few seconds.
 MIN_NEW_TOKENS = 4
 MAX_NEW_TOKENS = 16
+# The hub fetch below is bounded. A connection that is merely slow, rather than failing, would
+# otherwise block a self-hosted GPU runner indefinitely, and --timeout cannot interrupt a
+# blocked socket read. The contract here is to skip when the model is not reachable.
+FETCH_TIMEOUT_SECONDS = 300
+
+
+def _with_deadline(fn, timeout):
+    """Run fn on a daemon thread so a stalled hub connection ends with the deadline.
+
+    ThreadPoolExecutor joins its workers at interpreter exit, which would move the hang to
+    teardown rather than remove it.
+    """
+    box = {}
+
+    def run():
+        try:
+            box["result"] = fn()
+        except BaseException as exc:  # re-raised on the test thread below
+            box["error"] = exc
+
+    thread = threading.Thread(target = run, daemon = True)
+    thread.start()
+    thread.join(timeout)
+    if thread.is_alive():
+        raise TimeoutError(f"timed out after {timeout}s")
+    if "error" in box:
+        raise box["error"]
+    return box["result"]
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason = "requires a CUDA GPU")
@@ -37,10 +67,15 @@ def test_gpu_generation_smoke():
     # Gemma is numerically unstable in fp16 (it emits only <pad>); use bf16 where supported, else fp32. The model is
     # tiny, so fp32 is still fast.
     dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float32
-    try:
+    def load():
         tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
         model = AutoModelForCausalLM.from_pretrained(MODEL_ID, dtype = dtype).to("cuda")
-    except Exception as exc:  # offline / gated / download failure is not a code defect
+        return tokenizer, model
+
+    try:
+        # offline / gated / slow hub access is not a code defect
+        tokenizer, model = _with_deadline(load, FETCH_TIMEOUT_SECONDS)
+    except Exception as exc:
         pytest.skip(f"could not fetch/load {MODEL_ID}: {exc}")
 
     model.eval()


### PR DESCRIPTION
## What

`tests/studio/test_gpu_inference_smoke.py` is CUDA-gated, so it only runs where the hub may be slow,
and its fetch had no deadline. A hub connection that is *slow* rather than failing blocks
`AutoTokenizer.from_pretrained(MODEL_ID)` indefinitely, which contradicts the docstring's
"download failure is not a code defect" skip. On a self-hosted GPU runner that wedges the whole
suite, and `--timeout` cannot interrupt a blocked socket read.

Observed on an A100 before the change:

- the studio suite stalled partway through with no log output for 10+ minutes
- the test process sat in `do_poll` — blocked on a socket, not computing
- `~/.cache/huggingface` stayed at 0 bytes, so the download was not progressing
- `--timeout=600` fired but could not break the blocked read

Bisecting `tests/studio/` in 15-file chunks put the failure in the chunk containing this file, and
the suite's last logged test was `test_gpu_inference_smoke.py::test_gpu_generation_smoke`.

## Fix

Run the fetch on a daemon thread with a wall-clock deadline and skip when it expires. A daemon
thread is used rather than `ThreadPoolExecutor`, whose workers are joined at interpreter exit —
that would move the hang to teardown instead of removing it.

## Verification

On A100-PCIE-40GB:

- mechanism: `_with_deadline(lambda: time.sleep(30), 2)` raises `TimeoutError` after 2.0s, and the
  normal return path still returns its value
- real path with the hub pointed at a blackhole (`HF_ENDPOINT=http://10.255.255.1:9`) and the
  deadline temporarily lowered to 20s: `1 skipped in 20.09s` with `timed out after 20s` — before
  the change this blocked indefinitely
- the committed deadline is 300s, and no other file in the test is touched

The rest of `tests/studio/` is unaffected: the other nine 15-file chunks pass without it (the only
failing chunk was this one).

I searched issues and PRs for this and did not find an existing report.
