### PR TITLE
Name the method on the uploaded model card

### DIFF
--- a/tests/test_upload_model_card_method.py
+++ b/tests/test_upload_model_card_method.py
@@ -26,7 +26,12 @@ def uploading(monkeypatch):
     pushed = {}
 
     class RecordingCard(ModelCard):
-        def push_to_hub(self, repo_id, token = None, **kwargs):
+        def push_to_hub(
+            self,
+            repo_id,
+            token = None,
+            **kwargs,
+        ):
             pushed["repo_id"] = repo_id
             pushed["content"] = self.content
 

--- a/tests/test_upload_model_card_method.py
+++ b/tests/test_upload_model_card_method.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from huggingface_hub import ModelCard
+
+
+class Model:
+    config = SimpleNamespace(_name_or_path = "base/model", model_type = "llama")
+
+
+@pytest.fixture
+def uploading(monkeypatch):
+    """`upload_to_huggingface` plus `MODEL_CARD`, lifted out of save.py.
+
+    save.py cannot be imported here: it pulls in the accelerator at module scope. The two
+    definitions under test read nothing else from the module, so run them on their own.
+    """
+    source = Path(__file__).resolve().parents[1] / "unsloth/save.py"
+    tree = ast.parse(source.read_text(encoding = "utf-8"))
+
+    pushed = {}
+
+    class RecordingCard(ModelCard):
+        def push_to_hub(self, repo_id, token = None, **kwargs):
+            pushed["repo_id"] = repo_id
+            pushed["content"] = self.content
+
+    import huggingface_hub
+
+    monkeypatch.setattr(huggingface_hub, "ModelCard", RecordingCard)
+    monkeypatch.setattr(huggingface_hub, "create_repo", lambda **kwargs: None)
+
+    env = {
+        "HfApi": lambda token = None: SimpleNamespace(),
+        "_determine_username": lambda directory, old, token: (directory, directory.split("/")[0]),
+        "logger": SimpleNamespace(warning_once = lambda *args: None),
+    }
+    nodes = [
+        node
+        for node in tree.body
+        if (isinstance(node, ast.FunctionDef) and node.name == "upload_to_huggingface")
+        or (
+            isinstance(node, ast.Assign)
+            and any(isinstance(t, ast.Name) and t.id == "MODEL_CARD" for t in node.targets)
+        )
+    ]
+    assert len(nodes) == 2, "expected MODEL_CARD and upload_to_huggingface in save.py"
+    module = ast.Module(body = nodes, type_ignores = [])
+    exec(compile(ast.fix_missing_locations(module), str(source), "exec"), env)
+    return env, pushed
+
+
+def test_upload_model_card_names_the_method(uploading):
+    # The heading is "# Uploaded {method} model" and every caller in save.py passes "finetuned",
+    # so a card that does not name it came out as "Uploaded  model" with the gap left in.
+    env, pushed = uploading
+
+    env["upload_to_huggingface"](Model(), "owner/model", "token", "finetuned", "trl")
+
+    assert pushed["repo_id"] == "owner/model"
+    assert "# Uploaded finetuned model" in pushed["content"]
+    assert "# Uploaded  model" not in pushed["content"]
+
+
+def test_upload_model_card_still_carries_username_extra_and_datasets(uploading):
+    env, pushed = uploading
+
+    env["upload_to_huggingface"](
+        Model(), "owner/model", "token", "finetuned", "trl", datasets = ["owner/data"]
+    )
+
+    card = ModelCard(pushed["content"])
+    assert "**Developed by:** owner" in pushed["content"]
+    assert card.data.base_model == "base/model"
+    assert "trl" in card.data.tags and "unsloth" in card.data.tags
+    assert card.data.datasets == ["owner/data"]

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -2684,7 +2684,10 @@ def upload_to_huggingface(
             username = username,
             base_model = model.config._name_or_path,
             model_type = model.config.model_type,
-            method = "",
+            # The card's heading is "# Uploaded {method} model", so blanking this dropped the one
+            # thing `method` is passed for. Every caller passes "finetuned" and every card came
+            # out reading "Uploaded  model", with the gap still in it.
+            method = method,
             extra = extra,
         )
         card = ModelCard(content)


### PR DESCRIPTION
## What breaks

`upload_to_huggingface` takes `method` as a required positional argument and then throws it away:

```python
content = MODEL_CARD.format(
    username = username,
    base_model = model.config._name_or_path,
    model_type = model.config.model_type,
    method = "",
    extra = extra,
)
```

`MODEL_CARD`'s heading is `# Uploaded {method} model`, so every card this pushes comes out as:

```
# Uploaded  model
```

with the gap still in it. All four call sites in `save.py` pass `"finetuned"`, so that is what should be there.

## Why it is a bug and not a choice

Studio carries the same template and fills the placeholder in: `method = compressed_alias or format_type` in `studio/backend/core/export/export.py`. Its heading is `# Uploaded finetuned {method} model`. The placeholder is meant to carry a value.

## What changed

One line: pass `method` through. The heading now reads `# Uploaded finetuned model`.

## Tests

`tests/test_upload_model_card_method.py` lifts `MODEL_CARD` and `upload_to_huggingface` out with `ast` and runs them against a recording `ModelCard`, the way `tests/test_merged_hub_destination.py` does, because `save.py` cannot be imported without an accelerator.

- the heading names the method, and is not `# Uploaded  model`
- the username, the `extra` tag and `datasets` still reach the card

```
2 passed in 0.32s
```

The first fails on main:

```
assert '# Uploaded finetuned model' in '---\nbase_model: base/model\n...'
```

## Left alone

`create_huggingface_repo` and `_push_merged_to_hub_revision` also format the card with `method = ""`, and both print the same double space. Neither has a method to name, so fixing that means deciding what those two flows should be called. Happy to do it in a follow-up if you want a value there.


---

## Update from maintainer review

The "Left alone" note above is now resolved in this branch. `create_huggingface_repo` and `_push_merged_to_hub_revision` name the method too, on the same word the four existing `upload_to_huggingface` call sites already pass, and `test_no_card_in_save_py_is_formatted_without_a_method` walks every `MODEL_CARD.format` in the file so no fourth site can go back to an empty one.

## What this looks like in Unsloth Studio

Studio renders a model's card in the Model hub detail pane, and `stripChromeHeadings` in `studio/frontend/src/features/hub/lib/hf-readme.ts` only drops headings reading "model card" / "dataset card" / "details", so this heading does reach the panel.

![Studio Model hub README panel, before and after](https://raw.githubusercontent.com/danielhanchen/unsloth-staging-2/pr-10816-media/pr10816/hub_readme_before_after.png)

The h1 goes from `Uploaded model` to `Uploaded finetuned model`. Everything else in the pane is a control and is identical in both halves: the repo heading, the owner, the capability chips, the BF16 GGUF 56 GB row, all three card bullets and the "trained 2x faster with Unsloth" line.

Worth stating, because it changes what to look for: the defect is a double space, and HTML collapses runs of whitespace, so the BEFORE half does not render a visible gap. It reads as a perfectly ordinary `Uploaded model`. The visible symptom in a rendered card is the missing word, not the gap. The gap is only visible in the raw README on the Hub.

How the pair was produced: `git diff <merge-base>..<head> -- studio/` is empty for this PR, so the viewer is identical on both sides and both halves come from one Studio build. What differs is the card, and each half was served the exact bytes `upload_to_huggingface` produces when executed out of that side's `save.py` with the arguments its callers pass (`method = "finetuned"`): sha256 `c270d808c1` for BEFORE, `156d0d8ed2` for AFTER. Only the `README.md` response was served locally; the model listing and the detail pane are the live Hub.
