### PR TITLE
Studio: show prompt-processing progress in API monitor

### DIFF
--- a/studio/backend/core/inference/api_monitor.py
+++ b/studio/backend/core/inference/api_monitor.py
@@ -523,11 +523,7 @@ class ApiMonitor:
 
         with self._lock:
             entry = self._find_locked(entry_id)
-            if (
-                entry is None
-                or entry.status != "running"
-                or entry.kind != "request"
-            ):
+            if entry is None or entry.status != "running" or entry.kind != "request":
                 return
 
             entry.running_phase = "prompt_processing"

--- a/studio/backend/core/inference/api_monitor.py
+++ b/studio/backend/core/inference/api_monitor.py
@@ -523,14 +523,35 @@ class ApiMonitor:
 
         with self._lock:
             entry = self._find_locked(entry_id)
-            if entry is None or entry.status != "running" or entry.kind != "request":
+            if (
+                entry is None
+                or entry.status != "running"
+                or entry.kind != "request"
+                or entry.running_phase == "token_generation"
+            ):
                 return
 
+            # A tool loop can enter prompt processing more than once in one
+            # API request. Do not carry progress from the previous prefill round
+            # into the next one.
+            if entry.running_phase != "prompt_processing":
+                entry.prompt_progress_total = None
+                entry.prompt_progress_processed = None
+                entry.prompt_progress_cached = None
+                entry.prompt_progress_time_ms = None
+
             entry.running_phase = "prompt_processing"
-            entry.prompt_progress_total = total
+
+            # llama.cpp progress frames may omit fields after reporting them
+            # once, so keep the latest known value within the same prefill round.
+            if total is not None:
+                entry.prompt_progress_total = total
             entry.prompt_progress_processed = processed
-            entry.prompt_progress_cached = cached
-            entry.prompt_progress_time_ms = time_ms
+            if cached is not None:
+                entry.prompt_progress_cached = cached
+            if time_ms is not None:
+                entry.prompt_progress_time_ms = time_ms
+
             entry.updated_at = time.time()
 
     def discard(self, entry_id: Optional[str]) -> None:
@@ -745,6 +766,10 @@ class ApiMonitor:
                 entry.running_phase = "token_generation"
                 if entry.first_decode_monotonic is None:
                     entry.first_decode_monotonic = now
+            else:
+                # Tool/client output means prefill has ended, but the model is
+                # not decoding while Studio executes or awaits the tool.
+                entry.running_phase = None
 
     def set_reply(self, entry_id: Optional[str], text: str) -> None:
         if not entry_id:

--- a/studio/backend/core/inference/api_monitor.py
+++ b/studio/backend/core/inference/api_monitor.py
@@ -195,6 +195,15 @@ class ApiMonitorEntry:
     shared: bool = False
     # 0-100 for a running download row; None when not applicable.
     progress: Optional[float] = None
+    # Request sub-phase while status remains "running".
+    # Kept separate from lifecycle download progress above.
+    running_phase: Optional[str] = None
+    # Live llama.cpp prompt-processing progress.
+    # ``processed`` already includes cached tokens.
+    prompt_progress_total: Optional[int] = None
+    prompt_progress_processed: Optional[int] = None
+    prompt_progress_cached: Optional[int] = None
+    prompt_progress_time_ms: Optional[float] = None
     # Stamped on the first reply text; snapshot() prefers it over engine timings.
     first_token_monotonic: Optional[float] = None
     # The same instant, but only for output the model decoded. A tool card is client output that TTFT should count and
@@ -251,6 +260,30 @@ class ApiMonitorEntry:
             gen_s = self.finished_monotonic - self.first_decode_monotonic
             if gen_s > 0.05:
                 tok_per_sec = (self.completion_tokens - 1) / gen_s
+        prompt_progress = None
+        if self.prompt_progress_processed is not None:
+            percent = None
+            if self.prompt_progress_total is not None and self.prompt_progress_total > 0:
+                percent = min(
+                    100.0,
+                    max(
+                        0.0,
+                        self.prompt_progress_processed / self.prompt_progress_total * 100.0,
+                    ),
+                )
+
+            prompt_progress = {
+                "total": self.prompt_progress_total,
+                "processed": self.prompt_progress_processed,
+                "cached": self.prompt_progress_cached,
+                "time_ms": (
+                    round(self.prompt_progress_time_ms, 2)
+                    if self.prompt_progress_time_ms is not None
+                    else None
+                ),
+                "percent": round(percent, 1) if percent is not None else None,
+            }
+
         payload = {
             "id": self.id,
             "endpoint": self.endpoint,
@@ -278,6 +311,8 @@ class ApiMonitorEntry:
             "event": self.event,
             "reason": self.reason,
             "progress": self.progress,
+            "running_phase": self.running_phase,
+            "prompt_progress": prompt_progress,
             "ttft_ms": ttft_ms,
             "tok_per_sec": round(tok_per_sec, 2) if tok_per_sec is not None else None,
             "prompt_tok_per_sec": (
@@ -456,6 +491,52 @@ class ApiMonitor:
                 entry.progress = min(100.0, max(0.0, float(progress)))
                 entry.updated_at = time.time()
 
+    def set_prompt_progress(
+        self,
+        entry_id: Optional[str],
+        *,
+        total: Any = None,
+        processed: Any = None,
+        cached: Any = None,
+        time_ms: Any = None,
+    ) -> None:
+        """Record one live llama.cpp prompt-processing progress sample."""
+        if not entry_id:
+            return
+
+        total = _token_count_or_none(total)
+        processed = _token_count_or_none(processed)
+        cached = _token_count_or_none(cached)
+        time_ms = _finite_float_or_none(time_ms)
+
+        if processed is None:
+            return
+
+        if total is not None and total > 0:
+            processed = min(processed, total)
+
+        if cached is not None:
+            cached = min(cached, processed)
+
+        if time_ms is not None and time_ms < 0:
+            time_ms = None
+
+        with self._lock:
+            entry = self._find_locked(entry_id)
+            if (
+                entry is None
+                or entry.status != "running"
+                or entry.kind != "request"
+            ):
+                return
+
+            entry.running_phase = "prompt_processing"
+            entry.prompt_progress_total = total
+            entry.prompt_progress_processed = processed
+            entry.prompt_progress_cached = cached
+            entry.prompt_progress_time_ms = time_ms
+            entry.updated_at = time.time()
+
     def discard(self, entry_id: Optional[str]) -> None:
         """Drop a row that turned out not to be an event (an already-satisfied load)."""
         if not entry_id:
@@ -485,6 +566,7 @@ class ApiMonitor:
                 entry.openai_stream_last_segment_was_tool = False
             # Only a streaming delta stamps TTFT; a full-response append is end-to-end latency.
             if stamp_first_token:
+                entry.running_phase = "token_generation"
                 now = time.monotonic()
                 if entry.first_token_monotonic is None:
                     entry.first_token_monotonic = now
@@ -598,6 +680,7 @@ class ApiMonitor:
                 entry.first_token_monotonic = now
             if entry.first_decode_monotonic is None:
                 entry.first_decode_monotonic = now
+            entry.running_phase = "token_generation"
             entry.updated_at = time.time()
 
     def take_openai_tool_calls(
@@ -662,8 +745,10 @@ class ApiMonitor:
                 return
             if entry.first_token_monotonic is None:
                 entry.first_token_monotonic = now
-            if decoded and entry.first_decode_monotonic is None:
-                entry.first_decode_monotonic = now
+            if decoded:
+                entry.running_phase = "token_generation"
+                if entry.first_decode_monotonic is None:
+                    entry.first_decode_monotonic = now
 
     def set_reply(self, entry_id: Optional[str], text: str) -> None:
         if not entry_id:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -5928,6 +5928,9 @@ def _report_live_llama_timings(callback, chunk) -> None:
     sample.pop("prompt_ms", None)
     progress = chunk.get("prompt_progress")
     if isinstance(progress, dict):
+        # Keep the actual prefill event, not only the throughput derived from it.
+        # Consumers can use this to distinguish prompt processing from decoding.
+        sample["prompt_progress"] = dict(progress)
         try:
             processed = max(0.0, float(progress.get("processed", 0)))
             cached = max(0.0, float(progress.get("cache", 0)))

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -5810,6 +5810,20 @@ def _monitor_usage(
                     sink.get("context_length"),
                     timings = timings,
                 )
+    # Only a real llama.cpp prompt_progress frame means prefill is active.
+    # Final timing metadata must not move a decoding request back to this phase.
+    prompt_progress = (
+        timings.get("prompt_progress") if isinstance(timings, dict) else None
+    )
+    if monitor_id and isinstance(prompt_progress, dict):
+        api_monitor.set_prompt_progress(
+            monitor_id,
+            total = prompt_progress.get("total"),
+            processed = prompt_progress.get("processed"),
+            cached = prompt_progress.get("cache"),
+            time_ms = prompt_progress.get("time_ms"),
+        )
+
     # isinstance, not truthiness: a non-dict usage would raise on .get() into the
     # streaming generator and abort the user's response.
     if isinstance(usage, dict) and usage:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -5812,9 +5812,7 @@ def _monitor_usage(
                 )
     # Only a real llama.cpp prompt_progress frame means prefill is active.
     # Final timing metadata must not move a decoding request back to this phase.
-    prompt_progress = (
-        timings.get("prompt_progress") if isinstance(timings, dict) else None
-    )
+    prompt_progress = timings.get("prompt_progress") if isinstance(timings, dict) else None
     if monitor_id and isinstance(prompt_progress, dict):
         api_monitor.set_prompt_progress(
             monitor_id,

--- a/studio/frontend/src/features/api-monitor/api-monitor-page.tsx
+++ b/studio/frontend/src/features/api-monitor/api-monitor-page.tsx
@@ -416,7 +416,15 @@ function RequestDetail({
               statusTextClass(entry.status),
             )}
           >
-            {entry.status}
+            {entry.status === "running"
+              ? entry.running_phase === "prompt_processing"
+                ? entry.prompt_progress?.percent != null
+                  ? `Prompt processing · ${Math.round(entry.prompt_progress.percent)}%`
+                  : "Prompt processing"
+                : entry.running_phase === "token_generation"
+                  ? "Token generation"
+                  : "Running"
+              : entry.status}
           </span>
           <span className="ml-auto shrink-0 font-mono text-ui-10 text-muted-foreground">
             {entry.id}

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -462,6 +462,15 @@ export interface ApiMonitorEntry {
   reason?: "manual" | "idle" | "api" | null;
   // 0-100 while a download row is running.
   progress?: number | null;
+  // Current inference sub-phase while the request is running.
+  running_phase?: "prompt_processing" | "token_generation" | null;
+  prompt_progress?: {
+    total: number | null;
+    processed: number | null;
+    cached: number | null;
+    time_ms: number | null;
+    percent: number | null;
+  } | null;
   // Server-side time to first token (measured, else engine prefill).
   ttft_ms?: number | null;
   tok_per_sec?: number | null;


### PR DESCRIPTION
## Summary

Adds live inference phase reporting to the Studio API monitor.

Running GGUF requests now show:

- `Prompt processing · N%` while llama.cpp is processing the input prompt
- `Token generation` once decoded output begins

The existing request lifecycle status (`running`, `completed`, `error`, etc.) remains unchanged.

## Motivation

For large prompts, the API monitor previously showed only `running`, so it was impossible to tell whether a request was waiting, processing the prompt, or already generating tokens.

llama.cpp already exposes live `prompt_progress` information. This change surfaces that existing telemetry in the API monitor instead of inferring the phase from throughput.

## Implementation

- Preserve llama.cpp `prompt_progress` events in the request-scoped performance callback.
- Track the current inference sub-phase in `ApiMonitorEntry`.
- Store prompt progress values including total, processed, cached tokens, and elapsed prompt-processing time.
- Calculate prompt-processing percentage as `processed / total`.
- Switch the phase to `token_generation` when the first decoded model output arrives.
- Expose the new fields through the API monitor response and render them in the Studio UI.

No OpenAI-compatible response or SSE payloads are changed.

## Compatibility

Backends that do not expose live prompt progress continue to behave as before and fall back to the generic running state.

The percentage is currently available for llama.cpp/GGUF requests where `prompt_progress` is provided.

## Validation

- `npm run build` — passed
- Tested locally with a Qwen3.8 27B GGUF through the OpenAI-compatible API using OpenCode
- Verified live transition:
  - `Prompt processing · N%`
  - `Token generation`
  - completed request
- Verified prompt speed remains visible during prompt processing and generation speed appears once decoding begins
- 
<img width="1152" height="1030" alt="image" src="https://github.com/user-attachments/assets/f14eeef3-e2aa-4240-8c54-bb2d1d76fc94" />
<img width="1152" height="1030" alt="image" src="https://github.com/user-attachments/assets/512c0c92-89e9-4a17-bd96-062a32083836" />
