### PR TITLE
Stop a comment in unsloth_zoo from silently disabling the patched SFT trainer

### DIFF
--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -1272,7 +1272,9 @@ def test_require_replace_survives_a_trailing_comment_on_the_anchor():
     # Tolerance must not reach across a real code change: `b` -> `c` still raises.
     with pytest.raises(RuntimeError):
         _require_replace(
-            "dataset = pack_dataset(\n    a,\n    c,\n)", anchor, replacement,
+            "dataset = pack_dataset(\n    a,\n    c,\n)",
+            anchor,
+            replacement,
             where = "changed argument",
         )
 

--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -1247,6 +1247,40 @@ def test_require_replace_raises_on_missing_anchor():
     assert _require_replace("abc", "z", "Z", required = False, where = "optional") == "abc"
 
 
+def test_require_replace_survives_a_trailing_comment_on_the_anchor():
+    """A comment appearing on an anchored line is not a code change.
+
+    unsloth_zoo #1192 put `# noqa: F821` on the `pack_dataset(` call while
+    building a lint gate. The literal anchor stopped matching, the required edit
+    raised, and every SFT run silently fell back to TRL's own trainer -- losing
+    the packing and truncation fixes this module exists to apply. The code the
+    anchor points at never moved.
+    """
+    from unsloth.models.rl_replacements import _require_replace
+
+    anchor = "dataset = pack_dataset(\n    a,\n    b,\n)"
+    replacement = "dataset = pack_dataset(\n    a,\n    **kw,\n)"
+
+    # The exact shape that broke: a trailing comment on the first anchored line.
+    commented = "x = 1\ndataset = pack_dataset(  # noqa: F821 -- reached only past the probe\n    a,\n    b,\n)\ny = 2"
+    assert _require_replace(commented, anchor, replacement) == f"x = 1\n{replacement}\ny = 2"
+
+    # A comment on any other anchored line is tolerated too.
+    inner = "dataset = pack_dataset(\n    a,  # the columns\n    b,\n)"
+    assert _require_replace(inner, anchor, replacement) == replacement
+
+    # Tolerance must not reach across a real code change: `b` -> `c` still raises.
+    with pytest.raises(RuntimeError):
+        _require_replace(
+            "dataset = pack_dataset(\n    a,\n    c,\n)", anchor, replacement,
+            where = "changed argument",
+        )
+
+    # A `#` inside a string literal is not a comment and must still match exactly.
+    hashed = 'sep = "#"\n'
+    assert _require_replace(hashed + anchor, anchor, replacement) == hashed + replacement
+
+
 def test_resolve_string_model_config_forwards_token(monkeypatch):
     import transformers
 

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -471,10 +471,7 @@ def _comment_tolerant_anchor(old):
     drift this survives.
     """
     return re.compile(
-        "\n".join(
-            re.escape(line.rstrip()) + r"[ \t]*(?:\#[^\n]*)?"
-            for line in old.split("\n")
-        )
+        "\n".join(re.escape(line.rstrip()) + r"[ \t]*(?:\#[^\n]*)?" for line in old.split("\n"))
     )
 
 
@@ -498,7 +495,9 @@ def _require_replace(
         return function.replace(old, new, count)
 
     function, applied = _comment_tolerant_anchor(old).subn(
-        lambda _match: new, function, count = count,
+        lambda _match: new,
+        function,
+        count = count,
     )
     if applied:
         return function

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -457,6 +457,27 @@ def _warn_once(where, message):
     logger.warning(message)
 
 
+def _comment_tolerant_anchor(old):
+    """`old` as a regex that still matches once a line grows a trailing comment.
+
+    A literal anchor stops matching the moment the Zoo appends a comment to one of
+    its lines, and this repo edits comments in bulk: unsloth_zoo #1192 put a
+    `# noqa: F821` on the `pack_dataset(` call while building a lint gate, which
+    was enough to drop the whole patched SFT trainer. Nothing about the code
+    changed, so nothing about the match should have.
+
+    Every line is allowed an optional trailing comment, including lines that
+    already carry one, so a comment being added, reworded or removed upstream is
+    drift this survives.
+    """
+    return re.compile(
+        "\n".join(
+            re.escape(line.rstrip()) + r"[ \t]*(?:\#[^\n]*)?"
+            for line in old.split("\n")
+        )
+    )
+
+
 def _require_replace(
     function,
     old,
@@ -466,20 +487,33 @@ def _require_replace(
     required = True,
     where = "",
 ):
-    """str.replace that never silently no-ops a load-bearing source edit. Plain str.replace returns the source unchanged when the anchor is absent, so a drifted anchor in a newer TRL / unsloth_zoo would skip the edit while later edits still reference helper variables it should have introduced (NameError at runtime). Fail loudly for a required edit, warn once and skip for an optional one."""
-    if old not in function:
-        detail = f" ({where})" if where else ""
-        if required:
-            raise RuntimeError(
-                f"Unsloth: source anchor not found{detail}; the patched function is out "
-                "of sync with this TRL / unsloth_zoo version. Please file a bug report."
-            )
-        _warn_once(
-            where,
-            f"Unsloth: skipped an optional source edit{detail} (anchor not found).",
-        )
+    """str.replace that never silently no-ops a load-bearing source edit. Plain str.replace returns the source unchanged when the anchor is absent, so a drifted anchor in a newer TRL / unsloth_zoo would skip the edit while later edits still reference helper variables it should have introduced (NameError at runtime). Fail loudly for a required edit, warn once and skip for an optional one.
+
+    The literal anchor is tried first and a comment-tolerant form of the same
+    anchor second, so the only drift that reaches the raise below is drift in the
+    code itself. `re.sub` would read backslashes in `new` as group references, so
+    the replacement is handed over as a function.
+    """
+    if old in function:
+        return function.replace(old, new, count)
+
+    function, applied = _comment_tolerant_anchor(old).subn(
+        lambda _match: new, function, count = count,
+    )
+    if applied:
         return function
-    return function.replace(old, new, count)
+
+    detail = f" ({where})" if where else ""
+    if required:
+        raise RuntimeError(
+            f"Unsloth: source anchor not found{detail}; the patched function is out "
+            "of sync with this TRL / unsloth_zoo version. Please file a bug report."
+        )
+    _warn_once(
+        where,
+        f"Unsloth: skipped an optional source edit{detail} (anchor not found).",
+    )
+    return function
 
 
 # The one line every unsloth_zoo sft_prepare_dataset ends its worker count on, as a regex so a renamed right-hand side still matches and the indentation carries over. Unchanged since Aug 2025 (#257) while the block around it was rewritten repeatedly, hence a fallback anchor.


### PR DESCRIPTION
On current `main` against current `unsloth_zoo`, `import unsloth` prints:

```
Could not build the patched trl.trainer.sft_trainer, so training will use trl's
own trainer instead: RuntimeError: Unsloth: source anchor not found
(sft_prepare_dataset pack_dataset call); the patched function is out of sync
with this TRL / unsloth_zoo version. Please file a bug report.
```

Every SFT run then quietly uses TRL's own trainer, losing the packing and truncation fixes `rl_replacements.py` exists to apply. It is a warning, not an error, so a run looks normal.

## Cause

Nothing in the Zoo's code moved. `unsloth-zoo` #1192 added a `# noqa: F821` to the `pack_dataset(` call while building an undefined-name lint gate, and our literal anchor stopped matching a line that had only grown a comment:

```
repo's literal anchor present in zoo source? -> False
anchor + the zoo's trailing comment present?  -> True
```

The `# noqa` is correct on its own terms. `pack_dataset` really is an undefined name at that point, reached only past a bare-name probe, and the Zoo has no way to know this file string-matches its source. The brittleness is ours.

It is also not a one-off risk. We edit comments in bulk (#10504 "Reduce comment volume", #10116 "Trim comments"), so an anchored line gaining or losing a comment is routine drift, and today it silently disables a load-bearing patch.

## Fix

`_require_replace` tries the literal anchor first, then the same anchor with an optional trailing comment allowed on each line. The only drift that still raises is drift in the code itself.

The literal branch is untouched and tried first, so any Zoo that matched before takes the identical path and produces identical output. Fixing the shared helper covers all five `_require_replace` call sites rather than just the `pack_dataset` one.

## Checks

Against the 12 most recent `unsloth_zoo` revisions of `dataset_utils.py`, 2026-07-01 through 2026-09-12:

| zoo rev | date | literal matches | tolerant matches | result |
|---|---|---|---|---|
| 93aaae74 | 2026-09-12 | no | yes | patch applied |
| 7c9a7ac0 | 2026-08-12 | yes | yes | patch applied |
| 94b88604 | 2026-08-09 | yes | yes | patch applied |
| 40963429 | 2026-08-08 | yes | yes | patch applied |
| f2f55311 | 2026-08-05 | yes | yes | patch applied |
| 17e76fdc | 2026-08-05 | yes | yes | patch applied |
| 8fd68b10 | 2026-08-04 | yes | yes | patch applied |
| 9411f77e | 2026-08-04 | yes | yes | patch applied |
| 4d140e03 | 2026-07-30 | yes | yes | patch applied |
| d9298b27 | 2026-07-11 | yes | yes | patch applied |
| 7f4c6be6 | 2026-07-03 | yes | yes | patch applied |
| d4440e62 | 2026-07-01 | yes | yes | patch applied |

Only #1192 needs the tolerant form. The 11 older ones still match literally, which is the backwards-compatibility claim stated as a measurement rather than an argument.

The change is pure string matching over the Zoo's own source, so it touches no torch, TRL, transformers or PEFT API surface and carries no version sensitivity of its own.

The new test covers the exact shape that broke, a comment on an inner anchored line, a `#` inside a string literal (not a comment, so it must still match exactly), and asserts the tolerance does NOT reach across a real code change. `tests/utils/test_packing.py` and `tests/utils/test_dataset_num_proc.py`, which already cover these anchor helpers, pass together: 169 passed.

Suite effect, `pytest tests/ -n 64`: 30 failures to 16. The 16 that go away all trace to this one anchor:

- `tests/utils/test_packing.py` 5 to 0
- `tests/version_compat/test_trl_padding_free_max_length.py` 9 to 1 (the last one is `datasets` importing `VideoReader`, removed in torchvision 0.28, unrelated)
- `tests/version_compat/test_trl_grpo_fake_run.py` 1 to 0
- `tests/version_compat/test_trl_fake_train_cpu.py` 1 to 0
- `tests/python/test_rl_config_pickling.py` 1 to 0

The remaining 16 are separate and not addressed here: 7 pass in isolation and only fail under `-n 64` (GPU contention), 2 are tests asserting on process-global `sys.modules`, 1 is `unsloth_zoo/vllm_utils.py` hard-importing a module path vllm 0.29 removed, and the rest are environment (transformers 5.17.0 against our `<=5.5.0` pin, Triton without sm_100 kernels on this box, torchcodec build variants, an HTTP 401).
