### PR TITLE
Studio: Show an error when Anthropic fails a reply partway through

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -3060,11 +3060,9 @@ class ExternalProviderClient:
                             if thinking_open:
                                 yield _content_chunk("</think>")
                             error = event.get("error")
-                            overloaded = (
-                                isinstance(error, dict) and error.get("type") == "overloaded_error"
-                            )
+                            error_type = error.get("type") if isinstance(error, dict) else None
                             yield _error_sse_line(
-                                529 if overloaded else 502,
+                                _ANTHROPIC_ERROR_STATUS.get(error_type, 502),
                                 _json.dumps(event),
                                 self.provider_type,
                             )
@@ -6518,6 +6516,22 @@ def _readable_provider_error(status_code: int, message: str, provider_type: str)
 
     text = text.strip()
     return f"{text} ({code})" if code and code not in text else text
+
+
+# A mid-stream Anthropic error keeps the HTTP status its type has as a response, so a
+# rate limit still reads as 429 to callers that back off.
+_ANTHROPIC_ERROR_STATUS = {
+    "invalid_request_error": 400,
+    "authentication_error": 401,
+    "billing_error": 402,
+    "permission_error": 403,
+    "not_found_error": 404,
+    "request_too_large": 413,
+    "rate_limit_error": 429,
+    "api_error": 500,
+    "timeout_error": 504,
+    "overloaded_error": 529,
+}
 
 
 def _error_sse_line(

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -3055,6 +3055,20 @@ class ExternalProviderClient:
                             yield "data: [DONE]"
                             await response.aclose()  # set PoolByteStream._closed=True FIRST
                             break
+
+                        elif event_type == "error":
+                            if thinking_open:
+                                yield _content_chunk("</think>")
+                            error = event.get("error")
+                            overloaded = (
+                                isinstance(error, dict) and error.get("type") == "overloaded_error"
+                            )
+                            yield _error_sse_line(
+                                529 if overloaded else 502,
+                                _json.dumps(event),
+                                self.provider_type,
+                            )
+                            break
                 except GeneratorExit:
                     await response.aclose()  # set PoolByteStream._closed=True FIRST
                     await lines_gen.aclose()  # now safe — aclose() is a no-op

--- a/studio/backend/tests/test_anthropic_stream_error.py
+++ b/studio/backend/tests/test_anthropic_stream_error.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import httpx
+import pytest
+
+from .test_anthropic_thinking_translation import (
+    _anthropic_sse,
+    _collect,
+    _drive,
+    _make_client,
+    _mock_http_client,
+    _payloads_from_lines,
+)
+
+_MESSAGE_START = {
+    "type": "message_start",
+    "message": {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "content": [],
+        "usage": {"input_tokens": 5, "output_tokens": 1},
+    },
+}
+_TEXT = [
+    {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+    {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "text_delta", "text": "The three causes are"},
+    },
+]
+_THINKING = [
+    {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {"type": "thinking", "thinking": "", "signature": ""},
+    },
+    {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "thinking_delta", "thinking": "Let me plan"},
+    },
+]
+
+
+def _error(error_type, message):
+    return {"type": "error", "error": {"type": error_type, "message": message}}
+
+
+@pytest.mark.parametrize(
+    ("events", "error", "content", "expected"),
+    [
+        (
+            _TEXT,
+            _error("overloaded_error", "Overloaded"),
+            "The three causes are",
+            {"message": "Overloaded (overloaded_error)", "code": "529"},
+        ),
+        (
+            [],
+            _error("overloaded_error", "Overloaded"),
+            "",
+            {"message": "Overloaded (overloaded_error)", "code": "529"},
+        ),
+        (
+            _THINKING,
+            _error("overloaded_error", "Overloaded"),
+            "<think>Let me plan</think>",
+            {"message": "Overloaded (overloaded_error)", "code": "529"},
+        ),
+        (
+            _TEXT,
+            _error("api_error", "Internal server error"),
+            "The three causes are",
+            {"message": "Internal server error (api_error)", "code": "502"},
+        ),
+    ],
+)
+def test_midstream_error_event_ends_stream_with_error(
+    monkeypatch, events, error, content, expected
+):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content = _anthropic_sse([_MESSAGE_START, *events, error]),
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run():
+        client = _make_client()
+        lines = await _collect(
+            client._stream_anthropic(
+                messages = [{"role": "user", "content": "hi"}],
+                model = "claude-opus-4-6",
+                temperature = 0.7,
+                top_p = 0.95,
+                max_tokens = 4096,
+            )
+        )
+        await client.close()
+        return lines
+
+    payloads = _payloads_from_lines(_drive(run()))
+
+    assert payloads[-1:] == [
+        {"error": {**expected, "type": "provider_error", "provider": "anthropic"}}
+    ]
+    assert "[DONE]" not in payloads
+    combined = "".join(p["choices"][0]["delta"].get("content", "") for p in payloads[:-1])
+    assert combined == content

--- a/studio/backend/tests/test_anthropic_stream_error.py
+++ b/studio/backend/tests/test_anthropic_stream_error.py
@@ -4,6 +4,8 @@
 import httpx
 import pytest
 
+from core import research_runs
+
 from .test_anthropic_thinking_translation import (
     _anthropic_sse,
     _collect,
@@ -49,6 +51,33 @@ def _error(error_type, message):
     return {"type": "error", "error": {"type": error_type, "message": message}}
 
 
+def _stream_lines(monkeypatch, events):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content = _anthropic_sse([_MESSAGE_START, *events]),
+            headers = {"content-type": "text/event-stream"},
+        )
+
+    _mock_http_client(monkeypatch, handler)
+
+    async def run():
+        client = _make_client()
+        lines = await _collect(
+            client._stream_anthropic(
+                messages = [{"role": "user", "content": "hi"}],
+                model = "claude-opus-4-6",
+                temperature = 0.7,
+                top_p = 0.95,
+                max_tokens = 4096,
+            )
+        )
+        await client.close()
+        return lines
+
+    return _drive(run())
+
+
 @pytest.mark.parametrize(
     ("events", "error", "content", "expected"),
     [
@@ -74,37 +103,20 @@ def _error(error_type, message):
             _TEXT,
             _error("api_error", "Internal server error"),
             "The three causes are",
-            {"message": "Internal server error (api_error)", "code": "502"},
+            {"message": "Internal server error (api_error)", "code": "500"},
+        ),
+        (
+            _TEXT,
+            _error("some_new_error", "Something went wrong"),
+            "The three causes are",
+            {"message": "Something went wrong (some_new_error)", "code": "502"},
         ),
     ],
 )
 def test_midstream_error_event_ends_stream_with_error(
     monkeypatch, events, error, content, expected
 ):
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            200,
-            content = _anthropic_sse([_MESSAGE_START, *events, error]),
-            headers = {"content-type": "text/event-stream"},
-        )
-
-    _mock_http_client(monkeypatch, handler)
-
-    async def run():
-        client = _make_client()
-        lines = await _collect(
-            client._stream_anthropic(
-                messages = [{"role": "user", "content": "hi"}],
-                model = "claude-opus-4-6",
-                temperature = 0.7,
-                top_p = 0.95,
-                max_tokens = 4096,
-            )
-        )
-        await client.close()
-        return lines
-
-    payloads = _payloads_from_lines(_drive(run()))
+    payloads = _payloads_from_lines(_stream_lines(monkeypatch, [*events, error]))
 
     assert payloads[-1:] == [
         {"error": {**expected, "type": "provider_error", "provider": "anthropic"}}
@@ -112,3 +124,10 @@ def test_midstream_error_event_ends_stream_with_error(
     assert "[DONE]" not in payloads
     combined = "".join(p["choices"][0]["delta"].get("content", "") for p in payloads[:-1])
     assert combined == content
+
+
+def test_midstream_rate_limit_is_retried_by_research(monkeypatch):
+    lines = _stream_lines(monkeypatch, [_error("rate_limit_error", "Rate limited")])
+
+    assert _payloads_from_lines(lines)[-1]["error"]["code"] == "429"
+    assert research_runs._stream_rate_limit_delay(lines[0]) == 0.0

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -7789,41 +7789,39 @@ export function createOpenAIStreamAdapter(
           closeReasoningContent();
           const partialText = mergeContinuation(cumulativeText, { final: true });
           const partialContent = buildAssistantContent(partialText);
-          if (partialContent.length > 0) {
-            const partialTiming = buildTiming(
-              streamStartTime,
-              totalChunks,
-              firstTokenTime,
-              Date.now() - streamStartTime,
-              estimateTokenCount(partialText),
-              toolCallParts.length,
-            );
-            yield {
-              content: partialContent,
-              metadata: {
-                timing: partialTiming,
-                custom: {
-                  ...reasoningDurationTracker.metadata(),
-                  contextTruncation,
-                  // Unfinished too, so it also offers Continue -- unless the provider already
-                  // said why the model stopped.
-                  incomplete: {
-                    reason: resolveIncompleteReason(
-                      err instanceof GenerationLengthError
-                        ? ("length" as const)
-                        : err instanceof ChatGenerationTerminalError &&
-                            err.generationStatus === "cancelled"
-                          ? ("cancelled" as const)
-                          : ("interrupted" as const),
-                      contextWindowExceeded,
-                    ),
-                  },
-                  timing: partialTiming,
-                  ...generationCustom(),
+          const partialTiming = buildTiming(
+            streamStartTime,
+            totalChunks,
+            firstTokenTime,
+            Date.now() - streamStartTime,
+            estimateTokenCount(partialText),
+            toolCallParts.length,
+          );
+          yield {
+            content: partialContent,
+            metadata: {
+              timing: partialTiming,
+              custom: {
+                ...reasoningDurationTracker.metadata(),
+                contextTruncation,
+                // Unfinished too, so it also offers Continue -- unless the provider already
+                // said why the model stopped.
+                incomplete: {
+                  reason: resolveIncompleteReason(
+                    err instanceof GenerationLengthError
+                      ? ("length" as const)
+                      : err instanceof ChatGenerationTerminalError &&
+                          err.generationStatus === "cancelled"
+                        ? ("cancelled" as const)
+                        : ("interrupted" as const),
+                    contextWindowExceeded,
+                  ),
                 },
+                timing: partialTiming,
+                ...generationCustom(),
               },
-            };
-          }
+            },
+          };
         }
         throw err;
       } finally {

--- a/studio/frontend/tests/chat-continuation.test.ts
+++ b/studio/frontend/tests/chat-continuation.test.ts
@@ -1819,6 +1819,15 @@ test("a failure on a thread leaves a hold whose run is already streaming alone",
   assert.equal(keeper.held(), 0);
 });
 
+test("a turn that fails before any text is still saved as interrupted", () => {
+  const failure = CHAT_ADAPTER.slice(
+    CHAT_ADAPTER.indexOf("const partialContent = buildAssistantContent(partialText);"),
+  );
+  const saved = failure.slice(0, failure.indexOf("throw err;"));
+  assert.doesNotMatch(saved, /if \(partialContent\.length > 0\)/);
+  assert.match(saved, /yield \{\s*content: partialContent,[\s\S]*incomplete: \{/);
+});
+
 test("the keeper is wired to the failure the adapter already reports", () => {
   // There is exactly one signal for a run that failed on its way out, and it is not a
   // deadline: the adapter wrapper catches everything `adapter.run` throws and announces it


### PR DESCRIPTION
When Anthropic failed a reply after it had started, for example with an overloaded error, Studio saved the partial answer as if it had finished. There was no error and no way to continue it. If the failure came before any text, the reply was left blank. Anthropic sends these failures inside the reply stream, and Studio ignored that message and ended the reply normally.

Now Studio passes the error on to the chat, the same way it already does for OpenAI replies. The chat shows the error with a Retry button, and the partial answer is marked as interrupted so it can be continued. A reply that fails before any text is also saved as interrupted, so the error is still there after a page reload.

Replies that finish normally are unchanged. Tested in the Studio chat with a stand-in Anthropic server that fails partway through. Before, the half answer was saved as complete. After, the error, Retry, and Continue are shown, and they stay after a reload.


---

### Before / after in Studio

Both sides are a full `install.sh --local` build, BEFORE from this PR's merge base `8ee07d6ae` and AFTER from `7b9be3578`, each pointed at the same stand-in Anthropic Messages API that streams `The three causes are` and then the documented in-stream frame `{"type": "error", "error": {"type": "overloaded_error", "message": "Overloaded"}}`. No key is used and no request leaves the machine. Each side recorded exactly one `POST /v1/messages`, so both builds saw identical bytes.

**Live, once the turn settles.** BEFORE saves the half answer as a finished turn: no error, no Retry, no Continue. AFTER shows `Overloaded (overloaded_error)` with Retry, the `Response interrupted. Continue` bar, and a Generation failed toast.

![Studio chat, live turn, before and after](https://raw.githubusercontent.com/danielhanchen/unsloth-staging-2/f8c1e3e4e/evidence/pr-10811/pr10811_live.png)

**After a full page reload**, reopening the thread from Recents. BEFORE is still a finished turn. AFTER still carries the error box, Retry and Continue; its message falls back to the generic `An error occurred`, because the provider's own text is not persisted.

![Studio chat, after reload, before and after](https://raw.githubusercontent.com/danielhanchen/unsloth-staging-2/f8c1e3e4e/evidence/pr-10811/pr10811_after_reload.png)
