### PR TITLE
Replay tool-call arguments in the order the model generated (#10791)

### DIFF
--- a/studio/backend/core/inference/tool_loop_controller.py
+++ b/studio/backend/core/inference/tool_loop_controller.py
@@ -183,8 +183,16 @@ class CoercedArguments:
 
 
 def canonical_arguments_text(arguments: Any) -> str:
-    """The one JSON encoding of an argument mapping, so the card and the replay agree."""
-    return json.dumps(arguments, ensure_ascii = False, sort_keys = True, separators = (",", ":"))
+    """The one JSON encoding of an argument mapping, so the card and the replay agree.
+
+    Key order is preserved, not sorted: this text is replayed to the model as the
+    assistant tool call, and the model generated the arguments in its own order.
+    Re-sorting them renders a different token sequence than the one already in the
+    server's prompt cache, so every multi-parameter call re-processes from its first
+    parameter. Duplicate detection keeps its own sorted key in
+    `canonical_tool_call_key`.
+    """
+    return json.dumps(arguments, ensure_ascii = False, sort_keys = False, separators = (",", ":"))
 
 
 @dataclass(frozen = True)

--- a/studio/backend/tests/test_tool_loop_controller.py
+++ b/studio/backend/tests/test_tool_loop_controller.py
@@ -545,7 +545,36 @@ def test_an_mcp_tool_call_parsed_from_xml_arrives_typed():
     }
     # The turn replayed to the model carries the typed values too, not the strings.
     assert decision.as_assistant_tool_call()["function"]["arguments"] == (
-        '{"depth":null,"fuzzy":false,"limit":25,"query":"ship dates","tags":["a","b"]}'
+        '{"query":"ship dates","limit":25,"fuzzy":false,"tags":["a","b"],"depth":null}'
+    )
+
+
+def test_replayed_arguments_keep_the_order_the_model_generated():
+    """The replay is the text the model is told it wrote, so its key order must survive.
+
+    `edit_file` is written as `path` then `edits`, and each edit as `old_string` then
+    `new_string`. A sorted replay renders a different token sequence than the one already
+    in llama-server's prompt cache, and every multi-parameter call re-processes from its
+    first parameter (#10791).
+    """
+    edit_file = next(t for t in ALL_TOOLS if t["function"]["name"] == "edit_file")
+    arguments = {
+        "path": "calc.py",
+        "edits": [{"new_string": "def subtract", "old_string": "def add"}],
+    }
+    controller = ToolLoopController(tools = [edit_file])
+    decision = controller.prepare_call(
+        {"function": {"name": "edit_file", "arguments": json.dumps(arguments)}}
+    )
+
+    replayed = decision.as_assistant_tool_call()["function"]["arguments"]
+    assert replayed == '{"path":"calc.py","edits":[{"new_string":"def subtract","old_string":"def add"}]}'
+    # The card and the replay still share one encoder, so the two stay identical.
+    assert decision.tool_start_payload()["arguments_text"] == replayed
+    # Duplicate detection keeps its own sorted key, so it is order-insensitive.
+    flipped = {"path": "calc.py", "edits": [{"old_string": "def add", "new_string": "def subtract"}]}
+    assert canonical_tool_call_key("edit_file", decision.arguments) == (
+        canonical_tool_call_key("edit_file", flipped)
     )
 
 

--- a/studio/backend/tests/test_tool_loop_controller.py
+++ b/studio/backend/tests/test_tool_loop_controller.py
@@ -568,11 +568,17 @@ def test_replayed_arguments_keep_the_order_the_model_generated():
     )
 
     replayed = decision.as_assistant_tool_call()["function"]["arguments"]
-    assert replayed == '{"path":"calc.py","edits":[{"new_string":"def subtract","old_string":"def add"}]}'
+    assert (
+        replayed
+        == '{"path":"calc.py","edits":[{"new_string":"def subtract","old_string":"def add"}]}'
+    )
     # The card and the replay still share one encoder, so the two stay identical.
     assert decision.tool_start_payload()["arguments_text"] == replayed
     # Duplicate detection keeps its own sorted key, so it is order-insensitive.
-    flipped = {"path": "calc.py", "edits": [{"old_string": "def add", "new_string": "def subtract"}]}
+    flipped = {
+        "path": "calc.py",
+        "edits": [{"old_string": "def add", "new_string": "def subtract"}],
+    }
     assert canonical_tool_call_key("edit_file", decision.arguments) == (
         canonical_tool_call_key("edit_file", flipped)
     )


### PR DESCRIPTION
Fixes #10791.

## Problem

In agentic chats, every tool call with more than one parameter broke llama-server's prompt cache on the next step. \ToolCallDecision.as_assistant_tool_call()\ replays the arguments through \canonical_arguments_text()\, which used \sort_keys = True\. The replayed assistant tool call was therefore not the text the model generated — the chat template rendered a different token sequence than the one already in the KV cache, and llama-server re-processed the whole call (for \edit_file\, the full file contents).

The reporter measured ~14% of prompt-processing time spent re-processing already-cached tokens over a 1.5 h session, with the divergence landing exactly at the first parameter of the previous \edit_file\ call.

## Fix

\canonical_arguments_text()\ now preserves the model's key order. The card and the replay still share this one encoder, so the guarantee from #10023 (the card shows the argument text the tool is run with) holds unchanged. Duplicate detection keeps its own order-insensitive sorted key in \canonical_tool_call_key()\.

## Tests

- \	est_replayed_arguments_keep_the_order_the_model_generated\ — an \edit_file\ call replayed as \path\, \edits\ (and each edit as \
ew_string\, \old_string\ in the model's order); fails on main. Also pins card/replay agreement and the order-insensitivity of the duplicate key.
- \	est_an_mcp_tool_call_parsed_from_xml_arrives_typed\ updated to expect the model's parameter order instead of the sorted one.

Single-parameter tools (\	erminal\, \python\) were never affected, which matches the reporter's llama-server logs.

---

## What it looks like in Studio

`canonical_arguments_text` is also what the tool card renders, so the change is visible. Same call, same build inputs, two isolated installs from this PR's merge base (`fc6694816`) and its head:

![tool card argument order, before and after](https://raw.githubusercontent.com/danielhanchen/unsloth-staging-2/69f9f9590776c9d1178efbc90bdcb769ffe3b779/media/pr10845/tool_card_argument_order.png)

Both sides were served a byte-identical `edit_file` call written `path` then `edits`, and each edit `old_string` then `new_string`. Read back out of the live DOM:

| | top level | inside the edit |
|---|---|---|
| before | `["edits", "path"]` | `["new_string", "old_string"]` |
| after | `["path", "edits"]` | `["old_string", "new_string"]` |

The result row is identical on both sides, so the argument order is the only thing that moved.

## Verification

- Backend: 1050 tests across the 13 tool loop, chat template, history and generation suites pass on head.
- Whole `*tool*` / `*mcp*` / `*chat*` sweep, 4802 tests: the failure set on head is a strict subset of the merge base, so nothing regressed. The three differences are the order tests themselves, which fail before this change.
- Frontend: 7302 tests, none failing.
- Cross-platform CI on Linux, Windows and macOS, plus Playwright.
- Prompt cache, measured by rendering each step of a tool loop through a real chat template and comparing the common token prefix: with the sorted encoder `f_keep` drops to 0.05 / 0.52 / 0.67 after every `edit_file` and stays 1.000 after `terminal`; with this change it is 1.000 throughout. Same result on Qwen3, Llama 3.1, Devstral and gpt-oss templates: about 13k tokens re-processed over six steps before, zero after.
