### PR TITLE
Ask the vllm-free import tests in a clean interpreter, not in sys.modules

### DIFF
--- a/tests/vllm_compat/test_unsloth_zoo_imports.py
+++ b/tests/vllm_compat/test_unsloth_zoo_imports.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import importlib
 import importlib.util
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -85,40 +86,71 @@ def _has_vllm() -> bool:
     return importlib.util.find_spec("vllm") is not None
 
 
+def _pulls_in_vllm(module_name: str, *exports: str) -> tuple[bool, list[str]]:
+    """(did importing `module_name` pull in vllm, which of `exports` it has).
+
+    Asked in a FRESH interpreter, because `"vllm" in sys.modules` is a property
+    of the process, not of the import under test. In-process this answers "has
+    anything in this pytest worker ever imported vllm" -- the vllm-hard-import
+    tests in this same file do exactly that, and popping the module under test
+    from sys.modules cannot undo it, because its already-cached dependencies are
+    not re-imported on the second import either. So the check passed or failed on
+    test ordering and never observed what it claimed to.
+
+    The subprocess re-applies the same CPU spoof this module applies at import,
+    so a CPU-only runner is still covered. subprocess + sys.executable keeps this
+    working on Linux, macOS and Windows alike.
+    """
+    probe = (
+        "import sys\n"
+        f"sys.path.insert(0, {str(_SPOOF_DIR)!r})\n"
+        "import _zoo_aggressive_cuda_spoof as s\n"
+        "s.apply()\n"
+        f"m = __import__({module_name!r}, fromlist=['_'])\n"
+        "print('VLLM' if 'vllm' in sys.modules else 'NOVLLM')\n"
+        f"print(','.join(n for n in {list(exports)!r} if hasattr(m, n)))\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", probe], capture_output = True, text = True,
+    )
+    if proc.returncode != 0:
+        pytest.fail(
+            f"importing {module_name} in a clean interpreter failed:\n"
+            f"{proc.stdout}\n{proc.stderr}"
+        )
+    lines = proc.stdout.strip().split("\n")
+    found = [n for n in (lines[-1].split(",") if lines[-1] else [])]
+    return lines[-2] == "VLLM", found
+
+
 # rl_replacements: zero direct vllm imports;
 # the GRPO + fast_inference surface.
 @pytest.mark.skipif(not _has_unsloth_zoo(), reason = "unsloth_zoo not installed")
 def test_rl_replacements_imports_without_vllm():
     """unsloth_zoo.rl_replacements must NOT pull in vllm at import time."""
-    sys.modules.pop("unsloth_zoo.rl_replacements", None)
-    rl = importlib.import_module("unsloth_zoo.rl_replacements")
     # A transitive vllm import crashes GRPOTrainer construction on Colab.
-    assert "vllm" not in sys.modules, (
+    pulled, exports = _pulls_in_vllm(
+        "unsloth_zoo.rl_replacements", "RL_REPLACEMENTS", "RL_FUNCTIONS",
+    )
+    assert not pulled, (
         "unsloth_zoo.rl_replacements imported vllm transitively; this breaks "
         "GRPO on environments without vllm installed (the use_vllm=False path "
         "is supposed to work without vllm)."
     )
-    assert (
-        hasattr(rl, "RL_REPLACEMENTS")
-        or hasattr(rl, "RL_FUNCTIONS")
-        or any(name.startswith("grpo_") for name in dir(rl))
-    ), "expected at least one GRPO-related export in rl_replacements"
+    assert exports, "expected at least one GRPO-related export in rl_replacements"
 
 
 # empty_model: no vllm import;
 # pure builder for the fast_inference=True path.
 @pytest.mark.skipif(not _has_unsloth_zoo(), reason = "unsloth_zoo not installed")
 def test_empty_model_imports_without_vllm():
-    sys.modules.pop("unsloth_zoo.empty_model", None)
-    em = importlib.import_module("unsloth_zoo.empty_model")
-    assert (
-        "vllm" not in sys.modules
-    ), "unsloth_zoo.empty_model imported vllm transitively; expected to be vllm-free"
-    assert (
-        hasattr(em, "create_empty_causal_lm")
-        or hasattr(em, "create_empty_model")
-        or any(n.startswith("create_empty") for n in dir(em))
-    ), "expected a create_empty_* helper in empty_model"
+    pulled, exports = _pulls_in_vllm(
+        "unsloth_zoo.empty_model", "create_empty_causal_lm", "create_empty_model",
+    )
+    assert not pulled, (
+        "unsloth_zoo.empty_model imported vllm transitively; expected to be vllm-free"
+    )
+    assert exports, "expected a create_empty_* helper in empty_model"
 
 
 # vllm_lora_request / vllm_lora_worker_manager / vllm_utils: hard-import vllm,

--- a/tests/vllm_compat/test_unsloth_zoo_imports.py
+++ b/tests/vllm_compat/test_unsloth_zoo_imports.py
@@ -111,7 +111,9 @@ def _pulls_in_vllm(module_name: str, *exports: str) -> tuple[bool, list[str]]:
         f"print(','.join(n for n in {list(exports)!r} if hasattr(m, n)))\n"
     )
     proc = subprocess.run(
-        [sys.executable, "-c", probe], capture_output = True, text = True,
+        [sys.executable, "-c", probe],
+        capture_output = True,
+        text = True,
     )
     if proc.returncode != 0:
         pytest.fail(
@@ -130,7 +132,9 @@ def test_rl_replacements_imports_without_vllm():
     """unsloth_zoo.rl_replacements must NOT pull in vllm at import time."""
     # A transitive vllm import crashes GRPOTrainer construction on Colab.
     pulled, exports = _pulls_in_vllm(
-        "unsloth_zoo.rl_replacements", "RL_REPLACEMENTS", "RL_FUNCTIONS",
+        "unsloth_zoo.rl_replacements",
+        "RL_REPLACEMENTS",
+        "RL_FUNCTIONS",
     )
     assert not pulled, (
         "unsloth_zoo.rl_replacements imported vllm transitively; this breaks "
@@ -145,11 +149,13 @@ def test_rl_replacements_imports_without_vllm():
 @pytest.mark.skipif(not _has_unsloth_zoo(), reason = "unsloth_zoo not installed")
 def test_empty_model_imports_without_vllm():
     pulled, exports = _pulls_in_vllm(
-        "unsloth_zoo.empty_model", "create_empty_causal_lm", "create_empty_model",
+        "unsloth_zoo.empty_model",
+        "create_empty_causal_lm",
+        "create_empty_model",
     )
-    assert not pulled, (
-        "unsloth_zoo.empty_model imported vllm transitively; expected to be vllm-free"
-    )
+    assert (
+        not pulled
+    ), "unsloth_zoo.empty_model imported vllm transitively; expected to be vllm-free"
     assert exports, "expected a create_empty_* helper in empty_model"
 
 


### PR DESCRIPTION
`test_rl_replacements_imports_without_vllm` and `test_empty_model_imports_without_vllm` fail on current `main`, and what they report is not true. Neither module imports vllm:

```
$ python -c "import sys; import unsloth_zoo.rl_replacements; print('vllm' in sys.modules)"
False
$ python -c "import sys; import unsloth_zoo.empty_model; print('vllm' in sys.modules)"
False
```

## Why the check could not work

`"vllm" in sys.modules` is a property of the process, not of the import under test.

Three tests further down the same file import `vllm_lora_request`, `vllm_lora_worker_manager` and `vllm_utils`, all of which hard-import vllm. Once any of them has run, vllm is in `sys.modules` for the rest of the process. Popping the module under test first does not help either: its dependencies stay cached, so the re-import never re-executes them, and the assertion cannot observe what it claims to.

So the test passed or failed on test ordering, and on this box it was reporting a transitive vllm import that does not exist.

## Fix

Both checks run in a fresh interpreter through `subprocess`, which is the only place the question has a meaningful answer.

The probe re-applies the same CPU spoof this module applies at import time, so CPU-only runners keep their coverage, and `subprocess` + `sys.executable` behaves the same on Linux, macOS and Windows.

## The probe is not vacuous

Pointed at a module that genuinely does import vllm, it says so:

```
unsloth_zoo.rl_replacements    -> NOVLLM
unsloth_zoo.empty_model        -> NOVLLM
unsloth_zoo.vllm_lora_request  -> VLLM
```

So a real transitive vllm import would still fail the test, which is the property that matters.

## Result

`tests/vllm_compat/test_unsloth_zoo_imports.py` goes from 3 failed, 2 passed to 1 failed, 4 passed, running the whole file in one process, which is the ordering that used to break it.

The one that stays red is `test_vllm_utils_imports`, and it is a true positive rather than something to paper over. `unsloth_zoo/vllm_utils.py` hard-imports `vllm.model_executor.layers.quantization.bitsandbytes` at module scope, and vLLM 0.29 removed that module, so `import unsloth_zoo.vllm_utils` fails outright on current vllm. That needs a fix in unsloth-zoo and is filed separately.

## Note for later

The same pattern appears in a few other tests (`test_broken_tf_does_not_break_import.py`, `test_peft_tensor_parallel_compat.py`, `test_windows_no_sentencepiece.py`). They are green today, so I have left them alone rather than widen this diff, but they are exposed to the same ordering sensitivity. Several other tests in the tree already do the subprocess-probe thing correctly, so the pattern to copy is there.
