### PR TITLE
fix(sentence_transformer): resolve device consistently with sibling branches instead of hardcoding cuda

### DIFF
--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -1606,7 +1606,7 @@ class FastSentenceTransformer(FastModel):
             if isinstance(st_device, dict) or (
                 isinstance(st_device, str) and st_device in ["auto", "sequential"]
             ):
-                st_device = "cuda"
+                st_device = None
 
             model_kwargs = {"torch_dtype": dtype}
 


### PR DESCRIPTION
### What does this PR do?

Fixes an inconsistent device resolution in the fast-encoder path of `sentence_transformer.py`.

When `device_map` is a dict or `"auto"`/`"sequential"`, three similar code blocks handle the device. Two of them (the `for_inference` branch at line ~1538 and the normal loading branch at line ~1878) correctly set `st_device = None` to let `SentenceTransformer` detect the device itself. But the fast-encoder path (line ~1609) hardcodes `st_device = "cuda"` under the same condition.

This hardcode is:
- **Device-hostile**: On non-CUDA devices (Ascend NPU, Apple MPS, Intel XPU, etc.) `SentenceTransformer(device="cuda")` crashes with `Torch not compiled with CUDA enabled`.
- **Inconsistent**: The other two branches deliberately use `None` (device-agnostic) for exactly this case.

### Change

```diff
             st_device = device_map
             if isinstance(st_device, dict) or (
                 isinstance(st_device, str) and st_device in ["auto", "sequential"]
             ):
-                st_device = "cuda"
+                st_device = None
```

`st_device = None` lets `SentenceTransformer` resolve the actual compute device at runtime, matching the behavior of the two sibling branches. No behavior change on CUDA (where the device is auto-detected as before when `None` is passed for an auto/sequential device_map).

### Verification

On Ascend NPU (torch 2.14 + torch_npu), the previous `"cuda"` hardcode causes `SentenceTransformer(device="cuda")` to fail with `Torch not compiled with CUDA enabled`, while `st_device = None` lets the device resolve correctly. The fix is device-agnostic and does not alter CUDA semantics.
