### PR TITLE
fix(studio): bundle hf-xet for Desktop large Hub downloads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,7 @@ studio = [
     "pyjwt==2.13.0",
     "huggingface-hub>=1.23.0,<2.0 ; python_version >= '3.10'",
     "huggingface-hub==0.36.2 ; python_version < '3.10'",
+    "hf-xet>=1.5.1,<2.0 ; python_version >= '3.10'",
     "urllib3>=2.3.0",
     "jinja2>=3.1.0",
     "structlog>=24.1.0",

--- a/studio/backend/requirements/no-torch-runtime.txt
+++ b/studio/backend/requirements/no-torch-runtime.txt
@@ -48,7 +48,12 @@ accelerate>=0.34.1
 peft>=0.18.0,!=0.11.0
 huggingface_hub>=1.23.0,<2.0; python_version >= "3.10"
 huggingface_hub==0.36.2; python_version < "3.10"
+<<<<<<< HEAD
 hf_transfer==0.1.9
+=======
+hf-xet>=1.5.1,<2.0; python_version >= "3.10"
+hf_transfer
+>>>>>>> 55fd805a8 (fix(studio): bundle hf-xet for Desktop large Hub downloads)
 # diffusers: see diffusers-pin.txt, installed by its own step (this file is
 # installed --no-deps, and the pin has to apply on the torch path too).
 

--- a/studio/backend/requirements/no-torch-runtime.txt
+++ b/studio/backend/requirements/no-torch-runtime.txt
@@ -48,12 +48,8 @@ accelerate>=0.34.1
 peft>=0.18.0,!=0.11.0
 huggingface_hub>=1.23.0,<2.0; python_version >= "3.10"
 huggingface_hub==0.36.2; python_version < "3.10"
-<<<<<<< HEAD
-hf_transfer==0.1.9
-=======
 hf-xet>=1.5.1,<2.0; python_version >= "3.10"
-hf_transfer
->>>>>>> 55fd805a8 (fix(studio): bundle hf-xet for Desktop large Hub downloads)
+hf_transfer==0.1.9
 # diffusers: see diffusers-pin.txt, installed by its own step (this file is
 # installed --no-deps, and the pin has to apply on the torch path too).
 

--- a/studio/backend/requirements/single-env/constraints.txt
+++ b/studio/backend/requirements/single-env/constraints.txt
@@ -10,6 +10,7 @@ tokenizers>=0.22.0,<=0.23.0
 trl==0.23.1
 huggingface-hub>=1.23.0,<2.0; python_version >= "3.10"
 huggingface-hub==0.36.2; python_version < "3.10"
+hf-xet>=1.5.1,<2.0; python_version >= "3.10"
 
 # Unsloth stack
 datasets==4.3.0

--- a/studio/backend/requirements/studio.txt
+++ b/studio/backend/requirements/studio.txt
@@ -20,6 +20,8 @@ pyjwt==2.13.0
 # gradio>=4.0.0                  # 148 MB - Unsloth uses React + FastAPI, not Gradio
 huggingface-hub>=1.23.0,<2.0; python_version >= "3.10"
 huggingface-hub==0.36.2; python_version < "3.10"
+# Large / Xet-backed Hub blobs need hf-xet; huggingface-hub only pulls it transitively on a with-deps install.
+hf-xet>=1.5.1,<2.0; python_version >= "3.10"
 # truststore is vendored at backend/vendor/, deliberately not a dependency.
 # Transitive via requests, pinned here for one reason: the GGUF header range-read
 # preflight bounds itself by half-closing the socket, and HTTPResponse.shutdown is

--- a/tests/studio/install/test_no_torch_runtime_hf_xet.py
+++ b/tests/studio/install/test_no_torch_runtime_hf_xet.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""GGUF-only installs apply no-torch-runtime.txt with --no-deps, so Hub extras must be declared."""
+
+from __future__ import annotations
+
+import pathlib
+
+from packaging.requirements import Requirement
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+NO_TORCH_RUNTIME = REPO_ROOT / "studio" / "backend" / "requirements" / "no-torch-runtime.txt"
+
+
+def _requirement_names(path: pathlib.Path) -> set[str]:
+    names = set()
+    for line in path.read_text(encoding = "utf-8").splitlines():
+        text = line.split("#", 1)[0].strip()
+        if not text or text.startswith("-"):
+            continue
+        names.add(Requirement(text).name.lower().replace("_", "-"))
+    return names
+
+
+def test_no_torch_runtime_declares_hf_xet_for_hub_large_downloads():
+    names = _requirement_names(NO_TORCH_RUNTIME)
+    assert "hf-xet" in names, (
+        "no-torch-runtime.txt is installed --no-deps; without an explicit hf-xet pin, "
+        "Desktop GGUF-only envs fall back to HTTP and huggingface_hub raises on large blobs."
+    )


### PR DESCRIPTION
Fixes #10840

## Problem
Unsloth Desktop (AppImage) can fail when downloading large GGUF quants with:

```
ValueError: The file is too large to be downloaded using the regular download method.
Install hf_xet with pip install hf_xet for xet-powered downloads.
```

When `hf_xet` is not importable, Studio downgrades Hub downloads to HTTP. `huggingface_hub` then refuses many large / Xet-backed blobs without `hf_xet`.

GGUF-only installs apply `no-torch-runtime.txt` with `--no-deps`, so `huggingface_hub` does not pull `hf-xet` transitively even though full installs often would.

## Fix
- Declare `hf-xet>=1.5.1,<2.0` in `studio.txt`, `no-torch-runtime.txt`, and `single-env/constraints.txt`
- Mirror the pin in the `studio` extra in `pyproject.toml`
- Add a regression test for the no-torch requirements file

## Verification
`pytest tests/studio/install/test_no_torch_runtime_hf_xet.py tests/studio/install/test_studio_extra_matches_requirements.py`