### PR TITLE
feat(studio): browse and preview chat workspace files

### DIFF
--- a/studio/backend/core/workspace_files.py
+++ b/studio/backend/core/workspace_files.py
@@ -96,7 +96,7 @@ def list_directory(folder: dict, relative_path: str = "") -> dict:
             )
     resolve_path(folder, relative_path)
     entries.sort(
-        key=lambda entry: (not entry["isDirectory"], entry["name"].casefold(), entry["name"])
+        key = lambda entry: (not entry["isDirectory"], entry["name"].casefold(), entry["name"])
     )
     return {"entries": entries, "truncated": truncated}
 
@@ -122,7 +122,7 @@ def preview_file(folder: dict, relative_path: str) -> dict:
         if not stat.S_ISREG(opened.st_mode) or _identity(opened) != _identity(before):
             raise ValueError("File changed, please select it again")
         resolve_path(folder, relative_path)
-        with os.fdopen(fd, "rb", closefd=False) as stream:
+        with os.fdopen(fd, "rb", closefd = False) as stream:
             data = stream.read(limit + 1)
         after = os.fstat(fd)
         resolve_path(folder, relative_path)
@@ -139,8 +139,7 @@ def preview_file(folder: dict, relative_path: str) -> dict:
     try:
         # A truncated UTF-8 sequence at the boundary is not a binary file.
         import codecs
-
-        content = codecs.getincrementaldecoder("utf-8-sig")().decode(data, final=not truncated)
+        content = codecs.getincrementaldecoder("utf-8-sig")().decode(data, final = not truncated)
     except UnicodeDecodeError:
         return {"kind": "unsupported", "message": "No inline preview for this file type"}
     return {"kind": "text", "content": content, "truncated": truncated}
@@ -178,5 +177,5 @@ def search_files(folder: dict, query: str) -> dict:
                 matches.append(entry)
                 if len(matches) == MAX_ENTRIES:
                     return {"entries": matches, "truncated": True}
-    matches.sort(key=lambda entry: entry["path"].casefold())
+    matches.sort(key = lambda entry: entry["path"].casefold())
     return {"entries": matches, "truncated": truncated or bool(pending)}

--- a/studio/backend/core/workspace_files.py
+++ b/studio/backend/core/workspace_files.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Bounded, read-only workspace browsing. No indexing or file execution."""
+
+import base64
+import os
+import stat
+from pathlib import Path, PurePosixPath
+
+MAX_ENTRIES = 2000
+MAX_SEARCH_ENTRIES = 10000
+MAX_TEXT_BYTES = 256 * 1024
+MAX_IMAGE_BYTES = 8 * 1024 * 1024
+IMAGE_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+}
+
+
+def _identity(st: os.stat_result) -> tuple[int, int]:
+    return st.st_dev, st.st_ino
+
+
+def _regular_path(path: Path) -> os.stat_result:
+    info = os.lstat(path)
+    if stat.S_ISLNK(info.st_mode) or getattr(info, "st_file_attributes", 0) & 0x400:
+        raise ValueError("Symbolic links and junctions cannot be browsed")
+    if not (stat.S_ISDIR(info.st_mode) or stat.S_ISREG(info.st_mode)):
+        raise ValueError("Only regular files and folders can be browsed")
+    return info
+
+
+def resolve_path(folder: dict, relative_path: str = "") -> Path:
+    from utils.paths.sensitive import contains_sensitive_path_component
+
+    if "\x00" in relative_path or "\\" in relative_path or ":" in relative_path:
+        raise ValueError("Invalid relative path")
+    relative = PurePosixPath(relative_path)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise ValueError("Path must stay inside the workspace")
+    root = Path(folder["path"])
+    root_info = _regular_path(root)
+
+    def stored(value):
+        return (
+            int(value[1:], 16) if isinstance(value, str) and value.startswith("x") else int(value)
+        )
+
+    expected = stored(folder["root_device"]), stored(folder["root_inode"])
+    if not stat.S_ISDIR(root_info.st_mode) or _identity(root_info) != expected:
+        raise ValueError("Workspace changed, please refresh")
+    if os.path.normcase(os.path.realpath(root)) != os.path.normcase(str(root)):
+        raise ValueError("Workspace changed, please refresh")
+    if relative.parts and relative.parts[0] in {".unsloth_sandbox", ".unsloth_sandbox_remap.json"}:
+        raise ValueError("Internal workspace file")
+    current = root
+    for part in relative.parts:
+        current /= part
+        _regular_path(current)
+        if contains_sensitive_path_component(str(current.relative_to(root))):
+            raise ValueError("This folder cannot be browsed")
+    if os.path.commonpath([str(root), os.path.realpath(current)]) != str(root):
+        raise ValueError("Path must stay inside the workspace")
+    return current
+
+
+def list_directory(folder: dict, relative_path: str = "") -> dict:
+    directory = resolve_path(folder, relative_path)
+    if not directory.is_dir():
+        raise ValueError("Select a folder")
+    entries = []
+    truncated = False
+    with os.scandir(directory) as children:
+        for child in children:
+            relative = (PurePosixPath(relative_path) / child.name).as_posix()
+            try:
+                path = resolve_path(folder, relative)
+                info = _regular_path(path)
+            except (OSError, ValueError):
+                continue
+            if len(entries) == MAX_ENTRIES:
+                truncated = True
+                break
+            entries.append(
+                {
+                    "name": child.name,
+                    "path": relative,
+                    "isDirectory": stat.S_ISDIR(info.st_mode),
+                    "size": info.st_size,
+                }
+            )
+    resolve_path(folder, relative_path)
+    entries.sort(
+        key=lambda entry: (not entry["isDirectory"], entry["name"].casefold(), entry["name"])
+    )
+    return {"entries": entries, "truncated": truncated}
+
+
+def preview_file(folder: dict, relative_path: str) -> dict:
+    path = resolve_path(folder, relative_path)
+    before = _regular_path(path)
+    if not stat.S_ISREG(before.st_mode):
+        raise ValueError("Select a file")
+    mime = IMAGE_TYPES.get(path.suffix.lower())
+    limit = MAX_IMAGE_BYTES if mime else MAX_TEXT_BYTES
+    if mime and before.st_size > limit:
+        return {"kind": "unsupported", "message": "Image is too large to preview"}
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_BINARY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
+    fd = os.open(path, flags)
+    try:
+        opened = os.fstat(fd)
+        if not stat.S_ISREG(opened.st_mode) or _identity(opened) != _identity(before):
+            raise ValueError("File changed, please select it again")
+        resolve_path(folder, relative_path)
+        with os.fdopen(fd, "rb", closefd=False) as stream:
+            data = stream.read(limit + 1)
+        after = os.fstat(fd)
+        resolve_path(folder, relative_path)
+        if (opened.st_size, opened.st_mtime_ns) != (after.st_size, after.st_mtime_ns):
+            raise ValueError("File changed while reading, please try again")
+    finally:
+        os.close(fd)
+    if mime:
+        return {"kind": "image", "mimeType": mime, "data": base64.b64encode(data).decode("ascii")}
+    truncated = len(data) > limit
+    data = data[:limit]
+    if b"\x00" in data:
+        return {"kind": "unsupported", "message": "No inline preview for this file type"}
+    try:
+        # A truncated UTF-8 sequence at the boundary is not a binary file.
+        import codecs
+
+        content = codecs.getincrementaldecoder("utf-8-sig")().decode(data, final=not truncated)
+    except UnicodeDecodeError:
+        return {"kind": "unsupported", "message": "No inline preview for this file type"}
+    return {"kind": "text", "content": content, "truncated": truncated}
+
+
+def search_files(folder: dict, query: str) -> dict:
+    """Search names across the workspace with explicit traversal/result bounds."""
+    from collections import deque
+
+    pending = deque([""])
+    matches = []
+    visited = 0
+    inspected = 0
+    truncated = False
+    while pending and visited < 200:
+        directory = pending.popleft()
+        visited += 1
+        try:
+            listing = list_directory(folder, directory)
+        except (OSError, ValueError):
+            if not directory:
+                raise
+            continue
+        truncated |= listing["truncated"]
+        for entry in listing["entries"]:
+            inspected += 1
+            if inspected > MAX_SEARCH_ENTRIES:
+                return {"entries": matches, "truncated": True}
+            if entry["isDirectory"]:
+                if entry["path"].count("/") < 16 and len(pending) < 200:
+                    pending.append(entry["path"])
+                else:
+                    truncated = True
+            elif query.casefold() in entry["name"].casefold():
+                matches.append(entry)
+                if len(matches) == MAX_ENTRIES:
+                    return {"entries": matches, "truncated": True}
+    matches.sort(key=lambda entry: entry["path"].casefold())
+    return {"entries": matches, "truncated": truncated or bool(pending)}

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -300,6 +300,7 @@ from routes import (
     providers_router,
     openai_codex_auth_router,
     rag_router,
+    workspace_files_router,
     research_runs_router,
     chat_generation_runs_router,
     training_history_router,
@@ -1449,6 +1450,7 @@ app.include_router(llama_router, prefix = "/api/llama", tags = ["llama"])
 app.include_router(whisper_router, prefix = "/api/whisper", tags = ["whisper"])
 app.include_router(export_router, prefix = "/api/export", tags = ["export"])
 app.include_router(rag_router, prefix = "/api/rag", tags = ["rag"])
+app.include_router(workspace_files_router, prefix = "/api/workspace-files", tags = ["workspace-files"])
 app.include_router(training_history_router, prefix = "/api/train", tags = ["training-history"])
 app.include_router(hub_inventory_router, prefix = "/api/hub", tags = ["hub"])
 app.include_router(hub_datasets_router, prefix = "/api/hub/datasets", tags = ["hub"])

--- a/studio/backend/routes/__init__.py
+++ b/studio/backend/routes/__init__.py
@@ -20,6 +20,7 @@ from routes.providers import router as providers_router
 from routes.openai_codex_auth import router as openai_codex_auth_router
 from routes.mcp_servers import router as mcp_servers_router
 from routes.rag import router as rag_router
+from routes.workspace_files import router as workspace_files_router
 from routes.research_runs import router as research_runs_router
 from routes.chat_generation_runs import router as chat_generation_runs_router
 from routes.youtube import router as youtube_router
@@ -41,6 +42,7 @@ __all__ = [
     "openai_codex_auth_router",
     "mcp_servers_router",
     "rag_router",
+    "workspace_files_router",
     "research_runs_router",
     "chat_generation_runs_router",
     "youtube_router",

--- a/studio/backend/routes/workspace_files.py
+++ b/studio/backend/routes/workspace_files.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Read-only Files panel for the same workspace used by chat tools."""
+
+from contextlib import contextmanager
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from auth.authentication import get_current_subject
+from core.workspace_files import list_directory, preview_file, search_files
+
+router = APIRouter(dependencies=[Depends(get_current_subject)])
+
+
+def workspace_path(session: str) -> Path:
+    from core.inference.tools import resolve_sandbox_workdir
+
+    return Path(resolve_sandbox_workdir(session))
+
+
+@contextmanager
+def browse_errors():
+    try:
+        yield
+    except FileNotFoundError as exc:
+        raise HTTPException(404, "File or folder is no longer available") from exc
+    except PermissionError as exc:
+        raise HTTPException(403, "File or folder is not readable") from exc
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    except OSError as exc:
+        raise HTTPException(400, "Could not access this file or folder") from exc
+
+
+def folder_for(root: Path) -> dict:
+    info = root.lstat()
+    return {"path": str(root), "root_device": info.st_dev, "root_inode": info.st_ino}
+
+
+@router.get("/files")
+def files(
+    session: str = Query(min_length=1, max_length=4096),
+    path: str = Query(default="", max_length=4096),
+    q: str = Query(default="", max_length=256),
+) -> dict:
+    with browse_errors():
+        root = workspace_path(session)
+        if not root.exists() and not path:
+            return {"entries": [], "truncated": False}
+        folder = folder_for(root)
+        return search_files(folder, q) if q else list_directory(folder, path)
+
+
+@router.get("/preview")
+def preview(
+    session: str = Query(min_length=1, max_length=4096),
+    path: str = Query(min_length=1, max_length=4096),
+) -> dict:
+    with browse_errors():
+        return preview_file(folder_for(workspace_path(session)), path)

--- a/studio/backend/routes/workspace_files.py
+++ b/studio/backend/routes/workspace_files.py
@@ -10,12 +10,11 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from auth.authentication import get_current_subject
 from core.workspace_files import list_directory, preview_file, search_files
 
-router = APIRouter(dependencies=[Depends(get_current_subject)])
+router = APIRouter(dependencies = [Depends(get_current_subject)])
 
 
 def workspace_path(session: str) -> Path:
     from core.inference.tools import resolve_sandbox_workdir
-
     return Path(resolve_sandbox_workdir(session))
 
 
@@ -40,9 +39,9 @@ def folder_for(root: Path) -> dict:
 
 @router.get("/files")
 def files(
-    session: str = Query(min_length=1, max_length=4096),
-    path: str = Query(default="", max_length=4096),
-    q: str = Query(default="", max_length=256),
+    session: str = Query(min_length = 1, max_length = 4096),
+    path: str = Query(default = "", max_length = 4096),
+    q: str = Query(default = "", max_length = 256),
 ) -> dict:
     with browse_errors():
         root = workspace_path(session)
@@ -54,8 +53,8 @@ def files(
 
 @router.get("/preview")
 def preview(
-    session: str = Query(min_length=1, max_length=4096),
-    path: str = Query(min_length=1, max_length=4096),
+    session: str = Query(min_length = 1, max_length = 4096),
+    path: str = Query(min_length = 1, max_length = 4096),
 ) -> dict:
     with browse_errors():
         return preview_file(folder_for(workspace_path(session)), path)

--- a/studio/backend/tests/test_workspace_files.py
+++ b/studio/backend/tests/test_workspace_files.py
@@ -51,7 +51,7 @@ def test_nested_browsing_and_utf8_preview(folder):
 
     root = Path(folder["path"])
     (root / "src").mkdir()
-    (root / "src" / "main.py").write_text('print("héllo")', encoding="utf-8")
+    (root / "src" / "main.py").write_text('print("héllo")', encoding = "utf-8")
     assert browser.list_directory(folder, "src")["entries"][0]["path"] == "src/main.py"
     assert browser.preview_file(folder, "src/main.py") == {
         "kind": "text",
@@ -62,7 +62,6 @@ def test_nested_browsing_and_utf8_preview(folder):
 
 def test_binary_assets_have_no_text_preview(folder):
     from pathlib import Path
-
     (Path(folder["path"]) / "model.blend").write_bytes(b"BLENDER\x00data")
     assert browser.preview_file(folder, "model.blend")["kind"] == "unsupported"
 
@@ -89,7 +88,6 @@ def test_large_images_not_read(folder, monkeypatch):
 
 def test_image_preview(folder):
     from pathlib import Path
-
     (Path(folder["path"]) / "texture.png").write_bytes(b"png")
     assert browser.preview_file(folder, "texture.png") == {
         "kind": "image",
@@ -111,7 +109,7 @@ def test_listing_cap_is_visible(folder, monkeypatch):
 
 def test_replaced_root_rejected(folder):
     folder["root_inode"] += 1
-    with pytest.raises(ValueError, match="changed"):
+    with pytest.raises(ValueError, match = "changed"):
         browser.list_directory(folder)
 
 
@@ -123,7 +121,7 @@ def test_symlink_cannot_expose_outside_files(folder, tmp_path):
     (outside / "secret.py").write_text("private")
     link = Path(folder["path"]) / "linked"
     try:
-        link.symlink_to(outside, target_is_directory=True)
+        link.symlink_to(outside, target_is_directory = True)
     except OSError:
         pytest.skip("Symlink creation is unavailable")
     assert browser.list_directory(folder)["entries"] == []
@@ -150,7 +148,7 @@ def test_sensitive_folder_not_listed(folder):
         browser.list_directory(folder, ".ssh")
 
 
-@pytest.mark.skipif(os.name != "nt", reason="Windows junction regression")
+@pytest.mark.skipif(os.name != "nt", reason = "Windows junction regression")
 def test_windows_junction_cannot_expose_outside_files(folder, tmp_path):
     import subprocess
     from pathlib import Path
@@ -160,12 +158,12 @@ def test_windows_junction_cannot_expose_outside_files(folder, tmp_path):
     (outside / "secret.py").write_text("private")
     junction = Path(folder["path"]) / "junction"
     result = subprocess.run(
-        ["cmd", "/c", "mklink", "/J", str(junction), str(outside)], capture_output=True
+        ["cmd", "/c", "mklink", "/J", str(junction), str(outside)], capture_output = True
     )
     assert result.returncode == 0, result.stderr
     try:
         assert browser.list_directory(folder)["entries"] == []
-        with pytest.raises(ValueError, match="junction"):
+        with pytest.raises(ValueError, match = "junction"):
             browser.preview_file(folder, "junction/secret.py")
     finally:
         junction.rmdir()
@@ -186,13 +184,12 @@ def test_file_replaced_before_open_is_rejected(folder, monkeypatch):
         return original_open(path, flags)
 
     monkeypatch.setattr(browser.os, "open", replacing_open)
-    with pytest.raises(ValueError, match="changed"):
+    with pytest.raises(ValueError, match = "changed"):
         browser.preview_file(folder, "main.py")
 
 
 def test_internal_files_hidden_and_unreadable(folder):
     from pathlib import Path
-
     for name in (".unsloth_sandbox", ".unsloth_sandbox_remap.json"):
         (Path(folder["path"]) / name).write_text("internal")
         with pytest.raises(ValueError):
@@ -226,33 +223,33 @@ def test_routes_without_rag(folder, monkeypatch):
         module, "workspace_path", lambda session: root if session == "chat" else missing
     )
     app = FastAPI()
-    app.include_router(module.router, prefix="/api/workspace-files")
+    app.include_router(module.router, prefix = "/api/workspace-files")
     with TestClient(app) as client:
         assert (
-            client.get("/api/workspace-files/files", params={"session": "chat"}).status_code == 401
+            client.get("/api/workspace-files/files", params = {"session": "chat"}).status_code == 401
         )
         app.dependency_overrides[module.get_current_subject] = lambda: "test-user"
         (root / "main.py").write_text("print(42)")
         assert (
-            client.get("/api/workspace-files/files", params={"session": "chat"}).json()["entries"][
+            client.get("/api/workspace-files/files", params = {"session": "chat"}).json()["entries"][
                 0
             ]["name"]
             == "main.py"
         )
         assert (
             client.get(
-                "/api/workspace-files/preview", params={"session": "chat", "path": "main.py"}
+                "/api/workspace-files/preview", params = {"session": "chat", "path": "main.py"}
             ).json()["content"]
             == "print(42)"
         )
         assert (
             client.get(
-                "/api/workspace-files/preview", params={"session": "chat", "path": "../outside"}
+                "/api/workspace-files/preview", params = {"session": "chat", "path": "../outside"}
             ).status_code
             == 400
         )
         assert (
-            client.get("/api/workspace-files/files", params={"session": "other"}).json()["entries"]
+            client.get("/api/workspace-files/files", params = {"session": "other"}).json()["entries"]
             == []
         )
         assert not missing.exists()

--- a/studio/backend/tests/test_workspace_files.py
+++ b/studio/backend/tests/test_workspace_files.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import os
+
+import pytest
+
+from core import workspace_files as browser
+
+
+@pytest.fixture
+def folder(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+    info = root.stat()
+    return {"path": str(root), "root_device": info.st_dev, "root_inode": info.st_ino}
+
+
+def test_lists_assets_without_indexing_filter(folder):
+    from pathlib import Path
+
+    root = Path(folder["path"])
+    for name in ("main.py", "engine.cpp", "texture.png", "model.blend", "budget.xlsx", "README.md"):
+        (root / name).write_bytes(b"asset")
+    (root / "src").mkdir()
+    result = browser.list_directory(folder)
+    assert result["entries"][0]["name"] == "src"
+    assert {entry["name"] for entry in result["entries"]} == {
+        "src",
+        "main.py",
+        "engine.cpp",
+        "texture.png",
+        "model.blend",
+        "budget.xlsx",
+        "README.md",
+    }
+    assert not result["truncated"]
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["../secret", "/etc/passwd", "C:/Windows", "src/../../secret", "..\\secret", "foo\x00bar"],
+)
+def test_rejects_escape_paths(folder, path):
+    with pytest.raises(ValueError):
+        browser.resolve_path(folder, path)
+
+
+def test_nested_browsing_and_utf8_preview(folder):
+    from pathlib import Path
+
+    root = Path(folder["path"])
+    (root / "src").mkdir()
+    (root / "src" / "main.py").write_text('print("héllo")', encoding="utf-8")
+    assert browser.list_directory(folder, "src")["entries"][0]["path"] == "src/main.py"
+    assert browser.preview_file(folder, "src/main.py") == {
+        "kind": "text",
+        "content": 'print("héllo")',
+        "truncated": False,
+    }
+
+
+def test_binary_assets_have_no_text_preview(folder):
+    from pathlib import Path
+
+    (Path(folder["path"]) / "model.blend").write_bytes(b"BLENDER\x00data")
+    assert browser.preview_file(folder, "model.blend")["kind"] == "unsupported"
+
+
+def test_previews_are_bounded(folder, monkeypatch):
+    from pathlib import Path
+
+    monkeypatch.setattr(browser, "MAX_TEXT_BYTES", 4)
+    (Path(folder["path"]) / "main.py").write_bytes(b"abc\xc3\xa9more")
+    assert browser.preview_file(folder, "main.py") == {
+        "kind": "text",
+        "content": "abc",
+        "truncated": True,
+    }
+
+
+def test_large_images_not_read(folder, monkeypatch):
+    from pathlib import Path
+
+    monkeypatch.setattr(browser, "MAX_IMAGE_BYTES", 4)
+    (Path(folder["path"]) / "texture.png").write_bytes(b"12345")
+    assert browser.preview_file(folder, "texture.png")["kind"] == "unsupported"
+
+
+def test_image_preview(folder):
+    from pathlib import Path
+
+    (Path(folder["path"]) / "texture.png").write_bytes(b"png")
+    assert browser.preview_file(folder, "texture.png") == {
+        "kind": "image",
+        "mimeType": "image/png",
+        "data": "cG5n",
+    }
+
+
+def test_listing_cap_is_visible(folder, monkeypatch):
+    from pathlib import Path
+
+    monkeypatch.setattr(browser, "MAX_ENTRIES", 2)
+    for name in ("a.py", "b.cpp", "c.xlsx"):
+        (Path(folder["path"]) / name).touch()
+    result = browser.list_directory(folder)
+    assert len(result["entries"]) == 2
+    assert result["truncated"]
+
+
+def test_replaced_root_rejected(folder):
+    folder["root_inode"] += 1
+    with pytest.raises(ValueError, match="changed"):
+        browser.list_directory(folder)
+
+
+def test_symlink_cannot_expose_outside_files(folder, tmp_path):
+    from pathlib import Path
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.py").write_text("private")
+    link = Path(folder["path"]) / "linked"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("Symlink creation is unavailable")
+    assert browser.list_directory(folder)["entries"] == []
+    with pytest.raises(ValueError):
+        browser.preview_file(folder, "linked/secret.py")
+
+
+def test_fifo_not_read(folder):
+    from pathlib import Path
+
+    if not hasattr(os, "mkfifo"):
+        pytest.skip("FIFOs are not supported")
+    os.mkfifo(Path(folder["path"]) / "pipe")
+    with pytest.raises(ValueError):
+        browser.preview_file(folder, "pipe")
+
+
+def test_sensitive_folder_not_listed(folder):
+    from pathlib import Path
+
+    (Path(folder["path"]) / ".ssh").mkdir()
+    assert browser.list_directory(folder)["entries"] == []
+    with pytest.raises(ValueError):
+        browser.list_directory(folder, ".ssh")
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows junction regression")
+def test_windows_junction_cannot_expose_outside_files(folder, tmp_path):
+    import subprocess
+    from pathlib import Path
+
+    outside = tmp_path / "outside-junction"
+    outside.mkdir()
+    (outside / "secret.py").write_text("private")
+    junction = Path(folder["path"]) / "junction"
+    result = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(junction), str(outside)], capture_output=True
+    )
+    assert result.returncode == 0, result.stderr
+    try:
+        assert browser.list_directory(folder)["entries"] == []
+        with pytest.raises(ValueError, match="junction"):
+            browser.preview_file(folder, "junction/secret.py")
+    finally:
+        junction.rmdir()
+
+
+def test_file_replaced_before_open_is_rejected(folder, monkeypatch):
+    from pathlib import Path
+
+    root = Path(folder["path"])
+    target = root / "main.py"
+    target.write_text("original")
+    replacement = root / "replacement.py"
+    replacement.write_text("different file")
+    original_open = os.open
+
+    def replacing_open(path, flags):
+        replacement.replace(target)
+        return original_open(path, flags)
+
+    monkeypatch.setattr(browser.os, "open", replacing_open)
+    with pytest.raises(ValueError, match="changed"):
+        browser.preview_file(folder, "main.py")
+
+
+def test_internal_files_hidden_and_unreadable(folder):
+    from pathlib import Path
+
+    for name in (".unsloth_sandbox", ".unsloth_sandbox_remap.json"):
+        (Path(folder["path"]) / name).write_text("internal")
+        with pytest.raises(ValueError):
+            browser.preview_file(folder, name)
+    assert browser.list_directory(folder)["entries"] == []
+
+
+def test_search_nested_names(folder):
+    from pathlib import Path
+
+    root = Path(folder["path"])
+    (root / "src").mkdir()
+    (root / "src" / "Main.py").write_text("print(42)")
+    assert browser.search_files(folder, "MAIN")["entries"][0]["path"] == "src/Main.py"
+
+
+def test_routes_without_rag(folder, monkeypatch):
+    import importlib.util
+    from pathlib import Path
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    spec = importlib.util.spec_from_file_location(
+        "test_workspace_routes", Path(__file__).parents[1] / "routes" / "workspace_files.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    root = Path(folder["path"])
+    missing = root / "not-created"
+    monkeypatch.setattr(
+        module, "workspace_path", lambda session: root if session == "chat" else missing
+    )
+    app = FastAPI()
+    app.include_router(module.router, prefix="/api/workspace-files")
+    with TestClient(app) as client:
+        assert (
+            client.get("/api/workspace-files/files", params={"session": "chat"}).status_code == 401
+        )
+        app.dependency_overrides[module.get_current_subject] = lambda: "test-user"
+        (root / "main.py").write_text("print(42)")
+        assert (
+            client.get("/api/workspace-files/files", params={"session": "chat"}).json()["entries"][
+                0
+            ]["name"]
+            == "main.py"
+        )
+        assert (
+            client.get(
+                "/api/workspace-files/preview", params={"session": "chat", "path": "main.py"}
+            ).json()["content"]
+            == "print(42)"
+        )
+        assert (
+            client.get(
+                "/api/workspace-files/preview", params={"session": "chat", "path": "../outside"}
+            ).status_code
+            == 400
+        )
+        assert (
+            client.get("/api/workspace-files/files", params={"session": "other"}).json()["entries"]
+            == []
+        )
+        assert not missing.exists()
+
+
+def test_search_has_total_entry_budget(folder, monkeypatch):
+    from pathlib import Path
+
+    root = Path(folder["path"])
+    for index in range(4):
+        (root / f"file{index}.py").touch()
+    monkeypatch.setattr(browser, "MAX_SEARCH_ENTRIES", 2)
+    result = browser.search_files(folder, ".py")
+    assert len(result["entries"]) == 2
+    assert result["truncated"]

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -43,6 +43,16 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { WorkspaceFilesPanel } from "./components/workspace-files-panel";
+import { sandboxSessionIdFor } from "@/components/assistant-ui/sandbox-files";
+import { useChatProjectScope } from "./chat-project-scope";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -340,6 +350,13 @@ const SingleContent = memo(function SingleContent({
   const activeThreadId = useChatRuntimeStore((state) => state.activeThreadId);
   const isMobile = useIsMobile();
   const chatActive = useChatActive();
+  const projectScope = useChatProjectScope();
+  const filesSession = sandboxSessionIdFor(
+    threadId ?? activeThreadId ?? undefined,
+    projectScope,
+  );
+  const [filesSessionOpen, setFilesSessionOpen] = useState<string | null>(null);
+  const filesOpen = Boolean(filesSession && filesSessionOpen === filesSession);
   const openResearchRunId = useResearchRunStore((state) => state.openRunId);
   const closeResearchPanel = useResearchRunStore((state) => state.closePanel);
   useEffect(() => {
@@ -375,7 +392,10 @@ const SingleContent = memo(function SingleContent({
         ? !artifact.threadId || artifact.threadId === threadId
         : Boolean(artifact.threadId && artifact.threadId === activeThreadId)),
   );
-  const showContextPanel = showResearchPanel || showArtifactPanel;
+  const showFilesPanel =
+    filesOpen && !isMobile && !showResearchPanel && !showArtifactPanel;
+  const showContextPanel =
+    showResearchPanel || showArtifactPanel || showFilesPanel;
 
   const artifactLayoutActive = showContextPanel || isArtifactPanelLayoutActive;
   const artifactPanelSettledOpen =
@@ -436,6 +456,27 @@ const SingleContent = memo(function SingleContent({
 
   const threadPane = (
     <div className="flex min-h-0 min-w-0 flex-1 basis-0 flex-col overflow-hidden">
+      {filesSession && (
+        <div className="flex justify-end px-4 py-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="Browse workspace files"
+            aria-pressed={filesOpen}
+            onClick={() => {
+              if (filesOpen) setFilesSessionOpen(null);
+              else {
+                onCloseArtifact();
+                closeResearchPanel();
+                useChatRuntimeStore.getState().setSettingsPanelOpen(false);
+                setFilesSessionOpen(filesSession);
+              }
+            }}
+          >
+            Files
+          </Button>
+        </div>
+      )}
       <Thread hideWelcome={Boolean(threadId)} targetThreadId={threadId} />
     </div>
   );
@@ -516,10 +557,42 @@ const SingleContent = memo(function SingleContent({
                   openArtifact(artifact, { surface: "overlay" })
                 }
               />
+            ) : showFilesPanel && filesSession ? (
+              <WorkspaceFilesPanel
+                key={filesSession}
+                session={filesSession}
+                onClose={() => setFilesSessionOpen(null)}
+              />
             ) : null}
           </div>
         </ResizablePanel>
       </ResizablePanelGroup>
+      {isMobile && filesSession && (
+        <Sheet
+          open={chatActive && filesOpen && !researchMatchesThread}
+          onOpenChange={(open) => {
+            if (!open) setFilesSessionOpen(null);
+          }}
+        >
+          <SheetContent
+            showCloseButton={false}
+            className="gap-0 p-0"
+            style={{ width: "100vw", maxWidth: "100vw" }}
+          >
+            <SheetHeader className="sr-only">
+              <SheetTitle>Workspace files</SheetTitle>
+              <SheetDescription>
+                Browse and preview files in this chat’s workspace.
+              </SheetDescription>
+            </SheetHeader>
+            <WorkspaceFilesPanel
+              key={filesSession}
+              session={filesSession}
+              onClose={() => setFilesSessionOpen(null)}
+            />
+          </SheetContent>
+        </Sheet>
+      )}
       {openResearchRunId && researchMatchesThread ? (
         <ResearchActivitySheet
           runId={openResearchRunId}

--- a/studio/frontend/src/features/chat/components/workspace-files-panel.tsx
+++ b/studio/frontend/src/features/chat/components/workspace-files-panel.tsx
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { authFetch } from "@/features/auth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  ChevronRight,
+  File,
+  FileCode,
+  FileImage,
+  Folder,
+  RefreshCw,
+  X,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+
+type Entry = { name: string; path: string; isDirectory: boolean; size: number };
+type Listing = { entries: Entry[]; truncated: boolean };
+type Preview =
+  | { kind: "text"; content: string; truncated: boolean }
+  | { kind: "image"; mimeType: string; data: string }
+  | { kind: "unsupported"; message: string };
+
+async function request<T>(
+  endpoint: string,
+  session: string,
+  path: string,
+  signal: AbortSignal,
+  q = "",
+): Promise<T> {
+  const params = new URLSearchParams({ session, path, q });
+  const response = await authFetch(
+    `/api/workspace-files/${endpoint}?${params}`,
+    { signal },
+  );
+  const body = await response.json();
+  if (!response.ok)
+    throw new Error(
+      typeof body.detail === "string" ? body.detail : "Could not load files",
+    );
+  return body;
+}
+
+function FileGlyph({ entry }: { entry: Entry }) {
+  const Icon = entry.isDirectory
+    ? Folder
+    : /\.(png|jpe?g|gif|webp|bmp)$/i.test(entry.name)
+      ? FileImage
+      : /\.(py|js|jsx|ts|tsx|cpp|c|h|rs|json|html|css|sh)$/i.test(entry.name)
+        ? FileCode
+        : File;
+  return <Icon className="size-4 shrink-0 text-muted-foreground" />;
+}
+
+function Directory({
+  session,
+  path,
+  revision,
+  selected,
+  onSelect,
+  expanded,
+  onToggle,
+}: {
+  session: string;
+  path: string;
+  revision: number;
+  selected: string | undefined;
+  onSelect: (entry: Entry) => void;
+  expanded: Set<string>;
+  onToggle: (path: string) => void;
+}) {
+  const [listing, setListing] = useState<Listing | null>(null);
+  const [error, setError] = useState("");
+  useEffect(() => {
+    const controller = new AbortController();
+    request<Listing>("files", session, path, controller.signal)
+      .then((result) => {
+        if (!controller.signal.aborted) setListing(result);
+      })
+      .catch((reason: unknown) => {
+        if (!controller.signal.aborted)
+          setError(
+            reason instanceof Error ? reason.message : "Could not load folder",
+          );
+      });
+    return () => controller.abort();
+  }, [session, path, revision]);
+  if (error)
+    return (
+      <p role="alert" className="p-2 text-xs text-destructive">
+        {error}
+      </p>
+    );
+  if (!listing)
+    return (
+      <div className="p-2">
+        <Spinner />
+      </div>
+    );
+  return (
+    <ul className={path ? "ml-3 border-l pl-2" : ""}>
+      {listing.entries.map((entry) => (
+        <li key={entry.path}>
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent aria-[current=true]:bg-accent"
+            title={entry.path}
+            aria-expanded={
+              entry.isDirectory ? expanded.has(entry.path) : undefined
+            }
+            aria-current={
+              !entry.isDirectory && selected === entry.path ? "true" : undefined
+            }
+            onClick={() =>
+              entry.isDirectory ? onToggle(entry.path) : onSelect(entry)
+            }
+          >
+            {entry.isDirectory ? (
+              <ChevronRight
+                className={`size-3 shrink-0 transition-transform ${expanded.has(entry.path) ? "rotate-90" : ""}`}
+              />
+            ) : (
+              <span className="w-3 shrink-0" />
+            )}
+            <FileGlyph entry={entry} />
+            <span className="truncate">{entry.name}</span>
+          </button>
+          {entry.isDirectory && expanded.has(entry.path) && (
+            <Directory
+              session={session}
+              path={entry.path}
+              revision={revision}
+              selected={selected}
+              onSelect={onSelect}
+              expanded={expanded}
+              onToggle={onToggle}
+            />
+          )}
+        </li>
+      ))}
+      {!listing.entries.length && (
+        <li className="p-2 text-xs text-muted-foreground">
+          {path ? "Empty folder" : "No files in this workspace yet"}
+        </li>
+      )}
+      {listing.truncated && (
+        <li className="p-2 text-xs text-muted-foreground">
+          Folder limit reached, some entries are omitted.
+        </li>
+      )}
+    </ul>
+  );
+}
+
+function SearchResults({
+  session,
+  query,
+  selected,
+  onSelect,
+}: {
+  session: string;
+  query: string;
+  selected: string | undefined;
+  onSelect: (entry: Entry) => void;
+}) {
+  const [listing, setListing] = useState<Listing | null>(null);
+  const [error, setError] = useState("");
+  useEffect(() => {
+    const controller = new AbortController();
+    const timer = window.setTimeout(() => {
+      request<Listing>("files", session, "", controller.signal, query)
+        .then((result) => {
+          if (!controller.signal.aborted) setListing(result);
+        })
+        .catch((reason: unknown) => {
+          if (!controller.signal.aborted)
+            setError(
+              reason instanceof Error ? reason.message : "Search failed",
+            );
+        });
+    }, 250);
+    return () => {
+      controller.abort();
+      window.clearTimeout(timer);
+    };
+  }, [session, query]);
+  if (error)
+    return (
+      <p role="alert" className="p-2 text-xs text-destructive">
+        {error}
+      </p>
+    );
+  if (!listing)
+    return (
+      <div className="p-2">
+        <Spinner />
+      </div>
+    );
+  return (
+    <ul>
+      {listing.entries.map((entry) => (
+        <li key={entry.path}>
+          <button
+            type="button"
+            onClick={() => onSelect(entry)}
+            title={entry.path}
+            aria-current={selected === entry.path ? "true" : undefined}
+            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent aria-[current=true]:bg-accent"
+          >
+            <FileGlyph entry={entry} />
+            <span className="truncate">{entry.path}</span>
+          </button>
+        </li>
+      ))}
+      {!listing.entries.length && (
+        <li className="p-2 text-xs text-muted-foreground">No matching files</li>
+      )}
+      {listing.truncated && (
+        <li className="p-2 text-xs text-muted-foreground">
+          Search limit reached, results may be incomplete.
+        </li>
+      )}
+    </ul>
+  );
+}
+
+function FilePreview({ session, entry }: { session: string; entry: Entry }) {
+  const [preview, setPreview] = useState<Preview | null>(null);
+  const [error, setError] = useState("");
+  useEffect(() => {
+    const controller = new AbortController();
+    request<Preview>("preview", session, entry.path, controller.signal)
+      .then((result) => {
+        if (!controller.signal.aborted) setPreview(result);
+      })
+      .catch((reason: unknown) => {
+        if (!controller.signal.aborted)
+          setError(reason instanceof Error ? reason.message : "Preview failed");
+      });
+    return () => controller.abort();
+  }, [session, entry.path]);
+  if (error)
+    return (
+      <p role="alert" className="text-sm text-destructive">
+        {error}
+      </p>
+    );
+  if (!preview) return <Spinner />;
+  if (preview.kind === "text")
+    return (
+      <>
+        {preview.truncated && (
+          <p className="mb-2 text-xs text-muted-foreground">
+            Preview limited to the first 256 KB.
+          </p>
+        )}
+        <pre className="font-mono text-xs leading-relaxed">
+          <code>{preview.content}</code>
+        </pre>
+      </>
+    );
+  if (preview.kind === "image")
+    return (
+      <img
+        alt={entry.name}
+        className="max-h-full max-w-full object-contain"
+        onError={() => setError("Could not decode this image")}
+        src={`data:${preview.mimeType};base64,${preview.data}`}
+      />
+    );
+  return <p className="text-sm text-muted-foreground">{preview.message}</p>;
+}
+
+/** Key by sandbox session so a late response or selection cannot cross chat workspaces. */
+export function WorkspaceFilesPanel({
+  session,
+  onClose,
+}: { session: string; onClose: () => void }) {
+  const [selected, setSelected] = useState<Entry | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [query, setQuery] = useState("");
+  const [revision, setRevision] = useState(0);
+  const toggle = (path: string) =>
+    setExpanded((previous) => {
+      const next = new Set(previous);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  return (
+    <aside
+      aria-label="Workspace files"
+      className="flex h-full min-h-0 flex-col border-l bg-background"
+    >
+      <header className="flex items-center gap-2 border-b px-3 py-2">
+        <Folder className="size-4" />
+        <h2 className="flex-1 text-sm font-medium">Files</h2>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Refresh files"
+          onClick={() => setRevision((value) => value + 1)}
+        >
+          <RefreshCw className="size-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Close files"
+          onClick={onClose}
+        >
+          <X className="size-4" />
+        </Button>
+      </header>
+      <div className="p-3">
+        <Input
+          aria-label="Filter files"
+          placeholder="Filter files…"
+          value={query}
+          maxLength={256}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+      </div>
+      <nav
+        aria-label="Workspace folders"
+        className={`${selected ? "h-2/5 shrink-0" : "flex-1"} min-h-0 overflow-auto px-2 pb-2`}
+      >
+        {query.trim() ? (
+          <SearchResults
+            key={`${session}:${query}:${revision}`}
+            session={session}
+            query={query.trim()}
+            selected={selected?.path}
+            onSelect={setSelected}
+          />
+        ) : (
+          <Directory
+            key={`${session}:${revision}`}
+            session={session}
+            path=""
+            revision={revision}
+            selected={selected?.path}
+            onSelect={setSelected}
+            expanded={expanded}
+            onToggle={toggle}
+          />
+        )}
+      </nav>
+      {selected ? (
+        <section
+          aria-label="File preview"
+          className="flex min-h-0 flex-1 flex-col border-t"
+        >
+          <div className="flex items-center gap-2 border-b px-3 py-2">
+            <span
+              title={selected.path}
+              className="min-w-0 flex-1 truncate text-xs font-medium"
+            >
+              {selected.path}
+            </span>
+            <span className="text-xs text-muted-foreground">Read only</span>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Close preview"
+              onClick={() => setSelected(null)}
+            >
+              <X className="size-3" />
+            </Button>
+          </div>
+          <div className="min-h-0 flex-1 overflow-auto p-3">
+            <FilePreview
+              key={`${session}:${selected.path}:${revision}`}
+              session={session}
+              entry={selected}
+            />
+          </div>
+        </section>
+      ) : (
+        <p className="border-t px-3 py-2 text-xs text-muted-foreground">
+          Select a file to preview it.
+        </p>
+      )}
+    </aside>
+  );
+}


### PR DESCRIPTION
Adds a Files panel beside a single chat so users can browse its workspace and preview code, text and raster images. Project chats use the shared project workspace. The tree expands folders on demand, supports bounded filename search and refresh, and clears the selected preview when switching workspaces. Small screens use a full-width sheet.

Sources remains unchanged and continues to manage RAG documents. Files uses independent authenticated endpoints and does not index files. This first version browses the existing chat/project workspace; choosing additional local folders, editing files and adding files to model context are outside this PR. Binary assets remain visible with an unsupported-preview message.

Filesystem reads reject traversal, symbolic links, Windows junctions, special files and internal workspace markers. Listings, recursive search and preview reads are bounded.

Validation:
- Backend regressions: 22 passed on Linux, 1 Windows-only skip; 21 passed on native Windows, 2 platform/privilege skips, including a passing junction test.
- Frontend TypeScript checks, production build, and ESLint for the new component; Ruff for the new Python modules.
- Playwright against the real Files component and API with fixture authentication/workspace resolution: nested expansion/search, code/image/binary previews, refresh, workspace switching, and a 390px layout without page overflow.

The component browser checks do not exercise the packaged desktop app or the complete ChatPage runtime. The frontend/API path is shared by browser and desktop; files belong to the backend's workspace.
