### PR TITLE
Studio: Export a full fine-tune as a real 16-bit model

### DIFF
--- a/studio/backend/mcp_server.py
+++ b/studio/backend/mcp_server.py
@@ -192,7 +192,7 @@ def create_studio_mcp() -> FastMCP:
     async def load_checkpoint(
         checkpoint_path: str,
         max_seq_length: int = 2048,
-        load_in_4bit: bool = True,
+        load_in_4bit: bool | None = None,
         trust_remote_code: bool = False,
         approved_remote_code_fingerprint: str | None = None,
         hf_token: str | None = None,
@@ -203,18 +203,22 @@ def create_studio_mcp() -> FastMCP:
         inference; it does not unload them, so a load can fail with a clear
         out-of-memory error if the GPU is already full. Pass hf_token to load a
         gated checkpoint, and approved_remote_code_fingerprint to retry a
-        trust_remote_code load that was blocked pending review.
+        trust_remote_code load that was blocked pending review. Leave
+        load_in_4bit unset to load full fine-tunes in 16-bit and adapters in
+        4-bit.
         """
         from models import LoadCheckpointRequest
         from routes.export import load_checkpoint as load
 
+        # Omit an unset load_in_4bit so the route can pick 16-bit for a full fine-tune.
+        optional = {} if load_in_4bit is None else {"load_in_4bit": load_in_4bit}
         request = LoadCheckpointRequest(
             checkpoint_path = checkpoint_path,
             max_seq_length = max_seq_length,
-            load_in_4bit = load_in_4bit,
             trust_remote_code = trust_remote_code,
             approved_remote_code_fingerprint = approved_remote_code_fingerprint,
             hf_token = hf_token,
+            **optional,
         )
         return _dump(await load(request, current_subject = "mcp", allow_ambient = False))
 

--- a/studio/backend/routes/export.py
+++ b/studio/backend/routes/export.py
@@ -91,6 +91,17 @@ def _resolve_export_hf_token(
     return hf_token_arg(token, allow_ambient_token = allow_ambient)
 
 
+def _is_unquantized_full_finetune(checkpoint_dir: Path) -> bool:
+    config_file = checkpoint_dir / "config.json"
+    try:
+        if not config_file.is_file() or (checkpoint_dir / "adapter_config.json").exists():
+            return False
+        config = json.loads(config_file.read_text(encoding = "utf-8-sig"))
+    except (OSError, ValueError):
+        return False
+    return isinstance(config, dict) and "quantization_config" not in config
+
+
 @router.post("/load-checkpoint", response_model = ExportOperationResponse)
 async def load_checkpoint(
     request: LoadCheckpointRequest,
@@ -106,6 +117,15 @@ async def load_checkpoint(
     """
     try:
         await _ensure_export_supported()
+        load_in_4bit = request.load_in_4bit
+        if "load_in_4bit" not in request.model_fields_set and _is_unquantized_full_finetune(
+            Path(request.checkpoint_path)
+        ):
+            load_in_4bit = False
+            logger.info(
+                f"Full fine-tune checkpoint {request.checkpoint_path} has no quantization_config - "
+                "loading in 16-bit for export"
+            )
         backend = get_export_backend()
         # Run in a worker thread (spawns and waits on a subprocess, can take
         # minutes) so the event loop stays free to serve the live log SSE stream.
@@ -113,7 +133,7 @@ async def load_checkpoint(
             backend.load_checkpoint,
             checkpoint_path = request.checkpoint_path,
             max_seq_length = request.max_seq_length,
-            load_in_4bit = request.load_in_4bit,
+            load_in_4bit = load_in_4bit,
             trust_remote_code = request.trust_remote_code,
             approved_remote_code_fingerprint = request.approved_remote_code_fingerprint,
             hf_token = _resolve_export_hf_token(request.hf_token, allow_ambient = allow_ambient),

--- a/studio/backend/tests/test_export_load_checkpoint_full_finetune.py
+++ b/studio/backend/tests/test_export_load_checkpoint_full_finetune.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from auth.authentication import allow_ambient_hf_token, get_current_subject
+from routes import export as export_routes
+
+
+async def _fake_ensure_export_supported():
+    pass
+
+
+_FULL_FINETUNE = {"config.json": {"model_type": "llama"}}
+_LORA_ADAPTER = {
+    "config.json": {"model_type": "llama"},
+    "adapter_config.json": {"base_model_name_or_path": "unsloth/Llama-3.2-1B"},
+}
+_BNB_QUANTIZED = {
+    "config.json": {
+        "model_type": "llama",
+        "quantization_config": {"quant_method": "bitsandbytes", "load_in_4bit": True},
+    }
+}
+_MALFORMED_CONFIG = {"config.json": "{not json"}
+
+
+@pytest.mark.parametrize(
+    "files,extra,expected",
+    [
+        (_FULL_FINETUNE, {}, False),
+        (_FULL_FINETUNE, {"load_in_4bit": True}, True),
+        (_LORA_ADAPTER, {}, True),
+        (_BNB_QUANTIZED, {}, True),
+        (_MALFORMED_CONFIG, {}, True),
+    ],
+    ids = [
+        "full_finetune",
+        "full_finetune_explicit_4bit",
+        "lora_adapter",
+        "bnb_quantized",
+        "malformed_config",
+    ],
+)
+def test_load_checkpoint_uses_16bit_for_unquantized_full_finetunes(
+    monkeypatch, tmp_path, files, extra, expected
+):
+    for name, content in files.items():
+        text = content if isinstance(content, str) else json.dumps(content)
+        (tmp_path / name).write_text(text, encoding = "utf-8")
+
+    monkeypatch.setattr(export_routes, "_ensure_export_supported", _fake_ensure_export_supported)
+    backend = MagicMock()
+    backend.load_checkpoint.return_value = (True, "loaded")
+    monkeypatch.setattr(export_routes, "get_export_backend", lambda: backend)
+
+    app = FastAPI()
+    app.include_router(export_routes.router, prefix = "/api/export")
+    app.dependency_overrides[get_current_subject] = lambda: "alice"
+    app.dependency_overrides[allow_ambient_hf_token] = lambda: True
+
+    response = TestClient(app).post(
+        "/api/export/load-checkpoint",
+        json = {"checkpoint_path": str(tmp_path), "hf_token": None, **extra},
+    )
+
+    assert response.status_code == 200
+    assert backend.load_checkpoint.call_args.kwargs["load_in_4bit"] is expected

--- a/studio/backend/tests/test_mcp_server.py
+++ b/studio/backend/tests/test_mcp_server.py
@@ -264,6 +264,30 @@ def test_load_checkpoint_forwards_token_and_fingerprint(monkeypatch):
     assert result["allow_ambient"] is False
 
 
+@pytest.mark.parametrize("load_in_4bit", [None, True, False])
+def test_load_checkpoint_leaves_unset_load_in_4bit_to_the_route(monkeypatch, load_in_4bit):
+    from models.export import LoadCheckpointRequest
+
+    captured = {}
+
+    async def fake_load(request, current_subject, allow_ambient):
+        captured["fields_set"] = request.model_fields_set
+        captured["load_in_4bit"] = request.load_in_4bit
+        return {}
+
+    _stub_module(monkeypatch, "models", LoadCheckpointRequest = LoadCheckpointRequest)
+    _stub_module(monkeypatch, "routes")
+    _stub_module(monkeypatch, "routes.export", load_checkpoint = fake_load)
+
+    extra = {} if load_in_4bit is None else {"load_in_4bit": load_in_4bit}
+    asyncio.run(_get_tool("load_checkpoint").fn(checkpoint_path = "/tmp/ckpt", **extra))
+
+    # The route only picks 16-bit for a full fine-tune when load_in_4bit was not sent.
+    assert ("load_in_4bit" in captured["fields_set"]) is (load_in_4bit is not None)
+    if load_in_4bit is not None:
+        assert captured["load_in_4bit"] is load_in_4bit
+
+
 def test_stop_training_forwards_job_scope(monkeypatch):
     captured = {}
 


### PR DESCRIPTION
Exporting a full fine-tune from the Export page as a 16-bit merged model saved a 4-bit model instead. The Export page does not say how to load a checkpoint, so the server used its default of 4-bit. A full fine-tune has no LoRA adapter to merge, so the export saved those 4-bit weights as they were. The result looked like a normal export, but it was a 4-bit model with lower quality answers.

Now, when the request does not ask for 4-bit and the checkpoint is a full fine-tune that is not already quantized, it loads in 16-bit for the export. If the checkpoint's config file cannot be read, loading works the same as before.

The Studio MCP `load_checkpoint` tool had the same problem, because it always sent `load_in_4bit=True`. It now leaves the setting out unless the caller passes it, so an agent exporting a full fine-tune gets the same 16-bit load.

LoRA checkpoints, already quantized checkpoints, and requests that ask for 4-bit on purpose are unchanged. Tested on a GPU with a small full fine-tune. Before, the export was 112 MB with 4-bit weights, and none of its answers to 10 prompts matched the original. After, it was 269 MB, the same size as the checkpoint, and all 10 answers matched exactly.


---

## Export page, before and after

Two isolated Studio installs, each built from its own tree with `install.sh --local`: BEFORE is this PR's merge base `a514d8377`, AFTER is `ac88df71c`. One byte-identical full fine-tune checkpoint is seeded into both, and the same five steps are driven in Chromium on each side: Fine-tuned source, training run `pr10808_full_finetune`, checkpoint `checkpoint-20`, Merged Model, 16-bit, Export.

![Export page before and after PR 10808](https://raw.githubusercontent.com/danielhanchen/unsloth-staging-2/evidence-pr10808-ac88df71c/evidence/pr10808_export_page_parity.png)

The two halves are the same, and that is the finding rather than a flat result: every field the Export page shows is identical, down to "Export finished successfully." and the Model / Export Method / Formats summary. Only the wall clock moves (43s vs 1m 12s). Nothing the page renders ever named the load precision, which is how a 4-bit model shipped behind a 16-bit label.

Note the line both halves show: **Est. size: ~257 MB**. On the BEFORE side the file actually written was 111,879,759 B (~107 MiB), so the page was not just silent about the 4-bit load, it advertised the size of the model the user did not get.

The live "Export output" panel was checked too, since it renders the export worker's stdout through `/api/export/logs` and a 16-bit load prints differently from a 4-bit one. It is the same set of lines on both sides once timestamps, the per-side save directory and the tqdm write rate are normalised. The route's new `logger.info` goes to the API server logger rather than that ring buffer, so it does not surface in the panel.

The difference this PR makes is in the bytes, which no screenshot can show. Measured on the same two runs: 111,879,759 B with 1050 bitsandbytes quantization tensors and a `bitsandbytes` `quantization_config` before; 269,060,552 B of pure BF16 with none after, `md5` equal to the source checkpoint only after.
