### PR TITLE
Studio: accept zero-based shard numbering in cached model weights

### DIFF
--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -392,8 +392,10 @@ def _has_complete_indexed_weights(path: Path, index_name: str, expected_suffix: 
             families.setdefault(family, set()).add(part)
     # Shards usually count 1..total, but some exporters count from zero
     # (model-00000-of-00001.safetensors). Accept either complete run, never a mix.
+    # Parts are distinct and within [0, total], so count, min and max identify the
+    # run without building a range from the total in an untrusted file name.
     return all(
-        parts in (set(range(1, total + 1)), set(range(total)))
+        len(parts) == total and (min(parts), max(parts)) in ((1, total), (0, total - 1))
         for (_, _, _, total), parts in families.items()
     )
 

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -381,7 +381,7 @@ def _has_complete_indexed_weights(path: Path, index_name: str, expected_suffix: 
         if match is not None:
             part = int(match.group("part"))
             total = int(match.group("total"))
-            if total < 1 or part < 1 or part > total:
+            if total < 1 or part < 0 or part > total:
                 return False
             family = (
                 os.path.normcase(str(shard_path.parent)),
@@ -390,7 +390,12 @@ def _has_complete_indexed_weights(path: Path, index_name: str, expected_suffix: 
                 total,
             )
             families.setdefault(family, set()).add(part)
-    return all(len(parts) == family[3] for family, parts in families.items())
+    # Shards usually count 1..total, but some exporters count from zero
+    # (model-00000-of-00001.safetensors). Accept either complete run, never a mix.
+    return all(
+        parts in (set(range(1, total + 1)), set(range(total)))
+        for (_, _, _, total), parts in families.items()
+    )
 
 
 def _trainable_local_roots(path: Path, model_name: Optional[str] = None) -> list[Path]:

--- a/studio/backend/tests/test_training_cached_start.py
+++ b/studio/backend/tests/test_training_cached_start.py
@@ -827,6 +827,42 @@ def test_client_error_probe_uses_complete_sharded_cache(tmp_path):
     assert result.cached_model_pin == ("unsloth/test", str(snapshot.resolve()))
 
 
+@pytest.mark.parametrize(
+    ("shards", "complete"),
+    [
+        (["model-00000-of-00001.safetensors"], True),
+        (["model-00000-of-00002.safetensors", "model-00001-of-00002.safetensors"], True),
+        (["model-00000-of-00002.safetensors"], False),
+        (["model-00000-of-00002.safetensors", "model-00002-of-00002.safetensors"], False),
+    ],
+)
+def test_zero_based_shard_numbering_uses_complete_cache(tmp_path, shards, complete):
+    route = _load_route_module(f"training_route_zero_based_shards_{len(shards)}_{complete}")
+    snapshot = tmp_path / "models--unsloth--test" / "snapshots" / "rev"
+    snapshot.mkdir(parents = True)
+    (snapshot / "config.json").write_text("{}")
+    for shard in shards:
+        (snapshot / shard).write_bytes(b"x")
+    (snapshot / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {"weight_map": {f"layer.{index}": shard for index, shard in enumerate(shards)}},
+        )
+    )
+
+    if not complete:
+        _shared_setup_1(route)
+        return
+
+    with patch.object(
+        route,
+        "_remote_untrainable_model_format",
+        side_effect = HTTPException(status_code = 403, detail = "unavailable"),
+    ):
+        result = route._reject_untrainable_model_request(_request())
+
+    assert result.cached_model_pin == ("unsloth/test", str(snapshot.resolve()))
+
+
 def test_incomplete_safetensors_index_is_not_masked_by_pytorch_weights(tmp_path):
     route = _load_route_module("training_route_incomplete_safe_index_with_pytorch")
     first_shard, second_shard, snapshot = _shared_setup_7(tmp_path)

--- a/studio/backend/tests/test_training_cached_start.py
+++ b/studio/backend/tests/test_training_cached_start.py
@@ -834,10 +834,12 @@ def test_client_error_probe_uses_complete_sharded_cache(tmp_path):
         (["model-00000-of-00002.safetensors", "model-00001-of-00002.safetensors"], True),
         (["model-00000-of-00002.safetensors"], False),
         (["model-00000-of-00002.safetensors", "model-00002-of-00002.safetensors"], False),
+        (["model-00000-of-1000000000.safetensors"], False),
     ],
 )
 def test_zero_based_shard_numbering_uses_complete_cache(tmp_path, shards, complete):
-    route = _load_route_module(f"training_route_zero_based_shards_{len(shards)}_{complete}")
+    total = shards[0].rsplit("-", 1)[-1].split(".")[0]
+    route = _load_route_module(f"training_route_zero_based_shards_{len(shards)}_{total}_{complete}")
     snapshot = tmp_path / "models--unsloth--test" / "snapshots" / "rev"
     snapshot.mkdir(parents = True)
     (snapshot / "config.json").write_text("{}")


### PR DESCRIPTION
Fixes #10853.

Studio refuses to train a cached model whose weights are indexed shards numbered from zero. `openbmb/MiniCPM5-2B` and `openbmb/MiniCPM5-1B` both ship

```
config.json
model.safetensors.index.json
model-00000-of-00001.safetensors
```

so every run after the first fails with "The selected local model does not contain trainable weights".

### Root cause

The report suggests the filename allowlist misses the shard, but `model.safetensors.index.json` is in `_MODEL_WEIGHT_CANDIDATES`, so these snapshots do reach `_has_complete_indexed_weights()`. That function then rejects the shard on

```python
if total < 1 or part < 1 or part > total:
    return False
```

because the part number is 0. transformers loads these checkpoints through the index's `weight_map`, so the files are valid; only the completeness check assumes 1-based numbering.

### Fix

Accept a shard family numbered either `1..total` or `0..total-1`, and require the complete run of one of the two. Only relaxing `part < 1` would not be enough: the old completeness test counted parts, so `{0, 2}` of 2 would have passed as two parts.

The check compares the number of parts with their minimum and maximum rather than building ranges, so a total taken from an untrusted file name (for example `model-00000-of-1000000000.safetensors`) cannot make the preflight allocate memory in proportion to it.

| index lists | before | after |
|---|---|---|
| `00000-of-00001` (MiniCPM5) | rejected | accepted |
| `00000-of-00002`, `00001-of-00002` | rejected | accepted |
| `00001-of-00002`, `00002-of-00002` | accepted | accepted |
| `00000-of-00002` only | rejected | rejected |
| `00000-of-00002`, `00002-of-00002` | rejected | rejected |
| `00000-of-1000000000` | rejected | rejected, without allocating |

### Testing

Added `test_zero_based_shard_numbering_uses_complete_cache` to `studio/backend/tests/test_training_cached_start.py`, next to the existing sharded-cache tests and built the same way. The two complete zero-based cases fail on `main` and pass with the change; the two incomplete ones are rejected both before and after.

`pytest studio/backend/tests/test_training_cached_start.py`: 196 passed (Python 3.12, macOS, CPU only). Formatted with `scripts/run_ruff_format.py`; `ruff check` passes.


---

### Before and after, in the UI

![Studio Train page before and after this PR](https://raw.githubusercontent.com/shimmyshimmer/unsloth-staging-4/pr-10857-media/pr10857_before_after.png)

Two isolated Studio installs, built with `install.sh --local` from this PR's merge base (`fe7452025`) and from its head (`96002ee01`), driven through the same scene.

Both halves hold the same state: the same cached model, the same dataset (`yahma/alpaca-cleaned`), the same project name, and the `modelLocalPath` the frontend persists after a first run, which is what makes every later run take the local branch. The cached weights are a single zero-numbered shard, `model-00000-of-00001.safetensors` plus its `model.safetensors.index.json`, exactly as `openbmb/MiniCPM5-2B` ships. That repo is 5 GB, so the scene re-lays a small real checkpoint into the same shape rather than downloading it; only the layout reaches the check under review, and real weights are what let the AFTER half get far enough to be worth photographing.

- BEFORE: the page stays on Configure and the alert under Start Training reads "The selected local model does not contain trainable weights."
- AFTER: no alert. The page moves to Current Run, the overlay reads "> unsloth training starts...", the dataset reports ready, and the model weights load out of the zero-based snapshot.

Measured on the same servers: `weights_missing_shown` true to false, `run_started` false to true.
