### PR TITLE
feat(dataprep): add audit_supervision, a pre-flight report of what an SFT dataset actually supervises

### DIFF
--- a/tests/test_supervision_audit.py
+++ b/tests/test_supervision_audit.py
@@ -1,0 +1,822 @@
+#!/usr/bin/env python3
+"""Tests for unsloth.dataprep.supervision_audit, without heavy dependencies.
+
+Every counter is checked against hand-built rows whose token ids are written
+out explicitly, so an expectation here is a number you can recount by hand.
+"""
+
+import dataclasses
+import io
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+from datasets import Dataset
+
+from unsloth.dataprep.supervision_audit import SupervisionAuditReport, audit_supervision
+
+
+# ── offline tokenizer ──────────────────────────────────────────────────────
+
+
+class _Encoding(dict):
+    """The two accessors callers use on a transformers BatchEncoding: `["input_ids"]` and `.input_ids`."""
+
+    @property
+    def input_ids(self):
+        return self["input_ids"]
+
+
+class MockTokenizer:
+    """Word-level tokenizer: whitespace-separated words get ids in first-seen order.
+
+    <pad> = 0, <s> = 1 (BOS), </s> = 2 (EOS). `__call__` mirrors the surface
+    `train_on_responses_only` touches (`.input_ids` on the result), and `decode`
+    joins words with single spaces, so a decoded segment is exactly predictable.
+    """
+
+    def __init__(self):
+        self.pad_token, self.bos_token, self.eos_token = "<pad>", "<s>", "</s>"
+        self.pad_token_id, self.bos_token_id, self.eos_token_id = 0, 1, 2
+        self.vocab = {"<pad>": 0, "<s>": 1, "</s>": 2}
+        self.words = {0: "<pad>", 1: "<s>", 2: "</s>"}
+
+    def token_id(self, word):
+        if word not in self.vocab:
+            self.vocab[word] = len(self.vocab)
+            self.words[self.vocab[word]] = word
+        return self.vocab[word]
+
+    def ids(self, text):
+        return [self.token_id(word) for word in text.split()]
+
+    def __call__(self, text, add_special_tokens = False, return_tensors = None):
+        ids = self.ids(text)
+        if add_special_tokens:
+            ids = [self.bos_token_id] + ids
+        return _Encoding(input_ids = ids, attention_mask = [1] * len(ids))
+
+    def decode(self, token_ids, skip_special_tokens = False):
+        specials = {self.pad_token_id, self.bos_token_id, self.eos_token_id}
+        return " ".join(
+            self.words[int(i)]
+            for i in token_ids
+            if not (skip_special_tokens and int(i) in specials)
+        )
+
+
+class _Tty(io.StringIO):
+    def isatty(self):
+        return True
+
+
+class IndexableRows:
+    """Rows reachable only through `len()` and integer indexing (no `.iter`, no column access)."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __len__(self):
+        return len(self._rows)
+
+    def __getitem__(self, index):
+        if not isinstance(index, int):
+            raise TypeError(f"integer index expected, got {type(index).__name__}")
+        if index < 0 or index >= len(self._rows):
+            raise IndexError(index)
+        return self._rows[index]
+
+
+# ── hand-built rows ────────────────────────────────────────────────────────
+
+
+def chat_row(tok, prompt, response):
+    """`<s> user: {prompt} assistant: {response} </s>` with only the response and EOS supervised."""
+    prompt_ids = tok.ids(f"<s> user: {prompt} assistant:")
+    response_ids = tok.ids(f"{response} </s>")
+    return prompt_ids + response_ids, [-100] * len(prompt_ids) + response_ids
+
+
+def masked(row):
+    input_ids, _ = row
+    return input_ids, [-100] * len(input_ids)
+
+
+def columns(rows):
+    """(input_ids, labels) rows -> the column dict Dataset.from_dict takes."""
+    return {"input_ids": [r[0] for r in rows], "labels": [r[1] for r in rows]}
+
+
+def labels_rows(tok):
+    """Five rows: 34 tokens, 9 supervised (2 / 0 / 4 / 0 / 3 per row), EOS in every row."""
+    full = tok.ids("<s> Hello world </s>")
+    return [
+        chat_row(tok, "What is 2+2?", "4"),  # 8 tokens, 2 supervised
+        masked(chat_row(tok, "Hi", "Hello")),  # 6 tokens, 0 supervised, EOS masked
+        (full, list(full)),  # 4 tokens, all 4 supervised
+        masked(chat_row(tok, "Name a color", "Blue")),  # 8 tokens, 0 supervised, EOS masked
+        chat_row(tok, "Say hi", "hi there"),  # 8 tokens, 3 supervised
+    ]
+
+
+def padded_rows(tok):
+    """Four right-padded rows: 12 non-padding tokens, 9 supervised, EOS reachable in only two."""
+    a, b, c, d, e, g = (tok.token_id(w) for w in "a b c d e g".split())
+    return [
+        # 4 tokens, 3 supervised; the last non-padding token (EOS) is supervised
+        {"input_ids": [1, a, b, 2, 0, 0], "attention_mask": [1, 1, 1, 1, 0, 0], "labels": [-100, a, b, 2, -100, -100]},
+        # 3 tokens, all supervised; the label on the padded position must be ignored
+        {"input_ids": [1, c, 2, 0], "attention_mask": [1, 1, 1, 0], "labels": [1, c, 2, 7]},
+        # 3 tokens, 2 supervised; EOS sits in a masked-out position, so this row has no EOS
+        {"input_ids": [1, d, e, 2], "attention_mask": [1, 1, 1, 0], "labels": [-100, d, e, -100]},
+        # 2 tokens, 1 supervised; EOS masked out as well
+        {"input_ids": [1, g, 2], "attention_mask": [1, 1, 0], "labels": [-100, g, -100]},
+    ]
+
+
+def example_line(lines, row):
+    """The decoded text line under the `Example row {row}` header."""
+    header = next(i for i, line in enumerate(lines) if line.startswith(f"  Example row {row} "))
+    return lines[header + 1]
+
+
+# ── labels path ────────────────────────────────────────────────────────────
+
+
+def test_labels_path_counts_every_field():
+    tok = MockTokenizer()
+    ds = Dataset.from_dict(columns(labels_rows(tok)))
+
+    report = audit_supervision(ds, tokenizer = tok, verbose = False)
+
+    assert isinstance(report, SupervisionAuditReport)
+    assert report.num_rows == 5
+    assert report.num_rows_total == 5
+    assert report.labels_source == "labels"
+    assert report.num_tokens == 34
+    assert report.num_supervised_tokens == 9
+    assert report.supervised_fraction == pytest.approx(9 / 34)
+    assert report.supervised_tokens_per_row == pytest.approx({"min": 0, "median": 2, "mean": 1.8, "max": 4})
+    assert report.zero_supervision_rows == 2
+    assert report.zero_supervision_row_indices == [1, 3]
+    assert report.fully_supervised_rows == 1
+    assert report.max_seq_length is None
+    assert report.rows_at_max_length is None
+    assert report.rows_truncated_mid_response is None
+    assert report.eos_token_id == 2
+    assert report.rows_with_eos == 5
+    assert report.rows_with_supervised_eos == 3
+    assert report.bos_token_id == 1
+    assert report.rows_with_duplicated_bos == 0
+    assert len(report.examples) == 2
+    assert all(isinstance(segment, tuple) for segment in report.examples[0])
+    assert list(report.examples[0]) == [(False, "<s> user: What is 2+2? assistant:"), (True, "4 </s>")]
+    assert list(report.examples[1]) == [(False, "<s> user: Hi assistant: Hello </s>")]
+    assert report.warnings == [
+        "2 rows (40.0%) have zero supervised tokens and contribute nothing to training.",
+        "2 rows (40.0%) contain EOS only in masked (-100) positions, so the model does not learn to stop there.",
+    ]
+    assert report.ok is False
+
+
+def test_same_rows_give_the_same_report_whatever_the_container():
+    tok = MockTokenizer()
+    rows = labels_rows(tok)
+    as_dicts = [{"input_ids": ids, "labels": labels} for ids, labels in rows]
+
+    expected = audit_supervision(Dataset.from_dict(columns(rows)), tokenizer = tok, verbose = False).to_dict()
+
+    assert audit_supervision(as_dicts, tokenizer = tok, verbose = False).to_dict() == expected
+    assert audit_supervision(IndexableRows(as_dicts), tokenizer = tok, verbose = False).to_dict() == expected
+    assert expected["num_supervised_tokens"] == 9
+
+
+def test_render_layout_without_color():
+    tok = MockTokenizer()
+    report = audit_supervision(Dataset.from_dict(columns(labels_rows(tok))), tokenizer = tok, verbose = False)
+
+    rendered = report.render(color = False)
+    lines = rendered.splitlines()
+
+    assert lines[0] == "Unsloth: Supervision audit of 5 rows (labels from `labels`)"
+    expected = [
+        "  Supervised tokens: 9 of 34 (26.5%); per row min 0 / median 2 / max 4",
+        "  Rows with zero supervised tokens: 2 (40.0%)",
+        "  Rows fully supervised (no masking): 1 (20.0%)",
+        "  Rows containing EOS: 5 (100.0%); rows with a supervised EOS: 3 (60.0%)",
+        "  Rows starting with a duplicated BOS: 0 (0.0%)",
+        "  Example row 0 (supervised text in [[double brackets]]):",
+        "    <s> user: What is 2+2? assistant:[[4 </s>]]",
+        "    <s> user: Hi assistant: Hello </s>",
+        "  WARNING: 2 rows (40.0%) have zero supervised tokens and contribute nothing to training.",
+        "  WARNING: 2 rows (40.0%) contain EOS only in masked (-100) positions, so the model does not learn to stop there.",
+    ]
+    for line in expected:
+        assert line in lines, f"missing line {line!r} in:\n{rendered}"
+    positions = [lines.index(line) for line in expected]
+    assert positions == sorted(positions), rendered
+    assert example_line(lines, 1) == "    <s> user: Hi assistant: Hello </s>"
+    assert "Example row 2" not in rendered
+    assert "max_seq_length" not in rendered
+    assert "\x1b[" not in rendered
+    assert lines[-1].startswith("  WARNING: ")
+    assert lines[-2].startswith("  WARNING: ")
+
+
+def test_render_color_modes(monkeypatch):
+    tok = MockTokenizer()
+    report = audit_supervision(Dataset.from_dict(columns(labels_rows(tok))), tokenizer = tok, verbose = False)
+
+    ansi = report.render(color = True)
+    assert "\x1b[" in ansi
+    assert "[[" not in ansi
+    assert "4 </s>" in ansi
+    assert ansi.splitlines()[0] == "Unsloth: Supervision audit of 5 rows (labels from `labels`)"
+
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+    assert report.render() == report.render(color = False)
+    monkeypatch.setattr(sys, "stdout", _Tty())
+    assert report.render() == ansi
+
+
+def test_to_dict_is_json_serialisable():
+    tok = MockTokenizer()
+    report = audit_supervision(Dataset.from_dict(columns(labels_rows(tok))), tokenizer = tok, verbose = False)
+
+    as_dict = report.to_dict()
+
+    assert set(as_dict) == {field.name for field in dataclasses.fields(SupervisionAuditReport)}
+    assert json.loads(json.dumps(as_dict)) == as_dict
+    assert as_dict["examples"][0] == [[False, "<s> user: What is 2+2? assistant:"], [True, "4 </s>"]]
+    assert isinstance(as_dict["examples"][0][0], list)
+    assert as_dict["num_supervised_tokens"] == 9
+    assert as_dict["zero_supervision_row_indices"] == [1, 3]
+    assert as_dict["rows_at_max_length"] is None
+
+
+def test_verbose_controls_printing(capsys):
+    tok = MockTokenizer()
+    ds = Dataset.from_dict(columns(labels_rows(tok)))
+
+    audit_supervision(ds, tokenizer = tok, verbose = False)
+    assert capsys.readouterr().out == ""
+
+    report = audit_supervision(ds, tokenizer = tok)
+    out = capsys.readouterr().out
+    assert out.startswith("Unsloth: Supervision audit of 5 rows")
+    assert report.render(color = False) in out
+    assert "WARNING: 2 rows (40.0%) have zero supervised tokens" in out
+
+
+# ── other label sources ────────────────────────────────────────────────────
+
+
+def test_completion_mask_path_and_labels_precedence():
+    tok = MockTokenizer()
+    ids0 = tok.ids("<s> user: Hi assistant: Hello </s>")
+    ids1 = tok.ids("<s> user: Yo assistant: Hey </s>")
+    rows = [
+        {"input_ids": ids0, "completion_mask": [False, False, False, False, True, True]},
+        {"input_ids": ids1, "completion_mask": [0, 0, 0, 0, 0, 0]},
+    ]
+
+    report = audit_supervision(rows, tokenizer = tok, verbose = False)
+
+    assert report.labels_source == "completion_mask"
+    assert report.num_tokens == 12
+    assert report.num_supervised_tokens == 2
+    assert report.zero_supervision_rows == 1
+    assert report.zero_supervision_row_indices == [1]
+    assert report.fully_supervised_rows == 0
+    assert report.rows_with_eos == 2
+    assert report.rows_with_supervised_eos == 1
+    assert list(report.examples[0]) == [(False, "<s> user: Hi assistant:"), (True, "Hello </s>")]
+    assert report.render(color = False).splitlines()[0] == (
+        "Unsloth: Supervision audit of 2 rows (labels from `completion_mask`)"
+    )
+
+    both = Dataset.from_dict({"input_ids": [ids0], "labels": [ids0], "completion_mask": [[0] * 6]})
+    report = audit_supervision(both, tokenizer = tok, verbose = False)
+    assert report.labels_source == "labels"
+    assert report.num_supervised_tokens == 6
+    assert report.fully_supervised_rows == 1
+    assert report.warnings == []
+
+
+def test_no_labels_means_every_token_is_supervised():
+    tok = MockTokenizer()
+    ds = Dataset.from_dict({"input_ids": [tok.ids("<s> a b </s>"), tok.ids("<s> c </s>")]})
+
+    report = audit_supervision(ds, verbose = False)
+
+    assert report.labels_source == "all_tokens"
+    assert report.num_tokens == 7
+    assert report.num_supervised_tokens == 7
+    assert report.supervised_fraction == 1.0
+    assert report.fully_supervised_rows == report.num_rows == 2
+    assert report.zero_supervision_rows == 0
+    assert report.zero_supervision_row_indices == []
+    assert report.supervised_tokens_per_row == pytest.approx({"min": 3, "median": 3.5, "mean": 3.5, "max": 4})
+    assert report.eos_token_id is None
+    assert report.rows_with_eos is None
+    assert report.rows_with_supervised_eos is None
+    assert report.bos_token_id is None
+    assert report.rows_with_duplicated_bos is None
+    assert report.examples == []
+    assert report.warnings == []
+    assert report.ok is True
+
+    rendered = report.render(color = False)
+    lines = rendered.splitlines()
+    assert lines[0] == "Unsloth: Supervision audit of 2 rows (labels from `all_tokens`)"
+    assert "  Rows fully supervised (no masking): 2 (100.0%)" in lines
+    for absent in ("EOS", "BOS", "max_seq_length", "Example row", "WARNING"):
+        assert absent not in rendered, rendered
+
+    with_tok = audit_supervision(ds, tokenizer = tok, verbose = False)
+    assert with_tok.warnings == []
+    assert with_tok.rows_with_eos == 2
+    assert with_tok.rows_with_supervised_eos == 2
+    assert with_tok.rows_with_duplicated_bos == 0
+    assert list(with_tok.examples[0]) == [(True, "<s> a b </s>")]
+    assert "    [[<s> a b </s>]]" in with_tok.render(color = False).splitlines()
+
+
+# ── padding, tensors ───────────────────────────────────────────────────────
+
+
+def test_attention_mask_excludes_padding_everywhere():
+    tok = MockTokenizer()
+
+    report = audit_supervision(padded_rows(tok), tokenizer = tok, max_seq_length = 4, verbose = False)
+
+    assert report.num_rows == 4
+    assert report.num_tokens == 12
+    assert report.num_supervised_tokens == 9
+    assert report.supervised_tokens_per_row == pytest.approx({"min": 1, "median": 2.5, "mean": 2.25, "max": 3})
+    assert report.fully_supervised_rows == 1
+    assert report.zero_supervision_rows == 0
+    # only row 0 has 4 non-padding tokens; its last real token (EOS) is supervised
+    assert report.rows_at_max_length == 1
+    assert report.rows_truncated_mid_response == 1
+    # EOS inside a masked-out position does not count as present
+    assert report.rows_with_eos == 2
+    assert report.rows_with_supervised_eos == 2
+    assert report.rows_with_duplicated_bos == 0
+    assert list(report.examples[0]) == [(False, "<s>"), (True, "a b </s>")]
+    assert list(report.examples[1]) == [(True, "<s> c </s>")]
+
+    assert len(report.warnings) == 2
+    truncated, no_eos = report.warnings
+    assert truncated.startswith("1 row")
+    assert "(25.0%)" in truncated
+    assert "hit max_seq_length = 4 while still inside a supervised span" in truncated
+    assert no_eos == (
+        "2 rows (50.0%) do not contain the EOS token (id 2), so the model may never learn to stop generating."
+    )
+    lines = report.render(color = False).splitlines()
+    assert "  Rows at max_seq_length = 4: 1 (25.0%), 1 cut off mid-response" in lines
+    assert "  Rows containing EOS: 2 (50.0%); rows with a supervised EOS: 2 (50.0%)" in lines
+
+
+def test_tensor_and_numpy_rows_match_plain_lists():
+    torch = pytest.importorskip("torch")
+    np = pytest.importorskip("numpy")
+    tok = MockTokenizer()
+    rows = padded_rows(tok)
+
+    expected = audit_supervision(rows, tokenizer = tok, max_seq_length = 4, verbose = False).to_dict()
+    assert expected["num_supervised_tokens"] == 9
+
+    as_torch = [{key: torch.tensor(value) for key, value in row.items()} for row in rows]
+    as_numpy = [{key: np.array(value) for key, value in row.items()} for row in rows]
+    assert audit_supervision(as_torch, tokenizer = tok, max_seq_length = 4, verbose = False).to_dict() == expected
+    assert audit_supervision(as_numpy, tokenizer = tok, max_seq_length = 4, verbose = False).to_dict() == expected
+
+    # a torch-formatted padded Dataset hands `.iter()` 2-D tensors per column
+    width = max(len(row["input_ids"]) for row in rows)
+    square = {
+        "input_ids": [row["input_ids"] + [0] * (width - len(row["input_ids"])) for row in rows],
+        "attention_mask": [row["attention_mask"] + [0] * (width - len(row["attention_mask"])) for row in rows],
+        "labels": [row["labels"] + [-100] * (width - len(row["labels"])) for row in rows],
+    }
+    formatted = Dataset.from_dict(square).with_format("torch")
+    assert audit_supervision(formatted, tokenizer = tok, max_seq_length = 4, verbose = False).to_dict() == expected
+
+
+# ── iteration, max_rows, trainers ──────────────────────────────────────────
+
+
+def test_iterable_dataset_streams_and_stops_at_max_rows():
+    tok = MockTokenizer()
+    ds = Dataset.from_dict(columns(labels_rows(tok)))
+
+    report = audit_supervision(ds.to_iterable_dataset(), tokenizer = tok, max_rows = 2, verbose = False)
+
+    assert report.num_rows == 2
+    assert report.num_rows_total is None
+    assert report.num_tokens == 14
+    assert report.num_supervised_tokens == 2
+    assert report.zero_supervision_row_indices == [1]
+    assert report.render(color = False).splitlines()[0] == "Unsloth: Supervision audit of 2 rows (labels from `labels`)"
+
+    everything = audit_supervision(ds.to_iterable_dataset(), tokenizer = tok, max_rows = None, verbose = False)
+    sized = audit_supervision(ds, tokenizer = tok, verbose = False)
+    assert everything.num_rows == 5
+    assert everything.num_rows_total is None
+    assert everything.to_dict() == {**sized.to_dict(), "num_rows_total": None}
+
+
+def test_max_rows_smaller_than_dataset_reports_first_n_of_m():
+    tok = MockTokenizer()
+    rows = labels_rows(tok)
+    ds = Dataset.from_dict(columns(rows))
+
+    report = audit_supervision(ds, tokenizer = tok, max_rows = 2, verbose = False)
+
+    assert report.num_rows == 2
+    assert report.num_rows_total == 5
+    assert report.num_tokens == 14
+    assert report.num_supervised_tokens == 2
+    assert report.render(color = False).splitlines()[0] == (
+        "Unsloth: Supervision audit of the first 2 of 5 rows (labels from `labels`)"
+    )
+
+    as_dicts = [{"input_ids": ids, "labels": labels} for ids, labels in rows]
+    partial = audit_supervision(as_dicts, tokenizer = tok, max_rows = 3, verbose = False)
+    assert partial.num_rows == 3
+    assert partial.num_rows_total == 5
+
+    whole = audit_supervision(ds, tokenizer = tok, max_rows = 5, verbose = False)
+    assert whole.num_rows == whole.num_rows_total == 5
+    assert whole.render(color = False).splitlines()[0] == "Unsloth: Supervision audit of 5 rows (labels from `labels`)"
+
+    many = [{"input_ids": [7, 8]} for _ in range(1200)]
+    first_line = audit_supervision(many, max_rows = 1000, verbose = False).render(color = False).splitlines()[0]
+    assert first_line == "Unsloth: Supervision audit of the first 1,000 of 1,200 rows (labels from `all_tokens`)"
+
+
+def test_trainer_supplies_tokenizer_and_max_seq_length():
+    tok = MockTokenizer()
+    ds = Dataset.from_dict(columns(labels_rows(tok)))
+    trainer = SimpleNamespace(train_dataset = ds, processing_class = tok, args = SimpleNamespace(max_length = 8))
+
+    report = audit_supervision(trainer, verbose = False)
+
+    assert report.num_rows == 5
+    assert report.num_supervised_tokens == 9
+    assert report.max_seq_length == 8
+    assert report.eos_token_id == 2
+    assert report.bos_token_id == 1
+    assert len(report.examples) == 2
+    # rows 0, 3 and 4 have 8 tokens; the last token of rows 0 and 4 is a supervised EOS, row 3 is fully masked
+    assert report.rows_at_max_length == 3
+    assert report.rows_truncated_mid_response == 2
+    assert report.warnings == [
+        "2 rows (40.0%) have zero supervised tokens and contribute nothing to training.",
+        "2 rows (40.0%) hit max_seq_length = 8 while still inside a supervised span, so their responses are cut off before the end (and before EOS).",
+        "2 rows (40.0%) contain EOS only in masked (-100) positions, so the model does not learn to stop there.",
+    ]
+    assert "  Rows at max_seq_length = 8: 3 (60.0%), 2 cut off mid-response" in report.render(color = False).splitlines()
+
+    explicit = audit_supervision(trainer, max_seq_length = 6, verbose = False)
+    assert explicit.max_seq_length == 6
+    # rows 0, 1, 3, 4 have >= 6 tokens; rows 1 and 3 are fully masked
+    assert explicit.rows_at_max_length == 4
+    assert explicit.rows_truncated_mid_response == 2
+
+
+def test_trainer_tokenizer_and_length_fallbacks():
+    tok = MockTokenizer()
+    ds = Dataset.from_dict(columns(labels_rows(tok)))
+
+    old_style = SimpleNamespace(train_dataset = ds, tokenizer = tok, args = SimpleNamespace(max_seq_length = 8))
+    report = audit_supervision(old_style, verbose = False)
+    assert report.eos_token_id == 2
+    assert report.max_seq_length == 8
+    assert len(report.examples) == 2
+
+    processor = SimpleNamespace(tokenizer = tok, image_processor = object())
+    vlm = SimpleNamespace(
+        train_dataset = ds,
+        processing_class = processor,
+        args = SimpleNamespace(max_length = None, max_seq_length = 6),
+    )
+    report = audit_supervision(vlm, verbose = False)
+    assert report.eos_token_id == 2
+    assert report.max_seq_length == 6
+    assert list(report.examples[0]) == [(False, "<s> user: What is 2+2? assistant:"), (True, "4 </s>")]
+
+    bare = SimpleNamespace(train_dataset = ds, processing_class = tok, args = SimpleNamespace())
+    report = audit_supervision(bare, verbose = False)
+    assert report.max_seq_length is None
+    assert report.rows_at_max_length is None
+
+
+# ── truncation, EOS, BOS ───────────────────────────────────────────────────
+
+
+def test_truncation_counts_only_rows_whose_last_token_is_supervised():
+    rows = [
+        {"input_ids": [5, 6, 7, 8], "labels": [-100, -100, 7, 8]},  # at max, last token supervised
+        {"input_ids": [5, 6, 7, 8], "labels": [5, 6, 7, -100]},  # at max, last token masked
+        {"input_ids": [5, 6, 7], "labels": [-100, 6, 7]},  # under max
+        {"input_ids": [5, 6, 7, 8, 9], "labels": [-100, -100, -100, -100, 9]},  # over max, last token supervised
+    ]
+
+    report = audit_supervision(rows, max_seq_length = 4, verbose = False)
+
+    assert report.max_seq_length == 4
+    assert report.rows_at_max_length == 3
+    assert report.rows_truncated_mid_response == 2
+    assert report.zero_supervision_rows == 0
+    assert report.warnings == [
+        "2 rows (50.0%) hit max_seq_length = 4 while still inside a supervised span, so their responses are cut off before the end (and before EOS).",
+    ]
+    assert "  Rows at max_seq_length = 4: 3 (75.0%), 2 cut off mid-response" in report.render(color = False).splitlines()
+
+    unlimited = audit_supervision(rows, verbose = False)
+    assert unlimited.max_seq_length is None
+    assert unlimited.rows_at_max_length is None
+    assert unlimited.rows_truncated_mid_response is None
+    assert unlimited.warnings == []
+    assert "max_seq_length" not in unlimited.render(color = False)
+
+
+def test_eos_presence_and_supervision():
+    tok = MockTokenizer()
+    a, b = tok.token_id("a"), tok.token_id("b")
+    rows = [
+        {"input_ids": [1, a, 2, b, 2], "labels": [-100, -100, -100, b, 2]},  # two EOS, only the second supervised
+        {"input_ids": [1, a, b], "labels": [-100, a, b]},  # no EOS at all
+        {"input_ids": [1, a, 2], "labels": [-100, a, -100]},  # EOS masked
+        {"input_ids": [1, b, 2], "labels": [-100, -100, 2]},  # EOS supervised
+    ]
+
+    report = audit_supervision(rows, tokenizer = tok, verbose = False)
+
+    assert report.rows_with_eos == 3
+    assert report.rows_with_supervised_eos == 2
+    assert report.zero_supervision_rows == 0
+    assert len(report.warnings) == 2
+    no_eos, masked_eos = report.warnings
+    assert no_eos.startswith("1 row")
+    assert "(25.0%)" in no_eos
+    assert "do not contain the EOS token (id 2)" in no_eos
+    assert masked_eos.startswith("1 row")
+    assert "contain EOS only in masked (-100) positions" in masked_eos
+    assert "  Rows containing EOS: 3 (75.0%); rows with a supervised EOS: 2 (50.0%)" in report.render(color = False).splitlines()
+
+
+def test_duplicated_bos_uses_the_first_two_non_padding_tokens():
+    tok = MockTokenizer()
+    a = tok.token_id("a")
+    rows = [
+        {"input_ids": [1, 1, a, 2], "attention_mask": [1, 1, 1, 1]},  # duplicated
+        {"input_ids": [1, a, 1, 2], "attention_mask": [1, 1, 1, 1]},  # two BOS, but not adjacent at the start
+        {"input_ids": [0, 0, 1, 1, a, 2], "attention_mask": [0, 0, 1, 1, 1, 1]},  # left padded, duplicated
+        {"input_ids": [1, a, 2], "attention_mask": [1, 1, 1]},  # single BOS
+    ]
+
+    report = audit_supervision(rows, tokenizer = tok, verbose = False)
+
+    assert report.rows_with_duplicated_bos == 2
+    assert report.warnings == [
+        "2 rows (50.0%) start with two BOS tokens; your formatting adds BOS on top of the tokenizer's.",
+    ]
+    assert "  Rows starting with a duplicated BOS: 2 (50.0%)" in report.render(color = False).splitlines()
+
+
+# ── examples ───────────────────────────────────────────────────────────────
+
+
+def test_num_examples_controls_decoded_rows():
+    tok = MockTokenizer()
+    ds = Dataset.from_dict(columns(labels_rows(tok)))
+
+    none = audit_supervision(ds, tokenizer = tok, num_examples = 0, verbose = False)
+    assert none.examples == []
+    assert "Example row" not in none.render(color = False)
+    assert none.num_supervised_tokens == 9
+
+    assert len(audit_supervision(ds, tokenizer = tok, num_examples = 1, verbose = False).examples) == 1
+    assert len(audit_supervision(ds, tokenizer = tok, num_examples = 50, verbose = False).examples) == 5
+    assert len(audit_supervision(ds, tokenizer = tok, num_examples = 3, max_rows = 1, verbose = False).examples) == 1
+
+    no_decode = SimpleNamespace(eos_token_id = 2, bos_token_id = None)
+    report = audit_supervision(ds, tokenizer = no_decode, verbose = False)
+    assert report.examples == []
+    assert report.rows_with_eos == 5
+    assert report.rows_with_supervised_eos == 3
+    assert report.bos_token_id is None
+    assert report.rows_with_duplicated_bos is None
+    assert "BOS" not in report.render(color = False)
+
+    with pytest.raises(ValueError):
+        audit_supervision(ds, tokenizer = tok, num_examples = -1, verbose = False)
+
+
+def test_render_escapes_control_characters_and_truncates_long_examples():
+    tok = MockTokenizer()
+    newline, tab, a, b = tok.token_id("\n"), tok.token_id("\t"), tok.token_id("a"), tok.token_id("b")
+    short = {"input_ids": [1, a, newline, tab, b, 2], "labels": [-100, -100, -100, -100, b, 2]}
+    long = {"input_ids": [1] + [a] * 1498 + [2], "labels": [1] + [a] * 1498 + [2]}
+    tiny = {"input_ids": [1, b, 2], "labels": [-100, b, 2]}
+
+    report = audit_supervision([short, long, tiny], tokenizer = tok, max_seq_length = 2048, num_examples = 3, verbose = False)
+
+    rendered = report.render(color = False)
+    lines = rendered.splitlines()
+    assert lines[0] == "Unsloth: Supervision audit of 3 rows (labels from `labels`)"
+    assert "  Supervised tokens: 1,504 of 1,509 (99.7%); per row min 2 / median 2 / max 1,500" in lines
+    assert "  Rows at max_seq_length = 2,048: 0 (0.0%), 0 cut off mid-response" in lines
+
+    # control characters are shown escaped, so the example stays on one line
+    assert example_line(lines, 0) == "    <s> a \\n \\t[[b </s>]]"
+    header = lines.index("  Example row 0 (supervised text in [[double brackets]]):")
+    assert lines[header + 2].startswith("  Example row 1 ")
+
+    # the 1,500-token row is cut at 400 characters with an ellipsis, but the report keeps the full text
+    long_line = example_line(lines, 1)
+    assert long_line.startswith("    [[<s> a a a")
+    assert "…" in long_line[-3:], long_line[-20:]
+    assert len(long_line) <= 420, len(long_line)
+    assert list(report.examples[1]) == [(True, tok.decode(long["input_ids"]))]
+    assert len(report.examples[1][0][1]) > 2000
+    assert example_line(lines, 2) == "    <s>[[b </s>]]"
+
+
+# ── edge cases ─────────────────────────────────────────────────────────────
+
+
+def test_empty_dataset_warns_without_dividing_by_zero():
+    tok = MockTokenizer()
+
+    report = audit_supervision(Dataset.from_dict({"input_ids": []}), tokenizer = tok, verbose = False)
+
+    assert report.num_rows == 0
+    assert report.num_rows_total == 0
+    assert report.num_tokens == 0
+    assert report.num_supervised_tokens == 0
+    assert report.supervised_fraction == 0.0
+    assert report.supervised_tokens_per_row == {"min": 0.0, "median": 0.0, "mean": 0.0, "max": 0.0}
+    assert report.zero_supervision_rows == 0
+    assert report.zero_supervision_row_indices == []
+    assert report.fully_supervised_rows == 0
+    assert report.rows_with_eos == 0
+    assert report.rows_with_supervised_eos == 0
+    assert report.rows_with_duplicated_bos == 0
+    assert report.examples == []
+    assert report.warnings == ["The dataset is empty."]
+    assert report.ok is False
+
+    lines = report.render(color = False).splitlines()
+    assert lines[0] == "Unsloth: Supervision audit of 0 rows (labels from `all_tokens`)"
+    assert "  WARNING: The dataset is empty." in lines
+    json.dumps(report.to_dict())
+
+    bounded = audit_supervision(Dataset.from_dict({"input_ids": []}), max_seq_length = 4, verbose = False)
+    assert bounded.rows_at_max_length == 0
+    assert bounded.rows_truncated_mid_response == 0
+    assert bounded.warnings == ["The dataset is empty."]
+
+
+def test_rows_of_length_zero_are_counted_but_contribute_no_tokens():
+    tok = MockTokenizer()
+    a = tok.token_id("a")
+    rows = [
+        {"input_ids": [], "labels": []},
+        {"input_ids": [1, a, 2], "labels": [-100, a, 2]},
+    ]
+
+    report = audit_supervision(rows, tokenizer = tok, max_seq_length = 3, verbose = False)
+
+    assert report.num_rows == 2
+    assert report.num_tokens == 3
+    assert report.num_supervised_tokens == 2
+    assert report.zero_supervision_rows == 1
+    assert report.zero_supervision_row_indices == [0]
+    assert report.supervised_tokens_per_row["min"] == 0
+    assert report.supervised_tokens_per_row["max"] == 2
+    assert report.rows_with_eos == 1
+    assert report.rows_with_supervised_eos == 1
+    assert report.rows_with_duplicated_bos == 0
+    assert report.rows_at_max_length == 1
+    assert report.rows_truncated_mid_response == 1
+    assert len(report.examples) == 2
+    assert list(report.examples[0]) == []
+    assert list(report.examples[1]) == [(False, "<s>"), (True, "a </s>")]
+    assert "Example row 0" in report.render(color = False)
+    assert audit_supervision(Dataset.from_dict(columns([(r["input_ids"], r["labels"]) for r in rows])),
+                             tokenizer = tok, max_seq_length = 3, verbose = False).to_dict() == report.to_dict()
+
+    only_empty = audit_supervision([{"input_ids": []}, {"input_ids": []}], verbose = False)
+    assert only_empty.num_rows == 2
+    assert only_empty.num_tokens == 0
+    assert only_empty.supervised_fraction == 0.0
+    assert only_empty.zero_supervision_rows == 2
+    assert only_empty.warnings == [
+        "All 2 rows have zero supervised tokens, so the training loss will be 0. "
+        "If you used train_on_responses_only, its instruction_part / response_part do not match your chat template.",
+    ]
+
+
+def test_missing_input_ids_and_bad_arguments_raise_value_error():
+    tok = MockTokenizer()
+    ds = Dataset.from_dict(columns(labels_rows(tok)))
+
+    with pytest.raises(ValueError) as excinfo:
+        audit_supervision(Dataset.from_dict({"text": ["hello"]}), verbose = False)
+    assert "Unsloth: audit_supervision needs an `input_ids` column" in str(excinfo.value)
+
+    with pytest.raises(ValueError, match = "input_ids"):
+        audit_supervision([{"labels": [1, 2]}], verbose = False)
+
+    with pytest.raises(ValueError):
+        audit_supervision(ds, max_rows = 0, verbose = False)
+    with pytest.raises(ValueError):
+        audit_supervision(ds, max_rows = -1, verbose = False)
+
+
+# ── public surface ─────────────────────────────────────────────────────────
+
+
+def test_public_exports():
+    import unsloth.chat_templates as chat_templates
+    import unsloth.dataprep as dataprep
+    from unsloth.dataprep import supervision_audit as module
+
+    assert module.__all__ == ["audit_supervision", "SupervisionAuditReport"]
+    assert chat_templates.audit_supervision is audit_supervision
+    assert dataprep.audit_supervision is audit_supervision
+    assert dataprep.SupervisionAuditReport is SupervisionAuditReport
+    names = chat_templates.__all__
+    assert names.index("audit_supervision") == names.index("train_on_responses_only") + 1
+
+
+# ── integration with the real masking ──────────────────────────────────────
+
+
+def test_audits_labels_written_by_the_real_train_on_responses_only():
+    """Drive unsloth_zoo's masking closure with the offline tokenizer, then audit its labels.
+
+    `train_on_responses_only(None, tokenizer = ..., return_function = True)` only needs
+    `tokenizer(text, add_special_tokens = False).input_ids`, so the word-level mock is
+    enough to reproduce both the working case and the mismatched-marker case behind the
+    all-labels-are-(-100) reports.
+    """
+    from unsloth.chat_templates import train_on_responses_only
+
+    if train_on_responses_only is None:
+        pytest.skip("train_on_responses_only is unavailable on this host (unsloth_zoo.dataset_utils needs torch)")
+
+    tok = MockTokenizer()
+    texts = [
+        "<s> <user> What is 2+2? <assistant> 4 </s>",
+        "<s> <user> Name a color <assistant> Blue </s>",
+        "<s> <user> Say hi <assistant> hi there </s>",
+    ]
+    ds = Dataset.from_dict({"input_ids": [tok.ids(text) for text in texts]})
+
+    mask = train_on_responses_only(
+        None,
+        tokenizer = tok,
+        instruction_part = "<user>",
+        response_part = "<assistant>",
+        return_function = True,
+    )
+    labelled = ds.map(mask, batched = True)
+    assert labelled[0]["labels"] == [-100] * 6 + tok.ids("4 </s>")
+
+    report = audit_supervision(labelled, tokenizer = tok, verbose = False)
+    assert report.labels_source == "labels"
+    assert report.zero_supervision_rows == 0
+    assert 0 < report.supervised_fraction < 1
+    assert report.num_tokens == 24
+    assert report.num_supervised_tokens == 7
+    assert report.supervised_tokens_per_row == pytest.approx({"min": 2, "median": 2, "mean": 7 / 3, "max": 3})
+    assert report.rows_with_eos == 3
+    assert report.rows_with_supervised_eos == 3
+    assert list(report.examples[0]) == [(False, "<s> <user> What is 2+2? <assistant>"), (True, "4 </s>")]
+    assert report.warnings == []
+    assert report.ok is True
+
+    wrong = train_on_responses_only(
+        None,
+        tokenizer = tok,
+        instruction_part = "[INST]",
+        response_part = "[/INST]",
+        return_function = True,
+    )
+    report = audit_supervision(ds.map(wrong, batched = True), tokenizer = tok, verbose = False)
+    assert report.zero_supervision_rows == 3
+    assert report.num_supervised_tokens == 0
+    assert report.supervised_fraction == 0.0
+    assert report.rows_with_eos == 3
+    assert report.rows_with_supervised_eos == 0
+    assert report.warnings == [
+        "All 3 rows have zero supervised tokens, so the training loss will be 0. "
+        "If you used train_on_responses_only, its instruction_part / response_part do not match your chat template.",
+    ]
+    assert report.ok is False

--- a/tests/test_supervision_audit.py
+++ b/tests/test_supervision_audit.py
@@ -51,13 +51,22 @@ class MockTokenizer:
     def ids(self, text):
         return [self.token_id(word) for word in text.split()]
 
-    def __call__(self, text, add_special_tokens = False, return_tensors = None):
+    def __call__(
+        self,
+        text,
+        add_special_tokens = False,
+        return_tensors = None,
+    ):
         ids = self.ids(text)
         if add_special_tokens:
             ids = [self.bos_token_id] + ids
         return _Encoding(input_ids = ids, attention_mask = [1] * len(ids))
 
-    def decode(self, token_ids, skip_special_tokens = False):
+    def decode(
+        self,
+        token_ids,
+        skip_special_tokens = False,
+    ):
         specials = {self.pad_token_id, self.bos_token_id, self.eos_token_id}
         return " ".join(
             self.words[int(i)]
@@ -125,7 +134,11 @@ def padded_rows(tok):
     a, b, c, d, e, g = (tok.token_id(w) for w in "a b c d e g".split())
     return [
         # 4 tokens, 3 supervised; the last non-padding token (EOS) is supervised
-        {"input_ids": [1, a, b, 2, 0, 0], "attention_mask": [1, 1, 1, 1, 0, 0], "labels": [-100, a, b, 2, -100, -100]},
+        {
+            "input_ids": [1, a, b, 2, 0, 0],
+            "attention_mask": [1, 1, 1, 1, 0, 0],
+            "labels": [-100, a, b, 2, -100, -100],
+        },
         # 3 tokens, all supervised; the label on the padded position must be ignored
         {"input_ids": [1, c, 2, 0], "attention_mask": [1, 1, 1, 0], "labels": [1, c, 2, 7]},
         # 3 tokens, 2 supervised; EOS sits in a masked-out position, so this row has no EOS
@@ -157,7 +170,9 @@ def test_labels_path_counts_every_field():
     assert report.num_tokens == 34
     assert report.num_supervised_tokens == 9
     assert report.supervised_fraction == pytest.approx(9 / 34)
-    assert report.supervised_tokens_per_row == pytest.approx({"min": 0, "median": 2, "mean": 1.8, "max": 4})
+    assert report.supervised_tokens_per_row == pytest.approx(
+        {"min": 0, "median": 2, "mean": 1.8, "max": 4}
+    )
     assert report.zero_supervision_rows == 2
     assert report.zero_supervision_row_indices == [1, 3]
     assert report.fully_supervised_rows == 1
@@ -171,7 +186,10 @@ def test_labels_path_counts_every_field():
     assert report.rows_with_duplicated_bos == 0
     assert len(report.examples) == 2
     assert all(isinstance(segment, tuple) for segment in report.examples[0])
-    assert list(report.examples[0]) == [(False, "<s> user: What is 2+2? assistant:"), (True, "4 </s>")]
+    assert list(report.examples[0]) == [
+        (False, "<s> user: What is 2+2? assistant:"),
+        (True, "4 </s>"),
+    ]
     assert list(report.examples[1]) == [(False, "<s> user: Hi assistant: Hello </s>")]
     assert report.warnings == [
         "2 rows (40.0%) have zero supervised tokens and contribute nothing to training.",
@@ -185,16 +203,23 @@ def test_same_rows_give_the_same_report_whatever_the_container():
     rows = labels_rows(tok)
     as_dicts = [{"input_ids": ids, "labels": labels} for ids, labels in rows]
 
-    expected = audit_supervision(Dataset.from_dict(columns(rows)), tokenizer = tok, verbose = False).to_dict()
+    expected = audit_supervision(
+        Dataset.from_dict(columns(rows)), tokenizer = tok, verbose = False
+    ).to_dict()
 
     assert audit_supervision(as_dicts, tokenizer = tok, verbose = False).to_dict() == expected
-    assert audit_supervision(IndexableRows(as_dicts), tokenizer = tok, verbose = False).to_dict() == expected
+    assert (
+        audit_supervision(IndexableRows(as_dicts), tokenizer = tok, verbose = False).to_dict()
+        == expected
+    )
     assert expected["num_supervised_tokens"] == 9
 
 
 def test_render_layout_without_color():
     tok = MockTokenizer()
-    report = audit_supervision(Dataset.from_dict(columns(labels_rows(tok))), tokenizer = tok, verbose = False)
+    report = audit_supervision(
+        Dataset.from_dict(columns(labels_rows(tok))), tokenizer = tok, verbose = False
+    )
 
     rendered = report.render(color = False)
     lines = rendered.splitlines()
@@ -226,7 +251,9 @@ def test_render_layout_without_color():
 
 def test_render_color_modes(monkeypatch):
     tok = MockTokenizer()
-    report = audit_supervision(Dataset.from_dict(columns(labels_rows(tok))), tokenizer = tok, verbose = False)
+    report = audit_supervision(
+        Dataset.from_dict(columns(labels_rows(tok))), tokenizer = tok, verbose = False
+    )
 
     ansi = report.render(color = True)
     assert "\x1b[" in ansi
@@ -242,13 +269,18 @@ def test_render_color_modes(monkeypatch):
 
 def test_to_dict_is_json_serialisable():
     tok = MockTokenizer()
-    report = audit_supervision(Dataset.from_dict(columns(labels_rows(tok))), tokenizer = tok, verbose = False)
+    report = audit_supervision(
+        Dataset.from_dict(columns(labels_rows(tok))), tokenizer = tok, verbose = False
+    )
 
     as_dict = report.to_dict()
 
     assert set(as_dict) == {field.name for field in dataclasses.fields(SupervisionAuditReport)}
     assert json.loads(json.dumps(as_dict)) == as_dict
-    assert as_dict["examples"][0] == [[False, "<s> user: What is 2+2? assistant:"], [True, "4 </s>"]]
+    assert as_dict["examples"][0] == [
+        [False, "<s> user: What is 2+2? assistant:"],
+        [True, "4 </s>"],
+    ]
     assert isinstance(as_dict["examples"][0][0], list)
     assert as_dict["num_supervised_tokens"] == 9
     assert as_dict["zero_supervision_row_indices"] == [1, 3]
@@ -317,7 +349,9 @@ def test_no_labels_means_every_token_is_supervised():
     assert report.fully_supervised_rows == report.num_rows == 2
     assert report.zero_supervision_rows == 0
     assert report.zero_supervision_row_indices == []
-    assert report.supervised_tokens_per_row == pytest.approx({"min": 3, "median": 3.5, "mean": 3.5, "max": 4})
+    assert report.supervised_tokens_per_row == pytest.approx(
+        {"min": 3, "median": 3.5, "mean": 3.5, "max": 4}
+    )
     assert report.eos_token_id is None
     assert report.rows_with_eos is None
     assert report.rows_with_supervised_eos is None
@@ -354,7 +388,9 @@ def test_attention_mask_excludes_padding_everywhere():
     assert report.num_rows == 4
     assert report.num_tokens == 12
     assert report.num_supervised_tokens == 9
-    assert report.supervised_tokens_per_row == pytest.approx({"min": 1, "median": 2.5, "mean": 2.25, "max": 3})
+    assert report.supervised_tokens_per_row == pytest.approx(
+        {"min": 1, "median": 2.5, "mean": 2.25, "max": 3}
+    )
     assert report.fully_supervised_rows == 1
     assert report.zero_supervision_rows == 0
     # only row 0 has 4 non-padding tokens; its last real token (EOS) is supervised
@@ -391,18 +427,29 @@ def test_tensor_and_numpy_rows_match_plain_lists():
 
     as_torch = [{key: torch.tensor(value) for key, value in row.items()} for row in rows]
     as_numpy = [{key: np.array(value) for key, value in row.items()} for row in rows]
-    assert audit_supervision(as_torch, tokenizer = tok, max_seq_length = 4, verbose = False).to_dict() == expected
-    assert audit_supervision(as_numpy, tokenizer = tok, max_seq_length = 4, verbose = False).to_dict() == expected
+    assert (
+        audit_supervision(as_torch, tokenizer = tok, max_seq_length = 4, verbose = False).to_dict()
+        == expected
+    )
+    assert (
+        audit_supervision(as_numpy, tokenizer = tok, max_seq_length = 4, verbose = False).to_dict()
+        == expected
+    )
 
     # a torch-formatted padded Dataset hands `.iter()` 2-D tensors per column
     width = max(len(row["input_ids"]) for row in rows)
     square = {
         "input_ids": [row["input_ids"] + [0] * (width - len(row["input_ids"])) for row in rows],
-        "attention_mask": [row["attention_mask"] + [0] * (width - len(row["attention_mask"])) for row in rows],
+        "attention_mask": [
+            row["attention_mask"] + [0] * (width - len(row["attention_mask"])) for row in rows
+        ],
         "labels": [row["labels"] + [-100] * (width - len(row["labels"])) for row in rows],
     }
     formatted = Dataset.from_dict(square).with_format("torch")
-    assert audit_supervision(formatted, tokenizer = tok, max_seq_length = 4, verbose = False).to_dict() == expected
+    assert (
+        audit_supervision(formatted, tokenizer = tok, max_seq_length = 4, verbose = False).to_dict()
+        == expected
+    )
 
 
 # ── iteration, max_rows, trainers ──────────────────────────────────────────
@@ -419,9 +466,14 @@ def test_iterable_dataset_streams_and_stops_at_max_rows():
     assert report.num_tokens == 14
     assert report.num_supervised_tokens == 2
     assert report.zero_supervision_row_indices == [1]
-    assert report.render(color = False).splitlines()[0] == "Unsloth: Supervision audit of 2 rows (labels from `labels`)"
+    assert (
+        report.render(color = False).splitlines()[0]
+        == "Unsloth: Supervision audit of 2 rows (labels from `labels`)"
+    )
 
-    everything = audit_supervision(ds.to_iterable_dataset(), tokenizer = tok, max_rows = None, verbose = False)
+    everything = audit_supervision(
+        ds.to_iterable_dataset(), tokenizer = tok, max_rows = None, verbose = False
+    )
     sized = audit_supervision(ds, tokenizer = tok, verbose = False)
     assert everything.num_rows == 5
     assert everything.num_rows_total is None
@@ -450,17 +502,27 @@ def test_max_rows_smaller_than_dataset_reports_first_n_of_m():
 
     whole = audit_supervision(ds, tokenizer = tok, max_rows = 5, verbose = False)
     assert whole.num_rows == whole.num_rows_total == 5
-    assert whole.render(color = False).splitlines()[0] == "Unsloth: Supervision audit of 5 rows (labels from `labels`)"
+    assert (
+        whole.render(color = False).splitlines()[0]
+        == "Unsloth: Supervision audit of 5 rows (labels from `labels`)"
+    )
 
     many = [{"input_ids": [7, 8]} for _ in range(1200)]
-    first_line = audit_supervision(many, max_rows = 1000, verbose = False).render(color = False).splitlines()[0]
-    assert first_line == "Unsloth: Supervision audit of the first 1,000 of 1,200 rows (labels from `all_tokens`)"
+    first_line = (
+        audit_supervision(many, max_rows = 1000, verbose = False).render(color = False).splitlines()[0]
+    )
+    assert (
+        first_line
+        == "Unsloth: Supervision audit of the first 1,000 of 1,200 rows (labels from `all_tokens`)"
+    )
 
 
 def test_trainer_supplies_tokenizer_and_max_seq_length():
     tok = MockTokenizer()
     ds = Dataset.from_dict(columns(labels_rows(tok)))
-    trainer = SimpleNamespace(train_dataset = ds, processing_class = tok, args = SimpleNamespace(max_length = 8))
+    trainer = SimpleNamespace(
+        train_dataset = ds, processing_class = tok, args = SimpleNamespace(max_length = 8)
+    )
 
     report = audit_supervision(trainer, verbose = False)
 
@@ -478,7 +540,10 @@ def test_trainer_supplies_tokenizer_and_max_seq_length():
         "2 rows (40.0%) hit max_seq_length = 8 while still inside a supervised span, so their responses are cut off before the end (and before EOS).",
         "2 rows (40.0%) contain EOS only in masked (-100) positions, so the model does not learn to stop there.",
     ]
-    assert "  Rows at max_seq_length = 8: 3 (60.0%), 2 cut off mid-response" in report.render(color = False).splitlines()
+    assert (
+        "  Rows at max_seq_length = 8: 3 (60.0%), 2 cut off mid-response"
+        in report.render(color = False).splitlines()
+    )
 
     explicit = audit_supervision(trainer, max_seq_length = 6, verbose = False)
     assert explicit.max_seq_length == 6
@@ -491,7 +556,9 @@ def test_trainer_tokenizer_and_length_fallbacks():
     tok = MockTokenizer()
     ds = Dataset.from_dict(columns(labels_rows(tok)))
 
-    old_style = SimpleNamespace(train_dataset = ds, tokenizer = tok, args = SimpleNamespace(max_seq_length = 8))
+    old_style = SimpleNamespace(
+        train_dataset = ds, tokenizer = tok, args = SimpleNamespace(max_seq_length = 8)
+    )
     report = audit_supervision(old_style, verbose = False)
     assert report.eos_token_id == 2
     assert report.max_seq_length == 8
@@ -506,7 +573,10 @@ def test_trainer_tokenizer_and_length_fallbacks():
     report = audit_supervision(vlm, verbose = False)
     assert report.eos_token_id == 2
     assert report.max_seq_length == 6
-    assert list(report.examples[0]) == [(False, "<s> user: What is 2+2? assistant:"), (True, "4 </s>")]
+    assert list(report.examples[0]) == [
+        (False, "<s> user: What is 2+2? assistant:"),
+        (True, "4 </s>"),
+    ]
 
     bare = SimpleNamespace(train_dataset = ds, processing_class = tok, args = SimpleNamespace())
     report = audit_supervision(bare, verbose = False)
@@ -522,7 +592,10 @@ def test_truncation_counts_only_rows_whose_last_token_is_supervised():
         {"input_ids": [5, 6, 7, 8], "labels": [-100, -100, 7, 8]},  # at max, last token supervised
         {"input_ids": [5, 6, 7, 8], "labels": [5, 6, 7, -100]},  # at max, last token masked
         {"input_ids": [5, 6, 7], "labels": [-100, 6, 7]},  # under max
-        {"input_ids": [5, 6, 7, 8, 9], "labels": [-100, -100, -100, -100, 9]},  # over max, last token supervised
+        {
+            "input_ids": [5, 6, 7, 8, 9],
+            "labels": [-100, -100, -100, -100, 9],
+        },  # over max, last token supervised
     ]
 
     report = audit_supervision(rows, max_seq_length = 4, verbose = False)
@@ -534,7 +607,10 @@ def test_truncation_counts_only_rows_whose_last_token_is_supervised():
     assert report.warnings == [
         "2 rows (50.0%) hit max_seq_length = 4 while still inside a supervised span, so their responses are cut off before the end (and before EOS).",
     ]
-    assert "  Rows at max_seq_length = 4: 3 (75.0%), 2 cut off mid-response" in report.render(color = False).splitlines()
+    assert (
+        "  Rows at max_seq_length = 4: 3 (75.0%), 2 cut off mid-response"
+        in report.render(color = False).splitlines()
+    )
 
     unlimited = audit_supervision(rows, verbose = False)
     assert unlimited.max_seq_length is None
@@ -548,7 +624,10 @@ def test_eos_presence_and_supervision():
     tok = MockTokenizer()
     a, b = tok.token_id("a"), tok.token_id("b")
     rows = [
-        {"input_ids": [1, a, 2, b, 2], "labels": [-100, -100, -100, b, 2]},  # two EOS, only the second supervised
+        {
+            "input_ids": [1, a, 2, b, 2],
+            "labels": [-100, -100, -100, b, 2],
+        },  # two EOS, only the second supervised
         {"input_ids": [1, a, b], "labels": [-100, a, b]},  # no EOS at all
         {"input_ids": [1, a, 2], "labels": [-100, a, -100]},  # EOS masked
         {"input_ids": [1, b, 2], "labels": [-100, -100, 2]},  # EOS supervised
@@ -566,7 +645,10 @@ def test_eos_presence_and_supervision():
     assert "do not contain the EOS token (id 2)" in no_eos
     assert masked_eos.startswith("1 row")
     assert "contain EOS only in masked (-100) positions" in masked_eos
-    assert "  Rows containing EOS: 3 (75.0%); rows with a supervised EOS: 2 (50.0%)" in report.render(color = False).splitlines()
+    assert (
+        "  Rows containing EOS: 3 (75.0%); rows with a supervised EOS: 2 (50.0%)"
+        in report.render(color = False).splitlines()
+    )
 
 
 def test_duplicated_bos_uses_the_first_two_non_padding_tokens():
@@ -574,8 +656,14 @@ def test_duplicated_bos_uses_the_first_two_non_padding_tokens():
     a = tok.token_id("a")
     rows = [
         {"input_ids": [1, 1, a, 2], "attention_mask": [1, 1, 1, 1]},  # duplicated
-        {"input_ids": [1, a, 1, 2], "attention_mask": [1, 1, 1, 1]},  # two BOS, but not adjacent at the start
-        {"input_ids": [0, 0, 1, 1, a, 2], "attention_mask": [0, 0, 1, 1, 1, 1]},  # left padded, duplicated
+        {
+            "input_ids": [1, a, 1, 2],
+            "attention_mask": [1, 1, 1, 1],
+        },  # two BOS, but not adjacent at the start
+        {
+            "input_ids": [0, 0, 1, 1, a, 2],
+            "attention_mask": [0, 0, 1, 1, 1, 1],
+        },  # left padded, duplicated
         {"input_ids": [1, a, 2], "attention_mask": [1, 1, 1]},  # single BOS
     ]
 
@@ -585,7 +673,10 @@ def test_duplicated_bos_uses_the_first_two_non_padding_tokens():
     assert report.warnings == [
         "2 rows (50.0%) start with two BOS tokens; your formatting adds BOS on top of the tokenizer's.",
     ]
-    assert "  Rows starting with a duplicated BOS: 2 (50.0%)" in report.render(color = False).splitlines()
+    assert (
+        "  Rows starting with a duplicated BOS: 2 (50.0%)"
+        in report.render(color = False).splitlines()
+    )
 
 
 # ── examples ───────────────────────────────────────────────────────────────
@@ -602,7 +693,12 @@ def test_num_examples_controls_decoded_rows():
 
     assert len(audit_supervision(ds, tokenizer = tok, num_examples = 1, verbose = False).examples) == 1
     assert len(audit_supervision(ds, tokenizer = tok, num_examples = 50, verbose = False).examples) == 5
-    assert len(audit_supervision(ds, tokenizer = tok, num_examples = 3, max_rows = 1, verbose = False).examples) == 1
+    assert (
+        len(
+            audit_supervision(ds, tokenizer = tok, num_examples = 3, max_rows = 1, verbose = False).examples
+        )
+        == 1
+    )
 
     no_decode = SimpleNamespace(eos_token_id = 2, bos_token_id = None)
     report = audit_supervision(ds, tokenizer = no_decode, verbose = False)
@@ -619,17 +715,26 @@ def test_num_examples_controls_decoded_rows():
 
 def test_render_escapes_control_characters_and_truncates_long_examples():
     tok = MockTokenizer()
-    newline, tab, a, b = tok.token_id("\n"), tok.token_id("\t"), tok.token_id("a"), tok.token_id("b")
+    newline, tab, a, b = (
+        tok.token_id("\n"),
+        tok.token_id("\t"),
+        tok.token_id("a"),
+        tok.token_id("b"),
+    )
     short = {"input_ids": [1, a, newline, tab, b, 2], "labels": [-100, -100, -100, -100, b, 2]}
     long = {"input_ids": [1] + [a] * 1498 + [2], "labels": [1] + [a] * 1498 + [2]}
     tiny = {"input_ids": [1, b, 2], "labels": [-100, b, 2]}
 
-    report = audit_supervision([short, long, tiny], tokenizer = tok, max_seq_length = 2048, num_examples = 3, verbose = False)
+    report = audit_supervision(
+        [short, long, tiny], tokenizer = tok, max_seq_length = 2048, num_examples = 3, verbose = False
+    )
 
     rendered = report.render(color = False)
     lines = rendered.splitlines()
     assert lines[0] == "Unsloth: Supervision audit of 3 rows (labels from `labels`)"
-    assert "  Supervised tokens: 1,504 of 1,509 (99.7%); per row min 2 / median 2 / max 1,500" in lines
+    assert (
+        "  Supervised tokens: 1,504 of 1,509 (99.7%); per row min 2 / median 2 / max 1,500" in lines
+    )
     assert "  Rows at max_seq_length = 2,048: 0 (0.0%), 0 cut off mid-response" in lines
 
     # control characters are shown escaped, so the example stays on one line
@@ -676,7 +781,9 @@ def test_empty_dataset_warns_without_dividing_by_zero():
     assert "  WARNING: The dataset is empty." in lines
     json.dumps(report.to_dict())
 
-    bounded = audit_supervision(Dataset.from_dict({"input_ids": []}), max_seq_length = 4, verbose = False)
+    bounded = audit_supervision(
+        Dataset.from_dict({"input_ids": []}), max_seq_length = 4, verbose = False
+    )
     assert bounded.rows_at_max_length == 0
     assert bounded.rows_truncated_mid_response == 0
     assert bounded.warnings == ["The dataset is empty."]
@@ -708,8 +815,15 @@ def test_rows_of_length_zero_are_counted_but_contribute_no_tokens():
     assert list(report.examples[0]) == []
     assert list(report.examples[1]) == [(False, "<s>"), (True, "a </s>")]
     assert "Example row 0" in report.render(color = False)
-    assert audit_supervision(Dataset.from_dict(columns([(r["input_ids"], r["labels"]) for r in rows])),
-                             tokenizer = tok, max_seq_length = 3, verbose = False).to_dict() == report.to_dict()
+    assert (
+        audit_supervision(
+            Dataset.from_dict(columns([(r["input_ids"], r["labels"]) for r in rows])),
+            tokenizer = tok,
+            max_seq_length = 3,
+            verbose = False,
+        ).to_dict()
+        == report.to_dict()
+    )
 
     only_empty = audit_supervision([{"input_ids": []}, {"input_ids": []}], verbose = False)
     assert only_empty.num_rows == 2
@@ -769,7 +883,9 @@ def test_audits_labels_written_by_the_real_train_on_responses_only():
     from unsloth.chat_templates import train_on_responses_only
 
     if train_on_responses_only is None:
-        pytest.skip("train_on_responses_only is unavailable on this host (unsloth_zoo.dataset_utils needs torch)")
+        pytest.skip(
+            "train_on_responses_only is unavailable on this host (unsloth_zoo.dataset_utils needs torch)"
+        )
 
     tok = MockTokenizer()
     texts = [
@@ -795,10 +911,15 @@ def test_audits_labels_written_by_the_real_train_on_responses_only():
     assert 0 < report.supervised_fraction < 1
     assert report.num_tokens == 24
     assert report.num_supervised_tokens == 7
-    assert report.supervised_tokens_per_row == pytest.approx({"min": 2, "median": 2, "mean": 7 / 3, "max": 3})
+    assert report.supervised_tokens_per_row == pytest.approx(
+        {"min": 2, "median": 2, "mean": 7 / 3, "max": 3}
+    )
     assert report.rows_with_eos == 3
     assert report.rows_with_supervised_eos == 3
-    assert list(report.examples[0]) == [(False, "<s> <user> What is 2+2? <assistant>"), (True, "4 </s>")]
+    assert list(report.examples[0]) == [
+        (False, "<s> <user> What is 2+2? <assistant>"),
+        (True, "4 </s>"),
+    ]
     assert report.warnings == []
     assert report.ok is True
 

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -20,6 +20,7 @@ __all__ = [
     "standardize_data_formats",
     "apply_chat_template",
     "train_on_responses_only",
+    "audit_supervision",
 
     "test_construct_chat_template",
 ]
@@ -36,6 +37,12 @@ import os
 import shutil
 import re
 from .ollama_template_mappers import OLLAMA_TEMPLATES
+try:
+    from .dataprep.supervision_audit import audit_supervision
+except ImportError:
+    # dataprep/__init__ imports synthetic.py -> torch; keep chat_templates importable on torch-free (MLX)
+    # hosts, like the unsloth_zoo.dataset_utils import below.
+    audit_supervision = None
 try:
     from unsloth_zoo.dataset_utils import (
         train_on_responses_only as _zoo_train_on_responses_only,

--- a/unsloth/dataprep/__init__.py
+++ b/unsloth/dataprep/__init__.py
@@ -11,3 +11,4 @@
 
 from .synthetic import *
 from .raw_text import *
+from .supervision_audit import *

--- a/unsloth/dataprep/supervision_audit.py
+++ b/unsloth/dataprep/supervision_audit.py
@@ -1,0 +1,530 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import dataclasses
+from dataclasses import dataclass, field
+from itertools import compress, groupby
+from statistics import median
+from typing import List, Dict, Any, Optional, Tuple
+
+__all__ = [
+    "audit_supervision",
+    "SupervisionAuditReport",
+]
+
+# Label value that the loss ignores; train_on_responses_only writes it over every instruction token.
+IGNORE_INDEX = -100
+
+# Columns the audit reads; everything else is left untouched (and, on datasets.Dataset, not even decoded).
+_COLUMNS = ("input_ids", "labels", "completion_mask", "attention_mask")
+_BATCH_SIZE = 256
+_ZERO_ROW_INDICES_KEPT = 20
+_EXAMPLE_MAX_CHARS = 400
+_ANSI_GREEN = "\033[32m"
+_ANSI_RESET = "\033[0m"
+
+_MISSING_INPUT_IDS = (
+    "Unsloth: audit_supervision needs an `input_ids` column – tokenize the dataset (or pass the trainer) first."
+)
+
+
+@dataclass
+class SupervisionAuditReport:
+    """What an SFT dataset actually supervises, as counted by audit_supervision"""
+    num_rows: int
+    num_rows_total: Optional[int]
+    labels_source: str
+    num_tokens: int
+    num_supervised_tokens: int
+    supervised_fraction: float
+    supervised_tokens_per_row: Dict[str, float]
+    zero_supervision_rows: int
+    zero_supervision_row_indices: List[int]
+    fully_supervised_rows: int
+    max_seq_length: Optional[int]
+    rows_at_max_length: Optional[int]
+    rows_truncated_mid_response: Optional[int]
+    eos_token_id: Optional[int]
+    rows_with_eos: Optional[int]
+    rows_with_supervised_eos: Optional[int]
+    bos_token_id: Optional[int]
+    rows_with_duplicated_bos: Optional[int]
+    examples: List[List[Tuple[bool, str]]] = field(default_factory = list)
+    warnings: List[str] = field(default_factory = list)
+
+    @property
+    def ok(self) -> bool:
+        """True when the audit raised no warning"""
+        return not self.warnings
+
+    def to_dict(self) -> Dict[str, Any]:
+        """JSON-serialisable dict; example segments become [is_supervised, text] lists"""
+        result = dataclasses.asdict(self)
+        result["examples"] = [
+            [[bool(is_supervised), text] for is_supervised, text in segments]
+            for segments in self.examples
+        ]
+        return result
+
+    def render(self, color: Optional[bool] = None) -> str:
+        """Human-readable report; color = None marks supervised text in green only on a TTY"""
+        if color is None:
+            color = _stdout_is_tty()
+        n = self.num_rows
+        if self.num_rows_total is not None and self.num_rows_total > n:
+            scope = f"the first {n:,} of {self.num_rows_total:,} rows"
+        else:
+            scope = f"{n:,} rows"
+        per_row = self.supervised_tokens_per_row
+        lines = [
+            f"Unsloth: Supervision audit of {scope} (labels from `{self.labels_source}`)",
+            f"  Supervised tokens: {self.num_supervised_tokens:,} of {self.num_tokens:,} "
+            f"({_pct(self.num_supervised_tokens, self.num_tokens)}); per row "
+            f"min {_num(per_row.get('min', 0))} / median {_num(per_row.get('median', 0))} / "
+            f"max {_num(per_row.get('max', 0))}",
+            f"  Rows with zero supervised tokens: {self.zero_supervision_rows:,} "
+            f"({_pct(self.zero_supervision_rows, n)})",
+            f"  Rows fully supervised (no masking): {self.fully_supervised_rows:,} "
+            f"({_pct(self.fully_supervised_rows, n)})",
+        ]
+        if self.max_seq_length is not None and self.rows_at_max_length is not None:
+            lines.append(
+                f"  Rows at max_seq_length = {self.max_seq_length:,}: {self.rows_at_max_length:,} "
+                f"({_pct(self.rows_at_max_length, n)}), "
+                f"{self.rows_truncated_mid_response or 0:,} cut off mid-response"
+            )
+        if self.rows_with_eos is not None:
+            lines.append(
+                f"  Rows containing EOS: {self.rows_with_eos:,} ({_pct(self.rows_with_eos, n)}); "
+                f"rows with a supervised EOS: {self.rows_with_supervised_eos or 0:,} "
+                f"({_pct(self.rows_with_supervised_eos or 0, n)})"
+            )
+        if self.rows_with_duplicated_bos is not None:
+            lines.append(
+                f"  Rows starting with a duplicated BOS: {self.rows_with_duplicated_bos:,} "
+                f"({_pct(self.rows_with_duplicated_bos, n)})"
+            )
+        marker = "green" if color else "[[double brackets]]"
+        for i, segments in enumerate(self.examples):
+            lines.append(f"  Example row {i} (supervised text in {marker}):")
+            lines.append("    " + _render_segments(segments, color))
+        for warning in self.warnings:
+            lines.append(f"  WARNING: {warning}")
+        return "\n".join(lines)
+
+
+def audit_supervision(
+    dataset,
+    tokenizer = None,
+    max_seq_length = None,
+    max_rows = 10_000,
+    num_examples = 2,
+    verbose = True,
+) -> SupervisionAuditReport:
+    """Report what an SFT dataset actually supervises, before the first training step.
+
+    Over the first `max_rows` rows it counts the non-padding tokens that carry a label
+    (`labels != -100`, else a truthy `completion_mask`, else every token), the rows that
+    contribute no supervised token at all (the train_on_responses_only marker-mismatch
+    symptom that otherwise surfaces as "All labels in your dataset are -100"), the rows
+    that are fully supervised, the rows sitting at `max_seq_length` with the response cut
+    off mid-span, whether EOS is present and supervised, and whether BOS is duplicated.
+    The first `num_examples` rows are decoded with their supervised spans marked.
+
+    Typical use, right after masking the instruction tokens:
+
+        from unsloth.chat_templates import train_on_responses_only, audit_supervision
+        trainer = train_on_responses_only(trainer, instruction_part = ..., response_part = ...)
+        report = audit_supervision(trainer)
+        assert report.ok, report.warnings
+
+    `dataset` may be a datasets.Dataset / IterableDataset, a list of row dicts, anything
+    indexable with a length, or a trainer (its `train_dataset`, `processing_class` and
+    `args.max_length` / `args.max_seq_length` are picked up). Read-only: nothing is
+    modified, and nothing is printed unless `verbose` is True.
+    """
+    if max_rows is not None and max_rows <= 0:
+        raise ValueError(f"Unsloth: audit_supervision max_rows must be None or > 0, got {max_rows}.")
+    if num_examples < 0:
+        raise ValueError(f"Unsloth: audit_supervision num_examples must be >= 0, got {num_examples}.")
+
+    if hasattr(dataset, "train_dataset"):
+        trainer = dataset
+        dataset = trainer.train_dataset
+        if tokenizer is None:
+            tokenizer = getattr(trainer, "processing_class", None)
+            if tokenizer is None:
+                tokenizer = getattr(trainer, "tokenizer", None)
+        if max_seq_length is None:
+            args = getattr(trainer, "args", None)
+            max_seq_length = getattr(args, "max_length", None)
+            if max_seq_length is None:
+                max_seq_length = getattr(args, "max_seq_length", None)
+
+    tokenizer = _unwrap_tokenizer(tokenizer)
+    eos_token_id = getattr(tokenizer, "eos_token_id", None)
+    bos_token_id = getattr(tokenizer, "bos_token_id", None)
+    decode = getattr(tokenizer, "decode", None) if num_examples > 0 else None
+
+    num_rows_total = _num_rows_total(dataset)
+    labels_source = _labels_source_from_columns(dataset)
+
+    num_rows = 0
+    num_tokens = 0
+    num_supervised_tokens = 0
+    supervised_per_row = []
+    zero_supervision_rows = 0
+    zero_supervision_row_indices = []
+    fully_supervised_rows = 0
+    rows_at_max_length = 0
+    rows_truncated_mid_response = 0
+    rows_with_eos = 0
+    rows_with_supervised_eos = 0
+    rows_with_duplicated_bos = 0
+    examples = []
+
+    for index, row in _iter_rows(dataset, max_rows):
+        if labels_source is None:
+            labels_source = _labels_source_from_row(row)
+        input_ids = _to_list(row["input_ids"])
+        labels = _to_list(row.get("labels")) if labels_source == "labels" else None
+        completion_mask = (
+            _to_list(row.get("completion_mask")) if labels_source == "completion_mask" else None
+        )
+        attention_mask = _to_list(row.get("attention_mask"))
+
+        n_all = len(input_ids)
+        for name, column in (
+            ("labels", labels), ("completion_mask", completion_mask), ("attention_mask", attention_mask),
+        ):
+            if column is not None and len(column) != n_all:
+                raise ValueError(
+                    f"Unsloth: audit_supervision row {index} has {n_all} input_ids but "
+                    f"{len(column)} {name} – the columns must be aligned token for token."
+                )
+        # Padding is ignored everywhere: token counts, the last token, EOS and BOS all look at real tokens
+        # only. compress() is C-speed; the common unpadded row skips it.
+        if attention_mask is not None and 0 in attention_mask:
+            input_ids = list(compress(input_ids, attention_mask))
+            if labels is not None:
+                labels = list(compress(labels, attention_mask))
+            if completion_mask is not None:
+                completion_mask = list(compress(completion_mask, attention_mask))
+
+        n = len(input_ids)
+        # list.count() runs in C; a per-token Python comparison would dominate on 10k rows x 2k tokens.
+        if labels is not None:
+            n_supervised = n - labels.count(IGNORE_INDEX)
+        elif completion_mask is not None:
+            n_supervised = n - completion_mask.count(0)
+        else:
+            n_supervised = n
+
+        num_rows += 1
+        num_tokens += n
+        num_supervised_tokens += n_supervised
+        supervised_per_row.append(n_supervised)
+        if n_supervised == 0:
+            zero_supervision_rows += 1
+            if len(zero_supervision_row_indices) < _ZERO_ROW_INDICES_KEPT:
+                zero_supervision_row_indices.append(index)
+        elif n_supervised == n:
+            fully_supervised_rows += 1
+
+        if max_seq_length is not None and 0 < max_seq_length <= n:
+            rows_at_max_length += 1
+            if _is_supervised(labels, completion_mask, n - 1):
+                rows_truncated_mid_response += 1
+
+        if eos_token_id is not None and eos_token_id in input_ids:
+            rows_with_eos += 1
+            if _any_occurrence_supervised(input_ids, labels, completion_mask, eos_token_id):
+                rows_with_supervised_eos += 1
+
+        if bos_token_id is not None and n >= 2 and input_ids[0] == bos_token_id and input_ids[1] == bos_token_id:
+            rows_with_duplicated_bos += 1
+
+        if decode is not None and len(examples) < num_examples:
+            examples.append(_decode_segments(input_ids, labels, completion_mask, decode))
+
+    if labels_source is None:
+        labels_source = "all_tokens"
+
+    if supervised_per_row:
+        supervised_tokens_per_row = {
+            "min": float(min(supervised_per_row)),
+            "median": float(median(supervised_per_row)),
+            "mean": num_supervised_tokens / num_rows,
+            "max": float(max(supervised_per_row)),
+        }
+    else:
+        supervised_tokens_per_row = {"min": 0.0, "median": 0.0, "mean": 0.0, "max": 0.0}
+
+    warnings = []
+    if num_rows == 0:
+        warnings.append("The dataset is empty.")
+    elif zero_supervision_rows == num_rows:
+        warnings.append(
+            f"All {num_rows:,} rows have zero supervised tokens, so the training loss will be 0. "
+            "If you used train_on_responses_only, its instruction_part / response_part do not match "
+            "your chat template."
+        )
+    elif zero_supervision_rows > 0:
+        warnings.append(
+            f"{_rows(zero_supervision_rows)} ({_pct(zero_supervision_rows, num_rows)}) have zero "
+            "supervised tokens and contribute nothing to training."
+        )
+    if max_seq_length is not None and rows_truncated_mid_response > 0:
+        warnings.append(
+            f"{_rows(rows_truncated_mid_response)} ({_pct(rows_truncated_mid_response, num_rows)}) hit "
+            f"max_seq_length = {max_seq_length:,} while still inside a supervised span, so their responses "
+            "are cut off before the end (and before EOS)."
+        )
+    if eos_token_id is not None and rows_with_eos < num_rows:
+        missing = num_rows - rows_with_eos
+        warnings.append(
+            f"{_rows(missing)} ({_pct(missing, num_rows)}) do not contain the EOS token (id {eos_token_id}), "
+            "so the model may never learn to stop generating."
+        )
+    # Skipped when every row is already unsupervised: the all-rows warning above covers it.
+    if eos_token_id is not None and zero_supervision_rows < num_rows and rows_with_supervised_eos < rows_with_eos:
+        masked = rows_with_eos - rows_with_supervised_eos
+        warnings.append(
+            f"{_rows(masked)} ({_pct(masked, num_rows)}) contain EOS only in masked (-100) positions, "
+            "so the model does not learn to stop there."
+        )
+    if bos_token_id is not None and rows_with_duplicated_bos > 0:
+        warnings.append(
+            f"{_rows(rows_with_duplicated_bos)} ({_pct(rows_with_duplicated_bos, num_rows)}) start with two "
+            "BOS tokens; your formatting adds BOS on top of the tokenizer's."
+        )
+
+    report = SupervisionAuditReport(
+        num_rows = num_rows,
+        num_rows_total = num_rows_total,
+        labels_source = labels_source,
+        num_tokens = num_tokens,
+        num_supervised_tokens = num_supervised_tokens,
+        supervised_fraction = (num_supervised_tokens / num_tokens) if num_tokens else 0.0,
+        supervised_tokens_per_row = supervised_tokens_per_row,
+        zero_supervision_rows = zero_supervision_rows,
+        zero_supervision_row_indices = zero_supervision_row_indices,
+        fully_supervised_rows = fully_supervised_rows,
+        max_seq_length = max_seq_length,
+        rows_at_max_length = rows_at_max_length if max_seq_length is not None else None,
+        rows_truncated_mid_response = rows_truncated_mid_response if max_seq_length is not None else None,
+        eos_token_id = eos_token_id,
+        rows_with_eos = rows_with_eos if eos_token_id is not None else None,
+        rows_with_supervised_eos = rows_with_supervised_eos if eos_token_id is not None else None,
+        bos_token_id = bos_token_id,
+        rows_with_duplicated_bos = rows_with_duplicated_bos if bos_token_id is not None else None,
+        examples = examples,
+        warnings = warnings,
+    )
+    if verbose:
+        print(report.render())
+    return report
+
+
+def _unwrap_tokenizer(tokenizer):
+    """A VLM processor wraps the text tokenizer, which is the object that knows the token ids"""
+    if tokenizer is None or hasattr(tokenizer, "eos_token_id"):
+        return tokenizer
+    inner = getattr(tokenizer, "tokenizer", None)
+    return tokenizer if inner is None else inner
+
+
+def _num_rows_total(dataset):
+    """len(dataset), or None for streams (IterableDataset has no length)"""
+    try:
+        return len(dataset)
+    except TypeError:
+        return None
+
+
+def _labels_source_from_columns(dataset):
+    """Pick the supervision column from the schema when there is one; None defers to the first row"""
+    column_names = getattr(dataset, "column_names", None)
+    if not isinstance(column_names, (list, tuple)):
+        return None
+    if "input_ids" not in column_names:
+        raise ValueError(_MISSING_INPUT_IDS)
+    if "labels" in column_names:
+        return "labels"
+    if "completion_mask" in column_names:
+        return "completion_mask"
+    return "all_tokens"
+
+
+def _labels_source_from_row(row):
+    """Pick the supervision column from a row dict (lists of dicts, streams without features)"""
+    if row.get("labels") is not None:
+        return "labels"
+    if row.get("completion_mask") is not None:
+        return "completion_mask"
+    return "all_tokens"
+
+
+def _iter_rows(dataset, max_rows):
+    """Yield (index, {column: value}) for the first `max_rows` rows, streaming where the dataset can.
+
+    Dataset.iter() hands out Arrow batches instead of copying whole columns into Python
+    objects (see _iter_column in raw_text.py); select_columns() first, so a chat dataset's
+    `messages` / `text` columns are never decoded. Anything without iter() (lists, custom
+    __getitem__) is indexed or iterated row by row.
+    """
+    column_names = getattr(dataset, "column_names", None)
+    select_columns = getattr(dataset, "select_columns", None)
+    if isinstance(column_names, (list, tuple)) and callable(select_columns):
+        dataset = select_columns([column for column in _COLUMNS if column in column_names])
+
+    index = 0
+    batched = getattr(dataset, "iter", None)
+    if callable(batched):
+        for batch in batched(batch_size = _BATCH_SIZE):
+            if "input_ids" not in batch:
+                raise ValueError(_MISSING_INPUT_IDS)
+            present = [column for column in _COLUMNS if column in batch]
+            for i in range(len(batch["input_ids"])):
+                yield index, {column: batch[column][i] for column in present}
+                index += 1
+                if max_rows is not None and index >= max_rows:
+                    return
+        return
+
+    if hasattr(dataset, "__getitem__") and hasattr(dataset, "__len__"):
+        rows = (dataset[i] for i in range(len(dataset)))
+    else:
+        rows = iter(dataset)
+    for row in rows:
+        yield index, _row_columns(row)
+        index += 1
+        if max_rows is not None and index >= max_rows:
+            return
+
+
+def _row_columns(row):
+    """The audited columns of one row as a plain dict"""
+    result = {}
+    for column in _COLUMNS:
+        try:
+            result[column] = row[column]
+        except (KeyError, IndexError, TypeError):
+            continue
+    if "input_ids" not in result:
+        raise ValueError(_MISSING_INPUT_IDS)
+    return result
+
+
+def _to_list(value):
+    """Plain Python list from a list, tensor, numpy array or any sequence; None stays None"""
+    if value is None or isinstance(value, list):
+        return value
+    tolist = getattr(value, "tolist", None)
+    if callable(tolist):
+        return tolist()
+    return list(value)
+
+
+def _is_supervised(labels, completion_mask, i):
+    """Whether token i carries a label under the row's supervision column"""
+    if labels is not None:
+        return labels[i] != IGNORE_INDEX
+    if completion_mask is not None:
+        return completion_mask[i] != 0
+    return True
+
+
+def _any_occurrence_supervised(input_ids, labels, completion_mask, token_id):
+    """Whether at least one occurrence of token_id is supervised (list.index is C-speed per hit)"""
+    if labels is None and completion_mask is None:
+        return True
+    start = 0
+    while True:
+        try:
+            i = input_ids.index(token_id, start)
+        except ValueError:
+            return False
+        if _is_supervised(labels, completion_mask, i):
+            return True
+        start = i + 1
+
+
+def _decode_segments(input_ids, labels, completion_mask, decode):
+    """Decode a row as (is_supervised, text) runs, consecutive tokens with the same status merged"""
+    if labels is not None:
+        flags = [label != IGNORE_INDEX for label in labels]
+    elif completion_mask is not None:
+        flags = [mask != 0 for mask in completion_mask]
+    else:
+        flags = [True] * len(input_ids)
+    segments = []
+    for is_supervised, group in groupby(zip(input_ids, flags), key = lambda pair: pair[1]):
+        text = decode([token for token, _ in group], skip_special_tokens = False)
+        segments.append((bool(is_supervised), str(text)))
+    return segments
+
+
+def _render_segments(segments, color, limit = _EXAMPLE_MAX_CHARS):
+    """One example row as a single escaped line, supervised runs marked, cut at `limit` visible characters"""
+    open_marker, close_marker = (_ANSI_GREEN, _ANSI_RESET) if color else ("[[", "]]")
+    parts = []
+    remaining = limit
+    truncated = False
+    for is_supervised, text in segments:
+        text = _escape(text)
+        if not text:
+            continue
+        if remaining <= 0:
+            truncated = True
+            break
+        if len(text) > remaining:
+            text = text[:remaining]
+            truncated = True
+        remaining -= len(text)
+        parts.append(open_marker + text + close_marker if is_supervised else text)
+    line = "".join(parts)
+    if truncated:
+        line += "…"
+    return line
+
+
+def _escape(text):
+    """Show newlines and tabs as \\n and \\t so one example stays on one line"""
+    return text.replace("\r", "\\r").replace("\n", "\\n").replace("\t", "\\t")
+
+
+def _rows(count):
+    """`1 row` / `12 rows`, thousands-separated"""
+    return f"{count:,} row" if count == 1 else f"{count:,} rows"
+
+
+def _pct(count, total):
+    """`31.2%`; 0.0% when there is nothing to divide by"""
+    if not total:
+        return "0.0%"
+    return f"{100.0 * count / total:.1f}%"
+
+
+def _num(value):
+    """Thousands-separated number; whole values print without decimals"""
+    if float(value).is_integer():
+        return f"{int(value):,}"
+    return f"{value:,.1f}"
+
+
+def _stdout_is_tty():
+    """Whether stdout is a terminal (stdout can be None or replaced in notebooks and tests)"""
+    try:
+        return bool(sys.stdout.isatty())
+    except Exception:
+        return False

--- a/unsloth/dataprep/supervision_audit.py
+++ b/unsloth/dataprep/supervision_audit.py
@@ -32,14 +32,13 @@ _EXAMPLE_MAX_CHARS = 400
 _ANSI_GREEN = "\033[32m"
 _ANSI_RESET = "\033[0m"
 
-_MISSING_INPUT_IDS = (
-    "Unsloth: audit_supervision needs an `input_ids` column – tokenize the dataset (or pass the trainer) first."
-)
+_MISSING_INPUT_IDS = "Unsloth: audit_supervision needs an `input_ids` column – tokenize the dataset (or pass the trainer) first."
 
 
 @dataclass
 class SupervisionAuditReport:
     """What an SFT dataset actually supervises, as counted by audit_supervision"""
+
     num_rows: int
     num_rows_total: Optional[int]
     labels_source: str
@@ -153,9 +152,13 @@ def audit_supervision(
     modified, and nothing is printed unless `verbose` is True.
     """
     if max_rows is not None and max_rows <= 0:
-        raise ValueError(f"Unsloth: audit_supervision max_rows must be None or > 0, got {max_rows}.")
+        raise ValueError(
+            f"Unsloth: audit_supervision max_rows must be None or > 0, got {max_rows}."
+        )
     if num_examples < 0:
-        raise ValueError(f"Unsloth: audit_supervision num_examples must be >= 0, got {num_examples}.")
+        raise ValueError(
+            f"Unsloth: audit_supervision num_examples must be >= 0, got {num_examples}."
+        )
 
     if hasattr(dataset, "train_dataset"):
         trainer = dataset
@@ -204,7 +207,9 @@ def audit_supervision(
 
         n_all = len(input_ids)
         for name, column in (
-            ("labels", labels), ("completion_mask", completion_mask), ("attention_mask", attention_mask),
+            ("labels", labels),
+            ("completion_mask", completion_mask),
+            ("attention_mask", attention_mask),
         ):
             if column is not None and len(column) != n_all:
                 raise ValueError(
@@ -250,7 +255,12 @@ def audit_supervision(
             if _any_occurrence_supervised(input_ids, labels, completion_mask, eos_token_id):
                 rows_with_supervised_eos += 1
 
-        if bos_token_id is not None and n >= 2 and input_ids[0] == bos_token_id and input_ids[1] == bos_token_id:
+        if (
+            bos_token_id is not None
+            and n >= 2
+            and input_ids[0] == bos_token_id
+            and input_ids[1] == bos_token_id
+        ):
             rows_with_duplicated_bos += 1
 
         if decode is not None and len(examples) < num_examples:
@@ -296,7 +306,11 @@ def audit_supervision(
             "so the model may never learn to stop generating."
         )
     # Skipped when every row is already unsupervised: the all-rows warning above covers it.
-    if eos_token_id is not None and zero_supervision_rows < num_rows and rows_with_supervised_eos < rows_with_eos:
+    if (
+        eos_token_id is not None
+        and zero_supervision_rows < num_rows
+        and rows_with_supervised_eos < rows_with_eos
+    ):
         masked = rows_with_eos - rows_with_supervised_eos
         warnings.append(
             f"{_rows(masked)} ({_pct(masked, num_rows)}) contain EOS only in masked (-100) positions, "
@@ -321,7 +335,9 @@ def audit_supervision(
         fully_supervised_rows = fully_supervised_rows,
         max_seq_length = max_seq_length,
         rows_at_max_length = rows_at_max_length if max_seq_length is not None else None,
-        rows_truncated_mid_response = rows_truncated_mid_response if max_seq_length is not None else None,
+        rows_truncated_mid_response = rows_truncated_mid_response
+        if max_seq_length is not None
+        else None,
         eos_token_id = eos_token_id,
         rows_with_eos = rows_with_eos if eos_token_id is not None else None,
         rows_with_supervised_eos = rows_with_supervised_eos if eos_token_id is not None else None,
@@ -474,7 +490,11 @@ def _decode_segments(input_ids, labels, completion_mask, decode):
     return segments
 
 
-def _render_segments(segments, color, limit = _EXAMPLE_MAX_CHARS):
+def _render_segments(
+    segments,
+    color,
+    limit = _EXAMPLE_MAX_CHARS,
+):
     """One example row as a single escaped line, supervised runs marked, cut at `limit` visible characters"""
     open_marker, close_marker = (_ANSI_GREEN, _ANSI_RESET) if color else ("[[", "]]")
     parts = []


### PR DESCRIPTION
## Motivation

`train_on_responses_only` masks instruction tokens to -100 so the loss only covers assistant turns. When `instruction_part` / `response_part` don't match what the chat template really emits (Phi-3/Phi-4, Mistral's `[INST]` tokens, Qwen3, or a Llama-3 template pasted onto a non-Llama model), no span matches, every label becomes -100, and the first signal is `fix_zero_training_loss` raising `ZeroDivisionError: All labels in your dataset are -100` (it runs at the end of `train_on_responses_only` and again when training starts). The same failure keeps coming back as closed issues: #2364, #2199, #3198, #1128, #1290, #2771, #3041. #823 ("Documentation for train_on_responses_only?", 15 thumbs up, 22 comments) is people asking how to check that the masking did what they meant.

The check that exists today is narrow on purpose. `fix_zero_training_loss` (unsloth_zoo `training_utils.py`) looks at the first ~100 rows, only counts rows whose *every* label is -100, raises when that is all of them and prints a warning at 90% or more, and returns immediately for an `IterableDataset`. It cannot tell you that a third of your rows are fully masked because a system-prompt variant broke the match, that responses are cut off by `max_seq_length` before EOS, that EOS is present but sits in a masked position, or that BOS is doubled. The official conversational notebooks work around this with a hand-written "verify masking is actually done" cell that decodes `labels` for one row. #10734 (raw-text chunks got EOS appended mid-text) was the same class of silent bug, and it was only found by decoding tokens by hand.

This PR adds `audit_supervision`: one read-only call that answers "what will the loss actually see?" before the first step.

## What it reports

- rows audited (and the dataset total when known), and which supervision signals decided the labels: `labels`, `completion_mask` (when `completion_only_loss` applies), `assistant_masks`, or every token, intersected the way the trainer folds them into the labels
- supervised tokens vs non-padding tokens, and per-row min / median / mean / max
- rows with zero supervised tokens (with the first indices), and rows that are fully supervised (reported, not a warning: full-sequence SFT is legitimate)
- rows at `max_seq_length`, and how many of those end inside a supervised span (a response cut off before EOS). Rows longer than the cap are audited cut to their first `max_seq_length` tokens, as the trainer prepares them, and a row ending exactly at the cap with a supervised EOS counts as complete
- rows containing EOS, and rows where at least one EOS occurrence is supervised
- rows that start with a duplicated BOS
- the first rows decoded with the supervised spans marked (`[[...]]`, or green on a terminal)
- a `warnings` list; `report.ok` is `not report.warnings`; `report.to_dict()` is JSON-serialisable

## Usage

```python
from unsloth.chat_templates import train_on_responses_only, audit_supervision

trainer = train_on_responses_only(trainer, instruction_part = "<|im_start|>user\n", response_part = "<|im_start|>assistant\n")
report  = audit_supervision(trainer)   # prints the report; tokenizer and max_seq_length are read from the trainer
assert report.ok, report.warnings      # optional: fail fast in a script
```

It also takes a `datasets.Dataset` / `IterableDataset` / list of dict rows with `input_ids` (plus optional `labels`, `completion_mask`, `assistant_masks`, `attention_mask`) together with an explicit `tokenizer`, `max_seq_length` and, if the trainer will not use the completion mask, `completion_only_loss = False`.

## Demo output

Real `Qwen/Qwen2.5-0.5B-Instruct` tokenizer, four short chat rows tokenized with `apply_chat_template`, labels produced by the real `train_on_responses_only` masking function (`return_function = True`). Report 1 uses the Qwen markers. Report 2 uses the Llama-3 markers on the same rows: no span matches, every label is -100, and today the only signal is the `ZeroDivisionError`. Report 3 uses the correct markers on rows truncated to `max_seq_length = 40` the way the trainer truncates before the labels are built: the cut lands inside every response, so EOS is never supervised. Output is `render(color = False)`, verbatim; on a terminal the supervised spans are green instead of `[[...]]`.

```text
=== 1. Correct Qwen markers ===
Unsloth: Supervision audit of 4 rows (labels from `labels`)
  Supervised tokens: 57 of 195 (29.2%); per row min 13 / median 13.5 / max 17
  Rows with zero supervised tokens: 0 (0.0%)
  Rows fully supervised (no masking): 0 (0.0%)
  Rows at max_seq_length = 64: 0 (0.0%), 0 cut off mid-response
  Rows containing EOS: 4 (100.0%); rows with a supervised EOS: 4 (100.0%)
  Example row 0 (supervised text in [[double brackets]]):
    <|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\n<|im_start|>user\nWhat is 2+2?<|im_end|>\n<|im_start|>assistant\n[[2+2 equals 4, because adding two and two gives four.<|im_end|>\n]]
  Example row 1 (supervised text in [[double brackets]]):
    <|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\n<|im_start|>user\nName a primary color.<|im_end|>\n<|im_start|>assistant\n[[Red is a primary color, along with blue and yellow.<|im_end|>\n]]

=== 2. Llama-3 markers on the Qwen tokenizer ===
Unsloth: Supervision audit of 4 rows (labels from `labels`)
  Supervised tokens: 0 of 195 (0.0%); per row min 0 / median 0 / max 0
  Rows with zero supervised tokens: 4 (100.0%)
  Rows fully supervised (no masking): 0 (0.0%)
  Rows at max_seq_length = 64: 0 (0.0%), 0 cut off mid-response
  Rows containing EOS: 4 (100.0%); rows with a supervised EOS: 0 (0.0%)
  Example row 0 (supervised text in [[double brackets]]):
    <|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\n<|im_start|>user\nWhat is 2+2?<|im_end|>\n<|im_start|>assistant\n2+2 equals 4, because adding two and two gives four.<|im_end|>\n
  Example row 1 (supervised text in [[double brackets]]):
    <|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\n<|im_start|>user\nName a primary color.<|im_end|>\n<|im_start|>assistant\nRed is a primary color, along with blue and yellow.<|im_end|>\n
  WARNING: All 4 rows have zero supervised tokens, so the training loss will be 0. If you used train_on_responses_only, its instruction_part / response_part do not match your chat template.

=== 3. Correct markers, rows truncated to max_seq_length = 40 ===
Unsloth: Supervision audit of 4 rows (labels from `labels`)
  Supervised tokens: 22 of 160 (13.8%); per row min 4 / median 6 / max 6
  Rows with zero supervised tokens: 0 (0.0%)
  Rows fully supervised (no masking): 0 (0.0%)
  Rows at max_seq_length = 40: 4 (100.0%), 4 cut off mid-response
  Rows containing EOS: 4 (100.0%); rows with a supervised EOS: 0 (0.0%)
  Example row 0 (supervised text in [[double brackets]]):
    <|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\n<|im_start|>user\nWhat is 2+2?<|im_end|>\n<|im_start|>assistant\n[[2+2 equals]]
  Example row 1 (supervised text in [[double brackets]]):
    <|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\n<|im_start|>user\nName a primary color.<|im_end|>\n<|im_start|>assistant\n[[Red is a primary color,]]
  WARNING: 4 rows (100.0%) hit max_seq_length = 40 while still inside a supervised span, so their responses are cut off before the end (and before EOS).
  WARNING: 4 rows (100.0%) contain EOS only in masked (-100) positions, so the model does not learn to stop there.
```

<details>
<summary>Demo script</summary>

```python
"""audit_supervision demo: real Qwen2.5 tokenizer, real train_on_responses_only masking.

Run with unsloth installed (downloads the tokenizer on first run); it prints the
reports and writes them to DEMO_OUTPUT.txt next to this file.

Three reports: correct Qwen markers, Llama-3 markers on the Qwen tokenizer
(every label ends up -100), and correct markers on rows the trainer would have
truncated to max_seq_length (responses cut off before EOS).
"""
import os
import sys

from datasets import Dataset
from transformers import AutoTokenizer
from unsloth_zoo.dataset_utils import train_on_responses_only

from unsloth.chat_templates import audit_supervision

OUT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "DEMO_OUTPUT.txt")

MODEL = "Qwen/Qwen2.5-0.5B-Instruct"

CONVERSATIONS = [
    [{"role": "user", "content": "What is 2+2?"},
     {"role": "assistant", "content": "2+2 equals 4, because adding two and two gives four."}],
    [{"role": "user", "content": "Name a primary color."},
     {"role": "assistant", "content": "Red is a primary color, along with blue and yellow."}],
    [{"role": "user", "content": "Say hello in French."},
     {"role": "assistant", "content": "Bonjour! That is how you say hello in French."}],
    [{"role": "user", "content": "Give me three fruits."},
     {"role": "assistant", "content": "Apple, banana, and cherry are three common fruits."}],
]

QWEN_MARKERS = dict(
    instruction_part = "<|im_start|>user\n",
    response_part    = "<|im_start|>assistant\n",
)
# The "Llama chat template on a non Llama model" case from the fix_zero_training_loss message.
LLAMA3_MARKERS = dict(
    instruction_part = "<|start_header_id|>user<|end_header_id|>\n\n",
    response_part    = "<|start_header_id|>assistant<|end_header_id|>\n\n",
)

CLEAN_MAX_SEQ_LENGTH     = 64   # above every row: no truncation
TRUNCATED_MAX_SEQ_LENGTH = 40   # inside every response


def tokenize(tokenizer, conversations):
    input_ids = []
    for conversation in conversations:
        encoded = tokenizer.apply_chat_template(conversation, tokenize = True)
        ids = encoded if isinstance(encoded, list) else encoded["input_ids"]
        input_ids.append(list(ids))
    return Dataset.from_dict({
        "input_ids"      : input_ids,
        "attention_mask" : [[1] * len(ids) for ids in input_ids],
    })


def truncate(dataset, max_seq_length):
    # What the trainer does to over-long rows before the labels are built.
    return dataset.map(lambda row: {
        "input_ids"      : row["input_ids"][:max_seq_length],
        "attention_mask" : row["attention_mask"][:max_seq_length],
    })


def mask(dataset, tokenizer, markers):
    masking_fn = train_on_responses_only(
        None, tokenizer = tokenizer, return_function = True, **markers,
    )
    return dataset.map(masking_fn, batched = True)


def build(tokenizer):
    """Return [(title, dataset, max_seq_length)] for the three reports."""
    dataset = tokenize(tokenizer, CONVERSATIONS)
    return [
        ("1. Correct Qwen markers",
         mask(dataset, tokenizer, QWEN_MARKERS), CLEAN_MAX_SEQ_LENGTH),
        ("2. Llama-3 markers on the Qwen tokenizer",
         mask(dataset, tokenizer, LLAMA3_MARKERS), CLEAN_MAX_SEQ_LENGTH),
        (f"3. Correct markers, rows truncated to max_seq_length = {TRUNCATED_MAX_SEQ_LENGTH}",
         mask(truncate(dataset, TRUNCATED_MAX_SEQ_LENGTH), tokenizer, QWEN_MARKERS), TRUNCATED_MAX_SEQ_LENGTH),
    ]


def main():
    tokenizer = AutoTokenizer.from_pretrained(MODEL)
    sections = []
    for title, dataset, max_seq_length in build(tokenizer):
        print(f"\n=== {title} ===")
        report = audit_supervision(
            dataset, tokenizer = tokenizer, max_seq_length = max_seq_length, verbose = True,
        )
        sections.append(f"=== {title} ===\n{report.render(color = False)}\n")
    with open(OUT, "w") as f:
        f.write(
            f"# audit_supervision demo: {MODEL} tokenizer, {len(CONVERSATIONS)} chat rows,\n"
            "# labels from unsloth_zoo.dataset_utils.train_on_responses_only(return_function = True).\n\n"
        )
        f.write("\n".join(sections))
    print(f"\nWrote {OUT}")


if __name__ == "__main__":
    sys.exit(main())
```

</details>

## Design notes

- Supervision signals follow `_supervision_columns` in `unsloth/models/rl.py` (and TRL's dataset preparation): `labels` and `assistant_masks` apply on presence, `completion_mask` only under `completion_only_loss`, read from the trainer as it resolved it (`args._unsloth_resolved_completion_only`, then `trainer.completion_only_loss`, then the `SFTConfig` field, then the prompt/completion dataset shape). Without a trainer a present `completion_mask` is applied unless `completion_only_loss = False` is passed. Several signals are intersected.
- Read-only: it never modifies the dataset, the trainer, or the tokenizer. Nothing runs unless you call it; training-time output is unchanged.
- Streams through `dataset.iter(batch_size = 256)` when available (same reason as `_iter_column` in `raw_text.py`), plain iteration otherwise. `max_rows = 10_000` by default; `None` audits everything. Works on an `IterableDataset` (the total row count is then reported as unknown).
- Per-row counting is `list.count` on the label list, not a per-token Python loop.
- Python 3.9 compatible, no new dependencies; `datasets` is not even imported. The code duck-types `column_names` / `select_columns` / `iter`, so plain lists of rows and custom row sources work too.
- Lives in `unsloth/dataprep/supervision_audit.py` next to `raw_text.py`, exported from `unsloth.dataprep`, and re-exported from `unsloth.chat_templates` right after `train_on_responses_only` so the two are found together. `import unsloth.chat_templates` pulls in nothing new.

## Tests

`tests/test_supervision_audit.py` (27 tests, offline, word-level mock tokenizer, collected by the "Repo tests (CPU)" job in `studio-backend-ci.yml`):

- `labels`, `completion_mask` and no-labels paths; padding excluded via `attention_mask`; torch tensors and numpy inputs
- `datasets.Dataset`, `IterableDataset` with `max_rows`, and a trainer object (tokenizer and `max_seq_length` picked up; an explicit `max_seq_length` wins)
- truncation mid-response vs truncated-but-masked; a row ending exactly at the cap with a supervised EOS is complete; over-long rows are audited cut to the cap; EOS present / absent / masked; duplicated BOS
- `assistant_masks` applied on presence and intersected with `labels`; `completion_only_loss` resolution (explicit argument, trainer attribute, `SFTConfig` field, Unsloth's recorded value, prompt/completion dataset shape)
- empty dataset, zero-length rows, missing `input_ids` raises `ValueError`, `num_examples = 0`, `verbose = False` prints nothing
- exact `render(color = False)` lines including the `[[...]]` marking; `to_dict()` round-trips through `json.dumps`
- integration with the real `train_on_responses_only` masking function: correct markers give no zero rows; wrong markers give every row zero and the warning names `train_on_responses_only`

## Related issues

#823, #2364, #2199, #3198, #1128, #1290, #2771, #3041, #10734
