### PR TITLE
Advance the Q-GaLore Adam step counter once per update

### DIFF
--- a/.github/workflows/q-galore-tests.yml
+++ b/.github/workflows/q-galore-tests.yml
@@ -1,0 +1,40 @@
+name: Q-GaLore CPU tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "unsloth/optimizers/**"
+      - "tests/utils/test_q_galore.py"
+      - ".github/workflows/q-galore-tests.yml"
+  pull_request:
+    paths:
+      - "unsloth/optimizers/**"
+      - "tests/utils/test_q_galore.py"
+      - ".github/workflows/q-galore-tests.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  q-galore:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Install CPU optimizer test dependencies
+        run: |
+          python -m pip install --index-url https://download.pytorch.org/whl/cpu 'torch==2.10.0'
+          python -m pip install 'pytest==9.0.3' 'bitsandbytes==0.50.2'
+      - name: Run Q-GaLore regressions without the GPU-spoof fixture
+        run: python -m pytest --confcutdir=tests/utils tests/utils/test_q_galore.py -q

--- a/tests/utils/test_q_galore.py
+++ b/tests/utils/test_q_galore.py
@@ -288,6 +288,25 @@ class TestParamGroupHelper:
 # ======================================================================
 
 
+def test_optimizer_bias_correction_matches_adamw():
+    bnb = pytest.importorskip("bitsandbytes")
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu" and "cpu" not in getattr(bnb, "supported_torch_devices", set()):
+        pytest.skip("This bitsandbytes version has no CPU optimizer backend")
+
+    param = nn.Parameter(torch.ones(2, device = device))
+    reference = nn.Parameter(param.detach().clone())
+    optimizer = _adamw_mod.QGaLoreAdamW8bit([param], lr = 0.1, weight_decay = 0.0)
+    expected_optimizer = torch.optim.AdamW([reference], lr = 0.1, weight_decay = 0.0)
+    # Non-projected parameters use AdamW; small tensors use full-precision states.
+    for values in ([0.1, 0.2], [0.4, -0.2], [-0.05, 0.3]):
+        param.grad = torch.tensor(values, device = device)
+        reference.grad = param.grad.clone()
+        optimizer.step()
+        expected_optimizer.step()
+        torch.testing.assert_close(param, reference)
+
+
 class TestQGaLoreIntegration:
     """Integration tests that work without bitsandbytes on CPU."""
 

--- a/unsloth/optimizers/q_galore_adamw.py
+++ b/unsloth/optimizers/q_galore_adamw.py
@@ -201,8 +201,6 @@ class QGaLoreAdamW8bit(Optimizer2State):
                     # dequantizes before the next forward pass.
                     p.data = torch.empty(1, dtype = p.data.dtype, device = p.data.device)
 
-                state["step"] += 1
-
         if torch.cuda.is_available():
             torch.cuda.synchronize()
 


### PR DESCRIPTION
Q-GaLore uses Adam bias-correction steps 1, 3, 5 instead of 1, 2, 3. Three constant-gradient updates leave a parameter at 0.72876 instead of 0.70000.

**Cause:** bitsandbytes `update_step()` increments the counter, then Q-GaLore increments it again. Projection refreshes also run twice as often.
**Fix:** Let bitsandbytes own the increment.
**Test:** `python -m pytest --confcutdir=tests/utils tests/utils/test_q_galore.py -q`: regression fails before; 25 passed after with actual bitsandbytes CPU updates compared against `torch.optim.AdamW`.

A dedicated CPU job runs this previously excluded file with Python 3.12, torch 2.10.0 and bitsandbytes 0.50.2. Core/Backend failures also occur on [unchanged main](https://github.com/unslothai/unsloth/actions/runs/34721930429).