### PR TITLE
Retry an OpenAI-compatible upstream that rejects max_tokens as max_completion_tokens (#10787)

### DIFF
--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -1314,9 +1314,8 @@ class ExternalProviderClient:
                     if response.status_code != 200:
                         error_body = await response.aread()
                         error_text = error_body.decode("utf-8", errors = "replace")
-                        if (
-                            attempt_body is not body
-                            or not _unsupported_max_tokens_error(response.status_code, error_text)
+                        if attempt_body is not body or not _unsupported_max_tokens_error(
+                            response.status_code, error_text
                         ):
                             error_text = _friendly_provider_error_text(
                                 self.provider_type,
@@ -1415,7 +1414,9 @@ class ExternalProviderClient:
                             {
                                 "type": "tool_end",
                                 "tool_call_id": web_search_tool_id,
-                                "result": ("\n---\n".join(blocks) if blocks else "(search complete)"),
+                                "result": (
+                                    "\n---\n".join(blocks) if blocks else "(search complete)"
+                                ),
                             }
                         )
 
@@ -1490,7 +1491,9 @@ class ExternalProviderClient:
                                                     ):
                                                         if not isinstance(envelope, dict):
                                                             continue
-                                                        for ann in envelope.get("annotations") or []:
+                                                        for ann in (
+                                                            envelope.get("annotations") or []
+                                                        ):
                                                             _record_or_url_citation(ann)
                             # Verbatim relay, minus Unsloth's own UI control protocol: the frames this server writes to
                             # paint tool cards ride the same stream, so an endpoint that echoes them forges a card for a
@@ -1501,7 +1504,11 @@ class ExternalProviderClient:
                             yield relayed
                         # Stream ended without [DONE] (some upstreams just close the connection). Emit tool_end so the
                         # card does not stay in "running" forever.
-                        if web_search_active and web_search_tool_started and not web_search_tool_ended:
+                        if (
+                            web_search_active
+                            and web_search_tool_started
+                            and not web_search_tool_ended
+                        ):
                             yield _build_web_search_tool_end()
                             web_search_tool_ended = True
                     except GeneratorExit:

--- a/studio/backend/core/inference/external_provider.py
+++ b/studio/backend/core/inference/external_provider.py
@@ -1297,214 +1297,230 @@ class ExternalProviderClient:
         )
 
         try:
-            async with _http_client.stream(
-                "POST",
-                url,
-                json = body,
-                headers = self._auth_headers(),
-                timeout = self._stream_timeout,
-            ) as response:
-                if response.status_code != 200:
-                    error_body = await response.aread()
-                    error_text = error_body.decode("utf-8", errors = "replace")
-                    error_text = _friendly_provider_error_text(
-                        self.provider_type,
-                        response.status_code,
-                        error_text,
-                        model = model,
-                    )
-                    logger.error(
-                        "External provider returned %d: %s",
-                        response.status_code,
-                        error_text[:500],
-                    )
-                    yield _error_sse_line(
-                        response.status_code,
-                        error_text,
-                        self.provider_type,
-                        response.headers.get("Retry-After"),
-                    )
-                    return
+            # One retry when an OpenAI-compatible upstream rejects `max_tokens` outright
+            # (Azure-hosted gpt-5.x/o-series answer 400 unsupported_parameter, #10787).
+            # Nothing has been yielded yet at the status check, so re-sending with
+            # `max_completion_tokens` is invisible to the client.
+            for attempt_body in (
+                [body, _rename_max_tokens_body(body)] if "max_tokens" in body else [body]
+            ):
+                async with _http_client.stream(
+                    "POST",
+                    url,
+                    json = attempt_body,
+                    headers = self._auth_headers(),
+                    timeout = self._stream_timeout,
+                ) as response:
+                    if response.status_code != 200:
+                        error_body = await response.aread()
+                        error_text = error_body.decode("utf-8", errors = "replace")
+                        if (
+                            attempt_body is not body
+                            or not _unsupported_max_tokens_error(response.status_code, error_text)
+                        ):
+                            error_text = _friendly_provider_error_text(
+                                self.provider_type,
+                                response.status_code,
+                                error_text,
+                                model = model,
+                            )
+                            logger.error(
+                                "External provider returned %d: %s",
+                                response.status_code,
+                                error_text[:500],
+                            )
+                            yield _error_sse_line(
+                                response.status_code,
+                                error_text,
+                                self.provider_type,
+                                response.headers.get("Retry-After"),
+                            )
+                            return
+                        logger.info(
+                            "Upstream rejected max_tokens for %s; retrying with max_completion_tokens",
+                            model,
+                        )
+                        continue
 
-                # Manual __anext__ (not `async for`) so we can close the response BEFORE lines_gen, avoiding the
-                # httpcore 1.0 GeneratorExit -> RuntimeError path on Python 3.13.
-                lines_gen = response.aiter_lines().__aiter__()
-                # Diagnostic counters for the OAI-compat path; surface OpenRouter mid-stream errors otherwise
-                # invisible server-side.
-                event_counts: dict[str, int] = {}
-                chosen_model: Optional[str] = None
-                # OpenRouter has no web_search_call events -- citations arrive as url_citation annotations. Synthesise
-                # a tool_start/tool_end pair to match the OpenAI/Anthropic UX.
-                web_search_active = (
-                    self.provider_type == "openrouter"
-                    and not tool_choice_disabled
-                    and not _or_tool_choice_forced_function
-                    and bool(enabled_tools)
-                    and "web_search" in (enabled_tools or [])
-                )
-                web_search_tool_id = "openrouter_web_search"
-                web_search_citations: list[dict[str, str]] = []
-                web_search_tool_started = False
-                web_search_tool_ended = False
+                    # Manual __anext__ (not `async for`) so we can close the response BEFORE lines_gen, avoiding the
+                    # httpcore 1.0 GeneratorExit -> RuntimeError path on Python 3.13.
+                    lines_gen = response.aiter_lines().__aiter__()
+                    # Diagnostic counters for the OAI-compat path; surface OpenRouter mid-stream errors otherwise
+                    # invisible server-side.
+                    event_counts: dict[str, int] = {}
+                    chosen_model: Optional[str] = None
+                    # OpenRouter has no web_search_call events -- citations arrive as url_citation annotations. Synthesise
+                    # a tool_start/tool_end pair to match the OpenAI/Anthropic UX.
+                    web_search_active = (
+                        self.provider_type == "openrouter"
+                        and not tool_choice_disabled
+                        and not _or_tool_choice_forced_function
+                        and bool(enabled_tools)
+                        and "web_search" in (enabled_tools or [])
+                    )
+                    web_search_tool_id = "openrouter_web_search"
+                    web_search_citations: list[dict[str, str]] = []
+                    web_search_tool_started = False
+                    web_search_tool_ended = False
 
-                def _emit_synthetic_tool_event(payload: dict[str, Any]) -> str:
-                    _stamp_server_tool_marker(payload)
-                    chunk = {
-                        "id": f"chatcmpl-{self.provider_type}-synthetic",
-                        "object": "chat.completion.chunk",
-                        "choices": [
+                    def _emit_synthetic_tool_event(payload: dict[str, Any]) -> str:
+                        _stamp_server_tool_marker(payload)
+                        chunk = {
+                            "id": f"chatcmpl-{self.provider_type}-synthetic",
+                            "object": "chat.completion.chunk",
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "delta": {},
+                                    "finish_reason": None,
+                                }
+                            ],
+                            "_toolEvent": payload,
+                        }
+                        return f"data: {_json.dumps(chunk)}"
+
+                    def _record_or_url_citation(payload: Any) -> None:
+                        if not isinstance(payload, dict):
+                            return
+                        if payload.get("type") != "url_citation":
+                            return
+                        # OpenRouter (and OpenAI Chat Completions web_search) nest the citation under url_citation; some
+                        # variants ship the fields flat on the annotation itself. Accept both.
+                        cit = payload.get("url_citation")
+                        if not isinstance(cit, dict):
+                            cit = payload
+                        url = cit.get("url", "") if isinstance(cit, dict) else ""
+                        if not url or not isinstance(url, str):
+                            return
+                        if any(c["url"] == url for c in web_search_citations):
+                            return
+                        title = cit.get("title") or url
+                        snippet = cit.get("content") or cit.get("snippet") or ""
+                        web_search_citations.append(
                             {
-                                "index": 0,
-                                "delta": {},
-                                "finish_reason": None,
+                                "url": url,
+                                "title": title,
+                                "snippet": snippet if isinstance(snippet, str) else "",
                             }
-                        ],
-                        "_toolEvent": payload,
-                    }
-                    return f"data: {_json.dumps(chunk)}"
+                        )
 
-                def _record_or_url_citation(payload: Any) -> None:
-                    if not isinstance(payload, dict):
-                        return
-                    if payload.get("type") != "url_citation":
-                        return
-                    # OpenRouter (and OpenAI Chat Completions web_search) nest the citation under url_citation; some
-                    # variants ship the fields flat on the annotation itself. Accept both.
-                    cit = payload.get("url_citation")
-                    if not isinstance(cit, dict):
-                        cit = payload
-                    url = cit.get("url", "") if isinstance(cit, dict) else ""
-                    if not url or not isinstance(url, str):
-                        return
-                    if any(c["url"] == url for c in web_search_citations):
-                        return
-                    title = cit.get("title") or url
-                    snippet = cit.get("content") or cit.get("snippet") or ""
-                    web_search_citations.append(
-                        {
-                            "url": url,
-                            "title": title,
-                            "snippet": snippet if isinstance(snippet, str) else "",
-                        }
-                    )
+                    def _build_web_search_tool_end() -> str:
+                        blocks: list[str] = []
+                        for cit in web_search_citations:
+                            line = f"Title: {cit['title']}\nURL: {cit['url']}"
+                            if cit.get("snippet"):
+                                line += f"\nSnippet: {cit['snippet']}"
+                            blocks.append(line)
+                        return _emit_synthetic_tool_event(
+                            {
+                                "type": "tool_end",
+                                "tool_call_id": web_search_tool_id,
+                                "result": ("\n---\n".join(blocks) if blocks else "(search complete)"),
+                            }
+                        )
 
-                def _build_web_search_tool_end() -> str:
-                    blocks: list[str] = []
-                    for cit in web_search_citations:
-                        line = f"Title: {cit['title']}\nURL: {cit['url']}"
-                        if cit.get("snippet"):
-                            line += f"\nSnippet: {cit['snippet']}"
-                        blocks.append(line)
-                    return _emit_synthetic_tool_event(
-                        {
-                            "type": "tool_end",
-                            "tool_call_id": web_search_tool_id,
-                            "result": ("\n---\n".join(blocks) if blocks else "(search complete)"),
-                        }
-                    )
+                    if web_search_active:
+                        yield _emit_synthetic_tool_event(
+                            {
+                                "type": "tool_start",
+                                "tool_name": "web_search",
+                                "tool_call_id": web_search_tool_id,
+                                "arguments": {},
+                            }
+                        )
+                        web_search_tool_started = True
 
-                if web_search_active:
-                    yield _emit_synthetic_tool_event(
-                        {
-                            "type": "tool_start",
-                            "tool_name": "web_search",
-                            "tool_call_id": web_search_tool_id,
-                            "arguments": {},
-                        }
-                    )
-                    web_search_tool_started = True
-
-                try:
-                    while True:
-                        try:
-                            line = await lines_gen.__anext__()
-                        except StopAsyncIteration:
-                            break
-                        if not line.strip():
-                            continue
-                        if line.startswith("data:"):
-                            data_str = line[len("data:") :].strip()
-                            if data_str == "[DONE]":
-                                event_counts["done"] = event_counts.get("done", 0) + 1
-                                # Emit synthetic tool_end with collected citations BEFORE forwarding [DONE], so the
-                                # tool card transitions to "complete" before the stream closes.
-                                if (
-                                    web_search_active
-                                    and web_search_tool_started
-                                    and not web_search_tool_ended
-                                ):
-                                    yield _build_web_search_tool_end()
-                                    web_search_tool_ended = True
-                            elif data_str:
-                                try:
-                                    parsed = _json.loads(data_str)
-                                except Exception:
-                                    parsed = None
-                                if isinstance(parsed, dict):
-                                    # Mid-stream provider error event. OpenRouter in particular returns 200 then
-                                    # surfaces the failure as an SSE error event.
-                                    if "error" in parsed:
-                                        event_counts["error"] = event_counts.get("error", 0) + 1
-                                        logger.warning(
-                                            "%s SSE error event: %s",
-                                            self.provider_type,
-                                            parsed.get("error"),
-                                        )
-                                    else:
-                                        event_counts["delta"] = event_counts.get("delta", 0) + 1
-                                    # OpenRouter (and most OAI-compat providers) report the handling model in every
-                                    # chunk's `model` field. Latch the first non-empty value so the router-picked
-                                    # model surfaces in logs and reaches the proxy caller.
-                                    if chosen_model is None and isinstance(
-                                        parsed.get("model"), str
+                    try:
+                        while True:
+                            try:
+                                line = await lines_gen.__anext__()
+                            except StopAsyncIteration:
+                                break
+                            if not line.strip():
+                                continue
+                            if line.startswith("data:"):
+                                data_str = line[len("data:") :].strip()
+                                if data_str == "[DONE]":
+                                    event_counts["done"] = event_counts.get("done", 0) + 1
+                                    # Emit synthetic tool_end with collected citations BEFORE forwarding [DONE], so the
+                                    # tool card transitions to "complete" before the stream closes.
+                                    if (
+                                        web_search_active
+                                        and web_search_tool_started
+                                        and not web_search_tool_ended
                                     ):
-                                        chosen_model = parsed["model"]
-                                    # With web_search on, scan every chunk's delta and message objects for
-                                    # url_citation annotations. Different OpenRouter upstreams place them in different
-                                    # spots.
-                                    if web_search_active:
-                                        choices = parsed.get("choices") or []
-                                        if isinstance(choices, list):
-                                            for choice in choices:
-                                                if not isinstance(choice, dict):
-                                                    continue
-                                                for envelope in (
-                                                    choice.get("delta"),
-                                                    choice.get("message"),
-                                                ):
-                                                    if not isinstance(envelope, dict):
+                                        yield _build_web_search_tool_end()
+                                        web_search_tool_ended = True
+                                elif data_str:
+                                    try:
+                                        parsed = _json.loads(data_str)
+                                    except Exception:
+                                        parsed = None
+                                    if isinstance(parsed, dict):
+                                        # Mid-stream provider error event. OpenRouter in particular returns 200 then
+                                        # surfaces the failure as an SSE error event.
+                                        if "error" in parsed:
+                                            event_counts["error"] = event_counts.get("error", 0) + 1
+                                            logger.warning(
+                                                "%s SSE error event: %s",
+                                                self.provider_type,
+                                                parsed.get("error"),
+                                            )
+                                        else:
+                                            event_counts["delta"] = event_counts.get("delta", 0) + 1
+                                        # OpenRouter (and most OAI-compat providers) report the handling model in every
+                                        # chunk's `model` field. Latch the first non-empty value so the router-picked
+                                        # model surfaces in logs and reaches the proxy caller.
+                                        if chosen_model is None and isinstance(
+                                            parsed.get("model"), str
+                                        ):
+                                            chosen_model = parsed["model"]
+                                        # With web_search on, scan every chunk's delta and message objects for
+                                        # url_citation annotations. Different OpenRouter upstreams place them in different
+                                        # spots.
+                                        if web_search_active:
+                                            choices = parsed.get("choices") or []
+                                            if isinstance(choices, list):
+                                                for choice in choices:
+                                                    if not isinstance(choice, dict):
                                                         continue
-                                                    for ann in envelope.get("annotations") or []:
-                                                        _record_or_url_citation(ann)
-                        # Verbatim relay, minus Unsloth's own UI control protocol: the frames this server writes to
-                        # paint tool cards ride the same stream, so an endpoint that echoes them forges a card for a
-                        # tool that never ran.
-                        relayed = sanitize_provider_sse_line(line)
-                        if relayed is None:
-                            continue
-                        yield relayed
-                    # Stream ended without [DONE] (some upstreams just close the connection). Emit tool_end so the
-                    # card does not stay in "running" forever.
-                    if web_search_active and web_search_tool_started and not web_search_tool_ended:
-                        yield _build_web_search_tool_end()
-                        web_search_tool_ended = True
-                except GeneratorExit:
-                    await response.aclose()  # set PoolByteStream._closed=True FIRST
-                    await lines_gen.aclose()  # now safe — aclose() is a no-op
-                    raise
-                finally:
-                    logger.info(
-                        "%s stream complete (model=%s, chosen=%s, "
-                        "web_search_requested=%s, citations=%s, events=%s)",
-                        self.provider_type,
-                        model,
-                        chosen_model,
-                        web_search_active,
-                        len(web_search_citations),
-                        event_counts,
-                    )
-                    await response.aclose()
-                    await lines_gen.aclose()
+                                                    for envelope in (
+                                                        choice.get("delta"),
+                                                        choice.get("message"),
+                                                    ):
+                                                        if not isinstance(envelope, dict):
+                                                            continue
+                                                        for ann in envelope.get("annotations") or []:
+                                                            _record_or_url_citation(ann)
+                            # Verbatim relay, minus Unsloth's own UI control protocol: the frames this server writes to
+                            # paint tool cards ride the same stream, so an endpoint that echoes them forges a card for a
+                            # tool that never ran.
+                            relayed = sanitize_provider_sse_line(line)
+                            if relayed is None:
+                                continue
+                            yield relayed
+                        # Stream ended without [DONE] (some upstreams just close the connection). Emit tool_end so the
+                        # card does not stay in "running" forever.
+                        if web_search_active and web_search_tool_started and not web_search_tool_ended:
+                            yield _build_web_search_tool_end()
+                            web_search_tool_ended = True
+                    except GeneratorExit:
+                        await response.aclose()  # set PoolByteStream._closed=True FIRST
+                        await lines_gen.aclose()  # now safe — aclose() is a no-op
+                        raise
+                    finally:
+                        logger.info(
+                            "%s stream complete (model=%s, chosen=%s, "
+                            "web_search_requested=%s, citations=%s, events=%s)",
+                            self.provider_type,
+                            model,
+                            chosen_model,
+                            web_search_active,
+                            len(web_search_citations),
+                            event_counts,
+                        )
+                        await response.aclose()
+                        await lines_gen.aclose()
 
         except httpx.ConnectError as exc:
             logger.error("Connection error to %s: %s", self.provider_type, exc)
@@ -6133,6 +6149,24 @@ class ExternalProviderClient:
             headers = self._auth_headers(),
             timeout = self._timeout,
         )
+        # One retry when the upstream rejects `max_tokens` outright (#10787): Azure-hosted
+        # gpt-5.x/o-series behind OpenAI-compatible proxies answer 400
+        # unsupported_parameter naming the field.
+        if (
+            response.status_code == 400
+            and "max_tokens" in body
+            and _unsupported_max_tokens_error(response.status_code, response.text)
+        ):
+            logger.info(
+                "Upstream rejected max_tokens for %s; retrying with max_completion_tokens",
+                model,
+            )
+            response = await _http_client.post(
+                f"{self.base_url}/chat/completions",
+                json = _rename_max_tokens_body(body),
+                headers = self._auth_headers(),
+                timeout = self._timeout,
+            )
         response.raise_for_status()
         return response.json()
 
@@ -6426,6 +6460,37 @@ def _provider_display_name(provider_type: str) -> str:
     from core.inference.providers import get_provider_info
     info = get_provider_info(provider_type) or {}
     return str(info.get("display_name") or provider_type)
+
+
+def _unsupported_max_tokens_error(status_code: int, error_text: str) -> bool:
+    """Whether a 400 body reports `max_tokens` itself as the unsupported parameter.
+
+    Newer OpenAI models served through OpenAI-compatible proxies (Azure-hosted gpt-5.x,
+    o-series) answer 400 `unsupported_parameter` naming `max_tokens` and ask for
+    `max_completion_tokens` instead (#10787). Custom providers route to whatever upstream
+    they front, so this is detected from the error body rather than guessed from the
+    model name.
+    """
+    if status_code != 400:
+        return False
+    try:
+        error = _json.loads(error_text).get("error")
+        if isinstance(error, dict):
+            return (
+                str(error.get("code") or "") == "unsupported_parameter"
+                and str(error.get("param") or "") == "max_tokens"
+            )
+    except (ValueError, TypeError):
+        pass
+    lowered = error_text.lower()
+    return "unsupported_parameter" in lowered and "max_completion_tokens" in lowered
+
+
+def _rename_max_tokens_body(body: dict[str, Any]) -> dict[str, Any]:
+    """`body` with `max_tokens` renamed to `max_completion_tokens`, for the one-shot retry."""
+    renamed = dict(body)
+    renamed["max_completion_tokens"] = renamed.pop("max_tokens")
+    return renamed
 
 
 def _friendly_provider_error_text(

--- a/studio/backend/tests/test_external_provider_max_tokens_retry.py
+++ b/studio/backend/tests/test_external_provider_max_tokens_retry.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""An upstream that rejects `max_tokens` gets one retry with `max_completion_tokens`.
+
+Azure-hosted gpt-5.x / o-series behind OpenAI-compatible proxies answer 400
+``unsupported_parameter`` naming `max_tokens` and ask for `max_completion_tokens`
+(#10787). Custom providers route to whatever upstream they front, so the rename is
+detected from the error body, not guessed from the model name: the first response is
+400, the retry resends with the renamed field, and the client sees only the successful
+stream.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import httpx
+import pytest
+
+from core.inference import external_provider as ep_mod
+from core.inference.external_provider import (
+    ExternalProviderClient,
+    _rename_max_tokens_body,
+    _unsupported_max_tokens_error,
+)
+
+_ERROR_BODY = json.dumps(
+    {
+        "error": {
+            "message": "Unsupported parameter: 'max_tokens' is not supported with this model. "
+            "Use 'max_completion_tokens' instead.",
+            "type": "invalid_request_error",
+            "param": "max_tokens",
+            "code": "unsupported_parameter",
+        }
+    }
+).encode()
+
+# A 400 the retry must NOT react to: same shape, different parameter.
+_OTHER_ERROR_BODY = json.dumps(
+    {
+        "error": {
+            "message": "Unsupported parameter: 'temperature'.",
+            "type": "invalid_request_error",
+            "param": "temperature",
+            "code": "unsupported_parameter",
+        }
+    }
+).encode()
+
+_SSE = (
+    'data: {"choices":[{"index":0,"delta":{"content":"ok"}}]}\n\n'
+    'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n'
+    "data: [DONE]\n\n"
+).encode()
+
+_JSON_COMPLETION = json.dumps(
+    {"choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}]}
+).encode()
+
+
+class _RejectingHandler(BaseHTTPRequestHandler):
+    """`reject_body` on the first POST, a normal response afterwards; streaming requests
+    get SSE, non-streaming ones get a JSON completion."""
+
+    protocol_version = "HTTP/1.1"
+    reject_body = _ERROR_BODY
+
+    def log_message(self, *args, **kwargs) -> None:
+        return
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(length) if length else b"{}"
+        body = json.loads(raw.decode())
+        self.server.recorded.append(body)  # type: ignore[attr-defined]
+        if len(self.server.recorded) <= 1:  # type: ignore[attr-defined]
+            self.send_response(400)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(self.reject_body)))
+            self.end_headers()
+            self.wfile.write(self.reject_body)
+            return
+        payload = _SSE if body.get("stream") else _JSON_COMPLETION
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream" if body.get("stream") else "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+class _AlwaysRejectingHandler(_RejectingHandler):
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(length) if length else b"{}"
+        self.server.recorded.append(json.loads(raw.decode()))  # type: ignore[attr-defined]
+        self.send_response(400)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(self.reject_body)))
+        self.end_headers()
+        self.wfile.write(self.reject_body)
+
+
+class _OtherErrorHandler(_AlwaysRejectingHandler):
+    reject_body = _OTHER_ERROR_BODY
+
+
+class _Server:
+    def __init__(self, handler) -> None:
+        self._handler = handler
+
+    def __enter__(self) -> "_Server":
+        self._httpd = ThreadingHTTPServer(("127.0.0.1", 0), self._handler)
+        self._httpd.recorded = []  # type: ignore[attr-defined]
+        self._thread = threading.Thread(target = self._httpd.serve_forever, daemon = True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout = 10)
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self._httpd.server_address[1]}/v1"
+
+    @property
+    def bodies(self) -> list[dict]:
+        return self._httpd.recorded  # type: ignore[attr-defined]
+
+
+def _run(coro) -> None:
+    """One loop per call, with a matching client, mirroring the sibling test files."""
+    loop = asyncio.new_event_loop()
+    previous = ep_mod._http_client
+    client = httpx.AsyncClient()
+
+    async def wrapper() -> None:
+        try:
+            await coro()
+        finally:
+            await client.aclose()
+
+    ep_mod._http_client = client
+    try:
+        loop.run_until_complete(wrapper())
+    finally:
+        ep_mod._http_client = previous
+        loop.close()
+
+
+def test_a_rejected_max_tokens_is_retried_as_max_completion_tokens():
+    with _Server(_RejectingHandler) as server:
+        client = ExternalProviderClient(
+            provider_type = "custom",
+            base_url = server.base_url,
+            api_key = "",
+        )
+        chunks: list[str] = []
+
+        async def go() -> None:
+            async for chunk in client.stream_chat_completion(
+                messages = [{"role": "user", "content": "hi"}],
+                model = "gpt-5.5",
+                max_tokens = 512,
+            ):
+                chunks.append(chunk)
+
+        _run(go)
+
+        assert len(server.bodies) == 2, server.bodies
+        assert "max_tokens" in server.bodies[0]
+        assert "max_completion_tokens" not in server.bodies[0]
+        assert server.bodies[1]["max_completion_tokens"] == 512
+        assert "max_tokens" not in server.bodies[1]
+        # The client saw the successful stream, not the 400.
+        assert any('"content":"ok"' in chunk for chunk in chunks)
+        assert not any(chunk.startswith("data: {\"error\"") or "400" in chunk for chunk in chunks)
+
+
+def test_an_unrelated_400_is_not_retried():
+    with _Server(_OtherErrorHandler) as server:
+        client = ExternalProviderClient(
+            provider_type = "custom",
+            base_url = server.base_url,
+            api_key = "",
+        )
+        chunks: list[str] = []
+
+        async def go() -> None:
+            async for chunk in client.stream_chat_completion(
+                messages = [{"role": "user", "content": "hi"}],
+                model = "gpt-5.5",
+                max_tokens = 512,
+            ):
+                chunks.append(chunk)
+
+        _run(go)
+
+        # One request, and the error reached the client.
+        assert len(server.bodies) == 1
+        assert any("temperature" in chunk for chunk in chunks), chunks
+
+
+def test_non_streaming_chat_completion_retries_too():
+    with _Server(_RejectingHandler) as server:
+        client = ExternalProviderClient(
+            provider_type = "custom",
+            base_url = server.base_url,
+            api_key = "",
+        )
+
+        async def go() -> None:
+            await client.chat_completion(
+                messages = [{"role": "user", "content": "hi"}],
+                model = "gpt-5.5",
+                max_tokens = 256,
+            )
+
+        _run(go)
+
+        assert len(server.bodies) == 2
+        assert server.bodies[1]["max_completion_tokens"] == 256
+
+
+def test_unsupported_max_tokens_error_detection():
+    assert _unsupported_max_tokens_error(400, _ERROR_BODY.decode())
+    # Substring fallback for a body that is not the OpenAI JSON envelope.
+    assert _unsupported_max_tokens_error(
+        400, "HTTP 400: unsupported_parameter: use max_completion_tokens instead"
+    )
+    # A different unsupported parameter, a different status, or a 200 all read as no.
+    assert not _unsupported_max_tokens_error(
+        400, json.dumps({"error": {"code": "unsupported_parameter", "param": "temperature"}})
+    )
+    assert not _unsupported_max_tokens_error(429, _ERROR_BODY.decode())
+    assert not _unsupported_max_tokens_error(400, "unrelated failure")
+
+
+def test_rename_max_tokens_body_moves_only_that_field():
+    body = {"model": "m", "max_tokens": 7, "temperature": 0.5}
+    renamed = _rename_max_tokens_body(body)
+    assert renamed == {"model": "m", "max_completion_tokens": 7, "temperature": 0.5}
+    # The original body is untouched: the first attempt must still send max_tokens.
+    assert body == {"model": "m", "max_tokens": 7, "temperature": 0.5}

--- a/studio/backend/tests/test_external_provider_max_tokens_retry.py
+++ b/studio/backend/tests/test_external_provider_max_tokens_retry.py
@@ -59,7 +59,11 @@ _SSE = (
 ).encode()
 
 _JSON_COMPLETION = json.dumps(
-    {"choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}]}
+    {
+        "choices": [
+            {"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}
+        ]
+    }
 ).encode()
 
 
@@ -87,7 +91,9 @@ class _RejectingHandler(BaseHTTPRequestHandler):
             return
         payload = _SSE if body.get("stream") else _JSON_COMPLETION
         self.send_response(200)
-        self.send_header("Content-Type", "text/event-stream" if body.get("stream") else "application/json")
+        self.send_header(
+            "Content-Type", "text/event-stream" if body.get("stream") else "application/json"
+        )
         self.send_header("Content-Length", str(len(payload)))
         self.end_headers()
         self.wfile.write(payload)
@@ -180,7 +186,7 @@ def test_a_rejected_max_tokens_is_retried_as_max_completion_tokens():
         assert "max_tokens" not in server.bodies[1]
         # The client saw the successful stream, not the 400.
         assert any('"content":"ok"' in chunk for chunk in chunks)
-        assert not any(chunk.startswith("data: {\"error\"") or "400" in chunk for chunk in chunks)
+        assert not any(chunk.startswith('data: {"error"') or "400" in chunk for chunk in chunks)
 
 
 def test_an_unrelated_400_is_not_retried():


### PR DESCRIPTION
Fixes #10787.

## Problem

A custom provider pointing at an upstream that only accepts `max_completion_tokens` (Azure-hosted gpt-5.x / o-series behind OpenAI-compatible proxies) failed **every** request with:

```
Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead. (unsupported_parameter)
```

The existing rename only fires for `provider_type == "openai"`; `custom` providers send `max_tokens` verbatim. The reporter's upstream is exactly that shape (`provider=custom`, a gpt-5 model behind an institutional gateway).

## Fix

Detect the condition **from the error body** — 400 with `error.code == "unsupported_parameter"` and `error.param == "max_tokens"` (JSON), with a substring fallback for non-JSON bodies — rather than guessing from the model name, since custom providers route to arbitrary upstreams. On detection, retry **once** with `max_completion_tokens`:

- **Streaming path** (`stream_chat_completion`): the status check happens before any SSE byte is yielded, so the retry is invisible to the client. Any other 400 (or a retry that also fails) surfaces exactly as before, through `_friendly_provider_error_text`.
- **Non-streaming path** (`chat_completion`): same one-shot retry before `raise_for_status()`.

A two-field probe (send both) is not an option — upstreams reject that too.

## Tests

New `test_external_provider_max_tokens_retry.py` drives the real client against a loopback `http.server` (same pattern as `test_external_provider_sampling_over_the_wire.py`):

- `test_a_rejected_max_tokens_is_retried_as_max_completion_tokens`: two bodies hit the server — first with `max_tokens`, retry with `max_completion_tokens` — and the client consumes the successful stream, never the 400.
- `test_an_unrelated_400_is_not_retried`: a 400 naming a different parameter surfaces immediately, single request.
- `test_non_streaming_chat_completion_retries_too`.
- `test_unsupported_max_tokens_error_detection`: JSON match, substring fallback, and the negatives (other param, other status).
- `test_rename_max_tokens_body_moves_only_that_field`: the first attempt's body is untouched.

Note: the diff is large only because the streaming `async with` moved inside a two-attempt loop (mechanical re-indent); the streaming logic itself is unchanged.
