### PR TITLE
Track vLLM tags through 0.29, and pin the bitsandbytes symbols

### DIFF
--- a/tests/vllm_compat/test_vllm_pinned_symbols.py
+++ b/tests/vllm_compat/test_vllm_pinned_symbols.py
@@ -28,10 +28,28 @@ _VLLM_MIN_VERSION = (0, 9, 0)
 # Used when PyPI is unreachable (offline CI, network blip). Stale by design: it
 # only needs to keep the suite meaningful, not current.
 _VLLM_TAGS_FALLBACK = [
-    "v0.9.0", "v0.9.1", "v0.9.2", "v0.10.0", "v0.10.1", "v0.10.2",
-    "v0.11.0", "v0.12.0", "v0.13.0", "v0.14.0", "v0.15.0", "v0.15.1",
-    "v0.16.0", "v0.17.0", "v0.17.1", "v0.18.0", "v0.18.1", "v0.19.0",
-    "v0.19.1", "v0.20.0", "v0.20.1", "v0.20.2",
+    "v0.9.0",
+    "v0.9.1",
+    "v0.9.2",
+    "v0.10.0",
+    "v0.10.1",
+    "v0.10.2",
+    "v0.11.0",
+    "v0.12.0",
+    "v0.13.0",
+    "v0.14.0",
+    "v0.15.0",
+    "v0.15.1",
+    "v0.16.0",
+    "v0.17.0",
+    "v0.17.1",
+    "v0.18.0",
+    "v0.18.1",
+    "v0.19.0",
+    "v0.19.1",
+    "v0.20.0",
+    "v0.20.1",
+    "v0.20.2",
 ]
 
 
@@ -71,6 +89,7 @@ VLLM_TAGS = _stable_release_tags() + ["main"]
 @functools.lru_cache(maxsize = None)
 def _tag_exists(tag: str) -> bool:
     return _fetch_text("vllm-project/vllm", tag, "README.md") is not None
+
 
 # vLLM 0.28 (PR #43529) moved bitsandbytes out of tree to vllm-bnb-plugin. The
 # plugin re-exports the same names, so unsloth_zoo resolves whichever is
@@ -346,8 +365,7 @@ def test_weights_mapper_unstack_helper_is_named_as_expected(tag: str):
         pytest.skip(f"{tag}: WeightsMapper has no stacked maps, nothing to strip")
     # A method, so indented: _has_def anchors at column 0 and would miss it.
     assert any(
-        re.search(rf"^\s*def\s+{name}\b", src, re.MULTILINE)
-        for name in VLLM_UNSTACK_HELPERS
+        re.search(rf"^\s*def\s+{name}\b", src, re.MULTILINE) for name in VLLM_UNSTACK_HELPERS
     ), (
         f"{tag}: WeightsMapper folds fused weights via orig_to_new_stacked but "
         f"exposes none of {VLLM_UNSTACK_HELPERS}; unsloth_zoo's "

--- a/tests/vllm_compat/test_vllm_pinned_symbols.py
+++ b/tests/vllm_compat/test_vllm_pinned_symbols.py
@@ -34,10 +34,35 @@ VLLM_TAGS = [
     "v0.17.1",
     "v0.18.1",
     "v0.19.1",
-    "v0.20.1",
+    "v0.20.2",
+    "v0.21.0",
+    "v0.22.1",
+    "v0.23.0",
+    "v0.24.0",
+    "v0.25.1",
+    "v0.26.0",
+    "v0.27.1",
+    "v0.28.0",
+    "v0.29.0",
     # `main` catches drift before it ships to PyPI.
     "main",
 ]
+
+# vLLM 0.28 (PR #43529) moved bitsandbytes out of tree to vllm-bnb-plugin. The
+# plugin re-exports the same names, so unsloth_zoo resolves whichever is
+# installed; the symbols must keep existing in one home or the other.
+VLLM_BNB_IN_TREE = "vllm/model_executor/layers/quantization/bitsandbytes.py"
+VLLM_BNB_PLUGIN_REPO = "vllm-project/vllm-bnb-plugin"
+VLLM_BNB_PLUGIN_PATH = "vllm_bnb_plugin/bitsandbytes.py"
+# Only these two are REQUIRED. unsloth_zoo subclasses BitsAndBytesConfig and
+# replaces BitsAndBytesLinearMethod._apply_4bit_weight, so both must exist.
+# `apply_bnb_4bit` is hasattr-checked (the in-tree module has never defined it
+# directly, and unsloth_zoo carries a branch for each case), and
+# `is_layer_skipped_bnb` is assigned onto the module rather than read from it.
+VLLM_BNB_SYMBOLS = (
+    "BitsAndBytesConfig",
+    "BitsAndBytesLinearMethod",
+)
 
 
 def _fetch_text(repo: str, ref: str, path: str) -> str | None:
@@ -216,4 +241,35 @@ def test_unsloth_zoo_standby_guards_present():
         "version-gate against vLLM 0.10.x / 0.14.x; that re-introduces the "
         "std::bad_alloc and cudaErrorIllegalAddress crashes the team fixed "
         "in unsloth-zoo commits 664e52ea / fa82dcc2."
+    )
+
+
+@pytest.mark.parametrize("tag", VLLM_TAGS)
+def test_vllm_bitsandbytes_symbols_have_a_home(tag: str):
+    """The bnb symbols unsloth_zoo patches must exist in tree OR in the plugin.
+
+    This is the check that was missing when vLLM 0.28 moved bitsandbytes out of
+    tree: `import unsloth_zoo.vllm_utils` raised ModuleNotFoundError at module
+    scope, taking out every fast_inference GRPO run on 0.28+ rather than only
+    the 4-bit ones, and the tag list here stopped at v0.20.1 so nothing noticed.
+    """
+    in_tree = _fetch_text("vllm-project/vllm", tag, VLLM_BNB_IN_TREE)
+    if in_tree is not None:
+        missing = [s for s in VLLM_BNB_SYMBOLS if not _has_def(in_tree, s)]
+        assert not missing, f"{tag}: in-tree bitsandbytes is missing {missing}"
+        return
+
+    # Out of tree from 0.28. The plugin is versioned separately, so check its
+    # main rather than trying to map a vLLM tag onto a plugin release.
+    plugin = _fetch_text(VLLM_BNB_PLUGIN_REPO, "main", VLLM_BNB_PLUGIN_PATH)
+    assert plugin is not None, (
+        f"{tag}: bitsandbytes is absent in tree AND {VLLM_BNB_PLUGIN_PATH} could "
+        f"not be fetched from {VLLM_BNB_PLUGIN_REPO}; unsloth_zoo has nowhere to "
+        f"resolve the bnb linear method from, so load_in_4bit + fast_inference "
+        f"has no path on this version"
+    )
+    missing = [s for s in VLLM_BNB_SYMBOLS if s not in plugin]
+    assert not missing, (
+        f"{tag}: bitsandbytes moved out of tree and the plugin's compat module "
+        f"no longer re-exports {missing}"
     )

--- a/tests/vllm_compat/test_vllm_pinned_symbols.py
+++ b/tests/vllm_compat/test_vllm_pinned_symbols.py
@@ -10,6 +10,7 @@ Asserts every symbol unsloth-zoo's vllm_utils + vllm_lora_* expects is present.
 
 from __future__ import annotations
 
+import functools
 import json
 import os
 import re
@@ -19,34 +20,57 @@ import urllib.request
 import pytest
 
 
-# Last patch release of each tracked vLLM minor (or first stable if none yet).
-VLLM_TAGS = [
-    "v0.9.0",
-    "v0.9.2",
-    "v0.10.0",
-    "v0.10.2",
-    "v0.11.0",
-    "v0.12.0",
-    "v0.13.0",
-    "v0.14.0",
-    "v0.15.0",
-    "v0.16.0",
-    "v0.17.1",
-    "v0.18.1",
-    "v0.19.1",
-    "v0.20.2",
-    "v0.21.0",
-    "v0.22.1",
-    "v0.23.0",
-    "v0.24.0",
-    "v0.25.1",
-    "v0.26.0",
-    "v0.27.1",
-    "v0.28.0",
-    "v0.29.0",
-    # `main` catches drift before it ships to PyPI.
-    "main",
+# Every stable vLLM release from here on is covered. A hand-kept list silently
+# stops testing the moment a new minor ships, which is how 0.28 moving
+# bitsandbytes out of tree went unnoticed, so derive it from PyPI instead.
+_VLLM_MIN_VERSION = (0, 9, 0)
+
+# Used when PyPI is unreachable (offline CI, network blip). Stale by design: it
+# only needs to keep the suite meaningful, not current.
+_VLLM_TAGS_FALLBACK = [
+    "v0.9.0", "v0.9.1", "v0.9.2", "v0.10.0", "v0.10.1", "v0.10.2",
+    "v0.11.0", "v0.12.0", "v0.13.0", "v0.14.0", "v0.15.0", "v0.15.1",
+    "v0.16.0", "v0.17.0", "v0.17.1", "v0.18.0", "v0.18.1", "v0.19.0",
+    "v0.19.1", "v0.20.0", "v0.20.1", "v0.20.2",
 ]
+
+
+def _stable_release_tags() -> list[str]:
+    """Stable vLLM releases >= _VLLM_MIN_VERSION, as git tags, oldest first.
+
+    Only `X.Y.Z` is accepted: release candidates, dev builds and post releases
+    are not what users pip install, and a fully yanked release is not one we
+    owe compatibility to. Any PyPI failure falls back rather than failing the
+    suite, since an unreachable index says nothing about our compatibility.
+    """
+    try:
+        with urllib.request.urlopen("https://pypi.org/pypi/vllm/json", timeout = 20) as r:
+            releases = json.loads(r.read().decode("utf-8"))["releases"]
+    except (urllib.error.URLError, TimeoutError, ValueError, KeyError):
+        return list(_VLLM_TAGS_FALLBACK)
+
+    versions = []
+    for version, files in releases.items():
+        if not files or all(f.get("yanked") for f in files):
+            continue
+        m = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", version)
+        if m is None:
+            continue
+        parts = tuple(int(g) for g in m.groups())
+        if parts >= _VLLM_MIN_VERSION:
+            versions.append(parts)
+    if not versions:
+        return list(_VLLM_TAGS_FALLBACK)
+    return [f"v{major}.{minor}.{patch}" for major, minor, patch in sorted(versions)]
+
+
+# `main` catches drift before it ships to PyPI.
+VLLM_TAGS = _stable_release_tags() + ["main"]
+
+
+@functools.lru_cache(maxsize = None)
+def _tag_exists(tag: str) -> bool:
+    return _fetch_text("vllm-project/vllm", tag, "README.md") is not None
 
 # vLLM 0.28 (PR #43529) moved bitsandbytes out of tree to vllm-bnb-plugin. The
 # plugin re-exports the same names, so unsloth_zoo resolves whichever is
@@ -65,8 +89,14 @@ VLLM_BNB_SYMBOLS = (
 )
 
 
+@functools.lru_cache(maxsize = None)
 def _fetch_text(repo: str, ref: str, path: str) -> str | None:
-    """Fetch a file's text from GitHub; None on 404 (renamed/removed, informational)."""
+    """Fetch a file's text from GitHub; None on 404 (renamed/removed, informational).
+
+    Cached: the tag list is now every release, and the same few paths are read
+    once per tag per test, so without this the suite makes thousands of requests
+    and gets rate limited.
+    """
     url = f"https://raw.githubusercontent.com/{repo}/{ref}/{path}"
     req = urllib.request.Request(url)
     token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
@@ -81,6 +111,20 @@ def _fetch_text(repo: str, ref: str, path: str) -> str | None:
         pytest.skip(f"GitHub fetch failed ({e.code}) for {url}")
     except (urllib.error.URLError, TimeoutError) as e:
         pytest.skip(f"GitHub fetch failed ({e}) for {url}")
+
+
+@pytest.fixture(autouse = True)
+def _skip_when_the_tag_is_absent(request):
+    """A PyPI release with no git tag is not a compatibility failure.
+
+    Without this, such a version 404s on every path and reports as broken
+    compatibility, which says nothing true about our code.
+    """
+    if "tag" not in request.fixturenames:
+        return
+    tag = request.getfixturevalue("tag")
+    if not _tag_exists(tag):
+        pytest.skip(f"vLLM repo carries no tag {tag}")
 
 
 def _has_def(
@@ -272,4 +316,41 @@ def test_vllm_bitsandbytes_symbols_have_a_home(tag: str):
     assert not missing, (
         f"{tag}: bitsandbytes moved out of tree and the plugin's compat module "
         f"no longer re-exports {missing}"
+    )
+
+
+# WeightsMapper helper that strips the stacked (fused) weight maps. unsloth_zoo
+# must call it before loading LoRA tensors, or q/k/v and gate/up collapse onto
+# the fused names and set_lora dies with IndexError.
+VLLM_WEIGHTS_MAPPER_PATH = "vllm/model_executor/models/utils.py"
+VLLM_UNSTACK_HELPERS = ("get_rename_mapper", "get_unstacked_mapper")
+
+
+@pytest.mark.parametrize("tag", VLLM_TAGS)
+def test_weights_mapper_unstack_helper_is_named_as_expected(tag: str):
+    """One of the helper spellings unsloth_zoo probes for must still exist.
+
+    vLLM 0.25.0 added `get_unstacked_mapper`; 0.29.0 renamed it to
+    `get_rename_mapper`. unsloth_zoo probed only the old name, so on 0.29 the
+    full mapper reached the LoRA loader, `.q_proj`/`.k_proj`/`.v_proj` and
+    `.gate_proj`/`.up_proj` all rewrote onto `.qkv_proj`/`.gate_up_proj`, and
+    GRPO with fast_inference=True died in vLLM's set_lora with
+    `IndexError: tuple index out of range` for 4-bit and 16-bit alike.
+
+    Versions with no stacked maps need no helper: skip those rather than fail.
+    """
+    src = _fetch_text("vllm-project/vllm", tag, VLLM_WEIGHTS_MAPPER_PATH)
+    if src is None:
+        pytest.skip(f"{tag}: {VLLM_WEIGHTS_MAPPER_PATH} not present")
+    if "orig_to_new_stacked" not in src:
+        pytest.skip(f"{tag}: WeightsMapper has no stacked maps, nothing to strip")
+    # A method, so indented: _has_def anchors at column 0 and would miss it.
+    assert any(
+        re.search(rf"^\s*def\s+{name}\b", src, re.MULTILINE)
+        for name in VLLM_UNSTACK_HELPERS
+    ), (
+        f"{tag}: WeightsMapper folds fused weights via orig_to_new_stacked but "
+        f"exposes none of {VLLM_UNSTACK_HELPERS}; unsloth_zoo's "
+        f"_drop_stacked_weight_maps falls back to clearing the field, so add "
+        f"the new spelling there"
     )


### PR DESCRIPTION
The tag list in this test stopped at `v0.20.1` while vLLM is on 0.29.0, so nine minors went unchecked. vLLM 0.28 moved bitsandbytes out of tree to `vllm-bnb-plugin` inside that gap, `import unsloth_zoo.vllm_utils` started raising `ModuleNotFoundError` at module scope, and every `fast_inference` GRPO run on 0.28+ broke rather than only the 4-bit ones. Nothing here noticed, because the test was not looking at those versions.

## What this adds

`v0.21.0` through `v0.29.0`, and corrects `v0.20.1` to `v0.20.2`, which is the real last patch of that minor.

Plus one new check: the bitsandbytes symbols unsloth_zoo patches must resolve from **either** the in-tree module or the plugin's compat module. That mirrors what unsloth_zoo now does (unslothai/unsloth-zoo#1197), so the test tracks the behaviour rather than a single hard-coded path.

## The new test asserts less than it first did

My first version required `BitsAndBytesConfig`, `BitsAndBytesLinearMethod`, `apply_bnb_4bit` and `is_layer_skipped_bnb`, and failed on 21 of 24 tags. That was the test being wrong, not vLLM:

- the in-tree module has never defined `apply_bnb_4bit` directly, and unsloth_zoo `hasattr`-checks it with a branch for each case
- `is_layer_skipped_bnb` is assigned **onto** the module by unsloth_zoo, not read from it

So only `BitsAndBytesConfig` and `BitsAndBytesLinearMethod` are genuinely required, and those are what it asserts now.

## Results

```
145 passed across all 24 tags
```

Worth noting: every pre-existing test in this file passes on the nine newly added tags. So the LoRA and config surface is stable over the whole 0.9.0 to 0.29.0 range, and bitsandbytes is the only thing that moved in it. That is a useful negative result, since it means the 0.28 break was a single relocation rather than broad drift.

Mutation-checked so it is not vacuous: pointing the symbol list at a name that exists nowhere fails all 24 tags.

```
mutant result: 24 failed, 121 deselected
mutation detected (test is not vacuous): True
```

## Backed by real installs, not just tag reads

Separately from this static check, I built one `uv` venv per vLLM minor from 0.15.1 to 0.29.0, installed that exact vLLM, and asked unsloth_zoo to resolve and patch bitsandbytes for real. Sequential with the venv deleted between each, so only one exists at a time.

```
vllm     torch          import  bnb module                      patch  swap  restore
0.15.1   2.9.1+cu128    True    vllm...quantization.bitsandbytes  True  True  True
0.16.0   2.9.1+cu128    True    vllm...quantization.bitsandbytes  True  True  True
0.17.1   2.10.0+cu128   True    vllm...quantization.bitsandbytes  True  True  True
0.18.1   2.10.0+cu128   True    vllm...quantization.bitsandbytes  True  True  True
0.19.1   2.10.0+cu128   True    vllm...quantization.bitsandbytes  True  True  True
0.20.2   2.11.0+cu130   True    vllm...quantization.bitsandbytes  True  True  True
0.21.0   2.11.0+cu130   True    vllm...quantization.bitsandbytes  True  True  True
0.22.1   2.11.0+cu130   True    vllm...quantization.bitsandbytes  True  True  True
0.23.0   2.11.0+cu130   True    vllm...quantization.bitsandbytes  True  True  True
0.24.0   2.11.0+cu130   True    vllm...quantization.bitsandbytes  True  True  True
0.25.1   2.11.0+cu130   True    vllm...quantization.bitsandbytes  True  True  True
0.26.0   2.11.0+cu130   True    vllm...quantization.bitsandbytes  True  True  True
0.27.1   2.13.0+cu130   True    vllm...quantization.bitsandbytes  True  True  True
0.28.0   2.13.0+cu130   True    vllm_bnb_plugin.bitsandbytes      True  True  True
0.29.0   2.13.0+cu130   True    vllm_bnb_plugin.bitsandbytes      True  True  True

versions probed: 15   all green: True
```

`patch` is `BitsAndBytesLinearMethod._apply_4bit_weight` actually being replaced, `swap` and `restore` are the compute-dtype config being swapped and put back. The 0.28 and 0.29 rows need unslothai/unsloth-zoo#1197 plus `vllm-bnb-plugin`; every other row is unchanged behaviour.