### PR TITLE
Clear the metadata directory cache before scanning installed records

### DIFF
--- a/studio/install_manifest.py
+++ b/studio/install_manifest.py
@@ -151,10 +151,14 @@ def _metadata_scan_paths() -> List[str]:
 
 def _installed_metadata_records(dist_name: str) -> List[Tuple[str, Optional[Path]]]:
     """Every matching metadata version and its directory, when available."""
-    from importlib.metadata import distributions
+    from importlib.metadata import MetadataPathFinder, distributions
 
     wanted = _canonical(dist_name)
     paths = _metadata_scan_paths()
+    # importlib.metadata caches each directory listing. A dist-info that appeared after an
+    # earlier scan in this process -- a manifest write, an interrupted uninstall -- would
+    # stay invisible, and a damaged install would verify as healthy.
+    MetadataPathFinder.invalidate_caches()
     kwargs = {"path": paths} if paths else {}
     found: List[Tuple[str, Optional[Path]]] = []
     for dist in distributions(**kwargs):


### PR DESCRIPTION
## What

`_installed_metadata_records` enumerates installed distributions through `importlib.metadata.distributions()`, which caches each directory listing. A `*.dist-info` that appears **after an earlier scan in the same process** -- a manifest write, an interrupted uninstall -- therefore stayed invisible to `verify_install`. It saw only the healthy record and reported `manifest_ok: True` for a damaged install, so the malformed-metadata fallback in that same function could never fire.

## Reproduction

`tests/studio/install/test_install_manifest.py::test_malformed_matching_metadata_invalidates_the_manifest` writes the manifest, then creates a matching `demo-2.0.dist-info` whose `METADATA` is invalid UTF-8 (`b"\xff\xfe"`), and asserts `manifest_ok is False` with reason `studio_install_metadata_conflict`.

Before: `1 failed` -- `assert True is False` at line 210.
After: `1 passed`.

Instrumenting the module made the disconnect explicit. Inside the test, `installed_versions("demo")` returned `['1.0']` -- the malformed record missing entirely -- while a fresh process that created both records before the first scan returned `['', '1.0']` and correctly reported the conflict. The difference is only whether an earlier scan had already populated the cache.

## Fix

Call `MetadataPathFinder.invalidate_caches()` before the scan, so a directory that appeared since an earlier scan is seen.

## Verification

A100-PCIE-40GB, torch 2.8.0+cu128, Python 3.12:

- target test: `1 passed` (was `1 failed`)
- `tests/studio/install/test_install_manifest.py`: 39 passed
- `tests/studio/install/`: 3506 passed, 529 skipped

I searched issues and PRs for this and did not find an existing report.

## Note

The other failure in that suite, `tests/studio/test_gpu_inference_smoke.py::test_gpu_generation_smoke`, is an unrelated hang in the hub fetch; dealt with separately in #10796.


---

## Maintainer update (danielhanchen)

Took this over and pushed two commits: 925f2d0 (the compatibility fix plus tests) and a9196c6 (comment trim, comments and docstrings only, AST verified identical).

### What changed from the original patch

`MetadataPathFinder.invalidate_caches` only became a classmethod in CPython 3.11.9 and 3.12.3 (gh-116811, backported as GH-116865 and GH-116864). It was never backported to 3.10, which was security-only by then, and 3.9 has no such method. Calling it on the class therefore raised `TypeError: missing 1 required positional argument: 'cls'` on 3.10.\*, on 3.11.0 through 3.11.8 and on 3.12.0 through 3.12.2, taking `installed_versions`, `invalid_metadata_paths` and `verify_install` down with it. The call now goes through an instance, which binds either shape, with a `getattr` for 3.9.

`importlib.invalidate_caches()` is not an alternative: it reaches this cache only through `PathFinder`'s delegation, which the same patch added, so it silently no-ops on exactly the releases that need it.

### Correction to the reproduction above

The listing cache is keyed on the scan directory's `st_mtime`, and creating a `dist-info` normally advances that mtime, so the cited test passes on `main` on any nanosecond-granularity filesystem (XFS, ext4, APFS), both alone and as a whole file. The bug needs the mtime to be unchanged between the two scans. The new `test_a_metadata_record_added_since_the_last_scan_is_seen` restores it with `os.utime`, which reproduces the staleness on every filesystem.

### Why it matters in production

`studio/install_python_stack.py:6645`, `:6772`, `:6826` and `:6872` call `importlib.invalidate_caches()` right after a `pip --force-reinstall` or uninstall, then call `install_manifest.installed_versions(name)`. On the unpatched releases above that invalidation does nothing for metadata, so the repair loop reads a stale listing. Clearing the cache inside the scan is what makes those four sites correct.

### Verification

| interpreter | before | original patch | now |
|---|---|---|---|
| 3.9.25 | no listing cache, fresh | TypeError | fresh |
| 3.10.19 | stale | TypeError | fresh |
| 3.11.8 | stale | TypeError | fresh |
| 3.11.9 | stale | fresh | fresh |
| 3.12.2 | stale | TypeError | fresh |
| 3.12.3 | stale | fresh | fresh |
| 3.11.14, 3.12.12, 3.13.12, 3.14.3 | stale | fresh | fresh |
| 3.13.12t, 3.14.3t free-threaded | stale | fresh | fresh |

Detection is not widened, which matters because a false `studio_install_metadata_conflict` is auto-repairable in release builds and starts a full managed reinstall on launch:

- 31 edge cases across 12 interpreters, byte-identical before and after. Covers duplicate records, missing, undecodable and nameless `METADATA`, a stem with no hyphen, `.egg-info`, pip `~` backups, case variants, underscore-vs-hyphen canonicalisation, unicode and 200-character names, an empty `dist-info`, a missing scan dir, the `lib64 -> lib` dedupe, an empty scan-path list widening to `sys.path`, and a zip on the scan path.
- A healthy tree reports `manifest_ok is True` on four consecutive `verify_install` calls on every interpreter.
- Repair converges rather than looping: healthy, conflict, healthy, healthy.
- 6 scanning threads against 2 threads iterating `distributions()`: 0 errors, one consistent result, on all 12 interpreters including both free-threaded builds.

Cost of the global cache clear, per `installed_version_probe` (up to 4 scans) on 3.12.12: 8.9 to 10.5 ms at 50 packages, 66.4 to 78.3 ms at 400, 347 to 397 ms at 2000. Roughly 10 to 20 percent, or 2 to 3 ms per scan at a realistic size.

Suites: `tests/studio/install/` 4029 passed, `tests/python/test_install_python_stack.py` 189 passed, `unsloth_cli/tests` 1405 passed. `ruff check` clean, `scripts/run_ruff_format.py` a byte-level fixed point, import-hoist and duplicate-definition lints clean. Cross-platform: `test_install_manifest.py` 43 passed on `windows-latest` (real NTFS, Python 3.12.10); `ubuntu-latest` and `macos-15` results to follow.

### Follow-ups, not in this PR

1. `missing_requirements` uses bare `distribution(name)` with no path restriction and no invalidation, and runs inside `verify_install` before the invalidation, so one call can read two cache generations.
2. `_scan_payload_files` and `unsloth_cli/_studio_deps.py:472`, an independent re-implementation of the same scan, never invalidate.
3. No CI leg runs 3.10 or 3.9 despite `PYTHON_FLOOR: '3.10'` and `requires-python = ">=3.9"`, and `setup-python` resolves '3.11' and '3.12' to the newest patch. That gap is what let this through.
