### PR TITLE
Studio: Stop Deep Research deleting links from code in its report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,7 @@ studio = [
     "pymupdf==1.27.2.3",
     "pymupdf4llm==0.3.4",
     "python-docx==1.2.0",
+    "markdown-it-py>=3.0",
 ]
 
 triton = [

--- a/studio/backend/core/research/citations.py
+++ b/studio/backend/core/research/citations.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import re
 
+from core.research.parsing import _MARKDOWN_FENCE
 from core.research.redaction import _escape_link_destination
 
 
@@ -28,6 +29,7 @@ _SOURCES_HEADING = re.compile(
 _NUMBERED_CITATION = re.compile(r"(?<!\^)\[(\d+)]")
 _AUTOLINK = re.compile(r"<(https?://[^>\s]+)>")
 _RAW_URL = re.compile(r"https?://[^\s<>]+")
+_INLINE_CODE = re.compile(r"(?<!`)(`+)(?!`).*?(?<!`)\1(?!`)")
 
 
 def _citation_title(source: dict, fallback: str) -> str:
@@ -64,6 +66,42 @@ def _trim_url_tail(raw: str) -> str:
     return raw[:end]
 
 
+def _mask_code(text: str, placeholders: dict[str, str]) -> str:
+    def mask(code: str) -> str:
+        token = f"\x00research-code-{len(placeholders)}\x00"
+        placeholders[token] = code
+        return token
+
+    pieces = []
+    opening = None
+    fence_char = ""
+    fence_length = 0
+    offset = 0
+    for line in text.splitlines(keepends = True):
+        content = line.rstrip("\r\n")
+        fence = _MARKDOWN_FENCE.match(content)
+        if opening is None:
+            if fence is None or (fence.group(1)[0] == "`" and "`" in content[fence.end() :]):
+                pieces.append(_INLINE_CODE.sub(lambda match: mask(match.group(0)), line))
+            else:
+                opening = offset
+                fence_char = fence.group(1)[0]
+                fence_length = len(fence.group(1))
+        elif (
+            fence is not None
+            and fence.group(1)[0] == fence_char
+            and len(fence.group(1)) >= fence_length
+            and not content[fence.end() :].strip()
+        ):
+            pieces.append(mask(text[opening : offset + len(content)]))
+            pieces.append(line[len(content) :])
+            opening = None
+        offset += len(line)
+    if opening is not None:
+        pieces.append(mask(text[opening:]))
+    return "".join(pieces)
+
+
 def _validate_report_sources(report: str, sources: list[dict]) -> str:
     """Canonicalize citations and remove model-authored source lists."""
     source_by_url = {
@@ -72,6 +110,7 @@ def _validate_report_sources(report: str, sources: list[dict]) -> str:
     source_urls = list(source_by_url)
     placeholders: dict[str, str] = {}
 
+    report = _mask_code(report, placeholders)
     heading = _SOURCES_HEADING.search(report)
     if heading:
         report = report[: heading.start()]

--- a/studio/backend/core/research/citations.py
+++ b/studio/backend/core/research/citations.py
@@ -119,15 +119,20 @@ def _mask_code(text: str, placeholders: dict[str, str]) -> str:
     return "".join(pieces)
 
 
-def _validate_report_sources(report: str, sources: list[dict]) -> str:
-    """Canonicalize citations and remove model-authored source lists."""
+def _restore_placeholders(text: str, placeholders: dict[str, str]) -> str:
+    for token, value in placeholders.items():
+        text = text.replace(token, value)
+    return text
+
+
+def _validate_masked_sources(
+    report: str, sources: list[dict], placeholders: dict[str, str]
+) -> str:
     source_by_url = {
         str(source.get("url") or ""): source for source in sources if source.get("url")
     }
     source_urls = list(source_by_url)
-    placeholders: dict[str, str] = {}
 
-    report = _mask_code(report, placeholders)
     heading = _SOURCES_HEADING.search(report)
     if heading:
         report = report[: heading.start()]
@@ -227,10 +232,14 @@ def _validate_report_sources(report: str, sources: list[dict]) -> str:
     validated = _AUTOLINK.sub(replace_autolink, validated)
     validated = _NUMBERED_CITATION.sub(replace_number, validated)
     validated = _RAW_URL.sub(replace_raw_url, validated)
-    validated = validated.strip()
-    for token, link in placeholders.items():
-        validated = validated.replace(token, link)
-    return validated
+    return validated.strip()
+
+
+def _validate_report_sources(report: str, sources: list[dict]) -> str:
+    """Canonicalize citations and remove model-authored source lists."""
+    placeholders: dict[str, str] = {}
+    validated = _validate_masked_sources(_mask_code(report, placeholders), sources, placeholders)
+    return _restore_placeholders(validated, placeholders)
 
 
 def _document_source_citation(source: dict) -> str:
@@ -249,18 +258,32 @@ def _allowed_document_citations(sources: list[dict]) -> set[str]:
     return allowed
 
 
-def _validate_report_document_sources(report: str, sources: list[dict]) -> str:
+def _validate_masked_document_sources(
+    report: str, sources: list[dict], placeholders: dict[str, str]
+) -> str:
     allowed = _allowed_document_citations(sources)
     # Tokenize valid citations first so a "]" inside a filename ("budget [final].pdf") does not
     # truncate them, then strip the invalid ones and restore the valid.
-    placeholders: dict[str, str] = {}
-    report = _mask_code(report, placeholders)
     for index, citation in enumerate(sorted(allowed, key = len, reverse = True)):
         if citation in report:
             token = f"\x00document-citation-{index}\x00"
             placeholders[token] = citation
             report = report.replace(citation, token)
-    report = _DOCUMENT_CITATION.sub("", report)
-    for token, citation in placeholders.items():
-        report = report.replace(token, citation)
-    return report
+    return _DOCUMENT_CITATION.sub("", report)
+
+
+def _validate_report_document_sources(report: str, sources: list[dict]) -> str:
+    placeholders: dict[str, str] = {}
+    validated = _validate_masked_document_sources(
+        _mask_code(report, placeholders), sources, placeholders
+    )
+    return _restore_placeholders(validated, placeholders)
+
+
+def _validate_report(report: str, sources: list[dict], document_sources: list[dict]) -> str:
+    # Mask the draft once: removing a URL-only line can split a paragraph, and reparsing
+    # would then read an indented citation as code.
+    placeholders: dict[str, str] = {}
+    validated = _validate_masked_sources(_mask_code(report, placeholders), sources, placeholders)
+    validated = _validate_masked_document_sources(validated, document_sources, placeholders)
+    return _restore_placeholders(validated, placeholders)

--- a/studio/backend/core/research/citations.py
+++ b/studio/backend/core/research/citations.py
@@ -30,7 +30,8 @@ _SOURCES_HEADING = re.compile(
 )
 _NUMBERED_CITATION = re.compile(r"(?<!\^)\[(\d+)]")
 _AUTOLINK = re.compile(r"<(https?://[^>\s]+)>")
-_RAW_URL = re.compile(r"https?://[^\s<>]+")
+# \x00 stops a URL glued to masked code from swallowing its placeholder.
+_RAW_URL = re.compile(r"https?://[^\s<>\x00]+")
 
 
 def _citation_title(source: dict, fallback: str) -> str:

--- a/studio/backend/core/research/citations.py
+++ b/studio/backend/core/research/citations.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 
 import re
 
-from core.research.parsing import _MARKDOWN_FENCE
+from markdown_it import MarkdownIt
+from markdown_it.rules_inline.backticks import backtick
+
 from core.research.redaction import _escape_link_destination
 
 
@@ -29,7 +31,6 @@ _SOURCES_HEADING = re.compile(
 _NUMBERED_CITATION = re.compile(r"(?<!\^)\[(\d+)]")
 _AUTOLINK = re.compile(r"<(https?://[^>\s]+)>")
 _RAW_URL = re.compile(r"https?://[^\s<>]+")
-_INLINE_CODE = re.compile(r"(?<!`)(`+)(?!`).*?(?<!`)\1(?!`)")
 
 
 def _citation_title(source: dict, fallback: str) -> str:
@@ -66,39 +67,54 @@ def _trim_url_tail(raw: str) -> str:
     return raw[:end]
 
 
-def _mask_code(text: str, placeholders: dict[str, str]) -> str:
-    def mask(code: str) -> str:
-        token = f"\x00research-code-{len(placeholders)}\x00"
-        placeholders[token] = code
-        return token
+def _record_code_span(state, silent: bool) -> bool:
+    start = state.pos
+    count = len(state.tokens)
+    matched = backtick(state, silent)
+    if (
+        matched
+        and not silent
+        and state.src is state.env["code_source"]
+        and len(state.tokens) > count
+        and state.tokens[-1].type == "code_inline"
+    ):
+        state.env["code_spans"].append((start, state.pos))
+    return matched
 
+
+# Block maps retain the original lines, including indentation and container markers.
+# Parse inline source separately so code offsets refer to those original lines too.
+_CODE_MARKDOWN = MarkdownIt("commonmark").disable("inline")
+_CODE_MARKDOWN.inline.ruler.at("backticks", _record_code_span)
+
+
+def _mask_code(text: str, placeholders: dict[str, str]) -> str:
+    offsets = [0, *(match.end() for match in re.finditer(r"\r\n?|\n", text))]
+    if offsets[-1] != len(text):
+        offsets.append(len(text))
+    spans = []
+    for token in _CODE_MARKDOWN.parse(text):
+        if token.map is None:
+            continue
+        start, end = (offsets[line] for line in token.map)
+        if token.type in {"fence", "code_block"}:
+            # Keep the following heading on its own line while the block is masked.
+            end = start + len(text[start:end].rstrip("\r\n"))
+            spans.append((start, end))
+        elif token.type == "inline":
+            source = text[start:end]
+            env = {"code_source": source, "code_spans": []}
+            _CODE_MARKDOWN.inline.parse(source, _CODE_MARKDOWN, env, [])
+            spans.extend((start + first, start + last) for first, last in env["code_spans"])
     pieces = []
-    opening = None
-    fence_char = ""
-    fence_length = 0
-    offset = 0
-    for line in text.splitlines(keepends = True):
-        content = line.rstrip("\r\n")
-        fence = _MARKDOWN_FENCE.match(content)
-        if opening is None:
-            if fence is None or (fence.group(1)[0] == "`" and "`" in content[fence.end() :]):
-                pieces.append(_INLINE_CODE.sub(lambda match: mask(match.group(0)), line))
-            else:
-                opening = offset
-                fence_char = fence.group(1)[0]
-                fence_length = len(fence.group(1))
-        elif (
-            fence is not None
-            and fence.group(1)[0] == fence_char
-            and len(fence.group(1)) >= fence_length
-            and not content[fence.end() :].strip()
-        ):
-            pieces.append(mask(text[opening : offset + len(content)]))
-            pieces.append(line[len(content) :])
-            opening = None
-        offset += len(line)
-    if opening is not None:
-        pieces.append(mask(text[opening:]))
+    cursor = 0
+    for start, end in sorted(spans):
+        pieces.append(text[cursor:start])
+        token = f"\x00research-code-{len(placeholders)}\x00"
+        placeholders[token] = text[start:end]
+        pieces.append(token)
+        cursor = end
+    pieces.append(text[cursor:])
     return "".join(pieces)
 
 
@@ -210,9 +226,10 @@ def _validate_report_sources(report: str, sources: list[dict]) -> str:
     validated = _AUTOLINK.sub(replace_autolink, validated)
     validated = _NUMBERED_CITATION.sub(replace_number, validated)
     validated = _RAW_URL.sub(replace_raw_url, validated)
+    validated = validated.strip()
     for token, link in placeholders.items():
         validated = validated.replace(token, link)
-    return validated.strip()
+    return validated
 
 
 def _document_source_citation(source: dict) -> str:
@@ -236,6 +253,7 @@ def _validate_report_document_sources(report: str, sources: list[dict]) -> str:
     # Tokenize valid citations first so a "]" inside a filename ("budget [final].pdf") does not
     # truncate them, then strip the invalid ones and restore the valid.
     placeholders: dict[str, str] = {}
+    report = _mask_code(report, placeholders)
     for index, citation in enumerate(sorted(allowed, key = len, reverse = True)):
         if citation in report:
             token = f"\x00document-citation-{index}\x00"

--- a/studio/backend/core/research/citations.py
+++ b/studio/backend/core/research/citations.py
@@ -125,9 +125,7 @@ def _restore_placeholders(text: str, placeholders: dict[str, str]) -> str:
     return text
 
 
-def _validate_masked_sources(
-    report: str, sources: list[dict], placeholders: dict[str, str]
-) -> str:
+def _validate_masked_sources(report: str, sources: list[dict], placeholders: dict[str, str]) -> str:
     source_by_url = {
         str(source.get("url") or ""): source for source in sources if source.get("url")
     }

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -44,8 +44,6 @@ from core.research.citations import (
     _citation_title,
     _document_source_citation,
     _validate_report,
-    _validate_report_document_sources,
-    _validate_report_sources,
 )
 from core.research.redaction import _sanitize_public_query, _shield_untrusted
 from core.research.prompts import (

--- a/studio/backend/core/research_runs.py
+++ b/studio/backend/core/research_runs.py
@@ -43,6 +43,7 @@ from core.research.citations import (
     _allowed_document_citations,
     _citation_title,
     _document_source_citation,
+    _validate_report,
     _validate_report_document_sources,
     _validate_report_sources,
 )
@@ -2824,8 +2825,7 @@ class ResearchSupervisor:
             catalogs do not back, and a model that ran out of budget is exactly the one
             liable to pad with both, so raw length is not what the drafts should be judged
             on. Used only to compare them; whichever wins is stored as the model wrote it."""
-            validated = _validate_report_sources(draft, sources)
-            return _validate_report_document_sources(validated, document_sources)
+            return _validate_report(draft, sources, document_sources)
 
         if _synthesis_needs_recovery(report, synthesis_finish_reason):
             recovery_reason = (
@@ -2911,8 +2911,7 @@ class ResearchSupervisor:
                     requested_max_tokens = requested_max_tokens,
                     inference = _run_inference_request(run),
                 ).rstrip(".")
-        report = _validate_report_sources(report, sources)
-        report = _validate_report_document_sources(report, document_sources)
+        report = _validate_report(report, sources, document_sources)
         if not report:
             raise ValueError(
                 "Local model returned no safely identifiable final report. Disable thinking or "

--- a/studio/backend/requirements/studio.txt
+++ b/studio/backend/requirements/studio.txt
@@ -59,3 +59,5 @@ pymupdf==1.27.2.3
 # lockstep 1.27.x line makes it a hard dep we do not need for to_markdown().
 pymupdf4llm==0.3.4
 python-docx==1.2.0
+
+markdown-it-py>=3.0

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -21,6 +21,7 @@ from fastapi import HTTPException
 from core import research_runs
 from core.research.citations import (
     _citation_title,
+    _validate_report,
     _validate_report_document_sources,
     _validate_report_sources,
 )
@@ -3381,5 +3382,19 @@ def test_unclosed_quote_fence_stops_at_the_quote_boundary():
 def test_delivered_report_keeps_document_literals_in_code(code):
     report = f"Example:\n\n{code}\n\nProse [Document: missing.pdf]."
     expected = f"Example:\n\n{code}\n\nProse ."
-    validated = _validate_report_sources(report, [])
-    assert _validate_report_document_sources(validated, []) == expected
+    assert _validate_report(report, [], []) == expected
+    assert _validate_report_document_sources(_validate_report_sources(report, []), []) == expected
+
+
+@pytest.mark.parametrize(
+    ("report", "expected"),
+    [
+        ("Context\nhttps://nope.example\n    [Document: hallucinated]", "Context\n\n    "),
+        (
+            "Findings [1]\nhttps://nope.example\n    [Document: made-up.pdf, p. 3] supports this.",
+            "Findings [A](https://a.com)\n\n     supports this.",
+        ),
+    ],
+)
+def test_removed_url_line_does_not_turn_a_document_citation_into_code(report, expected):
+    assert _validate_report(report, [{"url": "https://a.com", "title": "A"}], []) == expected

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -3341,6 +3341,20 @@ def test_multiline_inline_code_keeps_urls_and_brackets():
     )
 
 
+@pytest.mark.parametrize(
+    ("report", "expected"),
+    [
+        ("参见https://a.com的`pip install unsloth`命令。", "参见`pip install unsloth`命令。"),
+        (
+            "Clone https://nope.example/`git clone repo` then build [1].",
+            "Clone `git clone repo` then build [A](https://a.com).",
+        ),
+    ],
+)
+def test_url_glued_to_inline_code_keeps_the_code(report, expected):
+    assert _validate_report_sources(report, [{"url": "https://a.com", "title": "A"}]) == expected
+
+
 def test_literal_escaped_backticks_do_not_hide_prose_urls():
     report = r"Literal \`https://nope.example\` then [1]."
     out = _validate_report_sources(report, [{"url": "https://a.com", "title": "A"}])

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -3306,3 +3306,66 @@ def test_note_server_address_defers_to_run_server_published_state():
     supervisor.note_server_address(("127.0.0.1", 9999))
     assert getattr(state, "research_request_host", None) is None
     assert supervisor._endpoint() == "http://192.168.1.239:8889/v1/chat/completions"
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "    git clone https://github.com/unslothai/unsloth\n    print(x[1])",
+        "\tgit clone https://github.com/unslothai/unsloth\n\tprint(x[1])",
+        "1. Install:\n\n    ```sh\n    git clone https://github.com/unslothai/unsloth\n    ```",
+        "- Install:\n\n      git clone https://github.com/unslothai/unsloth",
+    ],
+)
+def test_report_preserves_indented_and_list_code(code):
+    report = f"Setup:\n\n{code}\n\nUse this [1], not https://nope.example."
+    out = _validate_report_sources(report, [{"url": "https://a.com", "title": "A"}])
+    assert out == f"Setup:\n\n{code}\n\nUse this [A](https://a.com), not ."
+
+
+def test_report_starting_with_indented_code_keeps_its_indentation():
+    report = "    curl https://example.com/api\n\nExplanation."
+    assert _validate_report_sources(report, []) == report
+
+
+def test_indented_paragraph_continuation_is_still_validated():
+    report = "Explanation continues\n    at https://nope.example."
+    assert _validate_report_sources(report, []) == "Explanation continues\n    at ."
+
+
+def test_multiline_inline_code_keeps_urls_and_brackets():
+    code = "`pip install torch\n--index-url https://download.pytorch.org/whl/cu121`"
+    report = f"Use {code}, then [1]."
+    assert _validate_report_sources(report, [{"url": "https://a.com", "title": "A"}]) == (
+        f"Use {code}, then [A](https://a.com)."
+    )
+
+
+def test_literal_escaped_backticks_do_not_hide_prose_urls():
+    report = r"Literal \`https://nope.example\` then [1]."
+    out = _validate_report_sources(report, [{"url": "https://a.com", "title": "A"}])
+    assert "https://nope.example" not in out
+    assert out.endswith("then [A](https://a.com).")
+
+
+def test_unclosed_quote_fence_stops_at_the_quote_boundary():
+    code = "> ```sh\n> curl https://example.com/api"
+    report = f"{code}\n\nOutside https://nope.example and [1]."
+    assert _validate_report_sources(report, [{"url": "https://a.com", "title": "A"}]) == (
+        f"{code}\n\nOutside  and [A](https://a.com)."
+    )
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        '```python\npattern = "[Document: generated]"\n```',
+        '`pattern = "[Document: generated]"`',
+        '    pattern = "[Document: generated]"',
+    ],
+)
+def test_delivered_report_keeps_document_literals_in_code(code):
+    report = f"Example:\n\n{code}\n\nProse [Document: missing.pdf]."
+    expected = f"Example:\n\n{code}\n\nProse ."
+    validated = _validate_report_sources(report, [])
+    assert _validate_report_document_sources(validated, []) == expected

--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -1146,6 +1146,66 @@ def test_dropped_raw_url_does_not_unbalance_prose():
     assert out == "Claim () here."
 
 
+def test_code_keeps_its_urls_and_brackets():
+    sources = [{"url": "https://a.com", "title": "A"}, {"url": "https://b.com", "title": "B"}]
+    code = (
+        "```bash\n"
+        "git clone https://github.com/unslothai/unsloth\n"
+        "pip install torch --index-url https://download.pytorch.org/whl/cu121\n"
+        "curl http://localhost:8888/api/health\n"
+        "```\n"
+        "~~~python\n"
+        'client = OpenAI(base_url = "http://localhost:8888/v1")\n'
+        "print(x.shape[1], [2](https://nope.com))\n"
+        "~~~"
+    )
+    report = (
+        f"{code}\n\n"
+        'Run `sys.argv[1]` or ``OpenAI(base_url="http://localhost:8888/v1")`` '
+        "as shown [1], not https://nope.com/x."
+    )
+    out = _validate_report_sources(report, sources)
+    assert out == (
+        f"{code}\n\n"
+        'Run `sys.argv[1]` or ``OpenAI(base_url="http://localhost:8888/v1")`` '
+        "as shown [A](https://a.com), not ."
+    )
+
+
+def test_unterminated_code_fence_keeps_its_urls():
+    report = "Install it:\n\n```bash\npip install torch --index-url https://download.pytorch.org/whl/cu121"
+    assert _validate_report_sources(report, []) == report
+
+
+def test_sources_heading_inside_code_does_not_cut_the_report():
+    code = "```markdown\n## Sources\n- https://example.com\n```"
+    report = f"Template:\n\n{code}\n\nMore [1].\n\n## Sources\n- [A](https://a.com)"
+    out = _validate_report_sources(report, [{"url": "https://a.com", "title": "A"}])
+    assert out == f"Template:\n\n{code}\n\nMore [A](https://a.com)."
+
+
+def test_prose_citations_without_code_are_unchanged():
+    sources = [
+        {"url": "https://a.com", "title": "A"},
+        {"url": "https://b.com/x_(y)", "title": "[PDF] B"},
+    ]
+    report = (
+        "## Findings\n\n"
+        "Claim one [1] and two [2], bad [9], footnote [^1].\n"
+        "Linked [label](https://a.com) and [fake](https://nope.example/z).\n"
+        "Auto <https://b.com/x_(y)> and <https://nope.example/q>.\n"
+        "Raw (https://a.com). Raw https://nope.example/r, then https://b.com/x_(y).\n"
+        "\n**Sources**\n- [A](https://a.com)\n"
+    )
+    assert _validate_report_sources(report, sources) == (
+        "## Findings\n\n"
+        "Claim one [A](https://a.com) and two [PDF B](https://b.com/x_(y)), bad [9], footnote [^1].\n"
+        "Linked [A](https://a.com) and fake.\n"
+        "Auto [PDF B](https://b.com/x_(y)) and .\n"
+        "Raw ([A](https://a.com)). Raw , then [PDF B](https://b.com/x_(y))."
+    )
+
+
 def _install_probe_backends(monkeypatch, llama, native) -> None:
     """Stand in for the two backend modules _local_model_ready probes, so the check can be
     exercised without importing the ML stack. Pass an exception to make a probe raise."""

--- a/studio/backend/tests/test_research_runs_storage.py
+++ b/studio/backend/tests/test_research_runs_storage.py
@@ -378,13 +378,14 @@ def test_report_is_recovered_from_substantial_synthesis_reasoning():
 
 def test_document_citations_are_restricted_to_persisted_sources():
     from core import research_runs as worker
+    from core.research.citations import _validate_report_document_sources
 
     report = (
         "Supported [Document: private.pdf, p. 2]. "
         "Fabricated [Document: invented.pdf, p. 9] and "
         "[Document: multiline.pdf,\np. 3]."
     )
-    validated = worker._validate_report_document_sources(
+    validated = _validate_report_document_sources(
         report,
         [{"filename": "private.pdf", "page": 2}],
     )
@@ -1155,13 +1156,13 @@ def test_partial_report_is_persisted_and_emits_an_event(research_home):
 
 
 def test_report_citations_are_limited_to_gathered_sources():
-    from core.research_runs import _validate_report_sources
+    from core.research import citations
 
     report = (
         "Supported [claim](https://example.com/source) and "
         "invented [claim](https://invalid.example/guess)."
     )
-    validated = _validate_report_sources(
+    validated = citations._validate_report_sources(
         report,
         [
             {
@@ -1176,24 +1177,24 @@ def test_report_citations_are_limited_to_gathered_sources():
 
 
 def test_report_citations_preserve_balanced_parentheses_in_urls():
-    from core.research_runs import _validate_report_sources
+    from core.research import citations
 
     url = "https://en.wikipedia.org/wiki/Function_(mathematics)"
-    validated = _validate_report_sources(
+    validated = citations._validate_report_sources(
         f"Supported [generic label]({url}).",
         [{"url": url, "title": "Function (mathematics)"}],
     )
 
     assert f"[Function (mathematics)]({url})" in validated
     assert (
-        _validate_report_sources(
+        citations._validate_report_sources(
             f'With title [generic label]({url} "reference page").',
             [{"url": url, "title": "Function (mathematics)"}],
         )
         == f"With title [Function (mathematics)]({url})."
     )
     assert (
-        _validate_report_sources(
+        citations._validate_report_sources(
             f"Malformed [generic label]({url}",
             [{"url": url, "title": "Function (mathematics)"}],
         )
@@ -1202,13 +1203,13 @@ def test_report_citations_preserve_balanced_parentheses_in_urls():
 
 
 def test_report_citations_use_canonical_titles_without_model_sources_section():
-    from core.research_runs import _validate_report_sources
+    from core.research import citations
 
     report = (
         "A supported claim [generic source](https://example.com/a).\n\n"
         "## Sources\n\n- [Duplicate](https://example.com/a)"
     )
-    validated = _validate_report_sources(
+    validated = citations._validate_report_sources(
         report,
         [
             {"url": "https://example.com/a", "title": "Primary Report"},
@@ -1223,13 +1224,13 @@ def test_report_citations_use_canonical_titles_without_model_sources_section():
 
 
 def test_report_citations_normalize_numbered_bare_and_autolink_styles():
-    from core.research_runs import _validate_report_sources
+    from core.research import citations
 
     sources = [
         {"url": "https://example.com/a", "title": "Primary Report"},
         {"url": "https://example.com/b", "title": "Supporting Data"},
     ]
-    validated = _validate_report_sources(
+    validated = citations._validate_report_sources(
         "Numbered [1], bare https://example.com/b, and "
         "automatic <https://example.com/a>. Unknown https://invalid.example/x.",
         sources,


### PR DESCRIPTION
Deep Research removed web addresses from the code and commands in its reports. A git clone command lost its GitHub link, pip install lost its --index-url address, and base_url="http://localhost:8888/v1" became base_url=". Code like x.shape[1] was also turned into a link to a source. The broken text was saved as the report and shown in the chat, so copied commands did not work.

This happened because the step that removes unverified links and numbered citations ran over the whole report, including code. Now code blocks and inline code are set aside during that step and put back exactly as written. A Sources heading inside a code block also no longer cuts off the rest of the report.

Links and citations in normal text work as before. Tested with a full Deep Research run. Before, the saved report had the broken commands above. After, every command and code line was saved unchanged.


---

### Before and after in Studio

Two isolated Studio installs, built from this PR's merge base `8ee07d6ae` and from head `ba7dccc4c`, each running the real `ResearchSupervisor` end to end. The model is a saved `custom` connection answering from a scripted OpenAI-compatible server, so both sides receive byte-identical model output; the only other stub is `ddgs`, identical on both sides, because the supervisor refuses a run that gathers no evidence.

![Deep Research report with code, before and after](https://raw.githubusercontent.com/danielhanchen/unsloth-staging-2/6318f16c9a1dbab31ff90c2fbb04c72c7178728b/evidence/pr-10814/pr10814_report_code_before_after.png)

| Measured on the photographed Studio | BEFORE `8ee07d6ae` | AFTER `ba7dccc4c` |
| --- | --- | --- |
| Code fragments kept in the saved report | 0 of 6 | 6 of 6 |
| Code fragments kept in the rendered chat | 0 of 6 | 6 of 6 |
| Gathered source linked in prose | yes | yes |
| Ungathered URL removed from prose | yes | yes |
| Run status and sources | completed, 1 source | same |

The two prose rows are the control. They do not move, which is what makes the code rows attributable to this change rather than to a run that never validated anything.
