### PR TITLE
Studio: resolve trust_remote_code off the event loop in /api/inference/status

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -15426,6 +15426,31 @@ def _requires_trust_remote_code_for_model(
         return False
 
 
+def _stored_trust_remote_code(
+    model_info,
+    inference_config,
+    trust_remote_code_used = False,
+) -> Optional[bool]:
+    """The part of the resolution order that never touches the network: the value stored
+    on the model at load time -> the trust_remote_code the load actually used -> the YAML
+    default. None when only the raw ``auto_map`` check can answer."""
+    stored = (model_info or {}).get("requires_trust_remote_code")
+    if stored is not None:
+        return bool(stored)
+    if trust_remote_code_used or bool((inference_config or {}).get("trust_remote_code", False)):
+        return True
+    return None
+
+
+def _auto_map_trust_remote_code(model_id, hf_token = None) -> bool:
+    """The raw ``auto_map`` check: reads the config from the cache, or the Hub on a miss.
+    Callers guard it and keep it off the event loop."""
+    try:
+        return bool(_requires_trust_remote_code_for_model(model_id, hf_token))
+    except Exception:
+        return False
+
+
 def _resolve_loaded_trust_remote_code(
     model_id,
     model_info,
@@ -15446,15 +15471,10 @@ def _resolve_loaded_trust_remote_code(
     Resolution order: a value stored on the model at load time (so a status refresh does
     not re-derive it) -> the trust_remote_code the load actually used -> the YAML default
     -> the raw ``auto_map`` check (reads the config from the cache, or the Hub on a miss)."""
-    stored = (model_info or {}).get("requires_trust_remote_code")
-    if stored is not None:
-        return bool(stored)
-    if trust_remote_code_used or bool((inference_config or {}).get("trust_remote_code", False)):
-        return True
-    try:
-        return bool(_requires_trust_remote_code_for_model(model_id, hf_token))
-    except Exception:
-        return False
+    known = _stored_trust_remote_code(model_info, inference_config, trust_remote_code_used)
+    if known is not None:
+        return known
+    return _auto_map_trust_remote_code(model_id, hf_token)
 
 
 def _requires_security_review_for_model(
@@ -17349,10 +17369,12 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
         is_audio = False
         audio_type = None
         has_audio_input = False
-        # One snapshot for the whole response. Resolving trust_remote_code below awaits,
-        # and a load or unload completing in that window would otherwise pair the new
-        # model's identity with this one's capabilities and trust requirement.
+        # One snapshot for the whole response. Resolving trust_remote_code below can
+        # await, and a load or unload completing in that window would otherwise pair the
+        # new model's identity with this one's capabilities, trust requirement, or
+        # resident list.
         _active = backend.active_model_name
+        _loaded = list(backend.models.keys())
         model_info = {}
         if _active:
             model_info = backend.models.get(_active, {})
@@ -17377,17 +17399,23 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
         ):
             _loading_models.append(_tracked_loading_id)
 
-        # The auto_map fallback reads raw config JSON, so guarded and off-loop like validate_model.
+        # Stored at load, or the YAML default: no network, so no guard and no thread. The
+        # guard probes reachability on entry (memoised 5s, up to 3s cold), which a polled
+        # route would otherwise pay for a dict read.
         _requires_trc = False
         if _active:
-            _requires_trc = await asyncio.to_thread(
-                _offline_guarded,
-                [_active],
-                _resolve_loaded_trust_remote_code,
-                _active,
-                model_info,
-                inference_config,
-            )
+            _known = _stored_trust_remote_code(model_info, inference_config)
+            if _known is not None:
+                _requires_trc = _known
+            else:
+                # Only the raw auto_map fallback reads the Hub: guarded, and on the bounded
+                # status executor rather than the default one that drives token streaming.
+                _requires_trc = await asyncio.get_running_loop().run_in_executor(
+                    _STATUS_PROBE_EXECUTOR,
+                    functools.partial(
+                        _offline_guarded, [_active], _auto_map_trust_remote_code, _active
+                    ),
+                )
 
         return InferenceStatusResponse(
             active_model = _active,
@@ -17407,7 +17435,7 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
             chat_template_override = model_info.get("chat_template_override_requested"),
             chat_template_override_reason = model_info.get("chat_template_override_reason"),
             loading = _loading_models,
-            loaded = list(backend.models.keys()),
+            loaded = _loaded,
             inference = inference_config,
             requires_trust_remote_code = _requires_trc,
             supports_reasoning = _sf_flags["supports_reasoning"],

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -15445,7 +15445,7 @@ def _resolve_loaded_trust_remote_code(
 
     Resolution order: a value stored on the model at load time (so a status refresh does
     not re-derive it) -> the trust_remote_code the load actually used -> the YAML default
-    -> the raw ``auto_map`` check (reads the loaded model's cached config; no network)."""
+    -> the raw ``auto_map`` check (reads the config from the cache, or the Hub on a miss)."""
     stored = (model_info or {}).get("requires_trust_remote_code")
     if stored is not None:
         return bool(stored)
@@ -17375,6 +17375,18 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
         ):
             _loading_models.append(_tracked_loading_id)
 
+        # The auto_map fallback reads raw config JSON, so guarded and off-loop like validate_model.
+        _requires_trc = False
+        if backend.active_model_name:
+            _requires_trc = await asyncio.to_thread(
+                _offline_guarded,
+                [backend.active_model_name],
+                _resolve_loaded_trust_remote_code,
+                backend.active_model_name,
+                model_info,
+                inference_config,
+            )
+
         return InferenceStatusResponse(
             active_model = backend.active_model_name,
             model_identifier = backend.active_model_name,
@@ -17397,9 +17409,7 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
             loading = _loading_models,
             loaded = list(backend.models.keys()),
             inference = inference_config,
-            requires_trust_remote_code = _resolve_loaded_trust_remote_code(
-                backend.active_model_name, model_info, inference_config
-            ),
+            requires_trust_remote_code = _requires_trc,
             supports_reasoning = _sf_flags["supports_reasoning"],
             reasoning_style = _sf_flags["reasoning_style"],
             reasoning_effort_levels = _sf_flags.get("reasoning_effort_levels", []),

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -17349,9 +17349,13 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
         is_audio = False
         audio_type = None
         has_audio_input = False
+        # One snapshot for the whole response. Resolving trust_remote_code below awaits,
+        # and a load or unload completing in that window would otherwise pair the new
+        # model's identity with this one's capabilities and trust requirement.
+        _active = backend.active_model_name
         model_info = {}
-        if backend.active_model_name:
-            model_info = backend.models.get(backend.active_model_name, {})
+        if _active:
+            model_info = backend.models.get(_active, {})
             is_vision = model_info.get("is_vision", False)
             is_audio = model_info.get("is_audio", False)
             audio_type = model_info.get("audio_type")
@@ -17363,9 +17367,7 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
 
         # Non-GGUF: classify from the loaded template.
         _sf_flags = _detect_safetensors_features(backend, chat_template)
-        inference_config = (
-            load_inference_config(backend.active_model_name) if backend.active_model_name else None
-        )
+        inference_config = load_inference_config(_active) if _active else None
 
         # The backend and the attempt registry name the same load, so compare public ids
         # or a model loaded from a path is listed twice.
@@ -17377,24 +17379,22 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
 
         # The auto_map fallback reads raw config JSON, so guarded and off-loop like validate_model.
         _requires_trc = False
-        if backend.active_model_name:
+        if _active:
             _requires_trc = await asyncio.to_thread(
                 _offline_guarded,
-                [backend.active_model_name],
+                [_active],
                 _resolve_loaded_trust_remote_code,
-                backend.active_model_name,
+                _active,
                 model_info,
                 inference_config,
             )
 
         return InferenceStatusResponse(
-            active_model = backend.active_model_name,
-            model_identifier = backend.active_model_name,
+            active_model = _active,
+            model_identifier = _active,
             is_vision = is_vision,
             is_gguf = False,
-            is_local_model = bool(
-                backend.active_model_name and is_local_path(backend.active_model_name)
-            ),
+            is_local_model = bool(_active and is_local_path(_active)),
             is_audio = is_audio,
             audio_type = audio_type,
             has_audio_input = has_audio_input,

--- a/studio/backend/tests/test_status_trust_remote_code_off_event_loop.py
+++ b/studio/backend/tests/test_status_trust_remote_code_off_event_loop.py
@@ -68,6 +68,31 @@ def test_the_fallback_runs_inside_the_offline_guard(monkeypatch):
     ], "the trust_remote_code read did not go through _offline_guarded"
 
 
+def test_a_load_completing_mid_resolve_does_not_mix_two_models(monkeypatch):
+    """Going off-loop puts a suspension point between the snapshot and the response. A
+    load landing in that window must not pair the new model's identity with the trust
+    requirement and capabilities read for the one it replaced."""
+    backend = _backend("unsloth/Qwen3-8B")
+
+    def _resolve(*_args, **_kwargs):
+        backend.active_model_name = "unsloth/Llama-3.1-8B"
+        backend.models = {"unsloth/Llama-3.1-8B": {}}
+        return True
+
+    monkeypatch.setattr(inference_routes, "_peek_inference_backend", lambda *a, **k: backend)
+    monkeypatch.setattr(inference_routes, "_resolve_loaded_trust_remote_code", _resolve)
+
+    response = asyncio.new_event_loop().run_until_complete(
+        inference_routes.get_status(current_subject = "t")
+    )
+
+    assert response.active_model == "unsloth/Qwen3-8B", (
+        "reported the model that landed mid-resolve, while carrying the trust_remote_code "
+        "and capabilities read for the one it replaced"
+    )
+    assert response.requires_trust_remote_code is True
+
+
 def test_no_loaded_model_reads_nothing(monkeypatch):
     """Nothing is loaded, so there is no repo to ask about."""
     called: list[int] = []

--- a/studio/backend/tests/test_status_trust_remote_code_off_event_loop.py
+++ b/studio/backend/tests/test_status_trust_remote_code_off_event_loop.py
@@ -8,6 +8,10 @@ The frontend polls this route continuously, and the auto_map fallback reads raw 
 JSON from the Hub, so on an unreachable Hub that read parks the loop and the server stops
 answering anything, /api/liveness included.
 
+Only that fallback leaves the loop. The value stored at load and the YAML default are
+dict reads, and the offline guard probes reachability on entry, so sending those through
+it would charge a polled route a network probe for nothing.
+
 Asserts which thread the read ran on rather than timing it.
 """
 
@@ -20,30 +24,41 @@ from types import SimpleNamespace
 import routes.inference as inference_routes
 
 
-def _backend(active = "unsloth/Qwen3-8B"):
+def _backend(active = "unsloth/Qwen3-8B", info = None):
     return SimpleNamespace(
         active_model_name = active,
-        models = {active: {}} if active else {},
+        models = {active: dict(info or {})} if active else {},
         loading_models = set(),
     )
 
 
-def test_the_auto_map_fallback_runs_off_the_event_loop_thread(monkeypatch):
-    threads: list[int] = []
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
 
-    def _resolve(*_args, **_kwargs):
-        threads.append(threading.get_ident())
+
+def test_the_auto_map_fallback_runs_off_the_event_loop_thread(monkeypatch):
+    threads: list[tuple[int, str]] = []
+
+    def _auto_map(*_args, **_kwargs):
+        threads.append((threading.get_ident(), threading.current_thread().name))
         return False
 
     monkeypatch.setattr(inference_routes, "_peek_inference_backend", lambda *a, **k: _backend())
-    monkeypatch.setattr(inference_routes, "_resolve_loaded_trust_remote_code", _resolve)
+    monkeypatch.setattr(inference_routes, "_auto_map_trust_remote_code", _auto_map)
 
     # run_until_complete drives the loop on this thread.
     loop_thread = threading.get_ident()
-    asyncio.new_event_loop().run_until_complete(inference_routes.get_status(current_subject = "t"))
+    _run(inference_routes.get_status(current_subject = "t"))
 
-    assert threads, "status never resolved trust_remote_code"
-    assert loop_thread not in threads, "trust_remote_code was resolved on the event loop thread"
+    assert threads, "status never ran the auto_map fallback"
+    assert all(
+        ident != loop_thread for ident, _ in threads
+    ), "trust_remote_code was resolved on the event loop thread"
+    # The bounded status executor, not the default one: that pool drives local token
+    # streaming, and enough overlapping polls on a slow Hub would starve it.
+    assert all(
+        name.startswith("inference-status") for _, name in threads
+    ), f"the fallback ran on {[n for _, n in threads]}, not on _STATUS_PROBE_EXECUTOR"
 
 
 def test_the_fallback_runs_inside_the_offline_guard(monkeypatch):
@@ -57,40 +72,69 @@ def test_the_fallback_runs_inside_the_offline_guard(monkeypatch):
 
     monkeypatch.setattr(inference_routes, "_peek_inference_backend", lambda *a, **k: _backend())
     monkeypatch.setattr(inference_routes, "_offline_guarded", _offline_guarded)
-    monkeypatch.setattr(
-        inference_routes, "_resolve_loaded_trust_remote_code", lambda *a, **k: False
-    )
+    monkeypatch.setattr(inference_routes, "_auto_map_trust_remote_code", lambda *a, **k: False)
 
-    asyncio.new_event_loop().run_until_complete(inference_routes.get_status(current_subject = "t"))
+    _run(inference_routes.get_status(current_subject = "t"))
 
     assert guarded == [
         ("unsloth/Qwen3-8B",)
-    ], "the trust_remote_code read did not go through _offline_guarded"
+    ], "the auto_map read did not go through _offline_guarded"
+
+
+def test_a_trust_decision_stored_at_load_skips_the_guard_and_the_thread(monkeypatch):
+    """The load path stores requires_trust_remote_code on the model. Reporting it back is
+    a dict read, and the guard probes the Hub on entry (memoised 5s, up to 3s cold), so a
+    polled route must answer from the stored value without entering either."""
+    entered: list[str] = []
+
+    monkeypatch.setattr(
+        inference_routes,
+        "_peek_inference_backend",
+        lambda *a, **k: _backend(info = {"requires_trust_remote_code": True}),
+    )
+    monkeypatch.setattr(
+        inference_routes,
+        "_offline_guarded",
+        lambda *a, **k: entered.append("guard") or False,
+    )
+    monkeypatch.setattr(
+        inference_routes,
+        "_auto_map_trust_remote_code",
+        lambda *a, **k: entered.append("auto_map") or False,
+    )
+
+    response = _run(inference_routes.get_status(current_subject = "t"))
+
+    assert response.requires_trust_remote_code is True
+    assert entered == [], f"a stored trust decision still went through {entered}"
 
 
 def test_a_load_completing_mid_resolve_does_not_mix_two_models(monkeypatch):
     """Going off-loop puts a suspension point between the snapshot and the response. A
     load landing in that window must not pair the new model's identity with the trust
-    requirement and capabilities read for the one it replaced."""
+    requirement, capabilities, or resident list read for the one it replaced."""
     backend = _backend("unsloth/Qwen3-8B")
 
-    def _resolve(*_args, **_kwargs):
+    def _auto_map(*_args, **_kwargs):
         backend.active_model_name = "unsloth/Llama-3.1-8B"
         backend.models = {"unsloth/Llama-3.1-8B": {}}
         return True
 
     monkeypatch.setattr(inference_routes, "_peek_inference_backend", lambda *a, **k: backend)
-    monkeypatch.setattr(inference_routes, "_resolve_loaded_trust_remote_code", _resolve)
+    monkeypatch.setattr(inference_routes, "_auto_map_trust_remote_code", _auto_map)
 
-    response = asyncio.new_event_loop().run_until_complete(
-        inference_routes.get_status(current_subject = "t")
-    )
+    response = _run(inference_routes.get_status(current_subject = "t"))
 
     assert response.active_model == "unsloth/Qwen3-8B", (
         "reported the model that landed mid-resolve, while carrying the trust_remote_code "
         "and capabilities read for the one it replaced"
     )
     assert response.requires_trust_remote_code is True
+    # Same snapshot as active_model: a response whose active model is missing from its own
+    # resident list reads as "the active model is an unloaded cache entry".
+    assert response.loaded == [
+        "unsloth/Qwen3-8B"
+    ], f"loaded={response.loaded} was read after the await, against active_model from before it"
 
 
 def test_no_loaded_model_reads_nothing(monkeypatch):
@@ -100,13 +144,11 @@ def test_no_loaded_model_reads_nothing(monkeypatch):
     monkeypatch.setattr(inference_routes, "_peek_inference_backend", lambda *a, **k: _backend(None))
     monkeypatch.setattr(
         inference_routes,
-        "_resolve_loaded_trust_remote_code",
+        "_auto_map_trust_remote_code",
         lambda *a, **k: called.append(1) or False,
     )
 
-    response = asyncio.new_event_loop().run_until_complete(
-        inference_routes.get_status(current_subject = "t")
-    )
+    response = _run(inference_routes.get_status(current_subject = "t"))
 
-    assert not called, "status resolved trust_remote_code with no model loaded"
+    assert not called, "status ran the auto_map fallback with no model loaded"
     assert response.requires_trust_remote_code is False

--- a/studio/backend/tests/test_status_trust_remote_code_off_event_loop.py
+++ b/studio/backend/tests/test_status_trust_remote_code_off_event_loop.py
@@ -40,9 +40,7 @@ def test_the_auto_map_fallback_runs_off_the_event_loop_thread(monkeypatch):
 
     # run_until_complete drives the loop on this thread.
     loop_thread = threading.get_ident()
-    asyncio.new_event_loop().run_until_complete(
-        inference_routes.get_status(current_subject = "t")
-    )
+    asyncio.new_event_loop().run_until_complete(inference_routes.get_status(current_subject = "t"))
 
     assert threads, "status never resolved trust_remote_code"
     assert loop_thread not in threads, "trust_remote_code was resolved on the event loop thread"
@@ -63,13 +61,11 @@ def test_the_fallback_runs_inside_the_offline_guard(monkeypatch):
         inference_routes, "_resolve_loaded_trust_remote_code", lambda *a, **k: False
     )
 
-    asyncio.new_event_loop().run_until_complete(
-        inference_routes.get_status(current_subject = "t")
-    )
+    asyncio.new_event_loop().run_until_complete(inference_routes.get_status(current_subject = "t"))
 
-    assert guarded == [("unsloth/Qwen3-8B",)], (
-        "the trust_remote_code read did not go through _offline_guarded"
-    )
+    assert guarded == [
+        ("unsloth/Qwen3-8B",)
+    ], "the trust_remote_code read did not go through _offline_guarded"
 
 
 def test_no_loaded_model_reads_nothing(monkeypatch):

--- a/studio/backend/tests/test_status_trust_remote_code_off_event_loop.py
+++ b/studio/backend/tests/test_status_trust_remote_code_off_event_loop.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Reporting trust_remote_code on /api/inference/status must not read the Hub from the
+event loop thread.
+
+The frontend polls this route continuously, and the auto_map fallback reads raw config
+JSON from the Hub, so on an unreachable Hub that read parks the loop and the server stops
+answering anything, /api/liveness included.
+
+Asserts which thread the read ran on rather than timing it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+
+import routes.inference as inference_routes
+
+
+def _backend(active = "unsloth/Qwen3-8B"):
+    return SimpleNamespace(
+        active_model_name = active,
+        models = {active: {}} if active else {},
+        loading_models = set(),
+    )
+
+
+def test_the_auto_map_fallback_runs_off_the_event_loop_thread(monkeypatch):
+    threads: list[int] = []
+
+    def _resolve(*_args, **_kwargs):
+        threads.append(threading.get_ident())
+        return False
+
+    monkeypatch.setattr(inference_routes, "_peek_inference_backend", lambda *a, **k: _backend())
+    monkeypatch.setattr(inference_routes, "_resolve_loaded_trust_remote_code", _resolve)
+
+    # run_until_complete drives the loop on this thread.
+    loop_thread = threading.get_ident()
+    asyncio.new_event_loop().run_until_complete(
+        inference_routes.get_status(current_subject = "t")
+    )
+
+    assert threads, "status never resolved trust_remote_code"
+    assert loop_thread not in threads, "trust_remote_code was resolved on the event loop thread"
+
+
+def test_the_fallback_runs_inside_the_offline_guard(monkeypatch):
+    """Off-loop is not enough: the guard is what bounds the read to the memoised
+    reachability verdict instead of the connect timeout."""
+    guarded: list[tuple] = []
+
+    def _offline_guarded(targets, fn, /, *args, **kwargs):
+        guarded.append(tuple(targets))
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr(inference_routes, "_peek_inference_backend", lambda *a, **k: _backend())
+    monkeypatch.setattr(inference_routes, "_offline_guarded", _offline_guarded)
+    monkeypatch.setattr(
+        inference_routes, "_resolve_loaded_trust_remote_code", lambda *a, **k: False
+    )
+
+    asyncio.new_event_loop().run_until_complete(
+        inference_routes.get_status(current_subject = "t")
+    )
+
+    assert guarded == [("unsloth/Qwen3-8B",)], (
+        "the trust_remote_code read did not go through _offline_guarded"
+    )
+
+
+def test_no_loaded_model_reads_nothing(monkeypatch):
+    """Nothing is loaded, so there is no repo to ask about."""
+    called: list[int] = []
+
+    monkeypatch.setattr(inference_routes, "_peek_inference_backend", lambda *a, **k: _backend(None))
+    monkeypatch.setattr(
+        inference_routes,
+        "_resolve_loaded_trust_remote_code",
+        lambda *a, **k: called.append(1) or False,
+    )
+
+    response = asyncio.new_event_loop().run_until_complete(
+        inference_routes.get_status(current_subject = "t")
+    )
+
+    assert not called, "status resolved trust_remote_code with no model loaded"
+    assert response.requires_trust_remote_code is False


### PR DESCRIPTION

Split out of #10803.

`GET /api/inference/status` is `async def` and called `_resolve_loaded_trust_remote_code` inline. Its `auto_map` fallback can reach the Hub (`_config_has_auto_map` → `_load_remote_code_configs` → `hf_hub_download` on a cache miss), although its docstring says it does no network. On a link that black-holes IPv6, one status poll parked the event loop for the full address walk. `/api/liveness` stopped with it, and the watchdog sent SIGTERM after three misses.

`validate_model` and the transformers upgrade check already wrap the same read in `asyncio.to_thread(_offline_guarded, ...)`. This does the same for `get_status`, skips the read when no model is loaded, and fixes the docstring.

The second commit reads `backend.active_model_name` once, before the await. The offload added a suspension point, and a load or unload that finished inside it paired one model's name with another model's capabilities.

| | before | after |
|---|---|---|
| `GET /api/inference/status`, three black-holed records | 30 s, loop parked | 6 ms |
| `/api/liveness` during that poll | timed out past 12 s | 0.01 s |
| sweep of all 123 no-arg GET routes | 1 parked the loop | none |
