### PR TITLE
Docker: drop the baked uv cache from the Studio image and correct its labels and Hub page

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -253,6 +253,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # The action copies the repo's license (Apache-2.0), but both images carry
+          # Unsloth Studio (studio/, AGPL-3.0) too.
+          labels: |
+            org.opencontainers.image.licenses=Apache-2.0 AND AGPL-3.0-only
 
       - name: Build and push (per-arch by digest)
         id: build
@@ -444,6 +448,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # The action copies the repo's license (Apache-2.0), but both images carry
+          # Unsloth Studio (studio/, AGPL-3.0) too.
+          labels: |
+            org.opencontainers.image.licenses=Apache-2.0 AND AGPL-3.0-only
 
       - name: Build and push (per-arch by digest)
         id: build

--- a/docker/DOCKERHUB.md
+++ b/docker/DOCKERHUB.md
@@ -1,6 +1,6 @@
 # Unsloth Docker Image
 
-Pre-built images for [Unsloth](https://github.com/unslothai/unsloth): fine-tune and run LLMs, vision, audio and diffusion models with no setup. Every image carries the full training stack (PyTorch 2.11 with CUDA 12.8, Unsloth, unsloth-zoo, bitsandbytes, TRL, PEFT, plus xformers on `linux/amd64`), JupyterLab with the [Unsloth notebooks](https://github.com/unslothai/notebooks) pre-synced, and prebuilt llama.cpp and whisper.cpp for GGUF work.
+Pre-built images for [Unsloth](https://github.com/unslothai/unsloth): fine-tune and run LLMs, vision, audio and diffusion models with no setup. Every image carries the full training stack (PyTorch 2.11 with CUDA 12.8, Unsloth, unsloth-zoo, bitsandbytes, TRL, PEFT, plus xformers on `linux/amd64`), JupyterLab with the [Unsloth notebooks](https://github.com/unslothai/notebooks) pre-synced, and prebuilt llama.cpp for GGUF work. The `latest` image adds whisper.cpp for Studio's speech-to-text.
 
 Source: [`docker/`](https://github.com/unslothai/unsloth/tree/main/docker) in the main repository. Guide: [docs.unsloth.ai](https://docs.unsloth.ai/get-started/install/docker).
 
@@ -103,7 +103,8 @@ Turing has no bfloat16; Unsloth falls back to float16 there. AMD GPUs are not su
 | `SSH_KEY` or `PUBLIC_KEY` | OpenSSH public key for root login. Enables sshd on port 22. Password login is never enabled. |
 | `UNSLOTH_ALLOW_CPU=1` | Allow starting without a GPU. |
 | `UNSLOTH_JUPYTER_CLOUDFLARE=1` | Publish JupyterLab through a Cloudflare quick tunnel and print the URL. |
-| `UNSLOTH_SKIP_NOTEBOOK_SYNC=1` | Do not refresh the notebooks from GitHub on start. |
+| `UNSLOTH_SKIP_NOTEBOOK_REFRESH=1` | Do not refresh the notebooks from GitHub on start; the copy baked into the image is still used. |
+| `UNSLOTH_SKIP_NOTEBOOK_SYNC=1` | Do not set up the notebooks at all: no `/workspace/unsloth-notebooks` and no `/workspace/Unsloth Notebooks`. |
 | `HF_TOKEN`, `WANDB_API_KEY` | Forwarded to Hugging Face and Weights and Biases. |
 
 ## Volumes
@@ -118,7 +119,7 @@ The working directory is `/workspace`. Mount what you want to keep:
 | `/workspace/unsloth-notebooks` | The synced notebooks. Your edits are kept across refreshes. |
 | `/workspace/Unsloth Notebooks` | The same notebooks grouped by topic, rebuilt on each start. |
 
-The container runs as root by default. `--user <uid>:<gid>` is supported and keeps files on your mounts owned by you.
+The container runs as root by default. On `core`, `--user <uid>:<gid>` is supported and keeps files on your mounts owned by you. `latest` runs its services as root and does not start under `--user`.
 
 ## Updating inside a running container
 
@@ -128,7 +129,9 @@ On the `latest` image:
 - `unsloth-llama-update` fetches the newest prebuilt llama.cpp.
 - `unsloth-jupyter-tunnel` opens a Cloudflare quick tunnel to JupyterLab.
 
-On both images the notebooks refresh from GitHub on each start unless `UNSLOTH_SKIP_NOTEBOOK_SYNC=1`. Pull a new image tag to update everything else.
+On both images the notebooks refresh from GitHub on each start unless `UNSLOTH_SKIP_NOTEBOOK_REFRESH=1`. Pull a new image tag to update everything else.
+
+Setting them up costs roughly 10 to 20 seconds of every start, depending on the disk, so a one-shot `docker run --rm ... python script.py` is worth running with `UNSLOTH_SKIP_NOTEBOOK_SYNC=1`.
 
 ## Help
 
@@ -138,4 +141,4 @@ On both images the notebooks refresh from GitHub on each start unless `UNSLOTH_S
 
 ## License
 
-AGPL-3.0, following the main repository. See [LICENSE](https://github.com/unslothai/unsloth/blob/main/LICENSE).
+Unsloth is Apache-2.0 ([LICENSE](https://github.com/unslothai/unsloth/blob/main/LICENSE)). Both images also include Unsloth Studio's code (`studio/`), which is AGPL-3.0 ([studio/LICENSE.AGPL-3.0](https://github.com/unslothai/unsloth/blob/main/studio/LICENSE.AGPL-3.0)).

--- a/docker/Dockerfile.studio
+++ b/docker/Dockerfile.studio
@@ -85,6 +85,10 @@ RUN apt-get update \
 # build time would land on cpu/cu126). cu128 on both arches, mirroring the base.
 # Blackwell JIT (sm_103/sm_121) comes from the same cu13 NVRTC swap, repeated below.
 #
+# install.sh keeps its uv cache under $UNSLOTH_STUDIO_HOME/cache/uv, not /root/.cache,
+# so it is removed by path below. The venv's files are hardlinks into it and survive;
+# the ~5 GB the dedup replaced with symlinks had no other link.
+#
 # UNSLOTH_PYTHON=3.12 pins the Studio venv to the base's Python minor so the
 # nvidia-*-cu12 wheels are byte-identical and the dedup below can symlink them.
 #
@@ -128,6 +132,7 @@ RUN set -eux \
  && echo "OK: Studio kept the base image's CUDA llama.cpp bundle" \
  && rm -rf "${UNSLOTH_STUDIO_HOME}/src/.git" \
           "${UNSLOTH_STUDIO_HOME}/src/studio/frontend/node_modules" \
+          "${UNSLOTH_STUDIO_HOME}/cache/uv" \
           /root/.cache \
     # Stage the Studio venv's NVRTC like the base (.cu128.orig default + .cu13
     # alias, retargeted per device by select_cuda_jit_tools). Both arches.

--- a/tests/python/test_docker_hub_readme.py
+++ b/tests/python/test_docker_hub_readme.py
@@ -163,3 +163,29 @@ def test_the_sync_fails_without_a_token(sync_job: dict, tmp_path: Path):
     res, log = _run_sync(step, tmp_path, live_after_patch = "", token = "")
     assert res.returncode != 0
     assert "PATCH" not in log, "a PATCH was attempted with an empty token"
+
+
+def test_the_hub_readme_matches_what_each_image_ships():
+    text = HUB_README.read_text(encoding = "utf-8")
+    # whisper.cpp is installed by Studio's setup, so only the Studio image has it
+    assert "The `latest` image adds whisper.cpp" in text
+    # SKIP_NOTEBOOK_SYNC disables the notebooks; SKIP_NOTEBOOK_REFRESH skips only GitHub
+    assert "`UNSLOTH_SKIP_NOTEBOOK_REFRESH=1` | Do not refresh the notebooks from GitHub" in text
+    assert "`UNSLOTH_SKIP_NOTEBOOK_SYNC=1` | Do not set up the notebooks at all" in text
+    # the Studio image's services run as root and exit 1 under --user
+    assert "On `core`, `--user <uid>:<gid>` is supported" in text
+    assert "AGPL-3.0" in text and "Apache-2.0" in text
+
+
+def test_both_images_declare_both_licenses():
+    """metadata-action copies the repository license (Apache-2.0) into the OCI label,
+    but both images carry Studio's AGPL-3.0 code."""
+    text = WORKFLOW.read_text(encoding = "utf-8")
+    assert text.count("org.opencontainers.image.licenses=Apache-2.0 AND AGPL-3.0-only") == 2
+
+
+def test_the_studio_image_does_not_ship_the_uv_download_cache():
+    """install.sh keeps its uv cache under the Studio home, which the /root/.cache
+    cleanup never reached: ~9 GB baked into :latest, 5 GB of it referenced by nothing."""
+    body = (REPO_ROOT / "docker" / "Dockerfile.studio").read_text(encoding = "utf-8")
+    assert '"${UNSLOTH_STUDIO_HOME}/cache/uv"' in body


### PR DESCRIPTION
`unsloth/unsloth:latest` is 5.3 GB bigger than it needs to be, its license label names only one of the two licenses it ships, and four statements on the Docker Hub page do not match what the images do. This fixes all of it; nothing about how the image works changes.

## 1. A 9.2 GB uv cache is baked into the image

`install.sh` points uv's cache at `$UNSLOTH_STUDIO_HOME/cache/uv`, and `Dockerfile.studio` only removes `/root/.cache`, so the cache is committed with the image.

Most of that 9.2 GB is uv's hardlinks into the Studio venv, which cost nothing extra. But 5.2 GB has no other link: the CUDA libraries whose venv copies the image's own dedup step replaced with symlinks into the base venv. The dedup saved nothing, because the bytes stayed in the cache.

## 2. The OCI license label says Apache-2.0 only

`docker/metadata-action` copies the repository's license, and both images also carry Unsloth Studio (`studio/`), which is AGPL-3.0. The Docker Hub page has the opposite error: it calls the whole thing AGPL-3.0.

## 3. Four statements on the Docker Hub page are wrong

All found by running them:

| The page says | What actually happens |
| --- | --- |
| "prebuilt llama.cpp and whisper.cpp" on every image | whisper.cpp comes with Studio's setup, so `core` does not have it |
| `UNSLOTH_SKIP_NOTEBOOK_SYNC=1` skips the GitHub refresh | it disables the notebooks completely: no `/workspace/unsloth-notebooks`, no `/workspace/Unsloth Notebooks`. The variable that skips only the refresh, `UNSLOTH_SKIP_NOTEBOOK_REFRESH=1`, is not documented at all |
| "`--user <uid>:<gid>` is supported" on both images | on `latest` the container exits 1 at once with `/etc/profile.d/unsloth_env.sh: Permission denied` and `mkdir: cannot create directory '/root'`, because its services run as root |
| nothing about start-up cost | setting up the 1,245 notebooks costs roughly 10 to 20 seconds of every start, which matters for a one-shot `docker run --rm ... python script.py` |

## The change

- `Dockerfile.studio` removes `$UNSLOTH_STUDIO_HOME/cache/uv` in the same `RUN` that installs Studio, next to the existing `/root/.cache` cleanup.
- Both `Resolve labels` steps in `docker-publish.yml` pass `org.opencontainers.image.licenses=Apache-2.0 AND AGPL-3.0-only`.
- The Docker Hub page says where whisper.cpp is, documents both notebook variables with what they actually do, limits `--user` to `core`, states both licenses, and gives the notebook setup cost (measured end to end on `core`: a 9 to 12 second difference with a warm page cache, 22 seconds cold).

## Before and after

A is the published `unsloth/unsloth:latest`, B the same Dockerfile with this change, built on the published base image with the same pinned refs, both exercised on an RTX 3090. The image goes from 27,070 MB to 21,797 MB on disk and `/opt/unsloth-studio/cache/uv` is gone.

Everything built on that cache is unchanged: the Studio venv is still 4.1 GB with torch 2.11.0+cu128 and the same deduped `cudnn` symlink into the base venv, the ready block and Studio health, the 9/9 Playwright pass over Studio and JupyterLab, a 10-step Train run, whisper.cpp on CUDA and a later `uv pip install` into the venv all behave as they do on A.

For the label, `docker/metadata-action` was run both ways on a runner and the result built into an image, which is how `build-push-action` applies it in the publish workflow ([run](https://github.com/oobabooga/unsloth/actions/runs/34654018590)): `Apache-2.0` today, `Apache-2.0 AND AGPL-3.0-only` with this change, and the same value read back from the built image.

## Verification

- `tests/python/test_docker_hub_readme.py`: 10 passed, including three new cases for the whisper.cpp line, both notebook variables, the `--user` scope, both licenses in the page, the license label in the workflow, and the cache removal in the Dockerfile. All three fail on `main`.
- The other `tests/python/test_docker_*.py` suites pass unchanged.

## Not in this PR

The saving is on the uncompressed image. The layer that held the cache is 5.95 GB compressed, so the pull gets smaller too, but by how much only the next publish can say. uv's cache is rebuilt on demand, so a later `uv pip install` inside the container pays a download it previously had locally; `cache/uv-cache-dir`, which points uv at that path, is unchanged.

The notebook setup cost and `--user` are documented here, not changed. Running the Studio image's services as non-root is a separate change, as `Dockerfile.studio` already notes.

The `annotations` output of `metadata-action` still carries the repository license alone. The publish workflow does not use it, so nothing reads that value today.
