### PR TITLE
Docker: stop JupyterLab from silently taking Studio's port, and correct three host-script messages

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -93,9 +93,10 @@ DOCKER_BUILDKIT=1 docker build \
 echo
 echo "Built ${IMAGE_NAME}:${TAG}"
 echo
-echo "Smoke test on this host (B200, sm_100):"
+# the build host is whatever the user has; the message named the one it was written on
+HOST_GPU="$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1 || true)"
+echo "Smoke test on this host${HOST_GPU:+ (${HOST_GPU})}:"
 echo "  docker run --rm --gpus all ${IMAGE_NAME}:${TAG} python /workspace/smoke_test.py"
 echo
-echo "Smoke test on an RTX 5090 host (sm_120):"
+echo "On another host, the same command after:"
 echo "  docker pull ${IMAGE_NAME}:${TAG}   # or load .tar"
-echo "  docker run --rm --gpus all ${IMAGE_NAME}:${TAG} python /workspace/smoke_test.py"

--- a/docker/install_nvidia_toolkit.sh
+++ b/docker/install_nvidia_toolkit.sh
@@ -24,14 +24,18 @@ command -v docker >/dev/null 2>&1 \
 # Measured on `docker info` with a 50ms pause mid-output: status 141, the Docker Desktop guard skipped,
 # and the script elevating to install on the one daemon it exists to leave alone.
 
+# No Mac takes an NVIDIA GPU, whatever runs the daemon. Before the endpoint check below,
+# which sent colima and Rancher Desktop users off to configure a socket by hand.
+if [[ "$(uname -s)" == Darwin ]]; then
+    say "macOS: no NVIDIA GPU can be attached on a Mac, so there is nothing to install."
+    say "The image runs CPU-only there: drop --gpus and set UNSLOTH_ALLOW_CPU=1."
+    exit 0
+fi
+
 # Docker Desktop ships its own GPU integration; installing here would configure a daemon it does not use. Checked before elevating.
 docker_info="$(docker info 2>/dev/null || true)"
 if grep -qi 'Operating System: Docker Desktop' <<<"$docker_info"; then
-    if [[ "$(uname -s)" == Darwin ]]; then
-        say "Docker Desktop on macOS: no NVIDIA GPU can be attached on a Mac, so there is nothing to install."
-        say "The image runs CPU-only there: drop --gpus and set UNSLOTH_ALLOW_CPU=1."
-        exit 0
-    elif grep -qi microsoft "$PROC_VERSION" 2>/dev/null; then
+    if grep -qi microsoft "$PROC_VERSION" 2>/dev/null; then
         say "Docker Desktop with the WSL 2 backend: GPU support comes with it, nothing to install here."
         say "Keep a current NVIDIA Windows driver installed (from nvidia.com; wsl --update updates WSL itself, not the driver)."
         exit 0

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -89,7 +89,9 @@ if [[ ${#GPU_FLAG[@]} -gt 0 ]] && ! host_has_nvidia; then
                 [[ -n "$_gid" ]] && GPU_FLAG+=(--group-add "$_gid")
             done
         fi
-        printf "      AMD devices found: passing /dev/kfd and /dev/dri through.\n" >&2
+        printf "      AMD devices found: passing /dev/kfd and /dev/dri through, but nothing\n" >&2
+        printf "      in the image uses them yet: torch is cu128 and the bundled llama.cpp\n" >&2
+        printf "      has no HIP or Vulkan backend, so this container runs on the CPU.\n" >&2
     fi
     printf "\n" >&2
 fi

--- a/docker/studio_launch.sh
+++ b/docker/studio_launch.sh
@@ -19,6 +19,14 @@
 set -euo pipefail
 
 export JUPYTER_PORT="${JUPYTER_PORT:-8888}"
+# Studio's port is fixed at 8000 (studio_run.sh). JupyterLab starts first and wins the
+# bind, so Studio falls back to an unpublished 8001 while the summary below still sends
+# the user to 8000: Studio is simply gone, with no error.
+if [[ "${JUPYTER_PORT}" == "8000" ]]; then
+    printf "\033[1;31mERROR:\033[0m JUPYTER_PORT=8000 is Unsloth Studio's port inside the container.\n" >&2
+    printf "       Leave JupyterLab on 8888 and map the host side instead: -p 9000:8888\n" >&2
+    exit 1
+fi
 export UNSLOTH_STUDIO_HOME="${UNSLOTH_STUDIO_HOME:-/opt/unsloth-studio}"
 export UNSLOTH_JUPYTER_CLOUDFLARE="${UNSLOTH_JUPYTER_CLOUDFLARE:-0}"
 

--- a/tests/python/test_docker_build_ref_resolution.py
+++ b/tests/python/test_docker_build_ref_resolution.py
@@ -39,10 +39,13 @@ def _run(
     tmp_path: Path,
     git_body: str,
     env_extra: dict[str, str] | None = None,
+    stubs: dict[str, str] | None = None,
 ):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     args_file = tmp_path / "docker-args.txt"
+    for name, body in (stubs or {}).items():
+        _stub(bin_dir / name, body)
     _stub(bin_dir / "git", git_body)
     _stub(bin_dir / "docker", f'printf "%s\\n" "$@" > {args_file}\n')
     # no network: the llama.cpp tag lookup must not reach github from a unit test
@@ -93,6 +96,20 @@ def test_the_default_main_refs_are_frozen_to_commits(tmp_path):
     # the baked notebooks are the same shape of mutable-ref RUN layer, and the
     # publish workflow already freezes this one
     assert _build_arg(argv, "UNSLOTH_NOTEBOOKS_REF") == NB_SHA
+
+
+def test_the_smoke_test_message_names_the_build_hosts_own_gpu(tmp_path):
+    """It named a B200 on every host, including the ones that have no NVIDIA GPU."""
+    proc, _argv = _run(
+        tmp_path, LS_REMOTE_STUB, stubs = {"nvidia-smi": 'echo "NVIDIA GeForce RTX 3090"\n'}
+    )
+    assert "RTX 3090" in proc.stdout, proc.stdout
+    assert "B200" not in proc.stdout and "sm_100" not in proc.stdout
+
+
+def test_the_smoke_test_message_claims_no_gpu_when_there_is_none(tmp_path):
+    proc, _argv = _run(tmp_path, LS_REMOTE_STUB, stubs = {"nvidia-smi": "exit 9\n"})
+    assert "Smoke test on this host:" in proc.stdout, proc.stdout
 
 
 def test_an_explicit_tag_is_frozen_too(tmp_path):

--- a/tests/python/test_docker_cpu_fallback.py
+++ b/tests/python/test_docker_cpu_fallback.py
@@ -119,12 +119,17 @@ class TestRunShDegradesWithoutNvidia:
     def test_amd_host_gets_the_render_nodes_with_numeric_gids(self, tmp_path):
         """--group-add by NAME resolves inside the container, where the host's
         video/render groups do not exist, so the gids must be numeric."""
-        argv, _ = _invoke_run_sh(tmp_path, nvidia = False, amd = True)
+        argv, stderr = _invoke_run_sh(tmp_path, nvidia = False, amd = True)
         assert "--gpus" not in argv
         assert "--device" in argv
         assert "/dev/kfd" in argv and "/dev/dri" in argv
         gids = [argv[i + 1] for i, a in enumerate(argv) if a == "--group-add"]
         assert all(g.isdigit() for g in gids), f"non-numeric --group-add: {gids}"
+        # the devices go through, but no part of the image can drive them: torch is
+        # cu128 and the bundled llama.cpp has neither a HIP nor a Vulkan backend
+        assert "HIP" in stderr and "CPU" in stderr, (
+            "an AMD host must be told the container still runs on the CPU:\n" + stderr
+        )
 
     def test_the_group_lookup_is_guarded_on_getent_existing(self):
         """A host with no getent at all (busybox, some slim images) must skip the

--- a/tests/python/test_docker_nvidia_toolkit_install.py
+++ b/tests/python/test_docker_nvidia_toolkit_install.py
@@ -545,6 +545,18 @@ def test_docker_desktop_on_macos_says_cpu_only(tmp_path: Path):
     assert "GPU support comes with it" not in res.stdout
 
 
+def test_macos_says_cpu_only_whatever_runs_the_daemon(tmp_path: Path):
+    """colima and Rancher Desktop keep their socket outside /var/run, which took a Mac
+    to the endpoint check: it told the user to configure that daemon by hand, for a
+    toolkit no Mac can use."""
+    _, _, env = _setup(tmp_path, driver = False, uid = 1000)
+    _stub(tmp_path / "bin" / "uname", 'if [ "$1" = -s ]; then echo Darwin; else echo arm64; fi\n')
+    res = _run(env, extra_env = {"DOCKER_HOST": "unix:///Users/u/.colima/default/docker.sock"})
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "no NVIDIA GPU" in res.stdout and "UNSLOTH_ALLOW_CPU=1" in res.stdout
+    assert "by hand" not in res.stderr, res.stderr
+
+
 def test_the_old_driver_message_names_the_host_platform_even_without_verification(tmp_path: Path):
     _, _, env = _setup(tmp_path, driver_version = "550.54.15")
     _stub(tmp_path / "bin" / "uname", 'if [ "$1" = -s ]; then echo Linux; else echo aarch64; fi\n')

--- a/tests/python/test_docker_studio_launch_port_guard.py
+++ b/tests/python/test_docker_studio_launch_port_guard.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-Present the Unsloth team. See /studio/LICENSE.AGPL-3.0
+
+"""JupyterLab must not be started on Studio's port.
+
+Studio's port is fixed at 8000 (`studio_run.sh`), so with `JUPYTER_PORT=8000`
+JupyterLab wins the bind and Studio falls back to an unpublished 8001. Both report
+RUNNING and the summary still points at 8000, where Jupyter answers 404.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LAUNCH = REPO_ROOT / "docker" / "studio_launch.sh"
+
+pytestmark = pytest.mark.skipif(shutil.which("bash") is None, reason = "needs bash")
+
+
+def _run(port: str) -> subprocess.CompletedProcess:
+    env = dict(os.environ, JUPYTER_PORT = port)
+    return subprocess.run(
+        ["bash", str(LAUNCH)], capture_output = True, text = True, env = env, timeout = 120
+    )
+
+
+def test_jupyter_on_studios_port_is_refused_with_a_remedy():
+    res = _run("8000")
+    assert res.returncode != 0, "the container started with Studio unreachable"
+    assert "JUPYTER_PORT=8000" in res.stderr, res.stderr
+    assert "-p 9000:8888" in res.stderr, "the remedy must be printed:\n" + res.stderr
+
+
+def test_another_port_is_not_refused_here():
+    res = _run("8899")
+    assert "JUPYTER_PORT=8000" not in res.stderr, res.stderr


### PR DESCRIPTION
One bug and three messages that tell the user something untrue.

## The bug: `JUPYTER_PORT=8000` costs the user Studio, silently

Studio's port inside the container is fixed at 8000 (`studio_run.sh`), and `JUPYTER_PORT` is documented and can be set to the same value. supervisord starts JupyterLab first, it takes 8000, Studio falls back to 8001, and nothing publishes 8001. On `unsloth/unsloth:latest`:

```
$ docker run -e JUPYTER_PORT=8000 -p 8000:8000 unsloth/unsloth:latest
Unsloth Studio  -> http://localhost:8000   (password from UNSLOTH_STUDIO_PASSWORD env)
JupyterLab      -> http://localhost:8000   (generated password: ...)
$ docker exec <c> supervisorctl status
jupyter   RUNNING   studio   RUNNING
$ docker exec <c> curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8000/api/health
404        # the Jupyter server answering; Studio is on 8001, unpublished
```

Both services report `RUNNING`, the summary still points at 8000, and nothing anywhere says Studio moved.

`studio_launch.sh` now refuses that setting and names the remedy (keep JupyterLab on 8888 and map the host side, `-p 9000:8888`) instead of starting a container where Studio is unreachable. Checked on `unsloth/unsloth:latest` with this launcher copied in: it exits 1 naming the collision, and a default `JUPYTER_PORT` still reaches Studio health 200 with `jupyter` `RUNNING`.

## The three messages

**`install_nvidia_toolkit.sh` sends Mac users to configure a daemon by hand.** It has a macOS branch, but only behind its Docker Desktop check; colima and Rancher Desktop keep their socket outside `/var/run`, so on a Mac they fall through to the endpoint check and get `the Docker CLI talks to a daemon on unix:///Users/u/.colima/default/docker.sock ... configure that daemon by hand`. There is nothing to configure: no Mac takes an NVIDIA GPU. The macOS answer now comes before the script looks at the daemon at all. Run on a Mac (bash 3.2) against a colima-shaped `docker`, it goes from exit 2 to exit 0 with "nothing to install on a Mac, run it CPU-only"; with no Docker CLI at all it still exits 2.

**`run.sh` announces an AMD passthrough that nothing uses.** It prints `AMD devices found: passing /dev/kfd and /dev/dri through.` The torch in the image is cu128 and the bundled llama.cpp has neither a HIP nor a Vulkan backend, so the container runs on the CPU either way. The comment in the script says so; the message the user sees did not. It now does.

**`build.sh` names the machine it was written on.** Its closing line says `Smoke test on this host (B200, sm_100):` on every host, including hosts with no NVIDIA GPU. It now reads the host's GPU from `nvidia-smi`, and claims no GPU when there is none.

## Verification

- `tests/python/test_docker_studio_launch_port_guard.py` (new, 2 cases), plus new cases in `test_docker_nvidia_toolkit_install.py`, `test_docker_build_ref_resolution.py` and the AMD case in `test_docker_cpu_fallback.py`. Five of them fail on `main`.
- Those four files together: 67 passed.
- The formatter (pinned ruff) leaves the branch unchanged.

## Not in this PR

The guard covers the collision that costs the user Studio. `JUPYTER_PORT=22` against sshd is not guarded: sshd is off unless a key is set, and the loss is visible immediately.

`run.sh` still passes `/dev/kfd` and `/dev/dri`, so a user who installs a ROCm stack in the container keeps them. Giving the image an actual HIP or Vulkan llama.cpp is a separate change.
