### PR TITLE
Studio: Let the agent run a command again after it edits a file

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -32358,11 +32358,17 @@ class LlamaCppBackend:
                 # fallback (mirrors the safetensors loop; see _MAX_TOOL_CALLS_PER_TURN).
                 if tool_calls and not has_structured_tc and len(tool_calls) > 1:
                     _seen_keys: set = set()
+                    _last_workspace_key = None
                     _deduped: list = []
                     for _tc in tool_calls:
                         _fn = _tc.get("function", {}) or {}
                         _key = (_fn.get("name", ""), str(_fn.get("arguments", "")))
-                        if _key in _seen_keys and _fn.get("name") not in _WORKSPACE_TOOLS:
+                        if _fn.get("name") in _WORKSPACE_TOOLS:
+                            # A workspace repeat only matters after a different workspace call.
+                            if _key == _last_workspace_key:
+                                continue
+                            _last_workspace_key = _key
+                        elif _key in _seen_keys:
                             continue
                         _seen_keys.add(_key)
                         _deduped.append(_tc)

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -438,6 +438,7 @@ from core.inference.tool_call_parser import (
 from core.inference.passthrough_healing import nudge_enabled as _nudge_enabled
 from core.inference.repetition_guard import is_repetition_dominated
 from core.inference.tool_loop_controller import (
+    _WORKSPACE_TOOLS,
     ToolLoopController,
     append_deferred_nudges,
     awaiting_approval_status,
@@ -32361,7 +32362,7 @@ class LlamaCppBackend:
                     for _tc in tool_calls:
                         _fn = _tc.get("function", {}) or {}
                         _key = (_fn.get("name", ""), str(_fn.get("arguments", "")))
-                        if _key in _seen_keys:
+                        if _key in _seen_keys and _fn.get("name") not in _WORKSPACE_TOOLS:
                             continue
                         _seen_keys.add(_key)
                         _deduped.append(_tc)

--- a/studio/backend/core/inference/safetensors_agentic.py
+++ b/studio/backend/core/inference/safetensors_agentic.py
@@ -1306,11 +1306,17 @@ def run_safetensors_tool_loop(
         # Collapse exact-duplicate calls and cap the count (runaway-turn guard).
         if tool_calls:
             seen_keys: set = set()
+            last_workspace_key = None
             deduped: list = []
             for _tc in tool_calls:
                 _fn = _tc.get("function", {}) or {}
                 _key = (_fn.get("name", ""), str(_fn.get("arguments", "")))
-                if _key in seen_keys and _fn.get("name") not in _WORKSPACE_TOOLS:
+                if _fn.get("name") in _WORKSPACE_TOOLS:
+                    # A workspace repeat only matters after a different workspace call.
+                    if _key == last_workspace_key:
+                        continue
+                    last_workspace_key = _key
+                elif _key in seen_keys:
                     continue
                 seen_keys.add(_key)
                 deduped.append(_tc)

--- a/studio/backend/core/inference/safetensors_agentic.py
+++ b/studio/backend/core/inference/safetensors_agentic.py
@@ -54,6 +54,7 @@ from core.tool_healing import (
     strip_outside_think,
 )
 from core.inference.tool_loop_controller import (
+    _WORKSPACE_TOOLS,
     ToolLoopController,
     append_deferred_nudges,
     awaiting_approval_status,
@@ -1309,7 +1310,7 @@ def run_safetensors_tool_loop(
             for _tc in tool_calls:
                 _fn = _tc.get("function", {}) or {}
                 _key = (_fn.get("name", ""), str(_fn.get("arguments", "")))
-                if _key in seen_keys:
+                if _key in seen_keys and _fn.get("name") not in _WORKSPACE_TOOLS:
                     continue
                 seen_keys.add(_key)
                 deduped.append(_tc)

--- a/studio/backend/core/inference/tool_loop_controller.py
+++ b/studio/backend/core/inference/tool_loop_controller.py
@@ -1122,16 +1122,15 @@ class ToolLoopController:
                 action = decision.action,
             )
         )
+        # Failed commands can still have changed files before they exited.
+        if decision.tool_name in _WORKSPACE_TOOLS:
+            stale = {
+                key for key in self._successful_keys if key.partition(":")[0] in _WORKSPACE_TOOLS
+            }
+            self._successful_keys -= stale
+            for key in stale:
+                self._duplicate_noop_counts.pop(key, None)
         if not failed:
-            if decision.tool_name in _WORKSPACE_TOOLS:
-                stale = {
-                    key
-                    for key in self._successful_keys
-                    if key.partition(":")[0] in _WORKSPACE_TOOLS
-                }
-                self._successful_keys -= stale
-                for key in stale:
-                    self._duplicate_noop_counts.pop(key, None)
             self._successful_keys.add(decision.key)
             if decision.tool_name in self._one_shot_tools:
                 self._completed_one_shot_tools.add(decision.tool_name)

--- a/studio/backend/core/inference/tool_loop_controller.py
+++ b/studio/backend/core/inference/tool_loop_controller.py
@@ -935,6 +935,7 @@ _SANDBOX_TOOLS = frozenset({"python", "terminal"})
 # than the card the user is looking at.
 _IMAGE_SENTINEL_TOOLS = _SANDBOX_TOOLS | {"code_execution"}
 _SOURCE_MAP_TOOLS = frozenset({"search_knowledge_base", "search_conversation"})
+_WORKSPACE_TOOLS = _SANDBOX_TOOLS | {"edit_file"}
 
 
 def strip_result_for_model(result: str, tool_name: "str | None" = None) -> str:
@@ -1122,6 +1123,15 @@ class ToolLoopController:
             )
         )
         if not failed:
+            if decision.tool_name in _WORKSPACE_TOOLS:
+                stale = {
+                    key
+                    for key in self._successful_keys
+                    if key.partition(":")[0] in _WORKSPACE_TOOLS
+                }
+                self._successful_keys -= stale
+                for key in stale:
+                    self._duplicate_noop_counts.pop(key, None)
             self._successful_keys.add(decision.key)
             if decision.tool_name in self._one_shot_tools:
                 self._completed_one_shot_tools.add(decision.tool_name)

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -6362,3 +6362,35 @@ def test_only_the_tool_loop_flushes_held_text_on_cancel():
     ), f"exactly one cancel arm may flush held text; flushing arms: {flushing}"
     # The last arm is the synthesized final pass, which owns none of those buffers.
     assert flushing[0] != len(arms) - 1, "the final pass must not flush the tool loop's buffers"
+
+
+@pytest.mark.parametrize("edit_result", ["Edited notes.txt", "Error: failed after writing"])
+def test_textual_workspace_read_edit_read_in_one_turn(monkeypatch, edit_result):
+    read = '<tool_call>{"name":"terminal","arguments":{"command":"cat notes.txt"}}</tool_call>'
+    edit = '<tool_call>{"name":"edit_file","arguments":{"path":"notes.txt","edits":[]}}</tool_call>'
+    backend, _ = _backend_and_payloads(
+        monkeypatch,
+        [
+            [_sse({"content": read + edit + read}), _done()],
+            [_sse({"content": "Done."}), _done()],
+        ],
+    )
+    calls = []
+    results = iter(["before", edit_result, "after"])
+
+    def execute(name, arguments, **kwargs):
+        calls.append(name)
+        return next(results)
+
+    monkeypatch.setattr("core.inference.tools.execute_tool", execute)
+    list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "Read, edit, and verify notes.txt"}],
+            tools = [
+                {"type": "function", "function": {"name": name}}
+                for name in ("terminal", "edit_file")
+            ],
+            max_tool_iterations = 3,
+        )
+    )
+    assert calls == ["terminal", "edit_file", "terminal"]

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -6394,3 +6394,34 @@ def test_textual_workspace_read_edit_read_in_one_turn(monkeypatch, edit_result):
         )
     )
     assert calls == ["terminal", "edit_file", "terminal"]
+
+
+def test_textual_repeated_workspace_reads_do_not_crowd_out_a_later_edit(monkeypatch):
+    read = '<tool_call>{"name":"terminal","arguments":{"command":"cat notes.txt"}}</tool_call>'
+    edit = '<tool_call>{"name":"edit_file","arguments":{"path":"notes.txt","edits":[]}}</tool_call>'
+    backend, _ = _backend_and_payloads(
+        monkeypatch,
+        [
+            [_sse({"content": read * 8 + edit + read}), _done()],
+            [_sse({"content": "Done."}), _done()],
+        ],
+    )
+    calls = []
+    results = iter(["before", "Edited notes.txt", "after"])
+
+    def execute(name, arguments, **kwargs):
+        calls.append(name)
+        return next(results)
+
+    monkeypatch.setattr("core.inference.tools.execute_tool", execute)
+    list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "Read, edit, and verify notes.txt"}],
+            tools = [
+                {"type": "function", "function": {"name": name}}
+                for name in ("terminal", "edit_file")
+            ],
+            max_tool_iterations = 3,
+        )
+    )
+    assert calls == ["terminal", "edit_file", "terminal"]

--- a/studio/backend/tests/test_safetensors_tool_loop.py
+++ b/studio/backend/tests/test_safetensors_tool_loop.py
@@ -5259,3 +5259,27 @@ def test_workspace_read_edit_read_in_one_turn(edit_result):
         edit_result,
         "after",
     ]
+
+
+def test_repeated_workspace_reads_do_not_crowd_out_a_later_edit():
+    read = '<tool_call>{"name":"terminal","arguments":{"command":"cat notes.txt"}}</tool_call>'
+    edit = '<tool_call>{"name":"edit_file","arguments":{"path":"notes.txt","edits":[]}}</tool_call>'
+    turns = iter([read * 8 + edit + read, "Done."])
+
+    def single_turn(messages, **kwargs):
+        yield next(turns)
+
+    executor = FakeExecuteTool(["before", "Edited notes.txt", "after"])
+    _collect_events(
+        run_safetensors_tool_loop(
+            single_turn = single_turn,
+            messages = [{"role": "user", "content": "Read, edit, and verify notes.txt"}],
+            tools = [
+                {"type": "function", "function": {"name": name}}
+                for name in ("terminal", "edit_file")
+            ],
+            execute_tool = executor,
+            max_tool_iterations = 3,
+        )
+    )
+    assert [name for name, _ in executor.calls] == ["terminal", "edit_file", "terminal"]

--- a/studio/backend/tests/test_safetensors_tool_loop.py
+++ b/studio/backend/tests/test_safetensors_tool_loop.py
@@ -5229,3 +5229,33 @@ def test_call_single_turn_falls_back_to_legacy_signatures():
     assert list(_call_single_turn(no_flag, [], [{"x": 1}], False)) == ["a"]
     assert list(_call_single_turn(bare, [], [{"x": 1}], False)) == ["b"]
     assert seen == [("no_flag", [{"x": 1}]), ("bare", None)]
+
+
+@pytest.mark.parametrize("edit_result", ["Edited notes.txt", "Error: failed after writing"])
+def test_workspace_read_edit_read_in_one_turn(edit_result):
+    read = '<tool_call>{"name":"terminal","arguments":{"command":"cat notes.txt"}}</tool_call>'
+    edit = '<tool_call>{"name":"edit_file","arguments":{"path":"notes.txt","edits":[]}}</tool_call>'
+    turns = iter([read + edit + read, "Done."])
+
+    def single_turn(messages, **kwargs):
+        yield next(turns)
+
+    executor = FakeExecuteTool(["before", edit_result, "after"])
+    events = _collect_events(
+        run_safetensors_tool_loop(
+            single_turn = single_turn,
+            messages = [{"role": "user", "content": "Read, edit, and verify notes.txt"}],
+            tools = [
+                {"type": "function", "function": {"name": name}}
+                for name in ("terminal", "edit_file")
+            ],
+            execute_tool = executor,
+            max_tool_iterations = 3,
+        )
+    )
+    assert [name for name, _ in executor.calls] == ["terminal", "edit_file", "terminal"]
+    assert [event["result"] for event in events if event["type"] == "tool_end"] == [
+        "before",
+        edit_result,
+        "after",
+    ]

--- a/studio/backend/tests/test_tool_loop_controller.py
+++ b/studio/backend/tests/test_tool_loop_controller.py
@@ -199,6 +199,32 @@ def test_repeated_successful_duplicate_becomes_terminal_after_one_recovery_nudge
     assert controller.active_tools() == []
 
 
+def test_command_can_run_again_after_a_file_edit():
+    controller = ToolLoopController(
+        tools = [_tool("terminal"), _tool("edit_file"), _tool("web_search")]
+    )
+    run = _call("terminal", {"command": "python calc.py"})
+    edit = _call(
+        "edit_file", {"path": "calc.py", "edits": [{"old_string": "a", "new_string": "b"}]}
+    )
+    search = _call("web_search", {"query": "gpu prices"})
+
+    controller.record_result(controller.prepare_call(search), "ok")
+    controller.record_result(controller.prepare_call(run), "3")
+    assert controller.prepare_call(run).action == "duplicate"
+    controller.record_noop(controller.prepare_call(run))
+
+    controller.record_result(controller.prepare_call(edit), "Edited calc.py")
+    rerun = controller.prepare_call(run)
+    assert rerun.action == "execute"
+    controller.record_result(rerun, "-1")
+
+    controller.record_noop(controller.prepare_call(run))
+    assert not controller.force_final_answer
+    assert controller.prepare_call(edit).action == "execute"
+    assert controller.prepare_call(search).action == "duplicate"
+
+
 def test_failed_call_does_not_block_retry():
     controller = ToolLoopController(tools = [_tool("web_search")])
     first = controller.prepare_call(_call("web_search", {"query": "gpu prices"}))

--- a/studio/backend/tests/test_tool_loop_controller.py
+++ b/studio/backend/tests/test_tool_loop_controller.py
@@ -620,3 +620,14 @@ def test_a_success_that_opens_with_error_is_not_nudged_as_a_failure():
 
     assert not completion.is_error
     assert TOOL_ERROR_NUDGE not in completion.model_message()["content"]
+
+
+@pytest.mark.parametrize("tool_name", ["python", "terminal", "edit_file"])
+def test_failed_workspace_execution_invalidates_previous_reads(tool_name):
+    controller = ToolLoopController(tools = [_tool("terminal"), _tool(tool_name)])
+    read = _call("terminal", {"command": "cat notes.txt"})
+    controller.record_result(controller.prepare_call(read), "before")
+    write = _call(tool_name, {"code": "write_then_fail", "command": "write_then_fail"})
+    controller.record_result(controller.prepare_call(write), "Error: failed after writing")
+    assert controller.prepare_call(read).action == "execute"
+    assert controller.prepare_call(write).action == "execute"


### PR DESCRIPTION
Fixes #10792. When the agent ran a command, edited a file, and then ran the same command again, the second run was skipped. Studio remembered every successful call for the whole reply and treated any repeat as a duplicate, even when a file had changed in between. The agent was told the command had already run, so it could not check its own change, and trying again removed its tools and ended the reply.

Now when a python, terminal, or edit_file call succeeds, Studio forgets the earlier calls to those three tools, so a later identical command runs again. Running the exact same call twice in a row is still skipped, the limit on repeated duplicates from #5962 is kept, and web search still skips repeats.

Tested in the Studio chat with an agent that runs cat notes.txt, edits the file, and runs cat notes.txt again. Before, the second cat was skipped and the reply never finished. After, it ran and showed the edited file. This is separate from #10658, which only lets its own project task tools repeat.


---

## Before and after, in the chat thread

Two isolated Studio installs, built from this PR's merge base (`8ee07d6ae`) and its head. Both are driven by byte-identical model output: a scripted OpenAI-compatible connection on loopback serves a fixed five-turn script, so the real backend tool loop, controller and sandbox all run and the guard is the only moving part.

    1  edit_file   create notes.txt as "version one"
    2  terminal    cat notes.txt
    3  edit_file   replace "version one" with "version two"
    4  terminal    cat notes.txt      <- identical to turn 2, the call at issue
    5  (text)      a closing summary

![PR 10810 before and after](https://raw.githubusercontent.com/danielhanchen/unsloth-staging-2/34f42294c3b6b40c626414e0e9d40c84a0070fc8/evidence/pr-10810/pr10810_before_after.png)

Both halves render four tool cards and the same first `cat` and the same edit diff. The difference is what the SECOND `$ cat notes.txt` card says:

| | merge base | this PR |
|---|---|---|
| second `cat notes.txt` output | `Unsloth did not run this call because an identical one had already completed.` | `version two` |
| tool results the model was actually given | 3 | 4 |

Note what both halves then print: `notes.txt now reads version two.` On the merge base the model never saw the file, so that closing sentence is written blind. That is #10792.

